### PR TITLE
Pluggable encoding for nodes

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -8,7 +8,7 @@ pub use crate::{
 };
 use crate::{
     file,
-    merkle::{Merkle, MerkleError, Node, Proof, ProofError, TrieHash, TRIE_HASH_LEN},
+    merkle::{Bincode, Merkle, MerkleError, Node, Proof, ProofError, TrieHash, TRIE_HASH_LEN},
     storage::{
         buffer::{DiskBuffer, DiskBufferRequester},
         CachedSpace, MemStoreR, SpaceWrite, StoreConfig, StoreDelta, StoreRevMut, StoreRevShared,
@@ -275,7 +275,7 @@ impl<T: MemStoreR + 'static> Universe<Arc<T>> {
 #[derive(Debug)]
 pub struct DbRev<S> {
     header: shale::Obj<DbHeader>,
-    merkle: Merkle<S>,
+    merkle: Merkle<S, Bincode>,
 }
 
 #[async_trait]
@@ -321,7 +321,7 @@ impl<S: ShaleStore<Node> + Send + Sync> DbRev<S> {
     pub fn stream<K: KeyType>(
         &self,
         start_key: Option<K>,
-    ) -> Result<merkle::MerkleKeyValueStream<'_, S>, api::Error> {
+    ) -> Result<merkle::MerkleKeyValueStream<'_, S, Bincode>, api::Error> {
         self.merkle
             .get_iter(start_key, self.header.kv_root)
             .map_err(|e| api::Error::InternalError(Box::new(e)))
@@ -333,7 +333,7 @@ impl<S: ShaleStore<Node> + Send + Sync> DbRev<S> {
         Some(())
     }
 
-    fn borrow_split(&mut self) -> (&mut shale::Obj<DbHeader>, &mut Merkle<S>) {
+    fn borrow_split(&mut self) -> (&mut shale::Obj<DbHeader>, &mut Merkle<S, Bincode>) {
         (&mut self.header, &mut self.merkle)
     }
 

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -1,15 +1,19 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::shale::{disk_address::DiskAddress, CachedStore, ShaleError, ShaleStore, Storable};
+use crate::{
+    merkle::from_nibbles,
+    shale::{disk_address::DiskAddress, CachedStore, ShaleError, ShaleStore, Storable},
+};
 use bincode::{Error, Options};
 use bitflags::bitflags;
 use enum_as_inner::EnumAsInner;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, ser::SerializeSeq, Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use std::{
     fmt::Debug,
     io::{Cursor, Write},
+    marker::PhantomData,
     mem::size_of,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -22,7 +26,7 @@ mod extension;
 mod leaf;
 mod partial_path;
 
-pub use branch::BranchNode;
+pub use branch::{BranchNode, SIZE as BRANCH_NODE_SIZE};
 pub use extension::ExtNode;
 pub use leaf::{LeafNode, SIZE as LEAF_NODE_SIZE};
 pub use partial_path::PartialPath;
@@ -462,6 +466,203 @@ impl Storable for Node {
                 n.serialize(&mut cur.get_mut()[pos..])
             }
         }
+    }
+}
+
+pub struct EncodedNode<T: ?Sized> {
+    pub(crate) node: EncodedNodeType,
+    pub(crate) phantom: PhantomData<T>,
+}
+
+impl<T: ?Sized> EncodedNode<T> {
+    pub fn new(node: EncodedNodeType) -> Self {
+        Self {
+            node,
+            phantom: PhantomData,
+        }
+    }
+}
+pub enum EncodedNodeType {
+    Leaf(LeafNode),
+    Branch {
+        children: Box<[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>,
+        value: Option<Data>,
+    },
+}
+
+// Note that the serializer passed in should always be the same type as T in EncodedNode<T>.
+impl Serialize for EncodedNode<Bincode> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::Error;
+
+        match &self.node {
+            EncodedNodeType::Leaf(n) => {
+                let list = [
+                    Encoded::Raw(from_nibbles(&n.path.encode(true)).collect()),
+                    Encoded::Raw(n.data.to_vec()),
+                ];
+                let mut seq = serializer.serialize_seq(Some(list.len()))?;
+                for e in list {
+                    seq.serialize_element(&e)?;
+                }
+                seq.end()
+            }
+            EncodedNodeType::Branch { children, value } => {
+                let mut list = <[Encoded<Vec<u8>>; BranchNode::MAX_CHILDREN + 1]>::default();
+
+                for (i, c) in children
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, c)| c.as_ref().map(|c| (i, c)))
+                {
+                    if c.len() >= TRIE_HASH_LEN {
+                        let serialized_hash = Bincode::serialize(&Keccak256::digest(c).to_vec())
+                            .map_err(|e| S::Error::custom(format!("bincode error: {e}")))?;
+                        list[i] = Encoded::Data(serialized_hash);
+                    } else {
+                        list[i] = Encoded::Raw(c.to_vec());
+                    }
+                }
+                if let Some(Data(val)) = &value {
+                    let serialized_val = Bincode::serialize(val)
+                        .map_err(|e| S::Error::custom(format!("bincode error: {e}")))?;
+                    list[BranchNode::MAX_CHILDREN] = Encoded::Data(serialized_val);
+                }
+
+                let mut seq = serializer.serialize_seq(Some(list.len()))?;
+                for e in list {
+                    seq.serialize_element(&e)?;
+                }
+                seq.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for EncodedNode<Bincode> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let items: Vec<Encoded<Vec<u8>>> = Deserialize::deserialize(deserializer)?;
+        let len = items.len();
+        match len {
+            LEAF_NODE_SIZE => {
+                let mut items = items.into_iter();
+                let Some(Encoded::Raw(path)) = items.next() else {
+                    return Err(D::Error::custom(
+                        "incorrect encoded type for leaf node path",
+                    ));
+                };
+                let Some(Encoded::Raw(data)) = items.next() else {
+                    return Err(D::Error::custom(
+                        "incorrect encoded type for leaf node data",
+                    ));
+                };
+                let path = PartialPath::from_nibbles(Nibbles::<0>::new(&path).into_iter()).0;
+                let node = EncodedNodeType::Leaf(LeafNode {
+                    path,
+                    data: Data(data),
+                });
+                Ok(Self {
+                    node,
+                    phantom: PhantomData,
+                })
+            }
+            BRANCH_NODE_SIZE => {
+                let mut children: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN] = Default::default();
+                let mut value: Option<Data> = Default::default();
+                let len = items.len();
+
+                for (i, chd) in items.into_iter().enumerate() {
+                    if i == len - 1 {
+                        let data = match chd {
+                            Encoded::Raw(data) => Err(D::Error::custom(format!(
+                                "incorrect encoded type for branch node value {:?}",
+                                data
+                            )))?,
+                            Encoded::Data(data) => Bincode::deserialize(data.as_ref())
+                                .map_err(|e| D::Error::custom(format!("bincode error: {e}")))?,
+                        };
+                        // Extract the value of the branch node and set to None if it's an empty Vec
+                        value = Some(Data(data)).filter(|data| !data.is_empty());
+                    } else {
+                        let chd = match chd {
+                            Encoded::Raw(chd) => chd,
+                            Encoded::Data(chd) => Bincode::deserialize(chd.as_ref())
+                                .map_err(|e| D::Error::custom(format!("bincode error: {e}")))?,
+                        };
+                        children[i] = Some(chd).filter(|chd| !chd.is_empty());
+                    }
+                }
+                let node = EncodedNodeType::Branch {
+                    children: children.into(),
+                    value,
+                };
+                Ok(Self {
+                    node,
+                    phantom: PhantomData,
+                })
+            }
+            size => Err(D::Error::custom(format!("invalid size: {size}"))),
+        }
+    }
+}
+
+pub trait BinarySerde {
+    type SerializeError: serde::ser::Error;
+    type DeserializeError: serde::de::Error;
+
+    fn new() -> Self;
+
+    fn serialize<T: Serialize>(t: &T) -> Result<Vec<u8>, Self::SerializeError>
+    where
+        Self: Sized,
+    {
+        Self::new().serialize_impl(t)
+    }
+
+    fn deserialize<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> Result<T, Self::DeserializeError>
+    where
+        Self: Sized,
+    {
+        Self::new().deserialize_impl(bytes)
+    }
+
+    fn serialize_impl<T: Serialize>(&self, t: &T) -> Result<Vec<u8>, Self::SerializeError>;
+    fn deserialize_impl<'de, T: Deserialize<'de>>(
+        &self,
+        bytes: &'de [u8],
+    ) -> Result<T, Self::DeserializeError>;
+}
+
+pub struct Bincode(pub bincode::DefaultOptions);
+
+impl Debug for Bincode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "[bincode::DefaultOptions]")
+    }
+}
+
+impl BinarySerde for Bincode {
+    type SerializeError = bincode::Error;
+    type DeserializeError = Self::SerializeError;
+
+    fn new() -> Self {
+        Self(bincode::DefaultOptions::new())
+    }
+
+    fn serialize_impl<T: Serialize>(&self, t: &T) -> Result<Vec<u8>, Self::SerializeError> {
+        self.0.serialize(t)
+    }
+
+    fn deserialize_impl<'de, T: Deserialize<'de>>(
+        &self,
+        bytes: &'de [u8],
+    ) -> Result<T, Self::DeserializeError> {
+        self.0.deserialize(bytes)
     }
 }
 

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -26,7 +26,7 @@ mod extension;
 mod leaf;
 mod partial_path;
 
