### PR TITLE
Return Option<T> instead of erroring with api::Error:::KeyNotFound

### DIFF
--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -62,8 +62,6 @@ pub enum Error {
         provided: HashKey,
         current: HashKey,
     },
-    /// Key not found
-    KeyNotFound,
     IO(std::io::Error),
     InvalidProposal,
 }
@@ -131,10 +129,13 @@ pub trait DbView {
     async fn root_hash(&self) -> Result<HashKey, Error>;
 
     /// Get the value of a specific key
-    async fn val<K: KeyType>(&self, key: K) -> Result<Vec<u8>, Error>;
+    async fn val<K: KeyType>(&self, key: K) -> Result<Option<Vec<u8>>, Error>;
 
     /// Obtain a proof for a single key
-    async fn single_key_proof<K: KeyType, V: ValueType>(&self, key: K) -> Result<Proof<V>, Error>;
+    async fn single_key_proof<K: KeyType, V: ValueType>(
+        &self,
+        key: K,
+    ) -> Result<Option<Proof<V>>, Error>;
 
     /// Obtain a range proof over a set of keys
     ///
@@ -149,7 +150,7 @@ pub trait DbView {
         first_key: Option<K>,
         last_key: Option<K>,
         limit: usize,
-    ) -> Result<RangeProof<K, V>, Error>;
+    ) -> Result<Option<RangeProof<K, V>>, Error>;
 }
 
 /// A proposal for a new revision of the database.

--- a/firewood/src/v2/db.rs
+++ b/firewood/src/v2/db.rs
@@ -72,14 +72,14 @@ impl api::DbView for DbView {
         todo!()
     }
 
-    async fn val<K: KeyType>(&self, _key: K) -> Result<Vec<u8>, api::Error> {
+    async fn val<K: KeyType>(&self, _key: K) -> Result<Option<Vec<u8>>, api::Error> {
         todo!()
     }
 
     async fn single_key_proof<K: KeyType, V: ValueType>(
         &self,
         _key: K,
-    ) -> Result<api::Proof<V>, api::Error> {
+    ) -> Result<Option<api::Proof<V>>, api::Error> {
         todo!()
     }
 
@@ -88,7 +88,7 @@ impl api::DbView for DbView {
         _first_key: Option<K>,
         _last_key: Option<K>,
         _limit: usize,
-    ) -> Result<api::RangeProof<K, V>, api::Error> {
+    ) -> Result<Option<api::RangeProof<K, V>>, api::Error> {
         todo!()
     }
 }

--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -102,13 +102,13 @@ impl<T: api::DbView + Send + Sync> api::DbView for Proposal<T> {
         todo!()
     }
 
-    async fn val<K: KeyType>(&self, key: K) -> Result<Vec<u8>, api::Error> {
+    async fn val<K: KeyType>(&self, key: K) -> Result<Option<Vec<u8>>, api::Error> {
         // see if this key is in this proposal
         match self.delta.get(key.as_ref()) {
             Some(change) => match change {
                 // key in proposal, check for Put or Delete
-                KeyOp::Put(val) => Ok(val.clone()),
-                KeyOp::Delete => Err(api::Error::KeyNotFound), // key was deleted in this proposal
+                KeyOp::Put(val) => Ok(Some(val.clone())),
+                KeyOp::Delete => Ok(None), // key was deleted in this proposal
             },
             None => match &self.base {
                 // key not in this proposal, so delegate to base
@@ -121,7 +121,7 @@ impl<T: api::DbView + Send + Sync> api::DbView for Proposal<T> {
     async fn single_key_proof<K: KeyType, V: ValueType>(
         &self,
         _key: K,
-    ) -> Result<api::Proof<V>, api::Error> {
+    ) -> Result<Option<api::Proof<V>>, api::Error> {
         todo!()
     }
 
@@ -130,7 +130,7 @@ impl<T: api::DbView + Send + Sync> api::DbView for Proposal<T> {
         _first_key: Option<KT>,
         _last_key: Option<KT>,
         _limit: usize,
-    ) -> Result<api::RangeProof<KT, VT>, api::Error> {
+    ) -> Result<Option<api::RangeProof<KT, VT>>, api::Error> {
         todo!()
     }
 }


### PR DESCRIPTION
Instead of returning an Error when a key is not found, an Option will be returned.

This PR also modifies all the other functions inside the `api::DbView`, maybe only `val` should be updated at this stage.