### PR TITLE
Use the standard-library temp_dir function

### DIFF
--- a/firewood/examples/rev.rs
+++ b/firewood/examples/rev.rs
@@ -118,12 +118,15 @@ impl RevisionTracker {
         }
     }
 
-    fn create_revisions<K, V>(&mut self, iter: impl Iterator<Item = (K, V)>) -> Result<(), DbError>
+    fn create_revisions<K, V>(
+        &mut self,
+        mut iter: impl Iterator<Item = (K, V)>,
+    ) -> Result<(), DbError>
     where
         K: AsRef<[u8]>,
         V: AsRef<[u8]>,
     {
-        iter.map(|(k, v)| self.create_revision(k, v)).collect()
+        iter.try_for_each(|(k, v)| self.create_revision(k, v))
     }
 
     fn create_revision<K, V>(&mut self, k: K, v: V) -> Result<(), DbError>

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -635,17 +635,17 @@ mod tests {
     #[test]
     #[ignore = "ref: https://github.com/ava-labs/firewood/issues/45"]
     fn test_buffer_with_undo() {
-        let tmpdb = [
-            &std::env::var("CARGO_TARGET_DIR").unwrap_or("/tmp".to_string()),
-            "sender_api_test_db",
-        ];
+        let temp_dir = option_env!("CARGO_TARGET_DIR")
+            .map(PathBuf::from)
+            .unwrap_or(std::env::temp_dir());
+        let tmpdb = [temp_dir.to_str().unwrap(), "sender_api_test_db"];
 
         let buf_cfg = DiskBufferConfig::builder().max_buffered(1).build();
         let wal_cfg = WalConfig::builder().build();
         let disk_requester = init_buffer(buf_cfg, wal_cfg);
 
         // TODO: Run the test in a separate standalone directory for concurrency reasons
-        let path = std::path::PathBuf::from(r"/tmp/firewood");
+        let path = temp_dir.join("firewood");
         let (root_db_path, reset) = file::open_dir(path, file::Options::Truncate).unwrap();
 
         // file descriptor of the state directory

--- a/growth-ring/src/lib.rs
+++ b/growth-ring/src/lib.rs
@@ -349,7 +349,9 @@ mod tests {
     }
 
     fn get_temp_walfile_path(file: &str, line: u32) -> PathBuf {
-        let path = option_env!("CARGO_TARGET_TMPDIR").unwrap_or("/tmp");
-        Path::new(path).join(format!("{}_{}", file.replace('/', "-"), line))
+        let path = option_env!("CARGO_TARGET_TMPDIR")
+            .map(PathBuf::from)
+            .unwrap_or(std::env::temp_dir());
+        path.join(format!("{}_{}", file.replace('/', "-"), line))
     }
 }

--- a/libaio/tests/simple_test.rs
+++ b/libaio/tests/simple_test.rs
@@ -1,12 +1,11 @@
 use aiofut::AioBuilder;
-use futures::executor::LocalPool;
-use futures::future::FutureExt;
-use futures::task::LocalSpawnExt;
-use std::os::unix::io::AsRawFd;
-use std::path::Path;
+use futures::{executor::LocalPool, future::FutureExt, task::LocalSpawnExt};
+use std::{os::unix::io::AsRawFd, path::PathBuf};
 
-fn tmp_dir() -> &'static Path {
-    Path::new(option_env!("CARGO_TARGET_TMPDIR").unwrap_or("/tmp"))
+fn tmp_dir() -> PathBuf {
+    option_env!("CARGO_TARGET_TMPDIR")
+        .map(PathBuf::from)
+        .unwrap_or(std::env::temp_dir())
 }
 
 #[test]


### PR DESCRIPTION
We should always use standard-library built-ins where we can

