### PR TITLE
Correct some spelling errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ versions with no additional cost at all.
 
 ![architecture diagram](./docs/assets/architecture.svg)
 
-## Termimology
+## Terminology
 
 * `Revision` - A historical point-in-time state/version of the trie. This
    represents the entire trie, including all `Key`/`Value`s at that point
@@ -111,7 +111,7 @@ The focus of this milestone will be to support synchronization to other
 instances to replicate the state. A synchronization library should also
 be developed for this milestone.
 - [ ] :runner: Add support for Ava Labs generic test tool via grpc client
-- [ ] :runner: Pluggable encoding for nodes, for optional compatibilty with merkledb
+- [ ] :runner: Pluggable encoding for nodes, for optional compatibility with MerkleDB
 - [ ] Support replicating the full state with corresponding range proofs that
 verify the correctness of the data.
 - [ ] Support replicating the delta state from the last sync point with


### PR DESCRIPTION
`aspell check --mode=markdown --lang=en README.md` is your friend