-pub use branch::{BranchNode, SIZE as BRANCH_NODE_SIZE};
+pub use branch::BranchNode;
 pub use extension::ExtNode;
 pub use leaf::{LeafNode, SIZE as LEAF_NODE_SIZE};
 pub use partial_path::PartialPath;
@@ -469,12 +469,12 @@ impl Storable for Node {
     }
 }
 
-pub struct EncodedNode<T: ?Sized> {
+pub struct EncodedNode<T> {
     pub(crate) node: EncodedNodeType,
     pub(crate) phantom: PhantomData<T>,
 }
 
-impl<T: ?Sized> EncodedNode<T> {
+impl<T> EncodedNode<T> {
     pub fn new(node: EncodedNodeType) -> Self {
         Self {
             node,
@@ -571,7 +571,7 @@ impl<'de> Deserialize<'de> for EncodedNode<Bincode> {
                     phantom: PhantomData,
                 })
             }
-            BRANCH_NODE_SIZE => {
+            BranchNode::MSIZE => {
                 let mut children: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN] = Default::default();
                 let mut value: Option<Data> = Default::default();
                 let len = items.len();

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -19,7 +19,6 @@ pub type DataLen = u32;
 pub type EncodedChildLen = u8;
 
 const MAX_CHILDREN: usize = 16;
-pub const SIZE: usize = MAX_CHILDREN + 1;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct BranchNode {

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -19,6 +19,7 @@ pub type DataLen = u32;
 pub type EncodedChildLen = u8;
 
 const MAX_CHILDREN: usize = 16;
+pub const SIZE: usize = MAX_CHILDREN + 1;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct BranchNode {

--- a/firewood/tests/merkle.rs
+++ b/firewood/tests/merkle.rs
@@ -2,7 +2,7 @@
 // See the file LICENSE.md for licensing terms.
 
 use firewood::{
-    merkle::{Node, Proof, ProofError},
+    merkle::{Bincode, Node, Proof, ProofError},
     merkle_util::{new_merkle, DataStoreError, MerkleSetup},
     // TODO: we should not be using shale from an integration test
     shale::{cached::DynamicMem, compact::CompactSpace},
@@ -16,7 +16,7 @@ fn merkle_build_test<K: AsRef<[u8]> + std::cmp::Ord + Clone, V: AsRef<[u8]> + Cl
     items: Vec<(K, V)>,
     meta_size: u64,
     compact_size: u64,
-) -> Result<MerkleSetup<Store>, DataStoreError> {
+) -> Result<MerkleSetup<Store, Bincode>, DataStoreError> {
     let mut merkle = new_merkle(meta_size, compact_size);
 
     for (k, v) in items.iter() {


### PR DESCRIPTION
Closes #293.

With this one can use any serializer/deserializer for node encoding/decoding and adding a new encoding format by implement `serde` for `EncodedNode`.