### PR TITLE
Open-options instead of a truncate bool

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -472,7 +472,14 @@ impl Db<Store, SharedStore> {
         if cfg.truncate {
             let _ = std::fs::remove_dir_all(db_path.as_ref());
         }
-        let (db_path, reset) = file::open_dir(db_path, cfg.truncate)?;
+
+        let open_options = if cfg.truncate {
+            file::Options::Truncate
+        } else {
+            file::Options::NoTruncate
+        };
+
+        let (db_path, reset) = file::open_dir(db_path, open_options)?;
 
         let merkle_path = file::touch_dir("merkle", &db_path)?;
         let merkle_meta_path = file::touch_dir("meta", &merkle_path)?;

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -640,7 +640,7 @@ mod tests {
 
         // TODO: Run the test in a separate standalone directory for concurrency reasons
         let path = std::path::PathBuf::from(r"/tmp/firewood");
-        let (root_db_path, reset) = crate::file::open_dir(path, true).unwrap();
+        let (root_db_path, reset) = file::open_dir(path, file::Options::Truncate).unwrap();
 
         // file descriptor of the state directory
         let state_path = file::touch_dir("state", &root_db_path).unwrap();
@@ -728,7 +728,7 @@ mod tests {
         // TODO: Run the test in a separate standalone directory for concurrency reasons
         let tmp_dir = TempDir::new("firewood").unwrap();
         let path = get_file_path(tmp_dir.path(), file!(), line!());
-        let (root_db_path, reset) = crate::file::open_dir(path, true).unwrap();
+        let (root_db_path, reset) = file::open_dir(path, file::Options::Truncate).unwrap();
 
         // file descriptor of the state directory
         let state_path = file::touch_dir("state", &root_db_path).unwrap();
@@ -812,7 +812,7 @@ mod tests {
 
         let tmp_dir = TempDir::new("firewood").unwrap();
         let path = get_file_path(tmp_dir.path(), file!(), line!());
-        let (root_db_path, reset) = crate::file::open_dir(path, true).unwrap();
+        let (root_db_path, reset) = file::open_dir(path, file::Options::Truncate).unwrap();
 
         // file descriptor of the state directory
         let state_path = file::touch_dir("state", &root_db_path).unwrap();


### PR DESCRIPTION
I shouldn't have to go to the `open_dir` and `open_file` function definitions to figure out what the boolean parameter is doing. Now this is a little more clear.

