### PR TITLE
Always update actions-cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,15 +11,17 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    outputs:
+      cache-key: ${{ steps.cargo-cache.outputs.cache-primary-key }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-      - name: Cache Cargo intermediate products
-        uses: actions/cache@v3
+      - name: Restore Cargo Cache
+        id: cargo-cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -34,11 +36,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-deps-${{ hashFiles('**/Cargo.toml') }}-
             ${{ runner.os }}-deps-
-      # TODO: do a `cargo fetch` here first
       - name: Check
         run: cargo check --workspace --tests --examples --benches
       - name: Build
         run: cargo build --workspace --tests --examples --benches
+        # Always update the cache 
+      - name: Save Cargo Cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ steps.cargo-cache.outputs.cache-primary-key }}
 
   lint:
     needs: build
@@ -61,7 +73,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-deps-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/*.rs') }}
+          key: ${{ needs.build.outputs.cache-key }}
       - name: Format
         run: cargo fmt -- --check
       - name: Clippy
@@ -87,7 +99,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-deps-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/*.rs') }}
+          key: ${{ needs.build.outputs.cache-key }}
       - name: Run tests
         run: cargo test --verbose
 
@@ -110,7 +122,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-deps-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/*.rs') }}
+          key: ${{ needs.build.outputs.cache-key }}
       - name: Run simple example
         run: RUST_BACKTRACE=1 cargo run --example simple
       - name: Run dump example
@@ -140,7 +152,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-deps-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/*.rs') }}
+          key: ${{ needs.build.outputs.cache-key }}
       - name: Lint intra docs links
         run: cargo rustdoc -p firewood --lib -- -D rustdoc::broken-intra-doc-links
       - name: Lint missing crate-level docs

--- a/.github/workflows/default-branch-cache.yaml
+++ b/.github/workflows/default-branch-cache.yaml
@@ -19,9 +19,9 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Cache Cargo intermediate products
+      - name: Restore Cargo Cache
         id: cargo-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -41,3 +41,13 @@ jobs:
         run: cargo check --workspace --tests --examples --benches
       - name: Build
         run: cargo build --workspace --tests --examples --benches
+      - name: Save Cargo Cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ steps.cargo-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
If there are any Cargo index updates but our `**/*.rs` and `**/Cargo.toml` files haven't changed, we would rebuild the dependencies without saving the update. This change will force a save every time.

I also added some better variable use.

