### PR TITLE
Use v2::api::Proof<V> over proof::Proof

### DIFF
--- a/firewood/examples/rev.rs
+++ b/firewood/examples/rev.rs
@@ -6,8 +6,8 @@ use std::{collections::VecDeque, path::Path};
 use firewood::{
     db::{BatchOp, Db, DbConfig, Proposal, Revision, WalConfig},
     merkle::{Node, TrieHash},
-    proof::Proof,
     storage::StoreRevShared,
+    v2::api::Proof,
 };
 use shale::compact::CompactSpace;
 
@@ -166,7 +166,7 @@ impl RevisionTracker {
     }
 }
 
-fn build_proof(revision: &Revision<SharedStore>, items: &[(&str, &str)]) -> Proof {
+fn build_proof(revision: &Revision<SharedStore>, items: &[(&str, &str)]) -> Proof<Vec<u8>> {
     let mut proof = revision.prove(items[0].0).unwrap();
     let end = revision.prove(items.last().unwrap().0).unwrap();
     proof.concat_proofs(end);

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::{nibbles::Nibbles, proof::Proof};
+use crate::{nibbles::Nibbles, v2::api::Proof};
 use sha3::Digest;
 use shale::{disk_address::DiskAddress, ObjRef, ShaleError, ShaleStore};
 use std::{
@@ -1031,13 +1031,13 @@ impl<S: ShaleStore<Node> + Send + Sync> Merkle<S> {
     /// If the trie does not contain a value for key, the returned proof contains
     /// all nodes of the longest existing prefix of the key, ending with the node
     /// that proves the absence of the key (at least the root node).
-    pub fn prove<K: AsRef<[u8]>>(&self, key: K, root: DiskAddress) -> Result<Proof, MerkleError>
+    pub fn prove<K>(&self, key: K, root: DiskAddress) -> Result<Proof<Vec<u8>>, MerkleError>
     where
         K: AsRef<[u8]>,
     {
         let key_nibbles = Nibbles::<0>::new(key.as_ref());
 
-        let mut proofs: HashMap<[u8; TRIE_HASH_LEN], Vec<u8>> = HashMap::new();
+        let mut proofs = HashMap::new();
         if root.is_null() {
             return Ok(Proof(proofs));
         }

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -76,8 +76,10 @@ pub struct RangeProof<K: KeyType, V: ValueType> {
 }
 
 /// A proof that a single key is present
+///
+/// The generic N represents the storage for the node data
 #[derive(Debug)]
-pub struct Proof<V>(pub HashMap<HashKey, V>);
+pub struct Proof<N: Send>(pub HashMap<HashKey, N>);
 
 /// The database interface, which includes a type for a static view of
 /// the database (the DbView). The most common implementation of the DbView

--- a/firewood/tests/db.rs
+++ b/firewood/tests/db.rs
@@ -209,7 +209,7 @@ fn create_db_issue_proof() {
     let key = "doe".as_bytes();
     let root_hash = rev.kv_root_hash();
 
-    match rev.prove(key) {
+    match rev.prove::<&[u8]>(key) {
         Ok(proof) => {
             let verification = proof.verify_proof(key, *root_hash.unwrap()).unwrap();
             assert!(verification.is_some());

--- a/firewood/tests/merkle.rs
+++ b/firewood/tests/merkle.rs
@@ -1,7 +1,8 @@
 use firewood::{
     merkle::Node,
     merkle_util::{new_merkle, DataStoreError, MerkleSetup},
-    proof::{Proof, ProofError},
+    proof::ProofError,
+    v2::api::Proof,
 };
 use rand::Rng;
 use shale::{cached::DynamicMem, compact::CompactSpace};
@@ -679,7 +680,7 @@ fn test_all_elements_proof() -> Result<(), ProofError> {
     let keys: Vec<&[u8; 32]> = item_iter.clone().map(|item| item.0).collect();
     let vals: Vec<&[u8; 20]> = item_iter.map(|item| item.1).collect();
 
-    let empty_proof = Proof(HashMap::new());
+    let empty_proof = Proof(HashMap::<[u8; 32], Vec<u8>>::new());
     let empty_key: [u8; 32] = [0; 32];
     merkle.verify_range_proof(
         &empty_proof,


### PR DESCRIPTION
This adds generics for the storage of the nodes. It would be amazing if the proof shared the node storage with the actual node in shale, and this is one step toward getting us there.

Additionally, in order to implement the new v2 api we need proofs to be the new proofs