### PR TITLE
Turn to_nibbles into an extension method

### DIFF
--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -130,7 +130,7 @@ impl Proof {
         root_hash: [u8; 32],
     ) -> Result<Option<Vec<u8>>, ProofError> {
         let mut chunks = Vec::new();
-        chunks.extend(to_nibbles(key.as_ref()));
+        chunks.extend(key.as_ref().iter().copied().flat_map(to_nibble_array));
 
         let mut cur_key: &[u8] = &chunks;
         let mut cur_hash = root_hash;
@@ -171,8 +171,14 @@ impl Proof {
         let size = rlp.item_count().unwrap();
         match size {
             EXT_NODE_SIZE => {
-                let cur_key_path: Vec<_> =
-                    to_nibbles(&rlp.at(0).unwrap().as_val::<Vec<u8>>().unwrap()).collect();
+                let cur_key_path: Vec<_> = rlp
+                    .at(0)
+                    .unwrap()
+                    .as_val::<Vec<u8>>()
+                    .unwrap()
+                    .into_iter()
+                    .flat_map(to_nibble_array)
+                    .collect();
                 let (cur_key_path, term) = PartialPath::decode(cur_key_path);
                 let cur_key = cur_key_path.into_inner();
 
@@ -377,7 +383,7 @@ impl Proof {
         let mut u_ref = merkle.get_node(root).map_err(|_| ProofError::NoSuchNode)?;
 
         let mut chunks = Vec::new();
-        chunks.extend(to_nibbles(key.as_ref()));
+        chunks.extend(key.as_ref().iter().copied().flat_map(to_nibble_array));
 
         let mut cur_key: &[u8] = &chunks;
         let mut cur_hash = root_hash;
@@ -570,8 +576,15 @@ impl Proof {
         let size = rlp.item_count().unwrap();
         match size {
             EXT_NODE_SIZE => {
-                let cur_key_path: Vec<_> =
-                    to_nibbles(&rlp.at(0).unwrap().as_val::<Vec<u8>>().unwrap()).collect();
+                let cur_key_path: Vec<_> = rlp
+                    .at(0)
+                    .unwrap()
+                    .as_val::<Vec<u8>>()
+                    .unwrap()
+                    .into_iter()
+                    .flat_map(to_nibble_array)
+                    .collect();
+
                 let (cur_key_path, term) = PartialPath::decode(cur_key_path);
                 let cur_key = cur_key_path.into_inner();
 
@@ -695,10 +708,10 @@ fn unset_internal<K: AsRef<[u8]>>(
 ) -> Result<bool, ProofError> {
     // Add the sentinel root
     let mut left_chunks = vec![0];
-    left_chunks.extend(to_nibbles(left.as_ref()));
+    left_chunks.extend(left.as_ref().iter().copied().flat_map(to_nibble_array));
     // Add the sentinel root
     let mut right_chunks = vec![0];
-    right_chunks.extend(to_nibbles(right.as_ref()));
+    right_chunks.extend(right.as_ref().iter().copied().flat_map(to_nibble_array));
     let root = merkle_setup.get_root();
     let merkle = merkle_setup.get_merkle_mut();
     let mut u_ref = merkle.get_node(root).map_err(|_| ProofError::NoSuchNode)?;


### PR DESCRIPTION
This adds some type complexity to simplify reading the code at the callsite. It _should_ also make it easier for the compiler to optimize the code, but I'm less certain about this. In general, I don't think it's a good practice to convert types into interators inside functions, it's better to explicitly convert your type to an iterator and apply an adapter as I've done here. Also, if you're worried about those calls to `.copied()`, a `u8` is always smaller than a `usize` so copying should be more performant (but I'm sure the compiler was always smart enough to optimize the pass by reference vs copy anyway).

