### PR TITLE
[locking] Get a revision while a batch is active

### DIFF
--- a/firewood/examples/rev.rs
+++ b/firewood/examples/rev.rs
@@ -26,10 +26,7 @@ fn main() {
             "{}",
             hex::encode(*db.get_revision(2, None).unwrap().kv_root_hash().unwrap())
         );
-        let write = db
-            .new_writebatch()
-            .kv_insert("k", "v".as_bytes().to_vec())
-            .unwrap();
+        let write = db.new_writebatch().kv_insert("k", vec![b'v']).unwrap();
 
         // Get a revision while a batch is active.
         println!(


### PR DESCRIPTION
Closes #37  

This PR breaks the mutex lock on DBInner to separate ones on latest batch and revisions. So that users can get a revision while a batch is active. It also allows users to read their writes for a uncommitted batch.

A follow up PR will associate revisions with root hashes to ensure a revision has static meaning.