### PR TITLE
Refactor `buffer.rs` for better readability and maintainability

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -418,49 +418,43 @@ impl Db {
             disk_buffer.run()
         }));
 
-        let root_hash_cache = Arc::new(
-            CachedSpace::new(
-                &StoreConfig::builder()
-                    .ncached_pages(cfg.root_hash_ncached_pages)
-                    .ncached_files(cfg.root_hash_ncached_files)
-                    .space_id(ROOT_HASH_SPACE)
-                    .file_nbit(params.root_hash_file_nbit)
-                    .rootdir(root_hash_path)
-                    .build(),
-                disk_requester.clone(),
-            )
-            .unwrap(),
-        );
+        let root_hash_cache = CachedSpace::new(
+            &StoreConfig::builder()
+                .ncached_pages(cfg.root_hash_ncached_pages)
+                .ncached_files(cfg.root_hash_ncached_files)
+                .space_id(ROOT_HASH_SPACE)
+                .file_nbit(params.root_hash_file_nbit)
+                .rootdir(root_hash_path)
+                .build(),
+            disk_requester.clone(),
+        )
+        .unwrap();
 
         // setup disk buffer
         let data_cache = Universe {
             merkle: SubUniverse::new(
-                Arc::new(
-                    CachedSpace::new(
-                        &StoreConfig::builder()
-                            .ncached_pages(cfg.meta_ncached_pages)
-                            .ncached_files(cfg.meta_ncached_files)
-                            .space_id(MERKLE_META_SPACE)
-                            .file_nbit(params.meta_file_nbit)
-                            .rootdir(merkle_meta_path)
-                            .build(),
-                        disk_requester.clone(),
-                    )
-                    .unwrap(),
-                ),
-                Arc::new(
-                    CachedSpace::new(
-                        &StoreConfig::builder()
-                            .ncached_pages(cfg.payload_ncached_pages)
-                            .ncached_files(cfg.payload_ncached_files)
-                            .space_id(MERKLE_PAYLOAD_SPACE)
-                            .file_nbit(params.payload_file_nbit)
-                            .rootdir(merkle_payload_path)
-                            .build(),
-                        disk_requester.clone(),
-                    )
-                    .unwrap(),
-                ),
+                CachedSpace::new(
+                    &StoreConfig::builder()
+                        .ncached_pages(cfg.meta_ncached_pages)
+                        .ncached_files(cfg.meta_ncached_files)
+                        .space_id(MERKLE_META_SPACE)
+                        .file_nbit(params.meta_file_nbit)
+                        .rootdir(merkle_meta_path)
+                        .build(),
+                    disk_requester.clone(),
+                )
+                .unwrap(),
+                CachedSpace::new(
+                    &StoreConfig::builder()
+                        .ncached_pages(cfg.payload_ncached_pages)
+                        .ncached_files(cfg.payload_ncached_files)
+                        .space_id(MERKLE_PAYLOAD_SPACE)
+                        .file_nbit(params.payload_file_nbit)
+                        .rootdir(merkle_payload_path)
+                        .build(),
+                    disk_requester.clone(),
+                )
+                .unwrap(),
             ),
         };
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -418,7 +418,7 @@ impl Db {
             disk_buffer.run()
         }));
 
