### PR TITLE
Clean up remants of eth

### DIFF
--- a/shale/Cargo.toml
+++ b/shale/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 hex = "0.4.3"
 lru = "0.11.0"
 thiserror = "1.0.38"
+bytemuck = { version = "1.13.1", features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/shale/src/compact.rs
+++ b/shale/src/compact.rs
@@ -127,7 +127,8 @@ impl Storable for CompactDescriptor {
     }
 }
 
-#[derive(Debug)]
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::NoUninit)]
 pub struct CompactSpaceHeader {
     meta_space_tail: DiskAddress,
     compact_space_tail: DiskAddress,

--- a/shale/src/disk_address.rs
+++ b/shale/src/disk_address.rs
@@ -2,10 +2,13 @@ use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
 
+use bytemuck::NoUninit;
+
 use crate::{CachedStore, ShaleError, Storable};
 
 /// The virtual disk address of an object
-#[derive(Debug, Copy, Clone, Eq, Hash, Ord, PartialOrd, PartialEq)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone, Eq, Hash, Ord, PartialOrd, PartialEq, NoUninit)]
 pub struct DiskAddress(pub Option<NonZeroUsize>);
 
 impl Deref for DiskAddress {


### PR DESCRIPTION
This change shrinks the DbHeader to remove the old `acc_root`. It also fixes an initialization bug that shows up if you attempt to do this.