### PR TITLE
Add path to Branch-Nodes (don't use Extension-Nodes)

### DIFF
--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -10,14 +10,12 @@ use crate::shale::CachedStore;
 use crate::{
     merkle::{TrieHash, TRIE_HASH_LEN},
     storage::{buffer::BufferWrite, AshRecord, StoreRevMut},
-    v2::api::{self, KeyType, ValueType},
+    v2::api::{self, Batch, BatchOp, KeyType, ValueType},
 };
 use async_trait::async_trait;
 use parking_lot::{Mutex, RwLock};
 use std::{io::ErrorKind, sync::Arc};
 use tokio::task::block_in_place;
-
-pub use crate::v2::api::{Batch, BatchOp};
 
 /// An atomic batch of changes proposed against the latest committed revision,
 /// or any existing [Proposal]. Multiple proposals can be created against the

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -512,7 +512,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
                         .chain(key_nibbles.clone())
                         .collect::<Vec<_>>();
 
-                    let overlap = Overlap::from(&n.path, &key_remainder);
+                    let overlap = PrefixOverlap::from(&n.path, &key_remainder);
 
                     #[allow(clippy::indexing_slicing)]
                     match (overlap.unique_a.len(), overlap.unique_b.len()) {
@@ -669,7 +669,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
                         .chain(key_nibbles.clone())
                         .collect::<Vec<_>>();
 
-                    let overlap = Overlap::from(&n.path, &key_remainder);
+                    let overlap = PrefixOverlap::from(&n.path, &key_remainder);
 
                     #[allow(clippy::indexing_slicing)]
                     match (overlap.unique_a.len(), overlap.unique_b.len()) {
@@ -1917,14 +1917,18 @@ pub fn from_nibbles(nibbles: &[u8]) -> impl Iterator<Item = u8> + '_ {
     nibbles.chunks_exact(2).map(|p| (p[0] << 4) | p[1])
 }
 
+/// The [`PrefixOverlap`] type represents the _shared_ and _unique_ parts of two potentially overlapping slices.
+/// As the type-name implies, the `shared` property only constitues a shared *prefix*.
+/// The `unique_*` properties, [`unique_a`][`PrefixOverlap::unique_a`] and [`unique_b`][`PrefixOverlap::unique_b`]
+/// are set based on the argument order passed into the [`from`][`PrefixOverlap::from`] constructor.
 #[derive(Debug)]
-struct Overlap<'a, T> {
+struct PrefixOverlap<'a, T> {
     shared: &'a [T],
     unique_a: &'a [T],
     unique_b: &'a [T],
 }
 
-impl<'a, T: PartialEq> Overlap<'a, T> {
+impl<'a, T: PartialEq> PrefixOverlap<'a, T> {
     fn from(a: &'a [T], b: &'a [T]) -> Self {
         let mut split_index = 0;
 

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -200,9 +200,9 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
         })
     }
 
-    pub fn root_hash(&self, root: DiskAddress) -> Result<TrieHash, MerkleError> {
+    pub fn root_hash(&self, sentinel: DiskAddress) -> Result<TrieHash, MerkleError> {
         let root = self
-            .get_node(root)?
+            .get_node(sentinel)?
             .inner
             .as_branch()
             .ok_or(MerkleError::NotBranchNode)?
@@ -1396,7 +1396,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
         };
 
         for ptr in deleted.into_iter() {
-            self.free_node(dbg!(ptr))?;
+            self.free_node(ptr)?;
         }
 
         Ok(data.map(|data| data.0))

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -110,7 +110,10 @@ where
     fn encode(&self, node: &NodeObjRef) -> Result<Vec<u8>, MerkleError> {
         let encoded = match node.inner() {
             NodeType::Leaf(n) => EncodedNode::new(EncodedNodeType::Leaf(n.clone())),
+
             NodeType::Branch(n) => {
+                let path = n.path.clone();
+
                 // pair up DiskAddresses with encoded children and pick the right one
                 let encoded_children = n.chd().iter().zip(n.children_encoded.iter());
                 let children = encoded_children
@@ -127,6 +130,7 @@ where
                     .expect("MAX_CHILDREN will always be yielded");
 
                 EncodedNode::new(EncodedNodeType::Branch {
+                    path,
                     children,
                     value: n.value.clone(),
                 })
@@ -145,13 +149,19 @@ where
 
         match encoded.node {
             EncodedNodeType::Leaf(leaf) => Ok(NodeType::Leaf(leaf)),
-            EncodedNodeType::Branch { children, value } => {
-                let path = Vec::new().into();
+            EncodedNodeType::Branch {
+                path,
+                children,
+                value,
+            } => {
+                let path = PartialPath::decode(&path).0;
                 let value = value.map(|v| v.0);
-                Ok(NodeType::Branch(
+                let branch = NodeType::Branch(
                     BranchNode::new(path, [None; BranchNode::MAX_CHILDREN], value, *children)
                         .into(),
-                ))
+                );
+
+                Ok(branch)
             }
         }
     }
@@ -162,7 +172,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
         self.store
             .put_item(
                 Node::from_branch(BranchNode {
-                    // path: vec![].into(),
+                    path: vec![].into(),
                     children: [None; BranchNode::MAX_CHILDREN],
                     value: None,
                     children_encoded: Default::default(),
@@ -213,14 +223,14 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
 
     fn dump_(&self, u: DiskAddress, w: &mut dyn Write) -> Result<(), MerkleError> {
         let u_ref = self.get_node(u)?;
-        write!(
-            w,
-            "{u:?} => {}: ",
-            match u_ref.root_hash.get() {
-                Some(h) => hex::encode(**h),
-                None => "<lazy>".to_string(),
-            }
-        )?;
+
+        let hash = match u_ref.root_hash.get() {
+            Some(h) => h,
+            None => u_ref.get_root_hash::<S>(self.store.as_ref()),
+        };
+
+        write!(w, "{u:?} => {}: ", hex::encode(**hash))?;
+
         match &u_ref.inner {
             NodeType::Branch(n) => {
                 writeln!(w, "{n:?}")?;
@@ -235,6 +245,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
                 self.dump_(n.chd(), w)?
             }
         }
+
         Ok(())
     }
 
@@ -247,17 +258,18 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
         Ok(())
     }
 
+    // TODO: replace `split` with a `split_at` function. Handle the logic for matching paths in `insert` instead.
     #[allow(clippy::too_many_arguments)]
-    fn split(
-        &self,
-        mut node_to_split: NodeObjRef,
-        parents: &mut [(NodeObjRef, u8)],
+    fn split<'a>(
+        &'a self,
+        mut node_to_split: NodeObjRef<'a>,
+        parents: &mut [(NodeObjRef<'a>, u8)],
         insert_path: &[u8],
         n_path: Vec<u8>,
         n_value: Option<Data>,
         val: Vec<u8>,
         deleted: &mut Vec<DiskAddress>,
-    ) -> Result<Option<Vec<u8>>, MerkleError> {
+    ) -> Result<Option<(NodeObjRef<'a>, Vec<u8>)>, MerkleError> {
         let node_to_split_address = node_to_split.as_ptr();
         let split_index = insert_path
             .iter()
@@ -303,31 +315,19 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
             (chd[n_path[idx] as usize] = Some(address));
 
             let new_branch = Node::from_branch(BranchNode {
-                // path: PartialPath(matching_path[..idx].to_vec()),
+                path: PartialPath(matching_path[..idx].to_vec()),
                 children: chd,
                 value: None,
                 children_encoded: Default::default(),
             });
 
-            let new_branch_address = self.put_node(new_branch)?.as_ptr();
-
-            if idx > 0 {
-                self.put_node(Node::from(NodeType::Extension(ExtNode {
-                    #[allow(clippy::indexing_slicing)]
-                    path: PartialPath(matching_path[..idx].to_vec()),
-                    child: new_branch_address,
-                    child_encoded: None,
-                })))?
-                .as_ptr()
-            } else {
-                new_branch_address
-            }
+            self.put_node(new_branch)?.as_ptr()
         } else {
             // paths do not diverge
             let (leaf_address, prefix, idx, value) =
                 match (insert_path.len().cmp(&n_path.len()), n_value) {
                     // no node-value means this is an extension node and we can therefore continue walking the tree
-                    (Ordering::Greater, None) => return Ok(Some(val)),
+                    (Ordering::Greater, None) => return Ok(Some((node_to_split, val))),
 
                     // if the paths are equal, we overwrite the data
                     (Ordering::Equal, _) => {
@@ -368,7 +368,9 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
                                             result = Err(e);
                                         }
                                     }
-                                    NodeType::Branch(_) => unreachable!(),
+                                    NodeType::Branch(u) => {
+                                        u.value = Some(Data(val));
+                                    }
                                 }
 
                                 u.rehash();
@@ -440,24 +442,13 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
             #[allow(clippy::indexing_slicing)]
             (children[idx] = leaf_address.into());
 
-            let branch_address = self
-                .put_node(Node::from_branch(BranchNode {
-                    children,
-                    value,
-                    children_encoded: Default::default(),
-                }))?
-                .as_ptr();
-
-            if !prefix.is_empty() {
-                self.put_node(Node::from(NodeType::Extension(ExtNode {
-                    path: PartialPath(prefix.to_vec()),
-                    child: branch_address,
-                    child_encoded: None,
-                })))?
-                .as_ptr()
-            } else {
-                branch_address
-            }
+            self.put_node(Node::from_branch(BranchNode {
+                path: PartialPath(prefix.to_vec()),
+                children,
+                value,
+                children_encoded: Default::default(),
+            }))?
+            .as_ptr()
         };
 
         // observation:
@@ -509,7 +500,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
         // walk down the merkle tree starting from next_node, currently the root
         // return None if the value is inserted
         let next_node_and_val = loop {
-            let Some(current_nibble) = key_nibbles.next() else {
+            let Some(mut next_nibble) = key_nibbles.next() else {
                 break Some((node, val));
             };
 
@@ -518,28 +509,136 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
                 // to another node, we walk down that. Otherwise, we can store our
                 // value as a leaf and we're done
                 NodeType::Leaf(n) => {
-                    // we collided with another key; make a copy
-                    // of the stored key to pass into split
-                    let n_path = n.path.to_vec();
-                    let n_value = Some(n.data.clone());
-                    let rem_path = once(current_nibble).chain(key_nibbles).collect::<Vec<_>>();
+                    // TODO: avoid extra allocation
+                    let key_remainder = once(next_nibble)
+                        .chain(key_nibbles.clone())
+                        .collect::<Vec<_>>();
 
-                    self.split(
-                        node,
-                        &mut parents,
-                        &rem_path,
-                        n_path,
-                        n_value,
-                        val,
-                        &mut deleted,
-                    )?;
+                    let overlap = Overlap::from(&n.path, &key_remainder);
+
+                    match (overlap.unique_a.len(), overlap.unique_b.len()) {
+                        // same node, overwrite the data
+                        (0, 0) => {
+                            node.write(|node| {
+                                *node.inner.data_mut() = Data(val);
+                                node.rehash();
+                            })?;
+                        }
+
+                        // new node is a child of the old node
+                        (0, _) => {
+                            let (new_leaf_index, new_leaf_path) = {
+                                let (index, path) = overlap.unique_b.split_at(1);
+                                (index[0], path.to_vec())
+                            };
+
+                            let new_leaf = Node::from_leaf(LeafNode::new(
+                                PartialPath(new_leaf_path),
+                                Data(val),
+                            ));
+
+                            let new_leaf = self.put_node(new_leaf)?.as_ptr();
+
+                            let mut children = [None; BranchNode::MAX_CHILDREN];
+                            children[new_leaf_index as usize] = Some(new_leaf);
+
+                            let new_branch = BranchNode {
+                                path: PartialPath(overlap.shared.to_vec()),
+                                children,
+                                value: n.data.clone().into(),
+                                children_encoded: Default::default(),
+                            };
+
+                            let new_branch = Node::from_branch(new_branch);
+
+                            let new_branch = self.put_node(new_branch)?.as_ptr();
+
+                            set_parent(new_branch, &mut parents);
+
+                            deleted.push(node.as_ptr());
+                        }
+
+                        // old node is a child of the new node
+                        (_, 0) => {
+                            let (old_leaf_index, old_leaf_path) = {
+                                let (index, path) = overlap.unique_a.split_at(1);
+                                (index[0], path.to_vec())
+                            };
+
+                            let new_branch_path = overlap.shared.to_vec();
+
+                            node.write(move |old_leaf| {
+                                *old_leaf.inner.path_mut() = PartialPath(old_leaf_path.to_vec());
+                                old_leaf.rehash();
+                            })?;
+
+                            let old_leaf = node.as_ptr();
+
+                            let mut new_branch = BranchNode {
+                                path: PartialPath(new_branch_path),
+                                children: [None; BranchNode::MAX_CHILDREN],
+                                value: Some(val.into()),
+                                children_encoded: Default::default(),
+                            };
+
+                            new_branch.children[old_leaf_index as usize] = Some(old_leaf);
+
+                            let node = Node::from_branch(new_branch);
+                            let node = self.put_node(node)?.as_ptr();
+
+                            set_parent(node, &mut parents);
+                        }
+
+                        // nodes are siblings
+                        _ => {
+                            let (old_leaf_index, old_leaf_path) = {
+                                let (index, path) = overlap.unique_a.split_at(1);
+                                (index[0], path.to_vec())
+                            };
+
+                            let (new_leaf_index, new_leaf_path) = {
+                                let (index, path) = overlap.unique_b.split_at(1);
+                                (index[0], path.to_vec())
+                            };
+
+                            let new_branch_path = overlap.shared.to_vec();
+
+                            node.write(move |old_leaf| {
+                                *old_leaf.inner.path_mut() = PartialPath(old_leaf_path.to_vec());
+                                old_leaf.rehash();
+                            })?;
+
+                            let new_leaf = Node::from_leaf(LeafNode::new(
+                                PartialPath(new_leaf_path),
+                                Data(val),
+                            ));
+
+                            let old_leaf = node.as_ptr();
+
+                            let new_leaf = self.put_node(new_leaf)?.as_ptr();
+
+                            let mut new_branch = BranchNode {
+                                path: PartialPath(new_branch_path),
+                                children: [None; BranchNode::MAX_CHILDREN],
+                                value: None,
+                                children_encoded: Default::default(),
+                            };
+
+                            new_branch.children[old_leaf_index as usize] = Some(old_leaf);
+                            new_branch.children[new_leaf_index as usize] = Some(new_leaf);
+
+                            let node = Node::from_branch(new_branch);
+                            let node = self.put_node(node)?.as_ptr();
+
+                            set_parent(node, &mut parents);
+                        }
+                    }
 
                     break None;
                 }
 
-                NodeType::Branch(n) => {
-                    #[allow(clippy::indexing_slicing)]
-                    match n.children[current_nibble as usize] {
+                NodeType::Branch(n) if n.path.len() == 0 => {
+                    match n.children[next_nibble as usize] {
                         Some(c) => (node, c),
                         None => {
                             // insert the leaf to the empty slot
@@ -553,9 +652,9 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
                             // set the current child to point to this leaf
                             #[allow(clippy::unwrap_used)]
                             node.write(|u| {
-                                let uu = u.inner.as_branch_mut().unwrap();
                                 #[allow(clippy::indexing_slicing)]
-                                (uu.children[current_nibble as usize] = Some(leaf_ptr));
+                                let uu = u.inner.as_branch_mut().unwrap();
+                                uu.children[next_nibble as usize] = Some(leaf_ptr);
                                 u.rehash();
                             })
                             .unwrap();
@@ -565,16 +664,151 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
                     }
                 }
 
+                NodeType::Branch(n) => {
+                    // TODO: avoid extra allocation
+                    let key_remainder = once(next_nibble)
+                        .chain(key_nibbles.clone())
+                        .collect::<Vec<_>>();
+
+                    let overlap = Overlap::from(&n.path, &key_remainder);
+
+                    match (overlap.unique_a.len(), overlap.unique_b.len()) {
+                        // same node, overwrite the data
+                        (0, 0) => {
+                            node.write(|node| {
+                                *node.inner.data_mut() = Data(val);
+                                node.rehash();
+                            })?;
+
+                            break None;
+                        }
+
+                        // new node is a child of the old node
+                        (0, _) => {
+                            let (new_leaf_index, new_leaf_path) = {
+                                let (index, path) = overlap.unique_b.split_at(1);
+                                (index[0], path)
+                            };
+
+                            (0..overlap.shared.len()).for_each(|_| {
+                                key_nibbles.next();
+                            });
+
+                            next_nibble = new_leaf_index;
+
+                            match n.children[next_nibble as usize] {
+                                Some(ptr) => (node, ptr),
+                                None => {
+                                    let new_leaf = Node::from_leaf(LeafNode::new(
+                                        PartialPath(new_leaf_path.to_vec()),
+                                        Data(val),
+                                    ));
+
+                                    let new_leaf = self.put_node(new_leaf)?.as_ptr();
+                                    node.write(|node| {
+                                        let branch = node.inner.as_branch_mut().unwrap();
+                                        branch.children[next_nibble as usize] = Some(new_leaf);
+
+                                        node.rehash();
+                                    })?;
+
+                                    break None;
+                                }
+                            }
+                        }
+
+                        // old node is a child of the new node
+                        (_, 0) => {
+                            let (old_branch_index, old_branch_path) = {
+                                let (index, path) = overlap.unique_a.split_at(1);
+                                (index[0], path.to_vec())
+                            };
+
+                            let new_branch_path = overlap.shared.to_vec();
+
+                            node.write(move |old_branch| {
+                                *old_branch.inner.path_mut() =
+                                    PartialPath(old_branch_path.to_vec());
+                                old_branch.rehash();
+                            })?;
+
+                            let old_branch = node.as_ptr();
+
+                            let mut new_branch = BranchNode {
+                                path: PartialPath(new_branch_path),
+                                children: [None; BranchNode::MAX_CHILDREN],
+                                value: Some(val.into()),
+                                children_encoded: Default::default(),
+                            };
+
+                            new_branch.children[old_branch_index as usize] = Some(old_branch);
+
+                            let node = Node::from_branch(new_branch);
+                            let node = self.put_node(node)?.as_ptr();
+
+                            set_parent(node, &mut parents);
+
+                            break None;
+                        }
+
+                        // nodes are siblings
+                        _ => {
+                            let (old_branch_index, old_branch_path) = {
+                                let (index, path) = overlap.unique_a.split_at(1);
+                                (index[0], path.to_vec())
+                            };
+
+                            let (new_leaf_index, new_leaf_path) = {
+                                let (index, path) = overlap.unique_b.split_at(1);
+                                (index[0], path.to_vec())
+                            };
+
+                            let new_branch_path = overlap.shared.to_vec();
+
+                            node.write(move |old_branch| {
+                                *old_branch.inner.path_mut() =
+                                    PartialPath(old_branch_path.to_vec());
+                                old_branch.rehash();
+                            })?;
+
+                            let new_leaf = Node::from_leaf(LeafNode::new(
+                                PartialPath(new_leaf_path),
+                                Data(val),
+                            ));
+
+                            let old_branch = node.as_ptr();
+
+                            let new_leaf = self.put_node(new_leaf)?.as_ptr();
+
+                            let mut new_branch = BranchNode {
+                                path: PartialPath(new_branch_path),
+                                children: [None; BranchNode::MAX_CHILDREN],
+                                value: None,
+                                children_encoded: Default::default(),
+                            };
+
+                            new_branch.children[old_branch_index as usize] = Some(old_branch);
+                            new_branch.children[new_leaf_index as usize] = Some(new_leaf);
+
+                            let node = Node::from_branch(new_branch);
+                            let node = self.put_node(node)?.as_ptr();
+
+                            set_parent(node, &mut parents);
+
+                            break None;
+                        }
+                    }
+                }
+
                 NodeType::Extension(n) => {
                     let n_path = n.path.to_vec();
                     let n_ptr = n.chd();
-                    let rem_path = once(current_nibble)
+                    let rem_path = once(next_nibble)
                         .chain(key_nibbles.clone())
                         .collect::<Vec<_>>();
                     let n_path_len = n_path.len();
-                    let node_ptr = node.as_ptr();
 
-                    if let Some(v) = self.split(
+                    if let Some((node, v)) = self.split(
                         node,
                         &mut parents,
                         &rem_path,
@@ -592,7 +826,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
                         // extension node's next pointer
                         val = v;
 
-                        (self.get_node(node_ptr)?, n_ptr)
+                        (node, n_ptr)
                     } else {
                         // successfully inserted
                         break None;
@@ -601,7 +835,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
             };
 
             // push another parent, and follow the next pointer
-            parents.push((node_ref, current_nibble));
+            parents.push((node_ref, next_nibble));
             node = self.get_node(next_node_ptr)?;
         };
 
@@ -674,7 +908,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
 
                 let branch = self
                     .put_node(Node::from_branch(BranchNode {
-                        // path: vec![].into(),
+                        path: vec![].into(),
                         children: chd,
                         value: Some(Data(val)),
                         children_encoded: Default::default(),
@@ -1000,6 +1234,183 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
             return Ok(None);
         }
 
+        let mut deleted = Vec::new();
+
+        let data = {
+            let (node, mut parents) =
+                self.get_node_and_parents_by_key(self.get_node(root)?, key)?;
+
+            let Some(node) = node else {
+                return Ok(None);
+            };
+
+            let data = match &node.inner {
+                NodeType::Branch(n) => {
+                    let data = n.value.clone();
+
+                    if data.is_none() {
+                        return Ok(None);
+                    }
+
+                    // TODO: fix mutability issue here
+                    let mut node = self.get_node(node.as_ptr())?;
+
+                    node.write(|branch| {
+                        branch.inner.as_branch_mut().unwrap().value = None;
+                    })?;
+
+                    let branch = node.inner.as_branch().unwrap();
+
+                    let children: Vec<_> = branch
+                        .children
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(i, child)| child.map(|child| (i, child)))
+                        .collect();
+
+                    // don't change the sentinal node
+                    if children.len() == 1 && !parents.is_empty() {
+                        let branch_path = &branch.path.0;
+
+                        let (child_index, child) = children[0];
+                        let mut child = self.get_node(child)?;
+
+                        child.write(|child| {
+                            let child_path = child.inner.path_mut();
+                            let path = branch_path
+                                .iter()
+                                .copied()
+                                .chain(once(child_index as u8))
+                                .chain(child_path.0.iter().copied())
+                                .collect();
+                            *child_path = PartialPath(path);
+
+                            child.rehash();
+                        })?;
+
+                        set_parent(child.as_ptr(), &mut parents);
+
+                        deleted.push(node.as_ptr());
+                    } else {
+                        node.write(|node| node.rehash())?
+                    }
+
+                    data
+                }
+
+                NodeType::Leaf(n) => {
+                    let data = Some(n.data.clone());
+
+                    // TODO: handle unwrap better
+                    deleted.push(node.as_ptr());
+
+                    let (mut parent, child_index) = parents.pop().unwrap();
+
+                    parent.write(|parent| {
+                        parent.inner.as_branch_mut().unwrap().children[child_index as usize] = None;
+                    })?;
+
+                    let branch = parent.inner.as_branch().unwrap();
+
+                    let children: Vec<_> = branch
+                        .children
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(i, child)| child.map(|child| (i, child)))
+                        .collect();
+
+                    match (children.len(), &branch.value, !parents.is_empty()) {
+                        // node is invalid, all single-child nodes should have data
+                        (1, None, true) => {
+                            let parent_path = &branch.path.0;
+
+                            let (child_index, child) = children[0];
+                            let child = self.get_node(child)?;
+
+                            // TODO:
+                            // there's an optimization here for when the paths are the same length
+                            // and that clone isn't great but ObjRef causes problems
+                            // we can't write directly to the child because we could be changing its size
+                            let new_child = match child.inner.clone() {
+                                NodeType::Branch(mut child) => {
+                                    let path = parent_path
+                                        .iter()
+                                        .copied()
+                                        .chain(once(child_index as u8))
+                                        .chain(child.path.0.iter().copied())
+                                        .collect();
+
+                                    child.path = PartialPath(path);
+
+                                    Node::from_branch(child)
+                                }
+                                NodeType::Leaf(mut child) => {
+                                    let path = parent_path
+                                        .iter()
+                                        .copied()
+                                        .chain(once(child_index as u8))
+                                        .chain(child.path.0.iter().copied())
+                                        .collect();
+
+                                    child.path = PartialPath(path);
+
+                                    Node::from_leaf(child)
+                                }
+                                NodeType::Extension(_) => todo!(),
+                            };
+
+                            let child = self.put_node(new_child)?.as_ptr();
+
+                            set_parent(child, &mut parents);
+
+                            deleted.push(parent.as_ptr());
+                        }
+
+                        // branch nodes shouldn't have no children
+                        (0, Some(data), true) => {
+                            let leaf = Node::from_leaf(LeafNode::new(
+                                PartialPath(branch.path.0.clone()),
+                                data.clone(),
+                            ));
+
+                            let leaf = self.put_node(leaf)?.as_ptr();
+                            set_parent(leaf, &mut parents);
+
+                            deleted.push(parent.as_ptr());
+                        }
+
+                        _ => parent.write(|parent| parent.rehash())?,
+                    }
+
+                    data
+                }
+
+                NodeType::Extension(_) => todo!(),
+            };
+
+            for (mut parent, _) in parents {
+                parent.write(|u| u.rehash())?;
+            }
+
+            data
+        };
+
+        for ptr in deleted.into_iter() {
+            self.free_node(dbg!(ptr))?;
+        }
+
+        Ok(data.map(|data| data.0))
+    }
+
+    pub fn remove_old<K: AsRef<[u8]>>(
+        &mut self,
+        key: K,
+        root: DiskAddress,
+    ) -> Result<Option<Vec<u8>>, MerkleError> {
+        if root.is_null() {
+            return Ok(None);
+        }
+
         let (found, parents, deleted) = {
             let (node_ref, mut parents) =
                 self.get_node_and_parents_by_key(self.get_node(root)?, key)?;
@@ -1136,7 +1547,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
         let mut key_nibbles = Nibbles::<1>::new(key.as_ref()).into_iter();
 
         loop {
-            let Some(nib) = key_nibbles.next() else {
+            let Some(mut nib) = key_nibbles.next() else {
                 break;
             };
 
@@ -1144,10 +1555,36 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
 
             let next_ptr = match &node_ref.inner {
                 #[allow(clippy::indexing_slicing)]
-                NodeType::Branch(n) => match n.children[nib as usize] {
+                NodeType::Branch(n) if n.path.len() == 0 => match n.children[nib as usize] {
                     Some(c) => c,
                     None => return Ok(None),
                 },
+                NodeType::Branch(n) => {
+                    let mut n_path_iter = n.path.iter().copied();
+
+                    if n_path_iter.next() != Some(nib) {
+                        return Ok(None);
+                    }
+
+                    let path_matches = n_path_iter
+                        .map(Some)
+                        .all(|n_path_nibble| key_nibbles.next() == n_path_nibble);
+
+                    if !path_matches {
+                        return Ok(None);
+                    }
+
+                    nib = if let Some(nib) = key_nibbles.next() {
+                        nib
+                    } else {
+                        break;
+                    };
+
+                    match n.children[nib as usize] {
+                        Some(c) => c,
+                        None => return Ok(None),
+                    }
+                }
                 NodeType::Leaf(n) => {
                     let node_ref = if once(nib).chain(key_nibbles).eq(n.path.iter().copied()) {
                         Some(node_ref)
@@ -1472,6 +1909,36 @@ pub fn from_nibbles(nibbles: &[u8]) -> impl Iterator<Item = u8> + '_ {
     nibbles.chunks_exact(2).map(|p| (p[0] << 4) | p[1])
 }
 
+#[derive(Debug)]
+struct Overlap<'a, T> {
+    shared: &'a [T],
+    unique_a: &'a [T],
+    unique_b: &'a [T],
+}
+
+impl<'a, T: PartialEq> Overlap<'a, T> {
+    fn from(a: &'a [T], b: &'a [T]) -> Self {
+        let mut split_index = 0;
+
+        for i in 0..std::cmp::min(a.len(), b.len()) {
+            if a[i] != b[i] {
+                break;
+            }
+
+            split_index += 1;
+        }
+
+        let (shared, unique_a) = a.split_at(split_index);
+        let (_, unique_b) = b.split_at(split_index);
+
+        Self {
+            shared,
+            unique_a,
+            unique_b,
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
@@ -1542,9 +2009,14 @@ mod tests {
         create_generic_test_merkle::<Bincode>()
     }
 
-    fn branch(value: Option<Vec<u8>>, encoded_child: Option<Vec<u8>>) -> Node {
+    fn branch(path: &[u8], value: &[u8], encoded_child: Option<Vec<u8>>) -> Node {
+        let (path, value) = (path.to_vec(), value.to_vec());
+        let path = Nibbles::<0>::new(&path);
+        let path = PartialPath(path.into_iter().collect());
+
         let children = Default::default();
-        let value = value.map(Data);
+        // TODO: Properly test empty data as a value
+        let value = Some(value).map(Data);
         let mut children_encoded = <[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>::default();
 
         if let Some(child) = encoded_child {
@@ -1552,7 +2024,29 @@ mod tests {
         }
 
         Node::from_branch(BranchNode {
-            // path: vec![].into(),
+            path,
+            children,
+            value,
+            children_encoded,
+        })
+    }
+
+    fn branch_without_data(path: &[u8], encoded_child: Option<Vec<u8>>) -> Node {
+        let path = path.to_vec();
+        let path = Nibbles::<0>::new(&path);
+        let path = PartialPath(path.into_iter().collect());
+
+        let children = Default::default();
+        // TODO: Properly test empty data as a value
+        let value = None;
+        let mut children_encoded = <[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>::default();
+
+        if let Some(child) = encoded_child {
+            children_encoded[0] = Some(child);
+        }
+
+        Node::from_branch(BranchNode {
+            path,
             children,
             value,
             children_encoded,
@@ -1561,11 +2055,19 @@ mod tests {
 
     #[test_case(leaf(Vec::new(), Vec::new()) ; "empty leaf encoding")]
     #[test_case(leaf(vec![1, 2, 3], vec![4, 5]) ; "leaf encoding")]
-    #[test_case(branch(Some(b"value".to_vec()), vec![1, 2, 3].into()) ; "branch with chd")]
-    #[test_case(branch(Some(b"value".to_vec()), None); "branch without chd")]
-    #[test_case(branch(None, None); "branch without value and chd")]
+    #[test_case(branch(b"", b"value", vec![1, 2, 3].into()) ; "branch with chd")]
+    #[test_case(branch(b"", b"value", None); "branch without chd")]
+    #[test_case(branch_without_data(b"", None); "branch without value and chd")]
+    #[test_case(branch(b"", b"", None); "branch without path value or children")]
+    #[test_case(branch(b"", b"value", None) ; "branch with value")]
+    #[test_case(branch(&[2], b"", None); "branch with path")]
+    #[test_case(branch(b"", b"", vec![1, 2, 3].into()); "branch with children")]
+    #[test_case(branch(&[2], b"value", None); "branch with path and value")]
+    #[test_case(branch(b"", b"value", vec![1, 2, 3].into()); "branch with value and children")]
+    #[test_case(branch(&[2], b"", vec![1, 2, 3].into()); "branch with path and children")]
+    #[test_case(branch(&[2], b"value", vec![1, 2, 3].into()); "branch with path value and children")]
     #[test_case(extension(vec![1, 2, 3], DiskAddress::null(), vec![4, 5].into()) ; "extension without child address")]
-    fn encode_(node: Node) {
+    fn encode(node: Node) {
         let merkle = create_test_merkle();
 
         let node_ref = merkle.put_node(node).unwrap();
@@ -1578,14 +2080,14 @@ mod tests {
 
     #[test_case(Bincode::new(), leaf(Vec::new(), Vec::new()) ; "empty leaf encoding with Bincode")]
     #[test_case(Bincode::new(), leaf(vec![1, 2, 3], vec![4, 5]) ; "leaf encoding with Bincode")]
-    #[test_case(Bincode::new(), branch(Some(b"value".to_vec()), vec![1, 2, 3].into()) ; "branch with chd with Bincode")]
-    #[test_case(Bincode::new(), branch(Some(b"value".to_vec()), None); "branch without chd with Bincode")]
-    #[test_case(Bincode::new(), branch(None, None); "branch without value and chd with Bincode")]
+    #[test_case(Bincode::new(), branch(b"", b"value", vec![1, 2, 3].into()) ; "branch with chd with Bincode")]
+    #[test_case(Bincode::new(), branch(b"", b"value", None); "branch without chd with Bincode")]
+    #[test_case(Bincode::new(), branch_without_data(b"", None); "branch without value and chd with Bincode")]
     #[test_case(PlainCodec::new(), leaf(Vec::new(), Vec::new()) ; "empty leaf encoding with PlainCodec")]
     #[test_case(PlainCodec::new(), leaf(vec![1, 2, 3], vec![4, 5]) ; "leaf encoding with PlainCodec")]
-    #[test_case(PlainCodec::new(), branch(Some(b"value".to_vec()), vec![1, 2, 3].into()) ; "branch with chd with PlainCodec")]
-    #[test_case(PlainCodec::new(), branch(Some(b"value".to_vec()), Some(Vec::new())); "branch with empty chd with PlainCodec")]
-    #[test_case(PlainCodec::new(), branch(Some(Vec::new()), vec![1, 2, 3].into()); "branch with empty value with PlainCodec")]
+    #[test_case(PlainCodec::new(), branch(b"", b"value", vec![1, 2, 3].into()) ; "branch with chd with PlainCodec")]
+    #[test_case(PlainCodec::new(), branch(b"", b"value", Some(Vec::new())); "branch with empty chd with PlainCodec")]
+    #[test_case(PlainCodec::new(), branch(b"", b"", vec![1, 2, 3].into()); "branch with empty value with PlainCodec")]
     fn node_encode_decode<T>(_codec: T, node: Node)
     where
         T: BinarySerde,
@@ -1645,6 +2147,60 @@ mod tests {
     }
 
     #[test]
+    fn long_insert_and_retrieve_multiple() {
+        let key_val: Vec<(&'static [u8], _)> = vec![
+            (
+                &[0, 0, 0, 1, 0, 101, 151, 236],
+                [16, 15, 159, 195, 34, 101, 227, 73],
+            ),
+            (
+                &[0, 0, 1, 107, 198, 92, 205],
+                [26, 147, 21, 200, 138, 106, 137, 218],
+            ),
+            (&[0, 1, 0, 1, 0, 56], [194, 147, 168, 193, 19, 226, 51, 204]),
+            (&[1, 90], [101, 38, 25, 65, 181, 79, 88, 223]),
+            (
+                &[1, 1, 1, 0, 0, 0, 1, 59],
+                [105, 173, 182, 126, 67, 166, 166, 196],
+            ),
+            (
+                &[0, 1, 0, 0, 1, 1, 55, 33, 38, 194],
+                [90, 140, 160, 53, 230, 100, 237, 236],
+            ),
+            (
+                &[1, 1, 0, 1, 249, 46, 69],
+                [16, 104, 134, 6, 57, 46, 200, 35],
+            ),
+            (
+                &[1, 1, 0, 1, 0, 0, 1, 33, 163],
+                [95, 97, 187, 124, 198, 28, 75, 226],
+            ),
+            (
+                &[1, 1, 0, 1, 0, 57, 156],
+                [184, 18, 69, 29, 96, 252, 188, 58],
+            ),
+            (&[1, 0, 1, 1, 0, 218], [155, 38, 43, 54, 93, 134, 73, 209]),
+        ];
+
+        let mut merkle = create_test_merkle();
+        let root = merkle.init_root().unwrap();
+
+        for (key, val) in &key_val {
+            merkle.insert(key, val.to_vec(), root).unwrap();
+
+            let fetched_val = merkle.get(key, root).unwrap();
+
+            assert_eq!(fetched_val.as_deref(), val.as_slice().into());
+        }
+
+        for (key, val) in key_val {
+            let fetched_val = merkle.get(key, root).unwrap();
+
+            assert_eq!(fetched_val.as_deref(), val.as_slice().into());
+        }
+    }
+
+    #[test]
     fn remove_one() {
         let key = b"hello";
         let val = b"world";
@@ -1689,7 +2245,14 @@ mod tests {
             let key = &[key_val];
             let val = &[key_val];
 
-            let removed_val = merkle.remove(key, root).unwrap();
+            if key_val == 254 {
+                dbg!("hello");
+            }
+
+            let Ok(removed_val) = merkle.remove(key, root) else {
+                dbg!(key_val);
+                panic!();
+            };
             assert_eq!(removed_val.as_deref(), val.as_slice().into());
 
             let fetched_val = merkle.get(key, root).unwrap();

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -17,6 +17,7 @@ pub mod proof;
 mod stream;
 mod trie_hash;
 
+use node::write_branch;
 pub use node::{
     BinarySerde, Bincode, BranchNode, Data, EncodedNode, EncodedNodeType, ExtNode, LeafNode, Node,
     NodeType, PartialPath,
@@ -24,8 +25,6 @@ pub use node::{
 pub use proof::{Proof, ProofError};
 pub use stream::MerkleKeyValueStream;
 pub use trie_hash::{TrieHash, TRIE_HASH_LEN};
-
-use self::node::write_branch;
 
 type NodeObjRef<'a> = shale::ObjRef<'a, Node>;
 type ParentRefs<'a> = Vec<(NodeObjRef<'a>, u8)>;
@@ -2269,14 +2268,10 @@ mod tests {
             let key = &[key_val];
             let val = &[key_val];
 
-            if key_val == 254 {
-                dbg!("hello");
-            }
-
             let Ok(removed_val) = merkle.remove(key, root) else {
-                dbg!(key_val);
-                panic!();
+                panic!("({key_val}, {key_val}) missing");
             };
+
             assert_eq!(removed_val.as_deref(), val.as_slice().into());
 
             let fetched_val = merkle.get(key, root).unwrap();

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -331,15 +331,11 @@ impl Node {
     pub(super) fn set_dirty(&self, is_dirty: bool) {
         self.lazy_dirty.store(is_dirty, Ordering::Relaxed)
     }
-}
 
-pub(crate) fn write_branch<F: FnOnce(&mut Box<BranchNode>)>(f: F) -> impl FnOnce(&mut Node) {
-    move |node| {
-        let node = node
-            .inner_mut()
+    pub(crate) fn as_branch_mut(&mut self) -> &mut Box<BranchNode> {
+        self.inner_mut()
             .as_branch_mut()
-            .expect("must be a branch node");
-        f(node);
+            .expect("must be a branch node")
     }
 }
 

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -91,6 +91,13 @@ impl<T: DeserializeOwned + AsRef<[u8]>> Encoded<T> {
             Encoded::Data(data) => bincode::DefaultOptions::new().deserialize(data.as_ref()),
         }
     }
+
+    pub fn deserialize<De: BinarySerde>(self) -> Result<T, De::DeserializeError> {
+        match self {
+            Encoded::Raw(raw) => Ok(raw),
+            Encoded::Data(data) => De::deserialize(data.as_ref()),
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, Clone, Debug, EnumAsInner)]
@@ -148,9 +155,17 @@ impl NodeType {
 
     pub fn path_mut(&mut self) -> &mut PartialPath {
         match self {
-            NodeType::Branch(_u) => todo!(),
+            NodeType::Branch(u) => &mut u.path,
             NodeType::Leaf(node) => &mut node.path,
             NodeType::Extension(node) => &mut node.path,
+        }
+    }
+
+    pub fn data_mut(&mut self) -> &mut Data {
+        match self {
+            NodeType::Branch(u) => u.value.as_mut().unwrap(),
+            NodeType::Leaf(node) => &mut node.data,
+            NodeType::Extension(_) => unreachable!(),
         }
     }
 }
@@ -233,7 +248,7 @@ impl Node {
                 is_encoded_longer_than_hash_len: OnceLock::new(),
                 inner: NodeType::Branch(
                     BranchNode {
-                        // path: vec![].into(),
+                        path: vec![].into(),
                         children: [Some(DiskAddress::null()); BranchNode::MAX_CHILDREN],
                         value: Some(Data(Vec::new())),
                         children_encoded: Default::default(),
@@ -531,6 +546,7 @@ impl<T> EncodedNode<T> {
 pub enum EncodedNodeType {
     Leaf(LeafNode),
     Branch {
+        path: PartialPath,
         children: Box<[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>,
         value: Option<Data>,
     },
@@ -550,14 +566,19 @@ impl Serialize for EncodedNode<PlainCodec> {
     where
         S: serde::Serializer,
     {
-        let n = match &self.node {
+        let (chd, data, path) = match &self.node {
             EncodedNodeType::Leaf(n) => {
-                let data = Some(n.data.to_vec());
+                let data = Some(&*n.data);
                 let chd: Vec<(u64, Vec<u8>)> = Default::default();
-                let path = from_nibbles(&n.path.encode(true)).collect();
-                EncodedBranchNode { chd, data, path }
+                let path: Vec<_> = from_nibbles(&n.path.encode(true)).collect();
+                (chd, data, path)
             }
-            EncodedNodeType::Branch { children, value } => {
+
+            EncodedNodeType::Branch {
+                path,
+                children,
+                value,
+            } => {
                 let chd: Vec<(u64, Vec<u8>)> = children
                     .iter()
                     .enumerate()
@@ -571,19 +592,20 @@ impl Serialize for EncodedNode<PlainCodec> {
                     })
                     .collect();
 
-                let data = value.as_ref().map(|v| v.0.to_vec());
-                EncodedBranchNode {
-                    chd,
-                    data,
-                    path: Vec::new(),
-                }
+                let data = value.as_deref();
+
+                let path = from_nibbles(&path.encode(false)).collect();
+
+                (chd, data, path)
             }
         };
 
         let mut s = serializer.serialize_tuple(3)?;
-        s.serialize_element(&n.chd)?;
-        s.serialize_element(&n.data)?;
-        s.serialize_element(&n.path)?;
+
+        s.serialize_element(&chd)?;
+        s.serialize_element(&data)?;
+        s.serialize_element(&path)?;
+
         s.end()
     }
 }
@@ -593,30 +615,35 @@ impl<'de> Deserialize<'de> for EncodedNode<PlainCodec> {
     where
         D: serde::Deserializer<'de>,
     {
-        let node: EncodedBranchNode = Deserialize::deserialize(deserializer)?;
-        if node.chd.is_empty() {
-            let data = if let Some(d) = node.data {
+        let EncodedBranchNode { chd, data, path } = Deserialize::deserialize(deserializer)?;
+
+        let path = PartialPath::from_nibbles(Nibbles::<0>::new(&path).into_iter()).0;
+
+        if chd.is_empty() {
+            let data = if let Some(d) = data {
                 Data(d)
             } else {
                 Data(Vec::new())
             };
 
-            let path = PartialPath::from_nibbles(Nibbles::<0>::new(&node.path).into_iter()).0;
             let node = EncodedNodeType::Leaf(LeafNode { path, data });
+
             Ok(Self::new(node))
         } else {
             let mut children: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN] = Default::default();
-            let value = node.data.map(Data);
+            let value = data.map(Data);
 
-            for (i, chd) in node.chd {
-                #[allow(clippy::indexing_slicing)]
-                (children[i as usize] = Some(chd));
+            #[allow(clippy::indexing_slicing)]
+            for (i, chd) in chd {
+                children[i as usize] = Some(chd);
             }
 
             let node = EncodedNodeType::Branch {
+                path,
                 children: children.into(),
                 value,
             };
+
             Ok(Self::new(node))
         }
     }
@@ -639,34 +666,50 @@ impl Serialize for EncodedNode<Bincode> {
                 }
                 seq.end()
             }
-            EncodedNodeType::Branch { children, value } => {
-                let mut list = <[Encoded<Vec<u8>>; BranchNode::MAX_CHILDREN + 1]>::default();
 
-                for (i, c) in children
+            EncodedNodeType::Branch {
+                path,
+                children,
+                value,
+            } => {
+                let mut list = <[Encoded<Vec<u8>>; BranchNode::MAX_CHILDREN + 2]>::default();
+                let children = children
                     .iter()
                     .enumerate()
-                    .filter_map(|(i, c)| c.as_ref().map(|c| (i, c)))
-                {
-                    if c.len() >= TRIE_HASH_LEN {
-                        let serialized_hash = Bincode::serialize(&Keccak256::digest(c).to_vec())
-                            .map_err(|e| S::Error::custom(format!("bincode error: {e}")))?;
-                        #[allow(clippy::indexing_slicing)]
-                        (list[i] = Encoded::Data(serialized_hash));
+                    .filter_map(|(i, c)| c.as_ref().map(|c| (i, c)));
+
+                #[allow(clippy::indexing_slicing)]
+                for (i, child) in children {
+                    if child.len() >= TRIE_HASH_LEN {
+                        let serialized_hash =
+                            Bincode::serialize(&Keccak256::digest(child).to_vec())
+                                .map_err(|e| S::Error::custom(format!("bincode error: {e}")))?;
+                        list[i] = Encoded::Data(serialized_hash);
                     } else {
-                        #[allow(clippy::indexing_slicing)]
-                        (list[i] = Encoded::Raw(c.to_vec()));
+                        list[i] = Encoded::Raw(child.to_vec());
                     }
                 }
-                if let Some(Data(val)) = &value {
+
+                list[BranchNode::MAX_CHILDREN] = if let Some(Data(val)) = &value {
                     let serialized_val = Bincode::serialize(val)
                         .map_err(|e| S::Error::custom(format!("bincode error: {e}")))?;
-                    list[BranchNode::MAX_CHILDREN] = Encoded::Data(serialized_val);
-                }
+
+                    Encoded::Data(serialized_val)
+                } else {
+                    Encoded::default()
+                };
+
+                let serialized_path = Bincode::serialize(&path.encode(false))
+                    .map_err(|e| S::Error::custom(format!("bincode error: {e}")))?;
+
+                list[BranchNode::MAX_CHILDREN + 1] = Encoded::Data(serialized_path);
 
                 let mut seq = serializer.serialize_seq(Some(list.len()))?;
+
                 for e in list {
                     seq.serialize_element(&e)?;
                 }
+
                 seq.end()
             }
         }
@@ -680,8 +723,9 @@ impl<'de> Deserialize<'de> for EncodedNode<Bincode> {
     {
         use serde::de::Error;
 
-        let items: Vec<Encoded<Vec<u8>>> = Deserialize::deserialize(deserializer)?;
+        let mut items: Vec<Encoded<Vec<u8>>> = Deserialize::deserialize(deserializer)?;
         let len = items.len();
+
         match len {
             LEAF_NODE_SIZE => {
                 let mut items = items.into_iter();
@@ -702,10 +746,25 @@ impl<'de> Deserialize<'de> for EncodedNode<Bincode> {
                 });
                 Ok(Self::new(node))
             }
+
             BranchNode::MSIZE => {
+                let path = items
+                    .pop()
+                    .unwrap_or_default()
+                    .deserialize::<Bincode>()
+                    .map_err(D::Error::custom)?;
+                let path = PartialPath::from_nibbles(Nibbles::<0>::new(&path).into_iter()).0;
+
+                let mut value = items
+                    .pop()
+                    .unwrap_or_default()
+                    .deserialize::<Bincode>()
+                    .map_err(D::Error::custom)
+                    .map(Data)
+                    .map(Some)?
+                    .filter(|data| !data.is_empty());
+
                 let mut children: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN] = Default::default();
-                let mut value: Option<Data> = Default::default();
-                let len = items.len();
 
                 for (i, chd) in items.into_iter().enumerate() {
                     if i == len - 1 {
@@ -729,11 +788,17 @@ impl<'de> Deserialize<'de> for EncodedNode<Bincode> {
                         (children[i] = Some(chd).filter(|chd| !chd.is_empty()));
                     }
                 }
+
                 let node = EncodedNodeType::Branch {
+                    path,
                     children: children.into(),
                     value,
                 };
-                Ok(Self::new(node))
+
+                Ok(Self {
+                    node,
+                    phantom: PhantomData,
+                })
             }
             size => Err(D::Error::custom(format!("invalid size: {size}"))),
         }
@@ -847,7 +912,7 @@ mod tests {
     ) {
         let leaf = NodeType::Leaf(LeafNode::new(PartialPath(vec![1, 2, 3]), Data(vec![4, 5])));
         let branch = NodeType::Branch(Box::new(BranchNode {
-            // path: vec![].into(),
+            path: vec![].into(),
             children: [Some(DiskAddress::from(1)); BranchNode::MAX_CHILDREN],
             value: Some(Data(vec![1, 2, 3])),
             children_encoded: std::array::from_fn(|_| Some(vec![1])),
@@ -904,6 +969,7 @@ mod tests {
     }
 
     #[test_matrix(
+        [&[], &[0xf], &[0xf, 0xf]],
         [vec![], vec![1,0,0,0,0,0,0,1], vec![1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1], repeat(1).take(16).collect()],
         [Nil, 0, 15],
         [
@@ -915,10 +981,13 @@ mod tests {
         ]
     )]
     fn branch_encoding(
+        path: &[u8],
         children: Vec<usize>,
         value: impl Into<Option<u8>>,
         children_encoded: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN],
     ) {
+        let path = PartialPath(path.iter().copied().map(|x| x & 0xf).collect());
+
         let mut children = children.into_iter().map(|x| {
             if x == 0 {
                 None
@@ -934,7 +1003,7 @@ mod tests {
             .map(|x| Data(std::iter::repeat(x).take(x as usize).collect()));
 
         let node = Node::from_branch(BranchNode {
-            // path: vec![].into(),
+            path,
             children,
             value,
             children_encoded,

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -161,11 +161,11 @@ impl NodeType {
         }
     }
 
-    pub fn data_mut(&mut self) -> &mut Data {
+    pub fn set_data(&mut self, data: Data) {
         match self {
-            NodeType::Branch(u) => u.value.as_mut().unwrap(),
-            NodeType::Leaf(node) => &mut node.data,
-            NodeType::Extension(_) => unreachable!(),
+            NodeType::Branch(u) => u.value = Some(data),
+            NodeType::Leaf(node) => node.data = data,
+            NodeType::Extension(_) => (),
         }
     }
 }
@@ -330,6 +330,16 @@ impl Node {
 
     pub(super) fn set_dirty(&self, is_dirty: bool) {
         self.lazy_dirty.store(is_dirty, Ordering::Relaxed)
+    }
+}
+
+pub(crate) fn write_branch<F: FnOnce(&mut Box<BranchNode>)>(f: F) -> impl FnOnce(&mut Node) {
+    move |node| {
+        let node = node
+            .inner_mut()
+            .as_branch_mut()
+            .expect("must be a branch node");
+        f(node);
     }
 }
 

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -3,9 +3,9 @@
 
 use super::{Data, Encoded, Node};
 use crate::{
-    merkle::{PartialPath, TRIE_HASH_LEN},
-    shale::{DiskAddress, Storable},
-    shale::{ShaleError, ShaleStore},
+    merkle::{from_nibbles, to_nibble_array, PartialPath, TRIE_HASH_LEN},
+    nibbles::Nibbles,
+    shale::{DiskAddress, ShaleError, ShaleStore, Storable},
 };
 use bincode::{Error, Options};
 use std::{
@@ -14,6 +14,7 @@ use std::{
     mem::size_of,
 };
 
+type PathLen = u8;
 pub type DataLen = u32;
 pub type EncodedChildLen = u8;
 
@@ -21,7 +22,7 @@ const MAX_CHILDREN: usize = 16;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct BranchNode {
-    // pub(crate) path: PartialPath,
+    pub(crate) path: PartialPath,
     pub(crate) children: [Option<DiskAddress>; MAX_CHILDREN],
     pub(crate) value: Option<Data>,
     pub(crate) children_encoded: [Option<Vec<u8>>; MAX_CHILDREN],
@@ -30,7 +31,7 @@ pub struct BranchNode {
 impl Debug for BranchNode {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         write!(f, "[Branch")?;
-        // write!(f, " path={:?}", self.path)?;
+        write!(f, r#" path="{:?}""#, self.path)?;
 
         for (i, c) in self.children.iter().enumerate() {
             if let Some(c) = c {
@@ -57,16 +58,16 @@ impl Debug for BranchNode {
 
 impl BranchNode {
     pub const MAX_CHILDREN: usize = MAX_CHILDREN;
-    pub const MSIZE: usize = Self::MAX_CHILDREN + 1;
+    pub const MSIZE: usize = Self::MAX_CHILDREN + 2;
 
     pub fn new(
-        _path: PartialPath,
+        path: PartialPath,
         chd: [Option<DiskAddress>; Self::MAX_CHILDREN],
         value: Option<Vec<u8>>,
         chd_encoded: [Option<Vec<u8>>; Self::MAX_CHILDREN],
     ) -> Self {
         BranchNode {
-            // path,
+            path,
             children: chd,
             value: value.map(Data),
             children_encoded: chd_encoded,
@@ -112,6 +113,10 @@ impl BranchNode {
     pub(super) fn decode(buf: &[u8]) -> Result<Self, Error> {
         let mut items: Vec<Encoded<Vec<u8>>> = bincode::DefaultOptions::new().deserialize(buf)?;
 
+        let path = items.pop().unwrap().decode()?;
+        let path = Nibbles::<0>::new(&path);
+        let (path, _term) = PartialPath::from_nibbles(path.into_iter());
+
         // we've already validated the size, that's why we can safely unwrap
         #[allow(clippy::unwrap_used)]
         let data = items.pop().unwrap().decode()?;
@@ -128,9 +133,6 @@ impl BranchNode {
             (chd_encoded[i] = Some(data).filter(|data| !data.is_empty()));
         }
 
-        // TODO: add path
-        let path = Vec::new().into();
-
         Ok(BranchNode::new(
             path,
             [None; Self::MAX_CHILDREN],
@@ -140,8 +142,8 @@ impl BranchNode {
     }
 
     pub(super) fn encode<S: ShaleStore<Node>>(&self, store: &S) -> Vec<u8> {
-        // TODO: add path to encoded node
-        let mut list = <[Encoded<Vec<u8>>; Self::MAX_CHILDREN + 1]>::default();
+        // path + children + value
+        let mut list = <[Encoded<Vec<u8>>; Self::MSIZE]>::default();
 
         for (i, c) in self.children.iter().enumerate() {
             match c {
@@ -202,6 +204,11 @@ impl BranchNode {
         }
 
         #[allow(clippy::unwrap_used)]
+        let path = from_nibbles(&self.path.encode(false)).collect::<Vec<_>>();
+
+        list[Self::MAX_CHILDREN + 1] =
+            Encoded::Data(bincode::DefaultOptions::new().serialize(&path).unwrap());
+
         bincode::DefaultOptions::new()
             .serialize(list.as_slice())
             .unwrap()
@@ -215,12 +222,18 @@ impl Storable for BranchNode {
         let children_encoded_len = self.children_encoded.iter().fold(0, |len, child| {
             len + optional_data_len::<EncodedChildLen, _>(child.as_ref())
         });
+        let path_len_size = size_of::<PathLen>() as u64;
+        let path_len = self.path.serialized_len();
 
-        children_len + data_len + children_encoded_len
+        children_len + data_len + children_encoded_len + path_len_size + path_len
     }
 
     fn serialize(&self, to: &mut [u8]) -> Result<(), crate::shale::ShaleError> {
         let mut cursor = Cursor::new(to);
+
+        let path: Vec<u8> = from_nibbles(&self.path.encode(false)).collect();
+        cursor.write_all(&[path.len() as PathLen])?;
+        cursor.write_all(&path)?;
 
         for child in &self.children {
             let bytes = child.map(|addr| addr.to_le_bytes()).unwrap_or_default();
@@ -253,9 +266,41 @@ impl Storable for BranchNode {
         mut addr: usize,
         mem: &T,
     ) -> Result<Self, crate::shale::ShaleError> {
+        const PATH_LEN_SIZE: u64 = size_of::<PathLen>() as u64;
         const DATA_LEN_SIZE: usize = size_of::<DataLen>();
         const BRANCH_HEADER_SIZE: u64 =
             BranchNode::MAX_CHILDREN as u64 * DiskAddress::MSIZE + DATA_LEN_SIZE as u64;
+
+        let path_len = mem
+            .get_view(addr, PATH_LEN_SIZE)
+            .ok_or(ShaleError::InvalidCacheView {
+                offset: addr,
+                size: PATH_LEN_SIZE,
+            })?
+            .as_deref();
+
+        addr += PATH_LEN_SIZE as usize;
+
+        let path_len = {
+            let mut buf = [0u8; PATH_LEN_SIZE as usize];
+            let mut cursor = Cursor::new(path_len);
+            cursor.read_exact(buf.as_mut())?;
+
+            PathLen::from_le_bytes(buf) as u64
+        };
+
+        let path = mem
+            .get_view(addr, path_len)
+            .ok_or(ShaleError::InvalidCacheView {
+                offset: addr,
+                size: path_len,
+            })?
+            .as_deref();
+
+        addr += path_len as usize;
+
+        let path: Vec<u8> = path.into_iter().flat_map(to_nibble_array).collect();
+        let path = PartialPath::decode(&path).0;
 
         let node_raw =
             mem.get_view(addr, BRANCH_HEADER_SIZE)
@@ -342,8 +387,7 @@ impl Storable for BranchNode {
         }
 
         let node = BranchNode {
-            // TODO: add path
-            // path: Vec::new().into(),
+            path,
             children,
             value,
             children_encoded,

--- a/firewood/src/merkle/node/partial_path.rs
+++ b/firewood/src/merkle/node/partial_path.rs
@@ -40,7 +40,7 @@ impl PartialPath {
         self.0
     }
 
-    pub(super) fn encode(&self, is_terminal: bool) -> Vec<u8> {
+    pub(crate) fn encode(&self, is_terminal: bool) -> Vec<u8> {
         let mut flags = Flags::empty();
 
         if is_terminal {

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -440,6 +440,17 @@ fn locate_subproof(
             Ok((sub_proof.into(), key_nibbles))
         }
         NodeType::Branch(n) => {
+            let partial_path = &n.path.0;
+
+            let does_not_match = key_nibbles.size_hint().0 < partial_path.len()
+                || !partial_path
+                    .iter()
+                    .all(|val| key_nibbles.next() == Some(*val));
+
+            if dbg!(does_not_match) {
+                return Ok((None, Nibbles::<0>::new(&[]).into_iter()));
+            }
+
             let Some(index) = key_nibbles.next().map(|nib| nib as usize) else {
                 let encoded = n.value;
 

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -142,7 +142,7 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
         }
     }
 
-    pub fn concat_proofs(&mut self, other: Proof<N>) {
+    pub fn extend(&mut self, other: Proof<N>) {
         self.0.extend(other.0)
     }
 

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -457,7 +457,7 @@ fn locate_subproof(
                     .iter()
                     .all(|val| key_nibbles.next() == Some(*val));
 
-            if dbg!(does_not_match) {
+            if does_not_match {
                 return Ok((None, Nibbles::<0>::new(&[]).into_iter()));
             }
 
@@ -542,7 +542,7 @@ fn unset_internal<K: AsRef<[u8]>, S: ShaleStore<Node> + Send + Sync, T: BinarySe
             #[allow(clippy::indexing_slicing)]
             NodeType::Branch(n) => {
                 // If either the key of left proof or right proof doesn't match with
-                // shortnode, stop here and the forkpoint is the shortnode.
+                // stop here, this is the forkpoint.
                 let path = &*n.path;
 
                 if !path.is_empty() {
@@ -733,7 +733,7 @@ fn unset_internal<K: AsRef<[u8]>, S: ShaleStore<Node> + Send + Sync, T: BinarySe
             }
 
             let node = n.chd();
-            let cur_key = n.path.clone().into_inner();
+            let index = n.path.len();
 
             let p = u_ref.as_ptr();
             drop(u_ref);
@@ -746,7 +746,7 @@ fn unset_internal<K: AsRef<[u8]>, S: ShaleStore<Node> + Send + Sync, T: BinarySe
                     Some(node),
                     #[allow(clippy::indexing_slicing)]
                     &left_chunks[index..],
-                    cur_key.len(),
+                    index,
                     false,
                 )?;
 
@@ -760,7 +760,7 @@ fn unset_internal<K: AsRef<[u8]>, S: ShaleStore<Node> + Send + Sync, T: BinarySe
                     Some(node),
                     #[allow(clippy::indexing_slicing)]
                     &right_chunks[index..],
-                    cur_key.len(),
+                    index,
                     true,
                 )?;
 

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -90,7 +90,6 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                     .get_node(*merkle_root)
                     .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
-                // TODO: put this in a better spot
                 let mut check_child_nibble = false;
 
                 // traverse the trie along each nibble until we find a node with a value
@@ -771,7 +770,7 @@ mod tests {
         let mut stream = merkle.iter_from(root, vec![missing].into_boxed_slice());
 
         for key in keys {
-            let next = dbg!(stream.next().await.unwrap().unwrap());
+            let next = stream.next().await.unwrap().unwrap();
 
             assert_eq!(&*next.0, &*next.1);
             assert_eq!(&*next.0, key);
@@ -795,9 +794,7 @@ mod tests {
             merkle.insert(&key, key.clone(), root).unwrap();
         });
 
-        let mut stream = merkle.iter_from(root, vec![start_key].into_boxed_slice());
-
-        dbg!(&stream.next().await);
+        let stream = merkle.iter_from(root, vec![start_key].into_boxed_slice());
 
         check_stream_is_done(stream).await;
     }

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -107,7 +107,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                         )
                         .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
-                    let mut nibbles = Nibbles::<1>::new(&key).into_iter();
+                    let mut nibbles = Nibbles::<1>::new(key).into_iter();
 
                     let visited_node_path = visited_node_path
                         .into_iter()

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -3,6 +3,7 @@
 
 use super::{node::Node, BranchNode, Merkle, NodeObjRef, NodeType};
 use crate::{
+    nibbles::Nibbles,
     shale::{DiskAddress, ShaleStore},
     v2::api,
 };
@@ -18,6 +19,7 @@ enum IteratorState<'a> {
     StartAtKey(Key),
     /// Continue iterating after the last node in the `visited_node_path`
     Iterating {
+        check_child_nibble: bool,
         visited_node_path: Vec<(NodeObjRef<'a>, u8)>,
     },
 }
@@ -41,7 +43,7 @@ pub struct MerkleKeyValueStream<'a, S, T> {
 
 impl<'a, S: ShaleStore<Node> + Send + Sync, T> FusedStream for MerkleKeyValueStream<'a, S, T> {
     fn is_terminated(&self) -> bool {
-        matches!(&self.key_state, IteratorState::Iterating { visited_node_path } if visited_node_path.is_empty())
+        matches!(&self.key_state, IteratorState::Iterating { visited_node_path, .. } if visited_node_path.is_empty())
     }
 }
 
@@ -88,6 +90,9 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                     .get_node(*merkle_root)
                     .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
+                // TODO: put this in a better spot
+                let mut check_child_nibble = false;
+
                 // traverse the trie along each nibble until we find a node with a value
                 // TODO: merkle.iter_by_key(key) will simplify this entire code-block.
                 let (found_node, mut visited_node_path) = {
@@ -97,14 +102,51 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                         .get_node_by_key_with_callbacks(
                             root_node,
                             &key,
-                            |node_addr, i| visited_node_path.push((node_addr, i)),
+                            |node_addr, _| visited_node_path.push(node_addr),
                             |_, _| {},
                         )
                         .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
+                    let mut nibbles = Nibbles::<1>::new(&key).into_iter();
+
                     let visited_node_path = visited_node_path
                         .into_iter()
-                        .map(|(node, pos)| merkle.get_node(node).map(|node| (node, pos)))
+                        .map(|node| merkle.get_node(node))
+                        .map(|node_result| {
+                            let nibbles = &mut nibbles;
+
+                            node_result
+                                .map(|node| match node.inner() {
+                                    NodeType::Branch(branch) => {
+                                        let mut partial_path_iter = branch.path.iter();
+                                        let next_nibble = nibbles
+                                            .map(|nibble| (Some(nibble), partial_path_iter.next()))
+                                            .find(|(a, b)| a.as_ref() != *b);
+
+                                        match next_nibble {
+                                            // this case will be hit by all but the last nodes
+                                            // unless there is a deviation between the key and the path
+                                            None | Some((None, _)) => None,
+
+                                            Some((Some(key_nibble), Some(path_nibble))) => {
+                                                check_child_nibble = key_nibble < *path_nibble;
+                                                None
+                                            }
+
+                                            // path is subset of the key
+                                            Some((Some(nibble), None)) => {
+                                                check_child_nibble = true;
+                                                Some((node, nibble))
+                                            }
+                                        }
+                                    }
+                                    NodeType::Leaf(_) => Some((node, 0)),
+                                    NodeType::Extension(_) => Some((node, 0)),
+                                })
+                                .transpose()
+                        })
+                        .take_while(|node| node.is_some())
+                        .flatten()
                         .collect::<Result<Vec<_>, _>>()
                         .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
@@ -113,7 +155,10 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
 
                 if let Some(found_node) = found_node {
                     let value = match found_node.inner() {
-                        NodeType::Branch(branch) => branch.value.as_ref(),
+                        NodeType::Branch(branch) => {
+                            check_child_nibble = true;
+                            branch.value.as_ref()
+                        }
                         NodeType::Leaf(leaf) => Some(&leaf.data),
                         NodeType::Extension(_) => None,
                     };
@@ -126,7 +171,10 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
 
                     visited_node_path.push((found_node, 0));
 
-                    self.key_state = IteratorState::Iterating { visited_node_path };
+                    self.key_state = IteratorState::Iterating {
+                        check_child_nibble,
+                        visited_node_path,
+                    };
 
                     return Poll::Ready(next_result);
                 }
@@ -135,16 +183,23 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                 let found_key = key_from_nibble_iter(found_key);
 
                 if found_key > *key {
+                    check_child_nibble = false;
                     visited_node_path.pop();
                 }
 
-                self.key_state = IteratorState::Iterating { visited_node_path };
+                self.key_state = IteratorState::Iterating {
+                    check_child_nibble,
+                    visited_node_path,
+                };
 
                 self.poll_next(_cx)
             }
 
-            IteratorState::Iterating { visited_node_path } => {
-                let next = find_next_result(merkle, visited_node_path)
+            IteratorState::Iterating {
+                check_child_nibble,
+                visited_node_path,
+            } => {
+                let next = find_next_result(merkle, visited_node_path, check_child_nibble)
                     .map_err(|e| api::Error::InternalError(Box::new(e)))
                     .transpose();
 
@@ -184,20 +239,27 @@ impl<'a> NodeRef<'a> {
 fn find_next_result<'a, S: ShaleStore<Node>, T>(
     merkle: &'a Merkle<S, T>,
     visited_path: &mut Vec<(NodeObjRef<'a>, u8)>,
+    check_child_nibble: &mut bool,
 ) -> Result<Option<(Key, Value)>, super::MerkleError> {
-    let next = find_next_node_with_data(merkle, visited_path)?.map(|(next_node, value)| {
-        let partial_path = match next_node.inner() {
-            NodeType::Leaf(leaf) => leaf.path.iter().copied(),
-            NodeType::Extension(extension) => extension.path.iter().copied(),
-            _ => [].iter().copied(),
-        };
+    let next = find_next_node_with_data(merkle, visited_path, *check_child_nibble)?.map(
+        |(next_node, value)| {
+            let partial_path = match next_node.inner() {
+                NodeType::Leaf(leaf) => leaf.path.iter().copied(),
+                NodeType::Extension(extension) => extension.path.iter().copied(),
+                NodeType::Branch(branch) => branch.path.iter().copied(),
+            };
 
-        let key = key_from_nibble_iter(nibble_iter_from_parents(visited_path).chain(partial_path));
+            // always check the child for branch nodes with data
+            *check_child_nibble = next_node.inner().is_branch();
 
-        visited_path.push((next_node, 0));
+            let key =
+                key_from_nibble_iter(nibble_iter_from_parents(visited_path).chain(partial_path));
 
-        (key, value)
-    });
+            visited_path.push((next_node, 0));
+
+            (key, value)
+        },
+    );
 
     Ok(next)
 }
@@ -205,6 +267,7 @@ fn find_next_result<'a, S: ShaleStore<Node>, T>(
 fn find_next_node_with_data<'a, S: ShaleStore<Node>, T>(
     merkle: &'a Merkle<S, T>,
     visited_path: &mut Vec<(NodeObjRef<'a>, u8)>,
+    check_child_nibble: bool,
 ) -> Result<Option<(NodeObjRef<'a>, Vec<u8>)>, super::MerkleError> {
     use InnerNode::*;
 
@@ -244,7 +307,7 @@ fn find_next_node_with_data<'a, S: ShaleStore<Node>, T>(
             Visited(NodeType::Branch(branch)) => {
                 // if the first node that we check is a visited branch, that means that the branch had a value
                 // and we need to visit the first child, for all other cases, we need to visit the next child
-                let compare_op = if first_loop {
+                let compare_op = if first_loop && check_child_nibble {
                     <u8 as PartialOrd>::ge // >=
                 } else {
                     <u8 as PartialOrd>::gt
@@ -328,7 +391,13 @@ fn nibble_iter_from_parents<'a>(parents: &'a [(NodeObjRef, u8)]) -> impl Iterato
         .iter()
         .skip(1) // always skip the sentinal node
         .flat_map(|(parent, child_nibble)| match parent.inner() {
-            NodeType::Branch(_) => Either::Left(std::iter::once(*child_nibble)),
+            NodeType::Branch(branch) => Either::Left(
+                branch
+                    .path
+                    .iter()
+                    .copied()
+                    .chain(std::iter::once(*child_nibble)),
+            ),
             NodeType::Extension(extension) => Either::Right(extension.path.iter().copied()),
             NodeType::Leaf(leaf) => Either::Right(leaf.path.iter().copied()),
         })
@@ -700,6 +769,58 @@ mod tests {
         let keys = &keys[(missing as usize)..];
 
         let mut stream = merkle.iter_from(root, vec![missing].into_boxed_slice());
+
+        for key in keys {
+            let next = dbg!(stream.next().await.unwrap().unwrap());
+
+            assert_eq!(&*next.0, &*next.1);
+            assert_eq!(&*next.0, key);
+        }
+
+        check_stream_is_done(stream).await;
+    }
+
+    #[tokio::test]
+    async fn start_at_key_overlapping_with_extension_but_greater() {
+        let start_key = 0x0a;
+        let shared_path = 0x09;
+        // 0x0900, 0x0901, ... 0x0a0f
+        // path extension is 0x090
+        let children = (0..=0x0f).map(|val| vec![shared_path, val]);
+
+        let mut merkle = create_test_merkle();
+        let root = merkle.init_root().unwrap();
+
+        children.for_each(|key| {
+            merkle.insert(&key, key.clone(), root).unwrap();
+        });
+
+        let mut stream = merkle.iter_from(root, vec![start_key].into_boxed_slice());
+
+        dbg!(&stream.next().await);
+
+        check_stream_is_done(stream).await;
+    }
+
+    #[tokio::test]
+    async fn start_at_key_overlapping_with_extension_but_smaller() {
+        let start_key = 0x00;
+        let shared_path = 0x09;
+        // 0x0900, 0x0901, ... 0x0a0f
+        // path extension is 0x090
+        let children = (0..=0x0f).map(|val| vec![shared_path, val]);
+
+        let mut merkle = create_test_merkle();
+        let root = merkle.init_root().unwrap();
+
+        let keys: Vec<_> = children
+            .map(|key| {
+                merkle.insert(&key, key.clone(), root).unwrap();
+                key
+            })
+            .collect();
+
+        let mut stream = merkle.iter_from(root, vec![start_key].into_boxed_slice());
 
         for key in keys {
             let next = stream.next().await.unwrap().unwrap();

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -91,10 +91,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T: BinarySerde> MerkleSetup<S, T> {
         String::from_utf8(s).map_err(|_err| DataStoreError::UTF8Error)
     }
 
-    pub fn prove<K: AsRef<[u8]> + std::fmt::Debug>(
-        &self,
-        key: K,
-    ) -> Result<Proof<Vec<u8>>, DataStoreError> {
+    pub fn prove<K: AsRef<[u8]>>(&self, key: K) -> Result<Proof<Vec<u8>>, DataStoreError> {
         self.merkle
             .prove(key, self.root)
             .map_err(|_err| DataStoreError::ProofError)

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -1,10 +1,15 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::merkle::{BinarySerde, Bincode, Merkle, Node, Proof, ProofError, Ref, RefMut, TrieHash};
-use crate::shale::{
-    self, cached::DynamicMem, compact::CompactSpace, disk_address::DiskAddress, CachedStore,
-    ShaleStore, StoredView,
+use crate::{
+    merkle::{
+        proof::{Proof, ProofError},
+        BinarySerde, Bincode, Merkle, Node, Ref, RefMut, TrieHash,
+    },
+    shale::{
+        self, cached::DynamicMem, compact::CompactSpace, disk_address::DiskAddress, CachedStore,
+        ShaleStore, StoredView,
+    },
 };
 use std::num::NonZeroUsize;
 use thiserror::Error;
@@ -86,7 +91,10 @@ impl<S: ShaleStore<Node> + Send + Sync, T: BinarySerde> MerkleSetup<S, T> {
         String::from_utf8(s).map_err(|_err| DataStoreError::UTF8Error)
     }
 
-    pub fn prove<K: AsRef<[u8]>>(&self, key: K) -> Result<Proof<Vec<u8>>, DataStoreError> {
+    pub fn prove<K: AsRef<[u8]> + std::fmt::Debug>(
+        &self,
+        key: K,
+    ) -> Result<Proof<Vec<u8>>, DataStoreError> {
         self.merkle
             .prove(key, self.root)
             .map_err(|_err| DataStoreError::ProofError)

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -1,10 +1,10 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use crate::logger::trace;
 use crate::merkle::Node;
 use crate::shale::ObjCache;
 use crate::storage::{StoreRevMut, StoreRevShared};
-use crate::logger::trace;
 
 use super::disk_address::DiskAddress;
 use super::{CachedStore, Obj, ObjRef, ShaleError, ShaleStore, Storable, StoredView};

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -4,6 +4,7 @@
 use crate::merkle::Node;
 use crate::shale::ObjCache;
 use crate::storage::{StoreRevMut, StoreRevShared};
+use crate::logger::trace;
 
 use super::disk_address::DiskAddress;
 use super::{CachedStore, Obj, ObjRef, ShaleError, ShaleStore, Storable, StoredView};
@@ -13,17 +14,18 @@ use std::io::{Cursor, Write};
 use std::num::NonZeroUsize;
 use std::sync::RwLock;
 
-use crate::logger::trace;
+type PayLoadSize = u64;
 
 #[derive(Debug)]
 pub struct CompactHeader {
-    payload_size: u64,
+    payload_size: PayLoadSize,
     is_freed: bool,
     desc_addr: DiskAddress,
 }
 
 impl CompactHeader {
     pub const MSIZE: u64 = 17;
+
     pub const fn is_freed(&self) -> bool {
         self.is_freed
     }
@@ -71,11 +73,11 @@ impl Storable for CompactHeader {
 
 #[derive(Debug)]
 struct CompactFooter {
-    payload_size: u64,
+    payload_size: PayLoadSize,
 }
 
 impl CompactFooter {
-    const MSIZE: u64 = 8;
+    const MSIZE: u64 = std::mem::size_of::<PayLoadSize>() as u64;
 }
 
 impl Storable for CompactFooter {
@@ -103,7 +105,7 @@ impl Storable for CompactFooter {
 
 #[derive(Clone, Copy, Debug)]
 struct CompactDescriptor {
-    payload_size: u64,
+    payload_size: PayLoadSize,
     haddr: usize, // disk address of the free space
 }
 
@@ -312,6 +314,13 @@ impl<M: CachedStore> CompactSpaceInner<M> {
         let mut offset = addr - hsize;
         let header_payload_size = {
             let header = self.get_header(DiskAddress::from(offset as usize))?;
+
+            if header.is_freed {
+                dbg!(addr);
+                dbg!(hsize);
+                dbg!(offset);
+            }
+
             assert!(!header.is_freed);
             header.payload_size
         };

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -314,13 +314,6 @@ impl<M: CachedStore> CompactSpaceInner<M> {
         let mut offset = addr - hsize;
         let header_payload_size = {
             let header = self.get_header(DiskAddress::from(offset as usize))?;
-
-            if header.is_freed {
-                dbg!(addr);
-                dbg!(hsize);
-                dbg!(offset);
-            }
-
             assert!(!header.is_freed);
             header.payload_size
         };

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -318,6 +318,7 @@ impl<T: Storable + 'static> StoredView<T> {
     #[inline(always)]
     fn new<U: CachedStore>(offset: usize, len_limit: u64, space: &U) -> Result<Self, ShaleError> {
         let decoded = T::deserialize(offset, space)?;
+
         Ok(Self {
             offset,
             decoded,

--- a/firewood/tests/merkle.rs
+++ b/firewood/tests/merkle.rs
@@ -66,17 +66,12 @@ fn test_root_hash_fuzz_insertions() -> Result<(), DataStoreError> {
         key
     };
 
-    for i in 0..10 {
-        dbg!(i);
+    for _ in 0..10 {
         let mut items = Vec::new();
+
         for _ in 0..10 {
             let val: Vec<u8> = (0..8).map(|_| rng.borrow_mut().gen()).collect();
             items.push((keygen(), val));
-        }
-
-        if i == 6 {
-            eprintln!("{:?}", &items);
-            dbg!("this one breaks");
         }
 
         merkle_build_test(items, 0x1000000, 0x1000000)?;
@@ -190,12 +185,10 @@ fn test_root_hash_random_deletions() -> Result<(), DataStoreError> {
         let mut merkle = new_merkle(0x100000, 0x100000);
 
         for (k, v) in items.iter() {
-            dbg!(&k, &v);
             merkle.insert(k, v.to_vec())?;
         }
 
         for (k, v) in items.iter() {
-            dbg!(k);
             assert_eq!(&*merkle.get(k)?.unwrap(), &v[..]);
             assert_eq!(&*merkle.get_mut(k)?.unwrap().get(), &v[..]);
         }
@@ -212,7 +205,6 @@ fn test_root_hash_random_deletions() -> Result<(), DataStoreError> {
             items.remove(&k);
 
             for (k, v) in items.iter() {
-                dbg!(k);
                 assert_eq!(&*merkle.get(k)?.unwrap(), &v[..]);
                 assert_eq!(&*merkle.get_mut(k)?.unwrap().get(), &v[..]);
             }

--- a/firewood/tests/merkle.rs
+++ b/firewood/tests/merkle.rs
@@ -368,7 +368,7 @@ fn test_range_proof() -> Result<(), ProofError> {
         assert!(!proof.0.is_empty());
         let end_proof = merkle.prove(items[end - 1].0)?;
         assert!(!end_proof.0.is_empty());
-        proof.concat_proofs(end_proof);
+        proof.extend(end_proof);
 
         let mut keys = Vec::new();
         let mut vals = Vec::new();
@@ -404,7 +404,7 @@ fn test_bad_range_proof() -> Result<(), ProofError> {
         assert!(!proof.0.is_empty());
         let end_proof = merkle.prove(items[end - 1].0)?;
         assert!(!end_proof.0.is_empty());
-        proof.concat_proofs(end_proof);
+        proof.extend(end_proof);
 
         let mut keys: Vec<[u8; 32]> = Vec::new();
         let mut vals: Vec<[u8; 20]> = Vec::new();
@@ -501,7 +501,7 @@ fn test_range_proof_with_non_existent_proof() -> Result<(), ProofError> {
         assert!(!proof.0.is_empty());
         let end_proof = merkle.prove(last)?;
         assert!(!end_proof.0.is_empty());
-        proof.concat_proofs(end_proof);
+        proof.extend(end_proof);
 
         let mut keys: Vec<[u8; 32]> = Vec::new();
         let mut vals: Vec<[u8; 20]> = Vec::new();
@@ -520,7 +520,7 @@ fn test_range_proof_with_non_existent_proof() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(last)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     let (keys, vals): (Vec<&[u8; 32]>, Vec<&[u8; 20]>) = items.into_iter().unzip();
     merkle.verify_range_proof(&proof, &first, &last, keys, vals)?;
@@ -548,7 +548,7 @@ fn test_range_proof_with_invalid_non_existent_proof() -> Result<(), ProofError> 
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(items[end - 1].0)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     start = 105; // Gap created
     let mut keys: Vec<[u8; 32]> = Vec::new();
@@ -571,7 +571,7 @@ fn test_range_proof_with_invalid_non_existent_proof() -> Result<(), ProofError> 
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(last)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     end = 195; // Capped slice
     let mut keys: Vec<[u8; 32]> = Vec::new();
@@ -618,7 +618,7 @@ fn test_one_element_range_proof() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(items[start].0)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     merkle.verify_range_proof(
         &proof,
@@ -634,7 +634,7 @@ fn test_one_element_range_proof() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(last)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     merkle.verify_range_proof(
         &proof,
@@ -649,7 +649,7 @@ fn test_one_element_range_proof() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(last)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     merkle.verify_range_proof(
         &proof,
@@ -669,7 +669,7 @@ fn test_one_element_range_proof() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(key)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     merkle.verify_range_proof(&proof, first, key, vec![key], vec![val])?;
 
@@ -708,7 +708,7 @@ fn test_all_elements_proof() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(items[end].0)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     merkle.verify_range_proof(
         &proof,
@@ -725,7 +725,7 @@ fn test_all_elements_proof() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(last)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     merkle.verify_range_proof(&proof, &first, &last, keys, vals)?;
 
@@ -787,7 +787,7 @@ fn test_gapped_range_proof() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(items[last - 1].0)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     let middle = (first + last) / 2 - first;
     let (keys, vals): (Vec<&[u8; 32]>, Vec<&[u8; 4]>) = items[first..last]
@@ -822,7 +822,7 @@ fn test_same_side_proof() -> Result<(), DataStoreError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(last)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     assert!(merkle
         .verify_range_proof(&proof, first, last, vec![*items[pos].0], vec![items[pos].1])
@@ -836,7 +836,7 @@ fn test_same_side_proof() -> Result<(), DataStoreError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(last)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     assert!(merkle
         .verify_range_proof(&proof, first, last, vec![*items[pos].0], vec![items[pos].1])
@@ -867,7 +867,7 @@ fn test_single_side_range_proof() -> Result<(), ProofError> {
             assert!(!proof.0.is_empty());
             let end_proof = merkle.prove(items[case].0)?;
             assert!(!end_proof.0.is_empty());
-            proof.concat_proofs(end_proof);
+            proof.extend(end_proof);
 
             let item_iter = items.clone().into_iter().take(case + 1);
             let keys = item_iter.clone().map(|item| *item.0).collect();
@@ -901,7 +901,7 @@ fn test_reverse_single_side_range_proof() -> Result<(), ProofError> {
             assert!(!proof.0.is_empty());
             let end_proof = merkle.prove(end)?;
             assert!(!end_proof.0.is_empty());
-            proof.concat_proofs(end_proof);
+            proof.extend(end_proof);
 
             let item_iter = items.clone().into_iter().skip(case);
             let keys = item_iter.clone().map(|item| item.0).collect();
@@ -934,7 +934,7 @@ fn test_both_sides_range_proof() -> Result<(), ProofError> {
         assert!(!proof.0.is_empty());
         let end_proof = merkle.prove(end)?;
         assert!(!end_proof.0.is_empty());
-        proof.concat_proofs(end_proof);
+        proof.extend(end_proof);
 
         let (keys, vals): (Vec<&[u8; 32]>, Vec<&[u8; 20]>) = items.into_iter().unzip();
         merkle.verify_range_proof(&proof, &start, &end, keys, vals)?;
@@ -966,7 +966,7 @@ fn test_empty_value_range_proof() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(items[end - 1].0)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     let item_iter = items.clone().into_iter().skip(start).take(end - start);
     let keys = item_iter.clone().map(|item| item.0).collect();
@@ -1002,7 +1002,7 @@ fn test_all_elements_empty_value_range_proof() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(items[end].0)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     let item_iter = items.clone().into_iter();
     let keys = item_iter.clone().map(|item| item.0).collect();
@@ -1039,7 +1039,7 @@ fn test_range_proof_keys_with_shared_prefix() -> Result<(), ProofError> {
     assert!(!proof.0.is_empty());
     let end_proof = merkle.prove(&end)?;
     assert!(!end_proof.0.is_empty());
-    proof.concat_proofs(end_proof);
+    proof.extend(end_proof);
 
     let item_iter = items.into_iter();
     let keys = item_iter.clone().map(|item| item.0).collect();
@@ -1076,7 +1076,7 @@ fn test_bloadted_range_proof() -> Result<(), ProofError> {
     for (i, item) in items.iter().enumerate() {
         let cur_proof = merkle.prove(item.0)?;
         assert!(!cur_proof.0.is_empty());
-        proof.concat_proofs(cur_proof);
+        proof.extend(cur_proof);
         if i == 50 {
             keys.push(item.0);
             vals.push(item.1);

--- a/firewood/tests/merkle.rs
+++ b/firewood/tests/merkle.rs
@@ -138,7 +138,9 @@ fn test_root_hash_reversed_deletions() -> Result<(), DataStoreError> {
         hashes.reverse();
 
         for i in 0..hashes.len() {
+            #[allow(clippy::indexing_slicing)]
             let (new_hash, key, before_removal, after_removal) = &new_hashes[i];
+            #[allow(clippy::indexing_slicing)]
             let (expected_hash, expected_dump) = &hashes[i];
             let key = key.iter().fold(String::new(), |mut s, b| {
                 let _ = write!(s, "{:02x}", b);


### PR DESCRIPTION
- Add path to branch-node
- Split leaf, branch, and extension node files
- NodeType should box the branch-node
- Use leaf-node size
- Use an enum instead of numbers
- Refactor node-serialization
- WIP
