### PR TITLE
Rkuris/range proofs

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -305,7 +305,7 @@ impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
             .map_err(|e| api::Error::IO(std::io::Error::new(ErrorKind::Other, e)))
     }
 
-    async fn range_proof<K: api::KeyType, V, N>(
+    async fn range_proof<K: api::KeyType, V>(
         &self,
         _first_key: Option<K>,
         _last_key: Option<K>,

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -322,7 +322,7 @@ impl<S: ShaleStore<Node> + Send + Sync> DbRev<S> {
     ) -> Result<merkle::MerkleKeyValueStream<'_, S>, api::Error> {
         self.merkle
             .get_iter(start_key, self.header.kv_root)
-            .map_err(|e| api::Error::InternalError(e.into()))
+            .map_err(|e| api::Error::InternalError(Box::new(e)))
     }
 
     fn flush_dirty(&mut self) -> Option<()> {
@@ -454,7 +454,7 @@ impl Db {
         }
 
         block_in_place(|| Db::new_internal(db_path, cfg.clone()))
-            .map_err(|e| api::Error::InternalError(e.into()))
+            .map_err(|e| api::Error::InternalError(Box::new(e)))
     }
 
     /// Open a database.

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -351,7 +351,7 @@ impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
 
         // remove the last key from middle and do a proof on it
         let last_key = match middle.pop() {
-            None => return Err(api::Error::RangeProofError("Range too small".to_owned())),
+            None => return Err(api::Error::RangeTooSmall),
             Some((last_key, _)) => self.single_key_proof(last_key).await,
         };
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -29,6 +29,7 @@ use crate::{
 use async_trait::async_trait;
 use bytemuck::{cast_slice, AnyBitPattern};
 
+use futures::{future::ready, StreamExt as _, TryStreamExt as _};
 use metered::metered;
 use parking_lot::{Mutex, RwLock};
 use std::{
@@ -307,11 +308,62 @@ impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
 
     async fn range_proof<K: api::KeyType, V>(
         &self,
-        _first_key: Option<K>,
-        _last_key: Option<K>,
-        _limit: usize,
-    ) -> Result<Option<api::RangeProof<K, V, N>>, api::Error> {
-        todo!()
+        first_key: Option<K>,
+        last_key: Option<K>,
+        limit: Option<usize>,
+    ) -> Result<Option<api::RangeProof<Vec<u8>, Vec<u8>>>, api::Error> {
+        let mut stream = self.stream(first_key.as_ref())?;
+
+        // fetch the first key from the stream
+        let first_result = stream.next().await;
+
+        // transpose the Option<Result<T, E>> to Result<Option<T>, E>
+        // If this is an error, the ? operator will return it
+        let Some((key, _)) = first_result.transpose()? else {
+            // nothing returned, either the trie is empty or the key wasn't found
+            return Ok(None);
+        };
+
+        let Some(first_key) = self.single_key_proof(key).await? else {
+            return Ok(None);
+        };
+
+        // we stop streaming if either we hit the limit or the key returned was larger
+        // than the largest key requested
+        let mut middle = stream
+            .take(limit.unwrap_or(usize::MAX))
+            .take_while(|kv_result| {
+                // no last key asked for, so keep going
+                let Some(last_key) = last_key.as_ref() else {
+                    return ready(true);
+                };
+
+                // return the error if there was one
+                let Ok(kv) = kv_result else {
+                    return ready(true);
+                };
+
+                // keep going if the key returned is less than the last key requested
+                ready(kv.0.as_slice() <= last_key.as_ref())
+            })
+            .try_collect::<Vec<(Vec<u8>, Vec<u8>)>>()
+            .await?;
+
+        // remove the last key from middle and do a proof on it
+        let last_key = match middle.pop() {
+            None => return Err(api::Error::RangeProofError("Range too small".to_owned())),
+            Some((last_key, _)) => self.single_key_proof(last_key).await,
+        };
+
+        let Ok(Some(last_key)) = last_key else {
+            return Ok(None);
+        };
+
+        Ok(Some(api::RangeProof {
+            first_key,
+            middle,
+            last_key,
+        }))
     }
 }
 

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -295,12 +295,12 @@ impl api::DbView for Proposal {
             .map_err(|e| api::Error::IO(std::io::Error::new(ErrorKind::Other, e)))
     }
 
-    async fn range_proof<K, V, N>(
+    async fn range_proof<K, V>(
         &self,
         _first_key: Option<K>,
         _last_key: Option<K>,
-        _limit: usize,
-    ) -> Result<Option<api::RangeProof<K, V, N>>, api::Error>
+        _limit: Option<usize>,
+    ) -> Result<Option<api::RangeProof<Vec<u8>, Vec<u8>>>, api::Error>
     where
         K: api::KeyType,
     {

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1243,7 +1243,7 @@ impl<'a, S: shale::ShaleStore<node::Node> + Send + Sync> Stream for MerkleKeyVal
                 let root_node = self
                     .merkle
                     .get_node(self.merkle_root)
-                    .map_err(|e| api::Error::InternalError(e.into()))?;
+                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
                 let mut last_node = root_node;
                 let mut parents = vec![];
                 let leaf = loop {
@@ -1272,7 +1272,7 @@ impl<'a, S: shale::ShaleStore<node::Node> + Send + Sync> Stream for MerkleKeyVal
                             let next = self
                                 .merkle
                                 .get_node(leftmost_address)
-                                .map_err(|e| api::Error::InternalError(e.into()))?;
+                                .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
                             parents.push((last_node, leftmost_position as u8));
 
@@ -1295,12 +1295,12 @@ impl<'a, S: shale::ShaleStore<node::Node> + Send + Sync> Stream for MerkleKeyVal
                 let root_node = self
                     .merkle
                     .get_node(self.merkle_root)
-                    .map_err(|e| api::Error::InternalError(e.into()))?;
+                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
                 let (found_node, parents) = self
                     .merkle
                     .get_node_and_parents_by_key(root_node, &key)
-                    .map_err(|e| api::Error::InternalError(e.into()))?;
+                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
                 let Some(last_node) = found_node else {
                     return Poll::Ready(None);
@@ -1343,7 +1343,7 @@ impl<'a, S: shale::ShaleStore<node::Node> + Send + Sync> Stream for MerkleKeyVal
                         let current_node = self
                             .merkle
                             .get_node(child_address)
-                            .map_err(|e| api::Error::InternalError(e.into()))?;
+                            .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
                         let found_key = key_from_parents(&parents);
 
@@ -1389,7 +1389,7 @@ impl<'a, S: shale::ShaleStore<node::Node> + Send + Sync> Stream for MerkleKeyVal
                                         .merkle
                                         .get_node(found_address)
                                         .map(|node| (node, None))
-                                        .map_err(|e| api::Error::InternalError(e.into()))?;
+                                        .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
                                     // stop_descending if:
                                     //  - on a branch and it has a value; OR

--- a/firewood/src/merkle/range_proof.rs
+++ b/firewood/src/merkle/range_proof.rs
@@ -1,0 +1,88 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use std::future::ready;
+
+use futures::{StreamExt as _, TryStreamExt as _};
+
+use crate::{
+    shale::{disk_address::DiskAddress, ShaleStore},
+    v2::api,
+};
+
+use super::{Merkle, Node};
+
+impl<S: ShaleStore<Node> + Send + Sync> Merkle<S> {
+    pub(crate) async fn range_proof<K: api::KeyType + Send + Sync>(
+        &self,
+        root: DiskAddress,
+        first_key: Option<K>,
+        last_key: Option<K>,
+        limit: Option<usize>,
+    ) -> Result<Option<api::RangeProof<Vec<u8>, Vec<u8>>>, api::Error> {
+        // limit of 0 is always an empty RangeProof
+        if let Some(0) = limit {
+            return Ok(None);
+        }
+
+        let mut stream = self
+            .get_iter(first_key, root)
+            .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+
+        // fetch the first key from the stream
+        let first_result = stream.next().await;
+
+        // transpose the Option<Result<T, E>> to Result<Option<T>, E>
+        // If this is an error, the ? operator will return it
+        let Some((key, _)) = first_result.transpose()? else {
+            // nothing returned, either the trie is empty or the key wasn't found
+            return Ok(None);
+        };
+
+        let first_key = self
+            .prove(key, root)
+            .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+        let limit = limit.map(|old_limit| old_limit - 1);
+
+        // we stop streaming if either we hit the limit or the key returned was larger
+        // than the largest key requested
+        let mut middle = stream
+            .take(limit.unwrap_or(usize::MAX))
+            .take_while(|kv_result| {
+                // no last key asked for, so keep going
+                let Some(last_key) = last_key.as_ref() else {
+                    return ready(true);
+                };
+
+                // return the error if there was one
+                let Ok(kv) = kv_result else {
+                    return ready(true);
+                };
+
+                // keep going if the key returned is less than the last key requested
+                ready(kv.0.as_slice() <= last_key.as_ref())
+            })
+            .try_collect::<Vec<(Vec<u8>, Vec<u8>)>>()
+            .await?;
+
+        // remove the last key from middle and do a proof on it
+        let last_key = match middle.pop() {
+            None => {
+                return Ok(Some(api::RangeProof {
+                    first_key: first_key.clone(),
+                    middle: vec![],
+                    last_key: first_key,
+                }))
+            }
+            Some((last_key, _)) => self
+                .prove(last_key, root)
+                .map_err(|e| api::Error::InternalError(Box::new(e)))?,
+        };
+
+        Ok(Some(api::RangeProof {
+            first_key,
+            middle,
+            last_key,
+        }))
+    }
+}

--- a/firewood/src/merkle/range_proof.rs
+++ b/firewood/src/merkle/range_proof.rs
@@ -39,7 +39,7 @@ impl<S: ShaleStore<Node> + Send + Sync> Merkle<S> {
             return Ok(None);
         };
 
-        let first_key = self
+        let first_key_proof = self
             .prove(key, root)
             .map_err(|e| api::Error::InternalError(Box::new(e)))?;
         let limit = limit.map(|old_limit| old_limit - 1);
@@ -66,12 +66,12 @@ impl<S: ShaleStore<Node> + Send + Sync> Merkle<S> {
             .await?;
 
         // remove the last key from middle and do a proof on it
-        let last_key = match middle.pop() {
+        let last_key_proof = match middle.pop() {
             None => {
                 return Ok(Some(api::RangeProof {
-                    first_key: first_key.clone(),
+                    first_key_proof: first_key_proof.clone(),
                     middle: vec![],
-                    last_key: first_key,
+                    last_key_proof: first_key_proof,
                 }))
             }
             Some((last_key, _)) => self
@@ -80,9 +80,9 @@ impl<S: ShaleStore<Node> + Send + Sync> Merkle<S> {
         };
 
         Ok(Some(api::RangeProof {
-            first_key,
+            first_key_proof,
             middle,
-            last_key,
+            last_key_proof,
         }))
     }
 }

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -73,8 +73,8 @@ pub enum Error {
     #[error("Internal error")]
     InternalError(Box<dyn std::error::Error + Send>),
 
-    #[error("RangeProofError")]
-    RangeProofError(String),
+    #[error("Range too small")]
+    RangeTooSmall,
 }
 
 /// A range proof, consisting of a proof of the first key and the last key,

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -81,8 +81,8 @@ pub enum Error {
 /// and a vector of all key/value pairs
 #[derive(Debug)]
 pub struct RangeProof<K, V> {
-    pub first_key: Proof<Vec<u8>>,
-    pub last_key: Proof<Vec<u8>>,
+    pub first_key_proof: Proof<Vec<u8>>,
+    pub last_key_proof: Proof<Vec<u8>>,
     pub middle: Vec<(K, V)>,
 }
 

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -89,7 +89,7 @@ pub struct RangeProof<K, V> {
 /// A proof that a single key is present
 ///
 /// The generic N represents the storage for the node data
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Proof<N>(pub HashMap<HashKey, N>);
 
 /// The database interface, which includes a type for a static view of

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -71,15 +71,18 @@ pub enum Error {
     InvalidProposal,
 
     #[error("Internal error")]
-    InternalError(Box<dyn std::error::Error>),
+    InternalError(Box<dyn std::error::Error + Send>),
+
+    #[error("RangeProofError")]
+    RangeProofError(String),
 }
 
 /// A range proof, consisting of a proof of the first key and the last key,
 /// and a vector of all key/value pairs
 #[derive(Debug)]
-pub struct RangeProof<K, V, N> {
-    pub first_key: Proof<N>,
-    pub last_key: Proof<N>,
+pub struct RangeProof<K, V> {
+    pub first_key: Proof<Vec<u8>>,
+    pub last_key: Proof<Vec<u8>>,
     pub middle: Vec<(K, V)>,
 }
 
@@ -152,12 +155,12 @@ pub trait DbView {
     /// * `last_key` - If None, continue to the end of the database
     /// * `limit` - The maximum number of keys in the range proof
     ///
-    async fn range_proof<K: KeyType, V, N>(
+    async fn range_proof<K: KeyType, V: Send + Sync>(
         &self,
         first_key: Option<K>,
         last_key: Option<K>,
-        limit: usize,
-    ) -> Result<Option<RangeProof<K, V, N>>, Error>;
+        limit: Option<usize>,
+    ) -> Result<Option<RangeProof<Vec<u8>, Vec<u8>>>, Error>;
 }
 
 /// A proposal for a new revision of the database.

--- a/firewood/src/v2/db.rs
+++ b/firewood/src/v2/db.rs
@@ -32,11 +32,13 @@ pub struct Db<T> {
 impl From<DbError> for api::Error {
     fn from(value: DbError) -> Self {
         match value {
-            DbError::InvalidParams => api::Error::InternalError(value.into()),
-            DbError::Merkle(e) => api::Error::InternalError(e.into()),
+            DbError::InvalidParams => api::Error::InternalError(Box::new(value)),
+            DbError::Merkle(e) => api::Error::InternalError(Box::new(e)),
             DbError::System(e) => api::Error::IO(e.into()),
-            DbError::KeyNotFound | DbError::CreateError => api::Error::InternalError(value.into()),
-            DbError::Shale(e) => api::Error::InternalError(e.into()),
+            DbError::KeyNotFound | DbError::CreateError => {
+                api::Error::InternalError(Box::new(value))
+            }
+            DbError::Shale(e) => api::Error::InternalError(Box::new(e)),
             DbError::IO(e) => api::Error::IO(e),
             DbError::InvalidProposal => api::Error::InvalidProposal,
         }

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -66,12 +66,12 @@ impl DbView for HistoricalImpl {
         Ok(None)
     }
 
-    async fn range_proof<K: KeyType, V, N>(
+    async fn range_proof<K: KeyType, V>(
         &self,
         _first_key: Option<K>,
         _last_key: Option<K>,
-        _limit: usize,
-    ) -> Result<Option<RangeProof<K, V, N>>, Error> {
+        _limit: Option<usize>,
+    ) -> Result<Option<RangeProof<Vec<u8>, Vec<u8>>>, Error> {
         Ok(None)
     }
 }

--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -128,12 +128,12 @@ impl<T: api::DbView + Send + Sync> api::DbView for Proposal<T> {
         todo!()
     }
 
-    async fn range_proof<KT: KeyType, VT, NT>(
+    async fn range_proof<KT: KeyType, VT>(
         &self,
         _first_key: Option<KT>,
         _last_key: Option<KT>,
-        _limit: usize,
-    ) -> Result<Option<api::RangeProof<KT, VT, NT>>, api::Error> {
+        _limit: Option<usize>,
+    ) -> Result<Option<api::RangeProof<Vec<u8>, Vec<u8>>>, api::Error> {
         todo!()
     }
 }


### PR DESCRIPTION
The generic N can't be specified by the caller, since the method needs to create owned things of type N, so this generic was removed from the trait.

There is a subtle difference between `Into::into` and `Box::new` in that the former is not Send for some reason.