### PR TITLE
1/3: kv_dump should be done with the iterator

### DIFF
--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.66"
 env_logger = "0.10.0"
 log = "0.4.17"
 tokio = { version = "1.33.0", features = ["full"] }
+futures-util = "0.3.29"
 
 [dev-dependencies]
 assert_cmd = "2.0.7"

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -202,7 +202,7 @@ fn fwdctl_dump() -> Result<()> {
         .args([tmpdb::path()])
         .assert()
         .success()
-        .stdout(predicate::str::is_empty().not());
+        .stdout(predicate::str::contains("2023"));
 
     fwdctl_delete_db().map_err(|e| anyhow!(e))?;
 


### PR DESCRIPTION
Part one of removing kv_dump, which was used as a debugging aid. This removes the dependency on kv_dump from the cli, instead using the iterator and rendering the trie with all keys and values.

Dependent on all other streaming iterator work; suggest reviewing last commit (that is, those after rkuris/streaming_iterator_from_start)