### PR TITLE
Cleanup: Remove generics on Db

### DIFF
--- a/firewood/examples/rev.rs
+++ b/firewood/examples/rev.rs
@@ -107,11 +107,11 @@ fn main() {
 
 struct RevisionTracker {
     hashes: VecDeque<TrieHash>,
-    db: Db<SharedStore>,
+    db: Db,
 }
 
 impl RevisionTracker {
-    fn new(db: Db<SharedStore>) -> Self {
+    fn new(db: Db) -> Self {
         Self {
             hashes: VecDeque::new(),
             db,

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -370,16 +370,16 @@ pub struct DbRevInner<T> {
 
 /// Firewood database handle.
 #[derive(Debug)]
-pub struct Db<S> {
+pub struct Db {
     inner: Arc<RwLock<DbInner>>,
-    revisions: Arc<Mutex<DbRevInner<S>>>,
+    revisions: Arc<Mutex<DbRevInner<SharedStore>>>,
     payload_regn_nbit: u64,
     metrics: Arc<DbMetrics>,
     cfg: DbConfig,
 }
 
 // #[metered(registry = DbMetrics, visibility = pub)]
-impl Db<SharedStore> {
+impl Db {
     const PARAM_SIZE: u64 = size_of::<DbParams>() as u64;
 
     /// Open a database.
@@ -909,7 +909,7 @@ impl Db<SharedStore> {
 }
 
 #[metered(registry = DbMetrics, visibility = pub)]
-impl<S: ShaleStore<Node> + Send + Sync> Db<S> {
+impl Db {
     /// Dump the Trie of the latest generic key-value storage.
     pub fn kv_dump(&self, w: &mut dyn Write) -> Result<(), DbError> {
         self.revisions.lock().base_revision.kv_dump(w)

--- a/firewood/tests/db.rs
+++ b/firewood/tests/db.rs
@@ -1,9 +1,8 @@
 use firewood::{
     db::{BatchOp, Db as PersistedDb, DbConfig, DbError, WalConfig},
-    merkle::{Node, TrieHash},
-    storage::StoreRevShared,
+    merkle::TrieHash,
 };
-use firewood_shale::compact::CompactSpace;
+
 use std::{
     collections::VecDeque,
     fs::remove_dir_all,
@@ -22,9 +21,7 @@ macro_rules! kv_dump {
     }};
 }
 
-type SharedStore = CompactSpace<Node, StoreRevShared>;
-
-struct Db<'a, P: AsRef<Path> + ?Sized>(PersistedDb<SharedStore>, &'a P);
+struct Db<'a, P: AsRef<Path> + ?Sized>(PersistedDb, &'a P);
 
 impl<'a, P: AsRef<Path> + ?Sized> Db<'a, P> {
     fn new(path: &'a P, cfg: &DbConfig) -> Result<Self, DbError> {
@@ -231,7 +228,7 @@ fn create_db_issue_proof() {
 }
 
 impl<P: AsRef<Path> + ?Sized> Deref for Db<'_, P> {
-    type Target = PersistedDb<SharedStore>;
+    type Target = PersistedDb;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -239,7 +236,7 @@ impl<P: AsRef<Path> + ?Sized> Deref for Db<'_, P> {
 }
 
 impl<P: AsRef<Path> + ?Sized> DerefMut for Db<'_, P> {
-    fn deref_mut(&mut self) -> &mut PersistedDb<SharedStore> {
+    fn deref_mut(&mut self) -> &mut PersistedDb {
         &mut self.0
     }
 }


### PR DESCRIPTION
We never use a different type for this generic