### PR TITLE
Return &[u8] from val trait (Fixes #165)

### DIFF
--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -129,7 +129,7 @@ pub trait DbView {
     async fn root_hash(&self) -> Result<HashKey, Error>;
 
     /// Get the value of a specific key
-    async fn val<K: KeyType>(&self, key: K) -> Result<Option<Vec<u8>>, Error>;
+    async fn val<K: KeyType>(&self, key: K) -> Result<Option<&[u8]>, Error>;
 
     /// Obtain a proof for a single key
     async fn single_key_proof<K: KeyType, V: ValueType>(

--- a/firewood/src/v2/db.rs
+++ b/firewood/src/v2/db.rs
@@ -72,7 +72,7 @@ impl api::DbView for DbView {
         todo!()
     }
 
-    async fn val<K: KeyType>(&self, _key: K) -> Result<Option<Vec<u8>>, api::Error> {
+    async fn val<K: KeyType>(&self, _key: K) -> Result<Option<&[u8]>, api::Error> {
         todo!()
     }
 

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -54,7 +54,7 @@ impl DbView for HistoricalImpl {
         Ok(ROOT_HASH)
     }
 
-    async fn val<K: KeyType>(&self, _key: K) -> Result<Option<Vec<u8>>, Error> {
+    async fn val<K: KeyType>(&self, _key: K) -> Result<Option<&[u8]>, Error> {
         Ok(None)
     }
 

--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -102,12 +102,12 @@ impl<T: api::DbView + Send + Sync> api::DbView for Proposal<T> {
         todo!()
     }
 
-    async fn val<K: KeyType>(&self, key: K) -> Result<Option<Vec<u8>>, api::Error> {
+    async fn val<K: KeyType>(&self, key: K) -> Result<Option<&[u8]>, api::Error> {
         // see if this key is in this proposal
         match self.delta.get(key.as_ref()) {
             Some(change) => match change {
                 // key in proposal, check for Put or Delete
-                KeyOp::Put(val) => Ok(Some(val.clone())),
+                KeyOp::Put(val) => Ok(Some(val)),
                 KeyOp::Delete => Ok(None), // key was deleted in this proposal
             },
             None => match &self.base {


### PR DESCRIPTION
Instead of return a Vec<u8> return a reference to avoid cloning the data before returning.