### PR TITLE
rkuris/rename structs

### DIFF
--- a/firewood-shale/benches/shale-bench.rs
+++ b/firewood-shale/benches/shale-bench.rs
@@ -2,7 +2,7 @@ use bencher::{benchmark_group, benchmark_main, Bencher};
 
 extern crate firewood_shale as shale;
 use rand::Rng;
-use shale::{compact::CompactSpaceHeader, MemStore, MummyObj, ObjPtr, PlainMem};
+use shale::{compact::CompactSpaceHeader, CachedStore, ObjPtr, PlainMem, StoredView};
 
 fn get_view(b: &mut Bencher) {
     const SIZE: u64 = 2_000_000;
@@ -29,7 +29,7 @@ fn serialize(b: &mut Bencher) {
     b.iter(|| {
         let compact_header_obj: ObjPtr<CompactSpaceHeader> = ObjPtr::new_from_addr(0x0);
         let _compact_header =
-            MummyObj::ptr_to_obj(&m, compact_header_obj, shale::compact::CompactHeader::MSIZE)
+            StoredView::ptr_to_obj(&m, compact_header_obj, shale::compact::CompactHeader::MSIZE)
                 .unwrap();
     });
 }

--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use bencher::{benchmark_group, benchmark_main, Bencher};
 use firewood::merkle::{Hash, Merkle, HASH_SIZE};
 use firewood_shale::{
-    compact::CompactSpaceHeader, MemStore, MummyItem, MummyObj, ObjPtr, PlainMem,
+    compact::CompactSpaceHeader, CachedStore, ObjPtr, PlainMem, Storable, StoredView,
 };
 use rand::{distributions::Alphanumeric, Rng, SeedableRng};
 
@@ -30,7 +30,7 @@ fn bench_insert(b: &mut Bencher) {
     const TEST_MEM_SIZE: u64 = 20_000_000;
     let merkle_payload_header: ObjPtr<CompactSpaceHeader> = ObjPtr::new_from_addr(0);
 
-    let merkle_payload_header_ref = MummyObj::ptr_to_obj(
+    let merkle_payload_header_ref = StoredView::ptr_to_obj(
         &PlainMem::new(2 * firewood_shale::compact::CompactHeader::MSIZE, 9),
         merkle_payload_header,
         firewood_shale::compact::CompactHeader::MSIZE,

--- a/firewood/src/account.rs
+++ b/firewood/src/account.rs
@@ -6,7 +6,7 @@ use std::io::{Cursor, Write};
 
 use crate::merkle::{Hash, Node, ValueTransformer};
 use primitive_types::U256;
-use shale::{MemStore, MummyItem, ObjPtr, ObjRef, ShaleError, ShaleStore};
+use shale::{CachedStore, ObjPtr, ObjRef, ShaleError, ShaleStore, Storable};
 
 pub struct Account {
     pub nonce: u64,
@@ -98,16 +98,16 @@ pub enum Blob {
     Code(Vec<u8>),
 }
 
-impl MummyItem for Blob {
+impl Storable for Blob {
     // currently there is only one variant of Blob: Code
-    fn hydrate<T: MemStore>(addr: u64, mem: &T) -> Result<Self, ShaleError> {
+    fn hydrate<T: CachedStore>(addr: u64, mem: &T) -> Result<Self, ShaleError> {
         let raw = mem
             .get_view(addr, 4)
-            .ok_or(ShaleError::LinearMemStoreError)?;
+            .ok_or(ShaleError::LinearCachedStoreError)?;
         let len = u32::from_le_bytes(raw.as_deref()[..].try_into().unwrap()) as u64;
         let bytes = mem
             .get_view(addr + 4, len)
-            .ok_or(ShaleError::LinearMemStoreError)?;
+            .ok_or(ShaleError::LinearCachedStoreError)?;
         Ok(Self::Code(bytes.as_deref()))
     }
 

--- a/firewood/src/dynamic_mem.rs
+++ b/firewood/src/dynamic_mem.rs
@@ -9,7 +9,7 @@ use shale::*;
 
 pub type SpaceID = u8;
 
-/// Purely volatile, dynamically allocated vector-based implementation for [MemStore]. This is similar to
+/// Purely volatile, dynamically allocated vector-based implementation for [CachedStore]. This is similar to
 /// [PlainMem]. The only difference is, when [write] dynamically allocate more space if original space is
 /// not enough.
 #[derive(Debug)]
@@ -31,12 +31,12 @@ impl DynamicMem {
     }
 }
 
-impl MemStore for DynamicMem {
+impl CachedStore for DynamicMem {
     fn get_view(
         &self,
         offset: u64,
         length: u64,
-    ) -> Option<Box<dyn MemView<DerefReturn = Vec<u8>>>> {
+    ) -> Option<Box<dyn CachedView<DerefReturn = Vec<u8>>>> {
         let offset = offset as usize;
         let length = length as usize;
         let size = offset + length;
@@ -54,7 +54,7 @@ impl MemStore for DynamicMem {
         }))
     }
 
-    fn get_shared(&self) -> Option<Box<dyn DerefMut<Target = dyn MemStore>>> {
+    fn get_shared(&self) -> Option<Box<dyn DerefMut<Target = dyn CachedStore>>> {
         Some(Box::new(DynamicMemShared(Self {
             space: self.space.clone(),
             id: self.id,
@@ -93,8 +93,8 @@ impl Deref for DynamicMemView {
 }
 
 impl Deref for DynamicMemShared {
-    type Target = dyn MemStore;
-    fn deref(&self) -> &(dyn MemStore + 'static) {
+    type Target = dyn CachedStore;
+    fn deref(&self) -> &(dyn CachedStore + 'static) {
         &self.0
     }
 }
@@ -105,7 +105,7 @@ impl DerefMut for DynamicMemShared {
     }
 }
 
-impl MemView for DynamicMemView {
+impl CachedView for DynamicMemView {
     type DerefReturn = Vec<u8>;
 
     fn as_deref(&self) -> Self::DerefReturn {

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -72,17 +72,17 @@
 //! layout/representation of the data on disk from the actual logical data structure it retains:
 //!
 //! - Linear, memory-like space: the [shale](https://crates.io/crates/shale) crate from an academic
-//!   project (CedrusDB) code offers a `MemStore` abstraction for a (64-bit) byte-addressable space
+//!   project (CedrusDB) code offers a `CachedStore` abstraction for a (64-bit) byte-addressable space
 //!   that abstracts away the intricate method that actually persists the in-memory data on the
-//!   secondary storage medium (e.g., hard drive). The implementor of `MemStore` will provide the
-//!   functions to give the user of `MemStore` an illusion that the user is operating upon a
+//!   secondary storage medium (e.g., hard drive). The implementor of `CachedStore` will provide the
+//!   functions to give the user of `CachedStore` an illusion that the user is operating upon a
 //!   byte-addressable memory space. It is just a "magical" array of bytes one can view and change
 //!   that is mirrored to the disk. In reality, the linear space will be chunked into files under a
 //!   directory, but the user does not have to even know about this.
 //!
 //! - Persistent item storage stash: `ShaleStore` trait from `shale` defines a pool of typed
 //!   objects that are persisted on disk but also made accessible in memory transparently. It is
-//!   built on top of `MemStore` by defining how "items" of the given type are laid out, allocated
+//!   built on top of `CachedStore` by defining how "items" of the given type are laid out, allocated
 //!   and recycled throughout their life cycles (there is a disk-friendly, malloc-style kind of
 //!   basic implementation in `shale` crate, but one can always define his/her own `ShaleStore`).
 //!
@@ -99,7 +99,7 @@
 //! </p>
 //!
 //! Given the abstraction, one can easily realize the fact that the actual data that affect the
-//! state of the data structure (trie) is what the linear space (`MemStore`) keeps track of, that is,
+//! state of the data structure (trie) is what the linear space (`CachedStore`) keeps track of, that is,
 //! a flat but conceptually large byte vector. In other words, given a valid byte vector as the
 //! content of the linear space, the higher level data structure can be *uniquely* determined, there
 //! is nothing more (except for some auxiliary data that are kept for performance reasons, such as caching)
@@ -107,7 +107,7 @@
 //! separate the logical data from its physical representation, greatly simplifies the storage
 //! management, and allows reusing the code. It is still a very versatile abstraction, as in theory
 //! any persistent data could be stored this way -- sometimes you need to swap in a different
-//! `MemShale` or `MemStore` implementation, but without having to touch the code for the persisted
+//! `MemShale` or `CachedStore` implementation, but without having to touch the code for the persisted
 //! data structure.
 //!
 //! ## Page-based Shadowing and Revisions
@@ -117,7 +117,7 @@
 //! space. The writes may overlap and some frequent writes are even done to the same spot in the
 //! space. To reduce the overhead and be friendly to the disk, we partition the entire 64-bit
 //! virtual space into pages (yeah it appears to be more and more like an OS) and keep track of the
-//! dirty pages in some `MemStore` instantiation (see `storage::StoreRevMut`). When a
+//! dirty pages in some `CachedStore` instantiation (see `storage::StoreRevMut`). When a
 //! [`db::WriteBatch`] commits, both the recorded interval writes and the aggregated in-memory
 //! dirty pages induced by this write batch are taken out from the linear space. Although they are
 //! mathematically equivalent, interval writes are more compact than pages (which are 4K in size,

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -4,7 +4,7 @@
 use crate::merkle::*;
 use crate::proof::Proof;
 use crate::{dynamic_mem::DynamicMem, proof::ProofError};
-use shale::{compact::CompactSpaceHeader, MemStore, MummyObj, ObjPtr};
+use shale::{compact::CompactSpaceHeader, CachedStore, ObjPtr, StoredView};
 use std::rc::Rc;
 
 use thiserror::Error;
@@ -124,7 +124,7 @@ pub fn new_merkle(meta_size: u64, compact_size: u64) -> MerkleSetup {
         &shale::to_dehydrated(&shale::compact::CompactSpaceHeader::new(RESERVED, RESERVED)),
     );
     let compact_header =
-        MummyObj::ptr_to_obj(&dm, compact_header, shale::compact::CompactHeader::MSIZE).unwrap();
+        StoredView::ptr_to_obj(&dm, compact_header, shale::compact::CompactHeader::MSIZE).unwrap();
     let mem_meta = Rc::new(dm);
     let mem_payload = Rc::new(DynamicMem::new(compact_size, 0x1));
 

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -487,7 +487,7 @@ mod tests {
         file,
         storage::{DeltaPage, StoreConfig, StoreRevMut, StoreRevMutDelta},
     };
-    use shale::MemStore;
+    use shale::CachedStore;
 
     const STATE_SPACE: SpaceID = 0x0;
     #[test]


### PR DESCRIPTION
    Rename structs for better readability
    
    These structures could use more meaningful names, making the code
    a little easier to follow. Here are the renamed traits and structs
    along with a brief description of each:
    
      1. MummyItem -> StorableStruct
       This trait is used to indicate that the structure will be stored
       in a cached storage layer
    
      2. MummyObj -> StoredView
       This struct is implemented on a StorableStruct and saves the location
       where the item is actually stored
    
      3. MemStore -> CachedStore
       This trait has a few implementations:
        PlainMem: keeps all items in fixed sized memory
        DynamicMem: keeps all items in a growing memory
        StoreRevShared: read-only version of StoreRevMut
        StoreRevMut: the writeable revision store
    
      4. MemView -> CachedView
       Provides read-only access to a portion of a CachedStore
    
      5. PlainMemView -> PlainMemCachedView
    
    Only other change here was better enforcement for instantiation of
    a StoredView; it now requires a StorableStruct (previously a MummyItem)
    in order to instantiate it, rather than only when using some of the
    methods, just to catch future compile errors earlier.
