### PR TITLE
Switch to unbounded channel

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -479,7 +479,7 @@ impl Db {
             .block_nbit(params.wal_block_nbit)
             .max_revisions(cfg.wal.max_revisions)
             .build();
-        let (sender, inbound) = tokio::sync::mpsc::channel(cfg.buffer.max_buffered);
+        let (sender, inbound) = tokio::sync::mpsc::unbounded_channel();
         let disk_requester = DiskBufferRequester::new(sender);
         let buffer = cfg.buffer.clone();
         let disk_thread = Some(std::thread::spawn(move || {

--- a/fwdctl/src/create.rs
+++ b/fwdctl/src/create.rs
@@ -150,16 +150,6 @@ pub struct Options {
     )]
     blob_ncached_objs: usize,
 
-    /// Disk Buffer options
-    #[arg(
-        long,
-        required = false,
-        default_value_t = 4096,
-        value_name = "DISK_BUFFER_MAX_BUFFERED",
-        help = "Maximum buffered disk buffer."
-    )]
-    max_buffered: usize,
-
     #[arg(
         long,
         required = false,
@@ -271,7 +261,6 @@ pub fn initialize_db_config(opts: &Options) -> DbConfig {
             merkle_ncached_objs: opts.merkle_ncached_objs,
         },
         buffer: DiskBufferConfig {
-            max_buffered: opts.max_buffered,
             max_pending: opts.max_pending,
             max_aio_requests: opts.max_aio_requests,
             max_aio_response: opts.max_aio_response,


### PR DESCRIPTION
This reduces the number of blocking calls for a spike, plus I can't imagine why anyone would want to tune this.