### PR TITLE
make storable generic

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -67,7 +67,7 @@ fn bench_trie_hash(criterion: &mut Criterion) {
     criterion
         .benchmark_group("TrieHash")
         .bench_function("dehydrate", |b| {
-            b.iter(|| ZERO_HASH.serialize(&mut to).unwrap());
+            b.iter(|| ZERO_HASH.serialize(&mut to[..]).unwrap());
         })
         .bench_function("hydrate", |b| {
             b.iter(|| TrieHash::deserialize(0, &store).unwrap());

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -31,7 +31,7 @@ use std::{
     collections::VecDeque,
     error::Error,
     fmt,
-    io::{Cursor, ErrorKind, Write},
+    io::{ErrorKind, Write},
     mem::size_of,
     num::NonZeroUsize,
     ops::Deref,
@@ -217,9 +217,8 @@ impl Storable for DbHeader {
         Self::MSIZE
     }
 
-    fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
-        let mut cur = Cursor::new(to);
-        cur.write_all(&self.kv_root.to_le_bytes())?;
+    fn serialize<W: Write>(&self, mut to: W) -> Result<(), ShaleError> {
+        to.write_all(&self.kv_root.to_le_bytes())?;
         Ok(())
     }
 }

--- a/firewood/src/merkle/trie_hash.rs
+++ b/firewood/src/merkle/trie_hash.rs
@@ -36,7 +36,7 @@ impl Storable for TrieHash {
         U64_TRIE_HASH_LEN
     }
 
-    fn serialize(&self, mut to: &mut [u8]) -> Result<(), ShaleError> {
+    fn serialize<W: Write>(&self, mut to: W) -> Result<(), ShaleError> {
         to.write_all(&self.0).map_err(ShaleError::Io)
     }
 }
@@ -56,7 +56,7 @@ mod tests {
         let zero_hash = TrieHash([0u8; TRIE_HASH_LEN]);
 
         let mut to = [1u8; TRIE_HASH_LEN];
-        zero_hash.serialize(&mut to).unwrap();
+        zero_hash.serialize(&mut to[..]).unwrap();
 
         assert_eq!(&to, &zero_hash.0);
     }

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -6,7 +6,7 @@ use crate::shale::ObjCache;
 use super::disk_address::DiskAddress;
 use super::{CachedStore, Obj, ObjRef, ShaleError, ShaleStore, Storable, StoredView};
 use std::fmt::Debug;
-use std::io::{Cursor, Write};
+use std::io::Write;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, RwLock};
 
@@ -52,11 +52,11 @@ impl Storable for CompactHeader {
         Self::MSIZE
     }
 
-    fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
-        let mut cur = Cursor::new(to);
-        cur.write_all(&self.payload_size.to_le_bytes())?;
-        cur.write_all(&[if self.is_freed { 1 } else { 0 }])?;
-        cur.write_all(&self.desc_addr.to_le_bytes())?;
+    fn serialize<W: Write>(&self, mut to: W) -> Result<(), ShaleError> {
+        to.write_all(&self.payload_size.to_le_bytes())?;
+        to.write_all(&[if self.is_freed { 1 } else { 0 }])?;
+        to.write_all(&self.desc_addr.to_le_bytes())?;
+
         Ok(())
     }
 }
@@ -86,8 +86,8 @@ impl Storable for CompactFooter {
         Self::MSIZE
     }
 
-    fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
-        Cursor::new(to).write_all(&self.payload_size.to_le_bytes())?;
+    fn serialize<W: Write>(&self, mut to: W) -> Result<(), ShaleError> {
+        to.write_all(&self.payload_size.to_le_bytes())?;
         Ok(())
     }
 }
@@ -123,10 +123,9 @@ impl Storable for CompactDescriptor {
         Self::MSIZE
     }
 
-    fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
-        let mut cur = Cursor::new(to);
-        cur.write_all(&self.payload_size.to_le_bytes())?;
-        cur.write_all(&self.haddr.to_le_bytes())?;
+    fn serialize<W: Write>(&self, mut to: W) -> Result<(), ShaleError> {
+        to.write_all(&self.payload_size.to_le_bytes())?;
+        to.write_all(&self.haddr.to_le_bytes())?;
         Ok(())
     }
 }
@@ -203,12 +202,12 @@ impl Storable for CompactSpaceHeader {
         Self::MSIZE
     }
 
