### PR TITLE
Fix new clippy lint (rust 1.74.0)

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1609,7 +1609,7 @@ mod tests {
 
     fn branch(value: Vec<u8>, encoded_child: Option<Vec<u8>>) -> Node {
         let children = Default::default();
-        let value = Some(value).map(Data);
+        let value = Some(Data(value));
         let mut children_encoded = <[Option<Vec<u8>>; NBRANCH]>::default();
 
         if let Some(child) = encoded_child {


### PR DESCRIPTION
error: unnecessary map on constructor Some(_)
    --> firewood/src/merkle.rs:1612:21
     |
1612 |         let value = Some(value).map(Data);
     |                     ^^^^^^^^^^^^^^^^^^^^^ help: try: `Some(Data(value))`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_on_constructor
     = note: `-D clippy::unnecessary-map-on-constructor` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::unnecessary_map_on_constructor)]`

    Checking fwdctl v0.0.4 (/home/runner/work/firewood/firewood/fwdctl)
error