### PR TITLE
2/3 Implement v2::api for the real DB

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -160,7 +160,7 @@ fn bench_db<const N: usize>(criterion: &mut Criterion) {
                 },
                 |(db, batch_ops)| {
                     let proposal = db.new_proposal(batch_ops).unwrap();
-                    proposal.commit().unwrap();
+                    proposal.commit_sync().unwrap();
                 },
                 BatchSize::SmallInput,
             );

--- a/firewood/examples/rev.rs
+++ b/firewood/examples/rev.rs
@@ -138,7 +138,7 @@ impl RevisionTracker {
             key: k,
             value: v.as_ref().to_vec(),
         }];
-        self.db.new_proposal(batch)?.commit()?;
+        self.db.new_proposal(batch)?.commit_sync()?;
 
         let hash = self.db.kv_root_hash().expect("root-hash should exist");
         self.hashes.push_front(hash);
@@ -146,7 +146,7 @@ impl RevisionTracker {
     }
 
     fn commit_proposal(&mut self, proposal: Proposal) {
-        proposal.commit().unwrap();
+        proposal.commit_sync().unwrap();
         let hash = self.db.kv_root_hash().expect("root-hash should exist");
         self.hashes.push_front(hash);
     }

--- a/firewood/examples/rev.rs
+++ b/firewood/examples/rev.rs
@@ -7,7 +7,7 @@ use firewood::{
     db::{BatchOp, Db, DbConfig, DbError, Proposal, Revision, WalConfig},
     merkle::{Node, TrieHash},
     storage::StoreRevShared,
-    v2::api::{Proof, ValueType, KeyType},
+    v2::api::{KeyType, Proof, ValueType},
 };
 use shale::compact::CompactSpace;
 

--- a/firewood/examples/rev.rs
+++ b/firewood/examples/rev.rs
@@ -7,7 +7,7 @@ use firewood::{
     db::{BatchOp, Db, DbConfig, DbError, Proposal, Revision, WalConfig},
     merkle::{Node, TrieHash},
     storage::StoreRevShared,
-    v2::api::Proof,
+    v2::api::{Proof, ValueType, KeyType},
 };
 use shale::compact::CompactSpace;
 
@@ -118,7 +118,7 @@ impl RevisionTracker {
         }
     }
 
