### PR TITLE
Add verify option to insert example

### DIFF
--- a/firewood/examples/insert.rs
+++ b/firewood/examples/insert.rs
@@ -11,10 +11,7 @@ use firewood::{
     db::{Batch, BatchOp, Db, DbConfig},
     v2::api::{Db as DbApi, DbView, Proposal},
 };
-use rand::{
-    distributions::Alphanumeric,
-    Rng,
-};
+use rand::{distributions::Alphanumeric, Rng};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -74,36 +71,51 @@ async fn main() -> Result<(), Box<dyn Error>> {
             })
             .map(|(key, value)| BatchOp::Put { key, value })
             .collect();
-        let verify: HashMap<Vec<u8>, Vec<u8>> = if args.read_verify_percent == 0 {
-            HashMap::new()
-        } else {
-            batch
-                .iter()
-                .filter(|_last_key| {
-                    rand::thread_rng().gen_range(0..=(100 - args.read_verify_percent)) == 0
-                })
-                .map(|op| {
-                    if let BatchOp::Put { key, value } = op {
-                        (key.clone(), value.clone())
-                    } else {
-                        unreachable!()
-                    }
-                })
-                .collect()
-        };
+
+        let verify = get_keys_to_verify(&batch, args.read_verify_percent);
+
         let proposal: Arc<firewood::db::Proposal> = db.propose(batch).await.unwrap().into();
         proposal.commit().await?;
-        if args.read_verify_percent > 0 {
-            let hash = db.root_hash().await?;
-            let revision = db.revision(hash).await?;
-            for (key, value) in verify {
-                assert_eq!(*value, revision.val(key).await?.unwrap());
-            }
-        }
+        verify_keys(&db, verify).await?;
     }
 
     let duration = start.elapsed();
-    println!("Generated and inserted {} batches of size {keys} in {duration:?}", args.inserts);
+    println!(
+        "Generated and inserted {} batches of size {keys} in {duration:?}",
+        args.inserts
+    );
 
+    Ok(())
+}
+
+fn get_keys_to_verify(batch: &Batch<Vec<u8>, Vec<u8>>, pct: u16) -> HashMap<Vec<u8>, Vec<u8>> {
+    if pct == 0 {
+        HashMap::new()
+    } else {
+        batch
+            .iter()
+            .filter(|_last_key| rand::thread_rng().gen_range(0..=(100 - pct)) == 0)
+            .map(|op| {
+                if let BatchOp::Put { key, value } = op {
+                    (key.clone(), value.clone())
+                } else {
+                    unreachable!()
+                }
+            })
+            .collect()
+    }
+}
+
+async fn verify_keys(
+    db: &Db,
+    verify: HashMap<Vec<u8>, Vec<u8>>,
+) -> Result<(), firewood::v2::api::Error> {
+    if !verify.is_empty() {
+        let hash = db.root_hash().await?;
+        let revision = db.revision(hash).await?;
+        for (key, value) in verify {
+            assert_eq!(*value, revision.val(key).await?.unwrap());
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
This example now allows you to read-verify some of the inserted values. It does make a copy of the inserted values since propose consumes the batch.