### PR TITLE
firewood: decouple local dependencies from cargo

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = [
      "Ted Yin (@Determinant) <ted@avalabs.org>",

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-firewood = { version = "0.0.1", path = "../firewood" }
+firewood = { version = "0.0.2", path = "../firewood" }
 clap = { version = "4.0.29", features = ["cargo", "derive"] }
 anyhow = "1.0.66"
 env_logger = "0.10.0"


### PR DESCRIPTION
Because the local dependencies are not going to independently be published at this time, this PR removes the static versions from Cargo.yaml.