### PR TITLE
Get the current committed state with `get_revision(0)`

### DIFF
--- a/firewood/examples/rev.rs
+++ b/firewood/examples/rev.rs
@@ -19,6 +19,15 @@ fn main() {
         db.kv_dump(&mut std::io::stdout()).unwrap();
         println!(
             "{}",
+            hex::encode(*db.get_revision(0, None).unwrap().kv_root_hash().unwrap())
+        );
+        // The latest committed revision matches with the current state without dirty writes.
+        assert_eq!(
+            db.kv_root_hash().unwrap(),
+            db.get_revision(0, None).unwrap().kv_root_hash().unwrap()
+        );
+        println!(
+            "{}",
             hex::encode(*db.get_revision(1, None).unwrap().kv_root_hash().unwrap())
         );
         let root_hash = *db.get_revision(1, None).unwrap().kv_root_hash().unwrap();
@@ -53,6 +62,12 @@ fn main() {
     {
         let db = DB::new("rev_db", &cfg.truncate(false).build()).unwrap();
         {
+            // The latest committed revision matches with the current state after replaying from WALs.
+            assert_eq!(
+                db.kv_root_hash().unwrap(),
+                db.get_revision(0, None).unwrap().kv_root_hash().unwrap()
+            );
+
             let rev = db.get_revision(1, None).unwrap();
             println!("{}", hex::encode(*rev.kv_root_hash().unwrap()));
             rev.kv_dump(&mut std::io::stdout()).unwrap();

--- a/firewood/src/storage/mod.rs
+++ b/firewood/src/storage/mod.rs
@@ -170,6 +170,11 @@ impl Deref for StoreDelta {
 }
 
 impl StoreDelta {
+    pub fn new_empty() -> Self {
+        let deltas = Vec::new();
+        Self(deltas)
+    }
+
     pub fn new(src: &dyn MemStoreR, writes: &[SpaceWrite]) -> Self {
         let mut deltas = Vec::new();
         let mut widx: Vec<_> = (0..writes.len())


### PR DESCRIPTION
Closes #50 

Currently, a revision is loaded from `StoreRevShared` which is composed of `prev` and `delta`. Since the latest committed state doesn't have a delta, `get_revision` always start one one rev before it.  This PR introduce an empty delta to represent the base case.