### PR TITLE
Remove proof feature from Cargo.toml

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -48,10 +48,6 @@ clap = { version = "4.3.1", features = ['derive'] }
 test-case = "3.1.0"
 pprof = { version = "0.13.0", features = ["flamegraph"] }
 
-[features]
-# proof API
-proof = []
-
 [[bench]]
 name = "hashops"
 harness = false


### PR DESCRIPTION
No longer referenced anywhere

Gone since https://github.com/ava-labs/firewood/pull/273