### PR TITLE
Enable lints for discussion

### DIFF
--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -16,3 +16,12 @@ futures-util = "0.3.29"
 assert_cmd = "2.0.7"
 predicates = "3.0.1"
 serial_test = "2.0.0"
+
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+unwrap_used = "warn"
+indexing_slicing = "warn"
+explicit_deref_methods = "warn"
+missing_const_for_fn = "warn"

--- a/fwdctl/src/create.rs
+++ b/fwdctl/src/create.rs
@@ -245,7 +245,7 @@ pub struct Options {
     max_revisions: u32,
 }
 
-pub fn initialize_db_config(opts: &Options) -> DbConfig {
+pub(super) const fn initialize_db_config(opts: &Options) -> DbConfig {
     DbConfig {
         meta_ncached_pages: opts.meta_ncached_pages,
         meta_ncached_files: opts.meta_ncached_files,
@@ -279,7 +279,7 @@ pub fn initialize_db_config(opts: &Options) -> DbConfig {
     }
 }
 
-pub async fn run(opts: &Options) -> Result<(), api::Error> {
+pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     let db_config = initialize_db_config(opts);
     log::debug!("database configuration parameters: \n{:?}\n", db_config);
 

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -27,7 +27,7 @@ pub struct Options {
     pub db: String,
 }
 
-pub async fn run(opts: &Options) -> Result<(), api::Error> {
+pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("deleting key {:?}", opts);
     let cfg = DbConfig::builder()
         .truncate(false)

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -23,7 +23,7 @@ pub struct Options {
     pub db: String,
 }
 
-pub async fn run(opts: &Options) -> Result<(), api::Error> {
+pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("dump database {:?}", opts);
     let cfg = DbConfig::builder()
         .truncate(false)
@@ -37,7 +37,7 @@ pub async fn run(opts: &Options) -> Result<(), api::Error> {
         match stream.next().await {
             None => break,
             Some(Ok((key, value))) => {
-                println!("'{}': '{}'", u8_to_string(&key), u8_to_string(&value))
+                println!("'{}': '{}'", u8_to_string(&key), u8_to_string(&value));
             }
             Some(Err(e)) => return Err(e),
         }

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -26,7 +26,7 @@ pub struct Options {
     pub db: String,
 }
 
-pub async fn run(opts: &Options) -> Result<(), api::Error> {
+pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("get key value pair {:?}", opts);
     let cfg = DbConfig::builder()
         .truncate(false)
@@ -39,7 +39,7 @@ pub async fn run(opts: &Options) -> Result<(), api::Error> {
     match rev.val(opts.key.as_bytes()).await {
         Ok(Some(val)) => {
             let s = String::from_utf8_lossy(val.as_ref());
-            println!("{:?}", s);
+            println!("{s:?}");
             Ok(())
         }
         Ok(None) => {

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -31,7 +31,7 @@ pub struct Options {
     pub db: String,
 }
 
-pub async fn run(opts: &Options) -> Result<(), api::Error> {
+pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("inserting key value pair {:?}", opts);
     let cfg = DbConfig::builder()
         .truncate(false)

--- a/fwdctl/src/root.rs
+++ b/fwdctl/src/root.rs
@@ -23,7 +23,7 @@ pub struct Options {
     pub db: String,
 }
 
-pub async fn run(opts: &Options) -> Result<(), api::Error> {
+pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("root hash {:?}", opts);
     let cfg = DbConfig::builder()
         .truncate(false)
@@ -32,6 +32,6 @@ pub async fn run(opts: &Options) -> Result<(), api::Error> {
     let db = Db::new(opts.db.clone(), &cfg.build()).await?;
 
     let root = db.root_hash().await?;
-    println!("{:X?}", root);
+    println!("{root:X?}");
     Ok(())
 }


### PR DESCRIPTION
These lints are only in fwdctl because it was easy to fix the few errors that popped up. Once we agree these are the right lints, we can move them to the top level.

For ease of review, here are links to the lint descriptions we are enabling as well reasons why I think they are important:

 - https://rust-lang.github.io/rust-clippy/rust-1.74.0/index.html#/unwrap_used
 - - code that panics should be avoided, except in tests
 - - not all panics have good error messages
 - https://rust-lang.github.io/rust-clippy/rust-1.74.0/index.html#/indexing_slicing
 - - panics
 - - there are good alternatives to index dereference that do not panic
 - https://rust-lang.github.io/rust-clippy/rust-1.74.0/index.html#/explicit_deref_methods
 - - easier and clearer just to dereference
 - https://rust-lang.github.io/rust-clippy/rust-1.74.0/index.html#/missing_const_for_fn
 - - non-const functions prevent callers from being const