### PR TITLE
Rename hydrate/dehydrate to serialize/deserialize

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -67,10 +67,10 @@ fn bench_trie_hash(criterion: &mut Criterion) {
     criterion
         .benchmark_group("TrieHash")
         .bench_function("dehydrate", |b| {
-            b.iter(|| ZERO_HASH.dehydrate(&mut to).unwrap());
+            b.iter(|| ZERO_HASH.serialize(&mut to).unwrap());
         })
         .bench_function("hydrate", |b| {
-            b.iter(|| TrieHash::hydrate(0, &store).unwrap());
+            b.iter(|| TrieHash::deserialize(0, &store).unwrap());
         });
 }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -201,7 +201,7 @@ impl DbHeader {
 }
 
 impl Storable for DbHeader {
-    fn hydrate<T: CachedStore>(addr: usize, mem: &T) -> Result<Self, shale::ShaleError> {
+    fn deserialize<T: CachedStore>(addr: usize, mem: &T) -> Result<Self, shale::ShaleError> {
         let raw = mem
             .get_view(addr, Self::MSIZE)
             .ok_or(ShaleError::InvalidCacheView {
@@ -213,11 +213,11 @@ impl Storable for DbHeader {
         })
     }
 
-    fn dehydrated_len(&self) -> u64 {
+    fn serialized_len(&self) -> u64 {
         Self::MSIZE
     }
 
-    fn dehydrate(&self, to: &mut [u8]) -> Result<(), ShaleError> {
+    fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
         let mut cur = Cursor::new(to);
         cur.write_all(&self.kv_root.to_le_bytes())?;
         Ok(())

--- a/firewood/src/merkle/trie_hash.rs
+++ b/firewood/src/merkle/trie_hash.rs
@@ -21,7 +21,7 @@ impl std::ops::Deref for TrieHash {
 }
 
 impl Storable for TrieHash {
-    fn hydrate<T: CachedStore>(addr: usize, mem: &T) -> Result<Self, ShaleError> {
+    fn deserialize<T: CachedStore>(addr: usize, mem: &T) -> Result<Self, ShaleError> {
         let raw = mem
             .get_view(addr, U64_TRIE_HASH_LEN)
             .ok_or(ShaleError::InvalidCacheView {
@@ -32,11 +32,11 @@ impl Storable for TrieHash {
         Ok(Self(raw.as_deref()[..TRIE_HASH_LEN].try_into().unwrap()))
     }
 
-    fn dehydrated_len(&self) -> u64 {
+    fn serialized_len(&self) -> u64 {
         U64_TRIE_HASH_LEN
     }
 
-    fn dehydrate(&self, mut to: &mut [u8]) -> Result<(), ShaleError> {
+    fn serialize(&self, mut to: &mut [u8]) -> Result<(), ShaleError> {
         to.write_all(&self.0).map_err(ShaleError::Io)
     }
 }
@@ -56,7 +56,7 @@ mod tests {
         let zero_hash = TrieHash([0u8; TRIE_HASH_LEN]);
 
         let mut to = [1u8; TRIE_HASH_LEN];
-        zero_hash.dehydrate(&mut to).unwrap();
+        zero_hash.serialize(&mut to).unwrap();
 
         assert_eq!(&to, &zero_hash.0);
     }

--- a/firewood/src/shale/disk_address.rs
+++ b/firewood/src/shale/disk_address.rs
@@ -165,17 +165,17 @@ impl DiskAddress {
 }
 
 impl Storable for DiskAddress {
-    fn dehydrated_len(&self) -> u64 {
+    fn serialized_len(&self) -> u64 {
         Self::MSIZE
     }
 
-    fn dehydrate(&self, to: &mut [u8]) -> Result<(), ShaleError> {
+    fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
         use std::io::{Cursor, Write};
         Cursor::new(to).write_all(&self.0.unwrap().get().to_le_bytes())?;
         Ok(())
     }
 
-    fn hydrate<U: CachedStore>(addr: usize, mem: &U) -> Result<Self, ShaleError> {
+    fn deserialize<U: CachedStore>(addr: usize, mem: &U) -> Result<Self, ShaleError> {
         let raw = mem
             .get_view(addr, Self::MSIZE)
             .ok_or(ShaleError::InvalidCacheView {


### PR DESCRIPTION
These names are more rust idiomatic.

Another option for these is serialize_for_storage, which might be helpful if we need serde implementations for these types.