### PR TITLE
chore: use `decode` in single key proof verification

### DIFF
--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -310,6 +310,10 @@ impl ExtNode {
         self.1
     }
 
+    pub fn chd_encoded(&self) -> &Option<Vec<u8>> {
+        &self.2
+    }
+
     pub fn chd_mut(&mut self) -> &mut DiskAddress {
         &mut self.1
     }

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -310,8 +310,8 @@ impl ExtNode {
         self.1
     }
 
-    pub fn chd_encoded(&self) -> Option<&Vec<u8>> {
-        self.2.as_ref()
+    pub fn chd_encoded(&self) -> Option<&[u8]> {
+        self.2.as_deref()
     }
 
     pub fn chd_mut(&mut self) -> &mut DiskAddress {

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -310,8 +310,8 @@ impl ExtNode {
         self.1
     }
 
-    pub fn chd_encoded(&self) -> &Option<Vec<u8>> {
-        &self.2
+    pub fn chd_encoded(&self) -> Option<&Vec<u8>> {
+        self.2.as_ref()
     }
 
     pub fn chd_mut(&mut self) -> &mut DiskAddress {

--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -148,23 +148,10 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
         mut key_nibbles: NibblesIterator<'a, 0>,
         encoded_node: &[u8],
     ) -> Result<(Option<SubProof>, NibblesIterator<'a, 0>), ProofError> {
-        let items: Vec<Encoded<Vec<u8>>> = bincode::DefaultOptions::new()
-            .deserialize(encoded_node)
-            .map_err(ProofError::DecodeError)?;
-
-        match items.len() {
-            EXT_NODE_SIZE => {
-                let mut items = items.into_iter();
-                let decoded_key: Vec<u8> = items.next().unwrap().decode()?;
-
-                let decoded_key_nibbles = Nibbles::<0>::new(&decoded_key);
-
-                let (cur_key_path, term) =
-                    PartialPath::from_nibbles(decoded_key_nibbles.into_iter());
-                let cur_key = cur_key_path.into_inner();
-
-                let data: Vec<u8> = items.next().unwrap().decode()?;
-
+        let node = NodeType::decode(encoded_node)?;
+        match node {
+            NodeType::Leaf(n) => {
+                let cur_key = &n.path().0;
                 // Check if the key of current node match with the given key
                 // and consume the current-key portion of the nibbles-iterator
                 let does_not_match = key_nibbles.size_hint().0 < cur_key.len()
@@ -174,33 +161,43 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
                     return Ok((None, Nibbles::<0>::new(&[]).into_iter()));
                 }
 
-                let sub_proof = if term {
-                    SubProof {
-                        encoded: data,
-                        hash: None,
-                    }
-                } else {
-                    self.generate_subproof(data)?
+                let data = n.data();
+
+                let sub_proof = SubProof {
+                    encoded: data.to_vec(),
+                    hash: None,
                 };
 
                 Ok((sub_proof.into(), key_nibbles))
             }
+            NodeType::Extension(n) => {
+                let cur_key = &n.path().0;
+                // Check if the key of current node match with the given key
+                // and consume the current-key portion of the nibbles-iterator
+                let does_not_match = key_nibbles.size_hint().0 < cur_key.len()
+                    || !cur_key.iter().all(|val| key_nibbles.next() == Some(*val));
 
-            BRANCH_NODE_SIZE if key_nibbles.size_hint().0 == 0 => Err(ProofError::NoSuchNode),
+                if does_not_match {
+                    return Ok((None, Nibbles::<0>::new(&[]).into_iter()));
+                }
+                let data = n.chd_encoded().as_ref().ok_or(ProofError::InvalidData)?;
 
-            BRANCH_NODE_SIZE => {
+                let sub_proof = self.generate_subproof(data.to_vec())?;
+
+                Ok((sub_proof.into(), key_nibbles))
+            }
+            NodeType::Branch(n) => {
+                if key_nibbles.size_hint().0 == 0 {
+                    return Err(ProofError::NoSuchNode);
+                }
                 let index = key_nibbles.next().unwrap() as usize;
-
                 // consume items returning the item at index
-                let data: Vec<u8> = items.into_iter().nth(index).unwrap().decode()?;
-
-                self.generate_subproof(data)
+                let data = n.chd_encode()[index]
+                    .as_ref()
+                    .ok_or(ProofError::InvalidData)?;
+                self.generate_subproof(data.to_vec())
                     .map(|subproof| (Some(subproof), key_nibbles))
             }
-
-            size => Err(ProofError::DecodeError(Box::new(
-                bincode::ErrorKind::Custom(format!("invalid size: {size}")),
-            ))),
         }
     }
 


### PR DESCRIPTION
One of the 'pluggable node encoding/decoding' series.