### PR TITLE
Remove 'static lifetime on key-type trait

### DIFF
--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -8,9 +8,9 @@ use async_trait::async_trait;
 /// A `KeyType` is something that can be xcast to a u8 reference,
 /// and can be sent and shared across threads. References with
 /// lifetimes are not allowed (hence 'static)
-pub trait KeyType: AsRef<[u8]> + Send + Sync + Debug + 'static {}
+pub trait KeyType: AsRef<[u8]> + Send + Sync + Debug {}
 
-impl<T> KeyType for T where T: AsRef<[u8]> + Send + Sync + Debug + 'static {}
+impl<T> KeyType for T where T: AsRef<[u8]> + Send + Sync + Debug {}
 
 /// A `ValueType` is the same as a `KeyType`. However, these could
 /// be a different type from the `KeyType` on a given API call.


### PR DESCRIPTION
You should be able to use a borrowed key for lookups

