### PR TITLE
Enable manual trigger of default-cache build

### DIFF
--- a/.github/workflows/default-branch-cache.yaml
+++ b/.github/workflows/default-branch-cache.yaml
@@ -2,6 +2,7 @@
 name: default-branch-cache
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Let's see if this works
docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch