### PR TITLE
ci: Fail in case of error publishing firewood crate

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p firewood-growth-ring
       - name: publish firewood crate
-        continue-on-error: true
+        continue-on-error: false
         run: |
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p firewood


### PR DESCRIPTION
Updates CI to fail in case of an error publishing the primary firewood crate. 

cc @patrick-ogrady 