-    fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
-        let mut cur = Cursor::new(to);
-        cur.write_all(&self.meta_space_tail.to_le_bytes())?;
-        cur.write_all(&self.compact_space_tail.to_le_bytes())?;
-        cur.write_all(&self.base_addr.to_le_bytes())?;
-        cur.write_all(&self.alloc_addr.to_le_bytes())?;
+    fn serialize<W: Write>(&self, mut to: W) -> Result<(), ShaleError> {
+        to.write_all(&self.meta_space_tail.to_le_bytes())?;
+        to.write_all(&self.compact_space_tail.to_le_bytes())?;
+        to.write_all(&self.base_addr.to_le_bytes())?;
+        to.write_all(&self.alloc_addr.to_le_bytes())?;
+
         Ok(())
     }
 }
@@ -629,9 +628,8 @@ mod tests {
             Self::MSIZE
         }
 
-        fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
-            let mut cur = to;
-            cur.write_all(&self.0)?;
+        fn serialize<W: Write>(&self, mut to: W) -> Result<(), ShaleError> {
+            to.write_all(&self.0)?;
             Ok(())
         }
     }

--- a/firewood/src/shale/disk_address.rs
+++ b/firewood/src/shale/disk_address.rs
@@ -2,6 +2,7 @@
 // See the file LICENSE.md for licensing terms.
 
 use std::hash::Hash;
+use std::io::Write;
 use std::mem::size_of;
 use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
@@ -169,9 +170,8 @@ impl Storable for DiskAddress {
         Self::MSIZE
     }
 
-    fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
-        use std::io::{Cursor, Write};
-        Cursor::new(to).write_all(&self.0.unwrap().get().to_le_bytes())?;
+    fn serialize<W: Write>(&self, mut to: W) -> Result<(), ShaleError> {
+        to.write_all(&self.0.unwrap().get().to_le_bytes())?;
         Ok(())
     }
 

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -5,6 +5,7 @@ use disk_address::DiskAddress;
 use std::any::type_name;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Debug, Formatter};
+use std::io::Write;
 use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, RwLock, RwLockWriteGuard};
@@ -136,7 +137,7 @@ impl<T: Storable> Obj<T> {
     pub fn flush_dirty(&mut self) {
         if !self.value.is_mem_mapped() {
             if let Some(new_value_len) = self.dirty.take() {
-                let mut new_value = vec![0; new_value_len as usize];
+                let mut new_value = Vec::with_capacity(new_value_len as usize);
                 // TODO: log error
                 self.value.write_mem_image(&mut new_value).unwrap();
                 let offset = self.value.get_offset();
@@ -228,7 +229,7 @@ pub trait ShaleStore<T: Storable> {
 /// compression/decompression is needed to reduce disk I/O and facilitate faster in-memory access.
 pub trait Storable {
     fn serialized_len(&self) -> u64;
-    fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError>;
+    fn serialize<W: Write>(&self, to: W) -> Result<(), ShaleError>;
     fn deserialize<T: CachedStore>(addr: usize, mem: &T) -> Result<Self, ShaleError>
     where
         Self: Sized;
@@ -238,7 +239,7 @@ pub trait Storable {
 }
 
 pub fn to_dehydrated<S: Storable>(item: &S) -> Result<Vec<u8>, ShaleError> {
-    let mut buff = vec![0; item.serialized_len() as usize];
+    let mut buff = Vec::with_capacity(item.serialized_len() as usize);
     item.serialize(&mut buff)?;
     Ok(buff)
 }
@@ -296,7 +297,7 @@ impl<T: Storable> StoredView<T> {
         }
     }
 
-    fn write_mem_image(&self, mem_image: &mut [u8]) -> Result<(), ShaleError> {
+    fn write_mem_image<W: Write>(&self, mem_image: W) -> Result<(), ShaleError> {
         self.decoded.serialize(mem_image)
     }
 

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -237,7 +237,7 @@ pub trait Storable {
     }
 }
 
-pub fn to_dehydrated(item: &dyn Storable) -> Result<Vec<u8>, ShaleError> {
+pub fn to_dehydrated<S: Storable>(item: &S) -> Result<Vec<u8>, ShaleError> {
     let mut buff = vec![0; item.serialized_len() as usize];
     item.serialize(&mut buff)?;
     Ok(buff)


### PR DESCRIPTION
We were always using `Cursor` before, but we should be able to write to bytes to anything that implements the `std::io::Write` trait. 

- Make `to_dehydrated` generic
- Make `serialize` generic over Write
