### PR TITLE
feat: add proposal

### DIFF
--- a/firewood/examples/rev.rs
+++ b/firewood/examples/rev.rs
@@ -126,11 +126,11 @@ fn main() {
 
 struct RevisionTracker {
     hashes: VecDeque<TrieHash>,
-    db: Db<Store>,
+    db: Db<Store, SharedStore>,
 }
 
 impl RevisionTracker {
-    fn new(db: Db<Store>) -> Self {
+    fn new(db: Db<Store, SharedStore>) -> Self {
         Self {
             hashes: VecDeque::new(),
             db,
@@ -159,7 +159,7 @@ impl RevisionTracker {
         self.hashes.push_front(hash);
     }
 
-    fn commit_batch(&mut self, batch: WriteBatch<Store>) {
+    fn commit_batch(&mut self, batch: WriteBatch<Store, SharedStore>) {
         batch.commit();
         let hash = self.db.kv_root_hash().expect("root-hash should exist");
         self.hashes.push_front(hash);

--- a/firewood/src/config.rs
+++ b/firewood/src/config.rs
@@ -2,7 +2,7 @@ pub use crate::storage::{buffer::DiskBufferConfig, WalConfig};
 use typed_builder::TypedBuilder;
 
 /// Database configuration.
-#[derive(TypedBuilder, Debug)]
+#[derive(Clone, TypedBuilder, Debug)]
 pub struct DbConfig {
     /// Maximum cached pages for the free list of the item stash.
     #[builder(default = 16384)] // 64M total size by default

--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -75,6 +75,7 @@ impl From<DbError> for ProofError {
                 ProofError::SystemError(nix::errno::Errno::from_i32(e.raw_os_error().unwrap()))
             }
             DbError::Shale(e) => ProofError::Shale(e),
+            DbError::InvalidProposal => ProofError::InvalidProof,
         }
     }
 }


### PR DESCRIPTION
This commits add the proposal feature which satisfies all the requirements from seasoned milestone for [proposal](https://github.com/ava-labs/firewood#seasoned-milestone), namely:

- support multiple proposed revisions against latest committed version.
- you can propose a batch against the existing committed revision, or propose a batch against any existing proposed revision.
- commit a batch that has been proposed. Note that this invalidates all other proposals that are not children of the committed proposed batch.

On top, you can get a `DbRev` from the `Proposal`, which you can get the root hash or get (range) proof, etc.

