### PR TITLE
Fix test shutdown race

### DIFF
--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -906,6 +906,7 @@ mod tests {
         let another_store = StoreRevMut::new(state_cache);
         let view = another_store.get_view(0, HASH_SIZE as u64).unwrap();
         assert_eq!(view.as_deref(), another_hash);
+        disk_requester.shutdown();
     }
 
     fn get_file_path(path: &Path, file: &str, line: u32) -> PathBuf {


### PR DESCRIPTION
We need to send a terminate message to the disk requester otherwise it panics when attempting to read from a dead socket.

This is just a test issue.

Fixes #253