-    fn create_revisions<K, V>(
+    fn create_revisions<K: KeyType, V: ValueType>(
         &mut self,
         mut iter: impl Iterator<Item = (K, V)>,
     ) -> Result<(), DbError>
@@ -129,7 +129,7 @@ impl RevisionTracker {
         iter.try_for_each(|(k, v)| self.create_revision(k, v))
     }
 
-    fn create_revision<K, V>(&mut self, k: K, v: V) -> Result<(), DbError>
+    fn create_revision<K: KeyType, V: ValueType>(&mut self, k: K, v: V) -> Result<(), DbError>
     where
         K: AsRef<[u8]>,
         V: AsRef<[u8]>,

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -274,7 +274,7 @@ pub struct DbRev<S> {
 }
 
 #[async_trait]
-impl<S: ShaleStore<Node> + Send + Sync, 'a> api::DbView for DbRev<S> {
+impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
     async fn root_hash(&self) -> Result<api::HashKey, api::Error> {
         self.merkle
             .root_hash(self.header.kv_root)
@@ -282,14 +282,14 @@ impl<S: ShaleStore<Node> + Send + Sync, 'a> api::DbView for DbRev<S> {
             .map_err(|e| api::Error::IO(std::io::Error::new(ErrorKind::Other, e)))
     }
 
-    async fn val<K: api::KeyType>(&self, key: K) -> Result<Option<&[u8]>, api::Error> {
+    async fn val<K: api::KeyType>(&self, key: K) -> Result<Option<Vec<u8>>, api::Error> {
         let obj_ref =
             self.merkle.get(key, self.header.kv_root);
         match obj_ref {
             Err(e) => Err(api::Error::IO(std::io::Error::new(ErrorKind::Other, e))),
             Ok(obj) => match obj {
                 None => Ok(None),
-                Some(inner) => Ok(Some(inner.as_ref())),
+                Some(inner) => Ok(Some(inner.as_ref().to_owned())),
             },
         }
     }

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -14,7 +14,7 @@ use crate::{
         CachedSpace, MemStoreR, SpaceWrite, StoreConfig, StoreDelta, StoreRevMut, StoreRevShared,
         ZeroStore, PAGE_SIZE_NBIT,
     },
-    v2::api::{self, {self, Proof}},
+    v2::api::{self, HashKey, KeyType, Proof, ValueType},
 };
 use async_trait::async_trait;
 use bytemuck::{cast_slice, AnyBitPattern};
@@ -283,8 +283,7 @@ impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
     }
 
     async fn val<K: api::KeyType>(&self, key: K) -> Result<Option<Vec<u8>>, api::Error> {
-        let obj_ref =
-            self.merkle.get(key, self.header.kv_root);
+        let obj_ref = self.merkle.get(key, self.header.kv_root);
         match obj_ref {
             Err(e) => Err(api::Error::IO(std::io::Error::new(ErrorKind::Other, e))),
             Ok(obj) => match obj {
@@ -294,11 +293,14 @@ impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
         }
     }
 
-    async fn single_key_proof<K: api::KeyType, N: AsRef<[u8]> + Send>(
+    async fn single_key_proof<K: api::KeyType>(
         &self,
-        _key: K,
-    ) -> Result<Option<Proof<N>>, api::Error> {
-        todo!()
+        key: K,
+    ) -> Result<Option<Proof<Vec<u8>>>, api::Error> {
+        self.merkle
+            .prove(key, self.header.kv_root)
+            .map(Some)
+            .map_err(|e| api::Error::IO(std::io::Error::new(ErrorKind::Other, e)))
     }
 
     async fn range_proof<K: api::KeyType, V, N>(
@@ -378,6 +380,28 @@ impl Drop for DbInner {
     fn drop(&mut self) {
         self.disk_requester.shutdown();
         self.disk_thread.take().map(JoinHandle::join);
+    }
+}
+
+#[async_trait]
+impl api::Db for DbInner {
+    type Historical = DbRev<SharedStore>;
+
+    type Proposal = DbRev<Store>;
+
+    async fn revision(&self, _hash: HashKey) -> Result<Arc<Self::Historical>, api::Error> {
+        todo!()
+    }
+
+    async fn root_hash(&self) -> Result<HashKey, api::Error> {
+        todo!()
+    }
+
+    async fn propose<K: KeyType, V: ValueType>(
+        &self,
+        _batch: api::Batch<K, V>,
+    ) -> Result<Self::Proposal, api::Error> {
+        todo!()
     }
 }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -7,7 +7,7 @@ pub use crate::{
 };
 use crate::{
     file,
-    merkle::{Merkle, MerkleError, Node, Ref, TrieHash, TRIE_HASH_LEN},
+    merkle::{Merkle, MerkleError, Node, TrieHash, TRIE_HASH_LEN},
     proof::ProofError,
     storage::{
         buffer::{DiskBuffer, DiskBufferRequester},
@@ -274,7 +274,7 @@ pub struct DbRev<S> {
 }
 
 #[async_trait]
-impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
+impl<S: ShaleStore<Node> + Send + Sync, 'a> api::DbView for DbRev<S> {
     async fn root_hash(&self) -> Result<api::HashKey, api::Error> {
         self.merkle
             .root_hash(self.header.kv_root)
@@ -283,7 +283,7 @@ impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
     }
 
     async fn val<K: api::KeyType>(&self, key: K) -> Result<Option<&[u8]>, api::Error> {
-        let obj_ref: Result<Option<crate::merkle::Ref>, _> =
+        let obj_ref =
             self.merkle.get(key, self.header.kv_root);
         match obj_ref {
             Err(e) => Err(api::Error::IO(std::io::Error::new(ErrorKind::Other, e))),
@@ -296,16 +296,16 @@ impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
 
     async fn single_key_proof<K: api::KeyType, N: AsRef<[u8]> + Send>(
         &self,
-        key: K,
+        _key: K,
     ) -> Result<Option<Proof<N>>, api::Error> {
         todo!()
     }
 
-    async fn range_proof<K: api::KeyType, V: api::ValueType, N: AsRef<[u8]> + Send>(
+    async fn range_proof<K: api::KeyType, V, N>(
         &self,
-        first_key: Option<K>,
-        last_key: Option<K>,
-        limit: usize,
+        _first_key: Option<K>,
+        _last_key: Option<K>,
+        _limit: usize,
     ) -> Result<Option<api::RangeProof<K, V, N>>, api::Error> {
         todo!()
     }

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     merkle::{TrieHash, TRIE_HASH_LEN},
     storage::{buffer::BufferWrite, AshRecord, StoreRevMut},
-    v2::api::{self, ValueType, KeyType},
+    v2::api::{self, KeyType, ValueType},
 };
 use async_trait::async_trait;
 use parking_lot::{Mutex, RwLock};
@@ -61,7 +61,10 @@ impl<T: crate::v2::api::DbView> crate::v2::api::Proposal<T> for Proposal {
 impl Proposal {
     // Propose a new proposal from this proposal. The new proposal will be
     // the child of it.
-    pub fn propose<K: KeyType, V: ValueType>(self: Arc<Self>, data: Batch<K, V>) -> Result<Proposal, DbError> {
+    pub fn propose<K: KeyType, V: ValueType>(
+        self: Arc<Self>,
+        data: Batch<K, V>,
+    ) -> Result<Proposal, DbError> {
         let store = self.store.new_from_other();
 
         let m = Arc::clone(&self.m);

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -139,10 +139,7 @@ pub trait DbView {
     async fn val<K: KeyType>(&self, key: K) -> Result<Option<Vec<u8>>, Error>;
 
     /// Obtain a proof for a single key
-    async fn single_key_proof<K: KeyType, V: ValueType>(
-        &self,
-        key: K,
-    ) -> Result<Option<Proof<V>>, Error>;
+    async fn single_key_proof<K: KeyType>(&self, key: K) -> Result<Option<Proof<Vec<u8>>>, Error>;
 
     /// Obtain a range proof over a set of keys
     ///

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -74,7 +74,7 @@ pub enum Error {
 /// A range proof, consisting of a proof of the first key and the last key,
 /// and a vector of all key/value pairs
 #[derive(Debug)]
-pub struct RangeProof<K: KeyType, V: ValueType, N: AsRef<[u8]> + Send> {
+pub struct RangeProof<K, V, N> {
     pub first_key: Proof<N>,
     pub last_key: Proof<N>,
     pub middle: Vec<(K, V)>,
@@ -152,7 +152,7 @@ pub trait DbView {
     /// * `last_key` - If None, continue to the end of the database
     /// * `limit` - The maximum number of keys in the range proof
     ///
-    async fn range_proof<K: KeyType, V: ValueType, N: AsRef<[u8]> + Send>(
+    async fn range_proof<K: KeyType, V, N>(
         &self,
         first_key: Option<K>,
         last_key: Option<K>,

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -74,7 +74,7 @@ pub enum Error {
 /// A range proof, consisting of a proof of the first key and the last key,
 /// and a vector of all key/value pairs
 #[derive(Debug)]
-pub struct RangeProof<K, V, N> {
+pub struct RangeProof<K: KeyType, V: ValueType, N: AsRef<[u8]> + Send> {
     pub first_key: Proof<N>,
     pub last_key: Proof<N>,
     pub middle: Vec<(K, V)>,
@@ -152,7 +152,7 @@ pub trait DbView {
     /// * `last_key` - If None, continue to the end of the database
     /// * `limit` - The maximum number of keys in the range proof
     ///
-    async fn range_proof<K: KeyType, V, N>(
+    async fn range_proof<K: KeyType, V: ValueType, N: AsRef<[u8]> + Send>(
         &self,
         first_key: Option<K>,
         last_key: Option<K>,

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -69,6 +69,9 @@ pub enum Error {
 
     #[error("Invalid proposal")]
     InvalidProposal,
+
+    #[error("Internal error")]
+    InternalError(Box<dyn std::error::Error>),
 }
 
 /// A range proof, consisting of a proof of the first key and the last key,

--- a/firewood/src/v2/db.rs
+++ b/firewood/src/v2/db.rs
@@ -7,7 +7,10 @@ use tokio::sync::Mutex;
 
 use async_trait::async_trait;
 
-use crate::{v2::api::{self, Batch, KeyType, ValueType}, db::DbError};
+use crate::{
+    db::DbError,
+    v2::api::{self, Batch, KeyType, ValueType},
+};
 
 use super::propose;
 

--- a/firewood/src/v2/db.rs
+++ b/firewood/src/v2/db.rs
@@ -79,10 +79,10 @@ impl api::DbView for DbView {
         todo!()
     }
 
-    async fn single_key_proof<K: KeyType, V: ValueType>(
+    async fn single_key_proof<K: KeyType>(
         &self,
         _key: K,
-    ) -> Result<Option<api::Proof<V>>, api::Error> {
+    ) -> Result<Option<api::Proof<Vec<u8>>>, api::Error> {
         todo!()
     }
 

--- a/firewood/src/v2/db.rs
+++ b/firewood/src/v2/db.rs
@@ -86,7 +86,7 @@ impl api::DbView for DbView {
         todo!()
     }
 
-    async fn range_proof<K: KeyType, V: ValueType, N: AsRef<[u8]> + Send>(
+    async fn range_proof<K: KeyType, V, N>(
         &self,
         _first_key: Option<K>,
         _last_key: Option<K>,

--- a/firewood/src/v2/db.rs
+++ b/firewood/src/v2/db.rs
@@ -86,7 +86,7 @@ impl api::DbView for DbView {
         todo!()
     }
 
-    async fn range_proof<K: KeyType, V, N>(
+    async fn range_proof<K: KeyType, V: ValueType, N: AsRef<[u8]> + Send>(
         &self,
         _first_key: Option<K>,
         _last_key: Option<K>,

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -62,10 +62,7 @@ impl DbView for HistoricalImpl {
         Ok(None)
     }
 
-    async fn single_key_proof<K: KeyType, V: ValueType>(
-        &self,
-        _key: K,
-    ) -> Result<Option<Proof<V>>, Error> {
+    async fn single_key_proof<K: KeyType>(&self, _key: K) -> Result<Option<Proof<Vec<u8>>>, Error> {
         Ok(None)
     }
 

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -69,7 +69,7 @@ impl DbView for HistoricalImpl {
         Ok(None)
     }
 
-    async fn range_proof<K: KeyType, V: ValueType, N: AsRef<[u8]> + Send>(
+    async fn range_proof<K: KeyType, V, N>(
         &self,
         _first_key: Option<K>,
         _last_key: Option<K>,

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -69,7 +69,7 @@ impl DbView for HistoricalImpl {
         Ok(None)
     }
 
-    async fn range_proof<K: KeyType, V, N>(
+    async fn range_proof<K: KeyType, V: ValueType, N: AsRef<[u8]> + Send>(
         &self,
         _first_key: Option<K>,
         _last_key: Option<K>,

--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -121,10 +121,10 @@ impl<T: api::DbView + Send + Sync> api::DbView for Proposal<T> {
         }
     }
 
-    async fn single_key_proof<K: KeyType, V: ValueType>(
+    async fn single_key_proof<K: KeyType>(
         &self,
         _key: K,
-    ) -> Result<Option<api::Proof<V>>, api::Error> {
+    ) -> Result<Option<api::Proof<Vec<u8>>>, api::Error> {
         todo!()
     }
 

--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -128,7 +128,7 @@ impl<T: api::DbView + Send + Sync> api::DbView for Proposal<T> {
         todo!()
     }
 
-    async fn range_proof<KT: KeyType, VT: ValueType, NT: AsRef<[u8]> + Send>(
+    async fn range_proof<KT: KeyType, VT, NT>(
         &self,
         _first_key: Option<KT>,
         _last_key: Option<KT>,

--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -128,7 +128,7 @@ impl<T: api::DbView + Send + Sync> api::DbView for Proposal<T> {
         todo!()
     }
 
-    async fn range_proof<KT: KeyType, VT, NT>(
+    async fn range_proof<KT: KeyType, VT: ValueType, NT: AsRef<[u8]> + Send>(
         &self,
         _first_key: Option<KT>,
         _last_key: Option<KT>,

--- a/firewood/tests/db.rs
+++ b/firewood/tests/db.rs
@@ -118,7 +118,7 @@ fn test_revisions() {
                     batch.push(write);
                 }
                 let proposal = db.new_proposal(batch).unwrap();
-                proposal.commit().unwrap();
+                proposal.commit_sync().unwrap();
             }
             while dumped.len() > 10 {
                 dumped.pop_back();
@@ -192,7 +192,7 @@ fn create_db_issue_proof() {
         batch.push(write);
     }
     let proposal = db.new_proposal(batch).unwrap();
-    proposal.commit().unwrap();
+    proposal.commit_sync().unwrap();
 
     let root_hash = db.kv_root_hash().unwrap();
 
@@ -206,7 +206,7 @@ fn create_db_issue_proof() {
         batch.push(write);
     }
     let proposal = db.new_proposal(batch).unwrap();
-    proposal.commit().unwrap();
+    proposal.commit_sync().unwrap();
 
     let rev = db.get_revision(&root_hash).unwrap();
     let key = "doe".as_bytes();
@@ -274,13 +274,13 @@ fn db_proposal() -> Result<(), DbError> {
         key: b"k2",
         value: "v2".as_bytes().to_vec(),
     }];
-    let proposal_2 = proposal.clone().propose(batch_2)?;
+    let proposal_2 = proposal.clone().propose_sync(batch_2)?;
     let rev = proposal_2.get_revision();
     assert_val!(rev, "k", "v");
     assert_val!(rev, "k2", "v2");
 
-    proposal.commit()?;
-    proposal_2.commit()?;
+    proposal.commit_sync()?;
+    proposal_2.commit_sync()?;
 
     std::thread::scope(|scope| {
         scope.spawn(|| -> Result<(), DbError> {
@@ -288,12 +288,12 @@ fn db_proposal() -> Result<(), DbError> {
                 key: b"another_k",
                 value: "another_v".as_bytes().to_vec(),
             }];
-            let another_proposal = proposal.clone().propose(another_batch)?;
+            let another_proposal = proposal.clone().propose_sync(another_batch)?;
             let rev = another_proposal.get_revision();
             assert_val!(rev, "k", "v");
             assert_val!(rev, "another_k", "another_v");
             // The proposal is invalid and cannot be committed
-            assert!(another_proposal.commit().is_err());
+            assert!(another_proposal.commit_sync().is_err());
             Ok(())
         });
 
@@ -302,7 +302,7 @@ fn db_proposal() -> Result<(), DbError> {
                 key: b"another_k_1",
                 value: "another_v_1".as_bytes().to_vec(),
             }];
-            let another_proposal = proposal.clone().propose(another_batch)?;
+            let another_proposal = proposal.clone().propose_sync(another_batch)?;
             let rev = another_proposal.get_revision();
             assert_val!(rev, "k", "v");
             assert_val!(rev, "another_k_1", "another_v_1");
@@ -326,13 +326,13 @@ fn db_proposal() -> Result<(), DbError> {
         key: b"k4",
         value: "v4".as_bytes().to_vec(),
     }];
-    let proposal_2 = proposal.clone().propose(batch_2)?;
+    let proposal_2 = proposal.clone().propose_sync(batch_2)?;
     let rev = proposal_2.get_revision();
     assert_val!(rev, "k", "v");
     assert_val!(rev, "k2", "v2");
     assert_val!(rev, "k3", "v3");
     assert_val!(rev, "k4", "v4");
 
-    proposal_2.commit()?;
+    proposal_2.commit_sync()?;
     Ok(())
 }

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -31,7 +31,9 @@ pub fn run(opts: &Options) -> Result<()> {
 
     let db = Db::new(opts.db.as_str(), &cfg.build()).map_err(Error::msg)?;
 
-    let batch:Vec<BatchOp<String, String>> = vec![BatchOp::Delete { key: opts.key.clone() }];
+    let batch: Vec<BatchOp<String, String>> = vec![BatchOp::Delete {
+        key: opts.key.clone(),
+    }];
     let proposal = db.new_proposal(batch).map_err(Error::msg)?;
     proposal.commit().map_err(Error::msg)?;
 

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -31,7 +31,7 @@ pub fn run(opts: &Options) -> Result<()> {
 
     let db = Db::new(opts.db.as_str(), &cfg.build()).map_err(Error::msg)?;
 
-    let batch = vec![BatchOp::Delete { key: &opts.key }];
+    let batch:Vec<BatchOp<String, String>> = vec![BatchOp::Delete { key: opts.key.clone() }];
     let proposal = db.new_proposal(batch).map_err(Error::msg)?;
     proposal.commit().map_err(Error::msg)?;
 

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -35,7 +35,7 @@ pub fn run(opts: &Options) -> Result<()> {
         key: opts.key.clone(),
     }];
     let proposal = db.new_proposal(batch).map_err(Error::msg)?;
-    proposal.commit().map_err(Error::msg)?;
+    proposal.commit_sync().map_err(Error::msg)?;
 
     println!("key {} deleted successfully", opts.key);
     Ok(())

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -43,7 +43,7 @@ pub fn run(opts: &Options) -> Result<()> {
         value: opts.value.bytes().collect(),
     }];
     let proposal = db.new_proposal(batch).map_err(Error::msg)?;
-    proposal.commit().map_err(Error::msg)?;
+    proposal.commit_sync().map_err(Error::msg)?;
 
     println!("{}", opts.key);
     Ok(())

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -38,8 +38,8 @@ pub fn run(opts: &Options) -> Result<()> {
         Err(_) => return Err(anyhow!("error opening database")),
     };
 
-    let batch = vec![BatchOp::Put {
-        key: &opts.key,
+    let batch: Vec<BatchOp<Vec<u8>, Vec<u8>>> = vec![BatchOp::Put {
+        key: opts.key.clone().into(),
         value: opts.value.bytes().collect(),
     }];
     let proposal = db.new_proposal(batch).map_err(Error::msg)?;


### PR DESCRIPTION
Changes:
 - Implement api::Db for Db 😄 
 - Change proposals Batch and BatchOp to use the new v2 ones
 - Rename propose() and commit() in Proposal to propose_sync and commit_sync

Still remaining (part 3)
 - Implement commit
 - Implement range proofs