-        let root_hash_cache = CachedSpace::new(
+        let root_hash_cache: Arc<CachedSpace> = CachedSpace::new(
             &StoreConfig::builder()
                 .ncached_pages(cfg.root_hash_ncached_pages)
                 .ncached_files(cfg.root_hash_ncached_files)
@@ -428,11 +428,12 @@ impl Db {
                 .build(),
             disk_requester.clone(),
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         // setup disk buffer
         let data_cache = Universe {
-            merkle: SubUniverse::new(
+            merkle: SubUniverse::<Arc<CachedSpace>>::new(
                 CachedSpace::new(
                     &StoreConfig::builder()
                         .ncached_pages(cfg.meta_ncached_pages)
@@ -443,7 +444,8 @@ impl Db {
                         .build(),
                     disk_requester.clone(),
                 )
-                .unwrap(),
+                .unwrap()
+                .into(),
                 CachedSpace::new(
                     &StoreConfig::builder()
                         .ncached_pages(cfg.payload_ncached_pages)
@@ -454,7 +456,8 @@ impl Db {
                         .build(),
                     disk_requester.clone(),
                 )
-                .unwrap(),
+                .unwrap()
+                .into(),
             ),
         };
 

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -657,6 +657,7 @@ mod tests {
             disk_requester,
         )
         .unwrap()
+        .into()
     }
 
     #[test]
@@ -828,7 +829,7 @@ mod tests {
         disk_requester.init_wal("wal", &root_db_path);
 
         // create a new state cache which tracks on disk state.
-        let state_cache = CachedSpace::new(
+        let state_cache: Arc<CachedSpace> = CachedSpace::new(
             &StoreConfig::builder()
                 .ncached_pages(1)
                 .ncached_files(1)
@@ -838,7 +839,8 @@ mod tests {
                 .build(),
             disk_requester.clone(),
         )
-        .unwrap();
+        .unwrap()
+        .into();
 
         // add an in memory cached space. this will allow us to write to the
         // disk buffer then later persist the change to disk.

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -646,20 +646,17 @@ mod tests {
         state_path: PathBuf,
         disk_requester: DiskBufferRequester,
     ) -> Arc<CachedSpace> {
-        // create a new state cache which tracks on disk state.
-        Arc::new(
-            CachedSpace::new(
-                &StoreConfig::builder()
-                    .ncached_pages(1)
-                    .ncached_files(1)
-                    .space_id(STATE_SPACE)
-                    .file_nbit(1)
-                    .rootdir(state_path)
-                    .build(),
-                disk_requester,
-            )
-            .unwrap(),
+        CachedSpace::new(
+            &StoreConfig::builder()
+                .ncached_pages(1)
+                .ncached_files(1)
+                .space_id(STATE_SPACE)
+                .file_nbit(1)
+                .rootdir(state_path)
+                .build(),
+            disk_requester,
         )
+        .unwrap()
     }
 
     #[test]
@@ -757,6 +754,7 @@ mod tests {
         // create a new wal directory on top of root_db_fd
         disk_requester.init_wal("wal", &root_db_path);
 
+        // create a new state cache which tracks on disk state.
         let state_cache = create_state_cache(state_path, disk_requester.clone());
 
         // add an in memory cached space. this will allow us to write to the
@@ -830,19 +828,17 @@ mod tests {
         disk_requester.init_wal("wal", &root_db_path);
 
         // create a new state cache which tracks on disk state.
-        let state_cache = Arc::new(
-            CachedSpace::new(
-                &StoreConfig::builder()
-                    .ncached_pages(1)
-                    .ncached_files(1)
-                    .space_id(STATE_SPACE)
-                    .file_nbit(1)
-                    .rootdir(state_path)
-                    .build(),
-                disk_requester.clone(),
-            )
-            .unwrap(),
-        );
+        let state_cache = CachedSpace::new(
+            &StoreConfig::builder()
+                .ncached_pages(1)
+                .ncached_files(1)
+                .space_id(STATE_SPACE)
+                .file_nbit(1)
+                .rootdir(state_path)
+                .build(),
+            disk_requester.clone(),
+        )
+        .unwrap();
 
         // add an in memory cached space. this will allow us to write to the
         // disk buffer then later persist the change to disk.

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -642,6 +642,26 @@ mod tests {
             .join("firewood")
     }
 
+    fn create_state_cache(
+        state_path: PathBuf,
+        disk_requester: DiskBufferRequester,
+    ) -> Arc<CachedSpace> {
+        // create a new state cache which tracks on disk state.
+        Arc::new(
+            CachedSpace::new(
+                &StoreConfig::builder()
+                    .ncached_pages(1)
+                    .ncached_files(1)
+                    .space_id(STATE_SPACE)
+                    .file_nbit(1)
+                    .rootdir(state_path)
+                    .build(),
+                disk_requester,
+            )
+            .unwrap(),
+        )
+    }
+
     #[test]
     #[ignore = "ref: https://github.com/ava-labs/firewood/issues/45"]
     fn test_buffer_with_undo() {
@@ -662,19 +682,7 @@ mod tests {
         disk_requester.init_wal("wal", &root_db_path);
 
         // create a new state cache which tracks on disk state.
-        let state_cache = Arc::new(
-            CachedSpace::new(
-                &StoreConfig::builder()
-                    .ncached_pages(1)
-                    .ncached_files(1)
-                    .space_id(STATE_SPACE)
-                    .file_nbit(1)
-                    .rootdir(state_path)
-                    .build(),
-                disk_requester.clone(),
-            )
-            .unwrap(),
-        );
+        let state_cache = create_state_cache(state_path, disk_requester.clone());
 
         // add an in memory cached space. this will allow us to write to the
         // disk buffer then later persist the change to disk.
@@ -749,20 +757,7 @@ mod tests {
         // create a new wal directory on top of root_db_fd
         disk_requester.init_wal("wal", &root_db_path);
 
-        // create a new state cache which tracks on disk state.
-        let state_cache = Arc::new(
-            CachedSpace::new(
-                &StoreConfig::builder()
-                    .ncached_pages(1)
-                    .ncached_files(1)
-                    .space_id(STATE_SPACE)
-                    .file_nbit(1)
-                    .rootdir(state_path)
-                    .build(),
-                disk_requester.clone(),
-            )
-            .unwrap(),
-        );
+        let state_cache = create_state_cache(state_path, disk_requester.clone());
 
         // add an in memory cached space. this will allow us to write to the
         // disk buffer then later persist the change to disk.

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -642,7 +642,7 @@ mod tests {
             .join("firewood")
     }
 
-    fn create_state_cache(
+    fn new_cached_space_for_test(
         state_path: PathBuf,
         disk_requester: DiskBufferRequester,
     ) -> Arc<CachedSpace> {
@@ -680,7 +680,7 @@ mod tests {
         disk_requester.init_wal("wal", &root_db_path);
 
         // create a new state cache which tracks on disk state.
-        let state_cache = create_state_cache(state_path, disk_requester.clone());
+        let state_cache = new_cached_space_for_test(state_path, disk_requester.clone());
 
         // add an in memory cached space. this will allow us to write to the
         // disk buffer then later persist the change to disk.
@@ -756,7 +756,7 @@ mod tests {
         disk_requester.init_wal("wal", &root_db_path);
 
         // create a new state cache which tracks on disk state.
-        let state_cache = create_state_cache(state_path, disk_requester.clone());
+        let state_cache = new_cached_space_for_test(state_path, disk_requester.clone());
 
         // add an in memory cached space. this will allow us to write to the
         // disk buffer then later persist the change to disk.

--- a/firewood/src/storage/mod.rs
+++ b/firewood/src/storage/mod.rs
@@ -723,10 +723,10 @@ impl CachedSpace {
     pub fn new(
         cfg: &StoreConfig,
         disk_requester: DiskBufferRequester,
-    ) -> Result<Self, StoreError<std::io::Error>> {
+    ) -> Result<Arc<Self>, StoreError<std::io::Error>> {
         let space_id = cfg.space_id;
         let files = Arc::new(FilePool::new(cfg)?);
-        Ok(Self {
+        Ok(Arc::new(Self {
             inner: Arc::new(RwLock::new(CachedSpaceInner {
                 cached_pages: lru::LruCache::new(
                     NonZeroUsize::new(cfg.ncached_pages).expect("non-zero cache size"),
@@ -736,7 +736,7 @@ impl CachedSpace {
                 disk_requester,
             })),
             space_id,
-        })
+        }))
     }
 
     pub fn clone_files(&self) -> Arc<FilePool> {

--- a/firewood/src/storage/mod.rs
+++ b/firewood/src/storage/mod.rs
@@ -723,10 +723,10 @@ impl CachedSpace {
     pub fn new(
         cfg: &StoreConfig,
         disk_requester: DiskBufferRequester,
-    ) -> Result<Arc<Self>, StoreError<std::io::Error>> {
+    ) -> Result<Self, StoreError<std::io::Error>> {
         let space_id = cfg.space_id;
         let files = Arc::new(FilePool::new(cfg)?);
-        Ok(Arc::new(Self {
+        Ok(Self {
             inner: Arc::new(RwLock::new(CachedSpaceInner {
                 cached_pages: lru::LruCache::new(
                     NonZeroUsize::new(cfg.ncached_pages).expect("non-zero cache size"),
@@ -736,7 +736,7 @@ impl CachedSpace {
                 disk_requester,
             })),
             space_id,
-        }))
+        })
     }
 
     pub fn clone_files(&self) -> Arc<FilePool> {


### PR DESCRIPTION
- Introduced `create_state_cache` utility function in tests module to reduce repetition.
- Refactored test functions to use the new utility function.
- ~Adjusted indentations for async operations and error handling. (rustfmt)~