### PR TITLE
Nibbles improvements

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1880,10 +1880,7 @@ impl<S: ShaleStore<Node> + Send + Sync> Merkle<S> {
                         // all bytes aren't there
                         break;
                     }
-                    if !remaining_path
-                        .take(n_path.len())
-                        .eq(n_path.iter().cloned())
-                    {
+                    if !remaining_path.take(n_path.len()).eq(n_path.iter().cloned()) {
                         // contents aren't the same
                         break;
                     }

--- a/firewood/src/nibbles.rs
+++ b/firewood/src/nibbles.rs
@@ -65,7 +65,6 @@ impl<'a, const LEADING_ZEROES: usize> Nibbles<'a, LEADING_ZEROES> {
     }
 }
 
-
 /// An interator returned by [Nibbles::iter]
 /// See their documentation for details.
 #[derive(Debug)]


### PR DESCRIPTION
Rather than implement skip() at the Nibbles layer, you get `Iter::skip` efficiently if you implement `Iter::nth`. This is trivial to do for Nibbles, and solves the problem of `skip(0)` on `Nibbles::<1>`, which now works correctly (test included)

Implementing `Iter::size_hint()` allows for a size check as well, which makes `Nibbles::len()` less useful, but I'm keeping it so that `size_hint` can use it.