### PR TITLE
chore: disable `test_buffer_with_redo`

### DIFF
--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -603,6 +603,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "ref: https://github.com/ava-labs/firewood/issues/45"]
     fn test_buffer_with_redo() {
         let buf_cfg = DiskBufferConfig::builder().max_buffered(1).build();
         let wal_cfg = WalConfig::builder().build();


### PR DESCRIPTION
`test_buffer_with_redo` is intermittently failing at https://github.com/ava-labs/firewood/blob/main/firewood/src/storage/buffer.rs#LL667C6-L667C68. Disable it for now and reenable/recheck after https://github.com/ava-labs/firewood/issues/45 is fixed.