### PR TITLE
Update README.md

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: ci
 
 on:
-  pull_request:
+  push:
     branches: 
       - "*"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Firewood: non-archival blockchain key-value store with hyper-fast recent state retrieval.
 
-![Github Actions](https://github.com/ava-labs/firewood/actions/workflows/ci.yaml/badge.svg)
+![Github Actions](https://github.com/ava-labs/firewood/actions/workflows/ci.yaml/badge.svg?branch=main)
 [![Ecosystem license](https://img.shields.io/badge/License-Ecosystem-blue.svg)](./LICENSE.md)
 
 > :warning: firewood is alpha-level software and is not ready for production


### PR DESCRIPTION
Ensures that the CI badge on the README is only referring to CI runs off the `main` branch.