### PR TITLE
feat: supports chains of `StoreRevMut`

### DIFF
--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -897,7 +897,7 @@ mod tests {
         assert_eq!(view.as_deref(), hash);
 
         state_cache.update(&another_redo_delta).unwrap();
-        let another_store = StoreRevMut::new(state_cache.clone());
+        let another_store = StoreRevMut::new(state_cache);
         let view = another_store.get_view(0, HASH_SIZE as u64).unwrap();
         assert_eq!(view.as_deref(), another_hash);
     }

--- a/firewood/tests/db.rs
+++ b/firewood/tests/db.rs
@@ -139,10 +139,11 @@ fn test_revisions() {
             .zip(hashes.iter().cloned())
             .map(|(data, hash)| (data, db.get_revision(&hash, None).unwrap()))
             .map(|(data, rev)| (data, kv_dump!(rev)))
-            .for_each(|(b, a)| {
-                if &a != b {
-                    print!("{a}\n{b}");
-                    panic!("not the same");
+            .for_each(|(previous_dump, after_reopen_dump)| {
+                if &after_reopen_dump != previous_dump {
+                    panic!(
+                        "not the same: pass {i}:\n{after_reopen_dump}\n--------\n{previous_dump}"
+                    );
                 }
             });
         println!("i = {i}");


### PR DESCRIPTION
This commits extends current implementation of `StoreRevMut` to support basing on top of another `StoreRevMut`, by chaining `prev_deltas` with current `deltas` from itself. This would be an essential step for `Proposal` support.