### PR TITLE
Add mermaid diagram for proposals

### DIFF
--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -33,6 +33,7 @@ impl<T: api::DbView> Clone for ProposalBase<T> {
 /// or from another proposal. Proposals are owned by the
 /// caller. A proposal can only be committed if it has a
 /// base of the current revision of the [[crate::v2::api::Db]].
+#[cfg_attr(doc, aquamarine::aquamarine)]
 /// ```mermaid
 /// graph LR
 ///   subgraph historical


### PR DESCRIPTION
Proposals are complicated and we need to talk about them with a diagram, particularly when we start talking about concurrency.