### PR TITLE
Iterator::position FTW?

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::{self, Debug};
 use std::io::{Cursor, Read, Write};
+use std::iter;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 
@@ -1902,12 +1903,14 @@ impl Merkle {
         key: K,
         root: ObjPtr<Node>,
     ) -> Result<Option<Ref>, MerkleError> {
-        let mut chunks = vec![0];
-        chunks.extend(key.as_ref().iter().copied().flat_map(to_nibble_array));
-
+        // TODO: Make this NonNull<ObjPtr<Node>> or something similar
         if root.is_null() {
             return Ok(None);
         }
+
+        let chunks: Vec<u8> = iter::once(0)
+            .chain(key.as_ref().iter().copied().flat_map(to_nibble_array))
+            .collect();
 
         let mut u_ref = self.get_node(root)?;
         let mut nskip = 0;


### PR DESCRIPTION
Small cleanup of for-loops. 

Using `Iterator::position` has a lower cognitive overhead than initializing a value at 0, then mutating the value further down. We also don't have to rely on a separate `found` boolean at all and can use the `let <pattern> = <variable> else` syntax to explicitly early return. Further, it's fewer lines of code!

I also moved an early-return up in another function so that we don't appear to be doing any unnecessary work if we're early returning. I'm sure the compiler would have done this anyway, but I would rather it be more explicit.
