### PR TITLE
Remove get_revision configuration option

### DIFF
--- a/firewood/examples/rev.rs
+++ b/firewood/examples/rev.rs
@@ -162,7 +162,7 @@ impl RevisionTracker {
 
     fn get_revision(&self, index: usize) -> Revision<SharedStore> {
         self.db
-            .get_revision(&self.hashes[index], None)
+            .get_revision(&self.hashes[index])
             .unwrap_or_else(|| panic!("revision-{index} should exist"))
     }
 }

--- a/firewood/src/api.rs
+++ b/firewood/src/api.rs
@@ -3,7 +3,7 @@
 
 use std::io::Write;
 
-use crate::db::{DbError, DbRevConfig};
+use crate::db::DbError;
 use crate::merkle::TrieHash;
 #[cfg(feature = "proof")]
 use crate::{merkle::MerkleError, proof::Proof};
@@ -14,7 +14,7 @@ pub type Nonce = u64;
 
 #[async_trait]
 pub trait Db<R: Revision> {
-    async fn get_revision(&self, root_hash: TrieHash, cfg: Option<DbRevConfig>) -> Option<R>;
+    async fn get_revision(&self, root_hash: TrieHash) -> Option<R>;
 }
 
 #[async_trait]

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -806,11 +806,7 @@ impl Db<SharedStore> {
     ///
     /// If no revision with matching root hash found, returns None.
     // #[measure([HitCount])]
-    pub fn get_revision(
-        &self,
-        root_hash: &TrieHash,
-        cfg: Option<DbRevConfig>,
-    ) -> Option<Revision<SharedStore>> {
+    pub fn get_revision(&self, root_hash: &TrieHash) -> Option<Revision<SharedStore>> {
         let mut revisions = self.revisions.lock();
         let inner_lock = self.inner.read();
 
@@ -883,8 +879,6 @@ impl Db<SharedStore> {
         // Release the lock after we find the revision
         drop(inner_lock);
 
-        let cfg = cfg.as_ref().unwrap_or(&self.cfg.rev);
-
         let db_header_ref = Db::get_db_header_ref(&space.merkle.meta).unwrap();
 
         let merkle_payload_header_ref =
@@ -906,7 +900,7 @@ impl Db<SharedStore> {
                 (space.blob.meta.clone(), space.blob.payload.clone()),
                 self.payload_regn_nbit,
                 0,
-                cfg,
+                &self.cfg.rev,
             )
             .unwrap(),
         }

--- a/firewood/src/service/client.rs
+++ b/firewood/src/service/client.rs
@@ -12,7 +12,7 @@ use std::{path::Path, thread};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::api::Revision;
-use crate::db::DbRevConfig;
+
 use crate::{
     db::{DbConfig, DbError},
     merkle::TrieHash,
@@ -181,15 +181,10 @@ impl crate::api::Db<RevisionHandle> for Connection
 where
     tokio::sync::mpsc::Sender<Request>: From<tokio::sync::mpsc::Sender<Request>>,
 {
-    async fn get_revision(
-        &self,
-        root_hash: TrieHash,
-        cfg: Option<DbRevConfig>,
-    ) -> Option<RevisionHandle> {
+    async fn get_revision(&self, root_hash: TrieHash) -> Option<RevisionHandle> {
         let (send, recv) = oneshot::channel();
         let msg = Request::NewRevision {
             root_hash,
-            cfg,
             respond_to: send,
         };
         self.sender

--- a/firewood/src/service/mod.rs
+++ b/firewood/src/service/mod.rs
@@ -3,10 +3,7 @@
 
 use tokio::sync::{mpsc, oneshot};
 
-use crate::{
-    db::{DbError, DbRevConfig},
-    merkle::TrieHash,
-};
+use crate::{db::DbError, merkle::TrieHash};
 
 mod client;
 mod server;
@@ -25,7 +22,6 @@ pub struct RevisionHandle {
 pub enum Request {
     NewRevision {
         root_hash: TrieHash,
-        cfg: Option<DbRevConfig>,
         respond_to: oneshot::Sender<Option<RevId>>,
     },
 

--- a/firewood/src/service/server.rs
+++ b/firewood/src/service/server.rs
@@ -39,11 +39,10 @@ impl FirewoodService {
             match msg {
                 Request::NewRevision {
                     root_hash,
-                    cfg,
                     respond_to,
                 } => {
                     let id: RevId = lastid.fetch_add(1, Ordering::Relaxed);
-                    let msg = match db.get_revision(&root_hash, cfg) {
+                    let msg = match db.get_revision(&root_hash) {
                         Some(rev) => {
                             revs.insert(id, rev);
                             Some(id)

--- a/firewood/tests/db.rs
+++ b/firewood/tests/db.rs
@@ -130,7 +130,7 @@ fn test_revisions() {
             dumped
                 .iter()
                 .zip(hashes.iter().cloned())
-                .map(|(data, hash)| (data, db.get_revision(&hash, None).unwrap()))
+                .map(|(data, hash)| (data, db.get_revision(&hash).unwrap()))
                 .map(|(data, rev)| (data, kv_dump!(rev)))
                 .for_each(|(b, a)| {
                     if &a != b {
@@ -144,7 +144,7 @@ fn test_revisions() {
         dumped
             .iter()
             .zip(hashes.iter().cloned())
-            .map(|(data, hash)| (data, db.get_revision(&hash, None).unwrap()))
+            .map(|(data, hash)| (data, db.get_revision(&hash).unwrap()))
             .map(|(data, rev)| (data, kv_dump!(rev)))
             .for_each(|(previous_dump, after_reopen_dump)| {
                 if &after_reopen_dump != previous_dump {
@@ -208,7 +208,7 @@ fn create_db_issue_proof() {
     let proposal = db.new_proposal(batch).unwrap();
     proposal.commit().unwrap();
 
-    let rev = db.get_revision(&root_hash, None).unwrap();
+    let rev = db.get_revision(&root_hash).unwrap();
     let key = "doe".as_bytes();
     let root_hash = rev.kv_root_hash();
 


### PR DESCRIPTION
This option isn't ever tested, and I'm not sure why anyone would want it, so I'm removing it. This lets you change the way revisions are maintained on the fly, which seems silly.