### PR TITLE
Propogate errors in growth-ring

### DIFF
--- a/growth-ring/Cargo.toml
+++ b/growth-ring/Cargo.toml
@@ -20,7 +20,8 @@ async-trait = "0.1.57"
 futures = "0.3.24"
 nix = "0.26.2"
 libc = "0.2.133"
-bytemuck = "1.13.1"
+bytemuck = {version = "1.13.1", features = ["derive"]}
+thiserror = "1.0.40"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/growth-ring/examples/demo1.rs
+++ b/growth-ring/examples/demo1.rs
@@ -1,6 +1,7 @@
 use futures::executor::block_on;
 use growthring::{
     wal::{WALBytes, WALLoader, WALRingId, WALWriter},
+    walerror::WALError,
     WALStoreAIO,
 };
 use rand::{seq::SliceRandom, Rng, SeedableRng};
@@ -15,7 +16,7 @@ fn test(records: Vec<String>, wal: &mut WALWriter<WALStoreAIO>) -> Vec<WALRingId
     res
 }
 
-fn recover(payload: WALBytes, ringid: WALRingId) -> Result<(), ()> {
+fn recover(payload: WALBytes, ringid: WALRingId) -> Result<(), WALError> {
     println!(
         "recover(payload={}, ringid={:?}",
         std::str::from_utf8(&payload).unwrap(),

--- a/growth-ring/src/walerror.rs
+++ b/growth-ring/src/walerror.rs
@@ -1,0 +1,18 @@
+use nix::errno::Errno;
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error)]
+pub enum WALError {
+    #[error("an unclassified error has occurred")]
+    Other,
+    #[error("an OS error {0} has occurred")]
+    UnixError(#[from] Errno),
+    #[error("a checksum check has failed")]
+    InvalidChecksum,
+}
+
+impl From<i32> for WALError {
+    fn from(value: i32) -> Self {
+        Self::UnixError(Errno::from_i32(value))
+    }
+}


### PR DESCRIPTION
Error handling improvements. Still to-do is remove all instances of WALError::Other.