### PR TITLE
docs: Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Firewood: non-archival blockchain key-value store with hyper-fast recent state retrieval.
 
+[![Latest version](https://img.shields.io/crates/v/firewood.svg)](https://crates.io/crates/firewood)
+[![Ecosystem license](https://img.shields.io/badge/License-Ecosystem-blue.svg)](./LICENSE.md)
+
 > :warning: firewood is alpha-level software and is not ready for production
 > use. Do not use firewood to store production data. See the
 > [license](./LICENSE.md) for more information regarding firewood usage.


### PR DESCRIPTION
Part of #25 

The CI badge doesn't render correctly -- I think it may be because the repo is still private. Once it's public we can add a CI badge to indicate the build is passing. 

<img width="342" alt="image" src="https://user-images.githubusercontent.com/31546601/232820086-42284b68-c872-4067-87cc-3ec1d850024b.png">
