### PR TITLE
Remove tempdir as it is not maintained

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -46,7 +46,6 @@ assert_cmd = "2.0.7"
 predicates = "3.0.1"
 serial_test = "2.0.0"
 clap = { version = "4.3.1", features = ['derive'] }
-tempdir = "0.3.7"
 test-case = "3.1.0"
 pprof = { version = "0.12.1", features = ["flamegraph"] }
 


### PR DESCRIPTION
We should be more careful when we add dependencies. This dependency was unmaintained when we added it.

