### PR TITLE
Delegate branch-storage logic to the branch mod

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 mod node;
 mod trie_hash;
 
-pub use node::{BranchNode, Data, ExtNode, LeafNode, Node, NodeType, PartialPath, MAX_CHILDREN};
+pub use node::{BranchNode, Data, ExtNode, LeafNode, Node, NodeType, PartialPath};
 pub use trie_hash::{TrieHash, TRIE_HASH_LEN};
 
 type ObjRef<'a> = shale::ObjRef<'a, Node>;
@@ -81,7 +81,7 @@ impl<S: ShaleStore<Node> + Send + Sync> Merkle<S> {
             .put_item(
                 Node::from_branch(BranchNode {
                     // path: vec![].into(),
-                    children: [None; MAX_CHILDREN],
+                    children: [None; BranchNode::MAX_CHILDREN],
                     value: None,
                     children_encoded: Default::default(),
                 }),
@@ -199,7 +199,7 @@ impl<S: ShaleStore<Node> + Send + Sync> Merkle<S> {
             ));
             let leaf_address = self.put_node(new_node)?.as_ptr();
 
-            let mut chd = [None; MAX_CHILDREN];
+            let mut chd = [None; BranchNode::MAX_CHILDREN];
 
             let last_matching_nibble = matching_path[idx];
             chd[last_matching_nibble as usize] = Some(leaf_address);
@@ -340,7 +340,7 @@ impl<S: ShaleStore<Node> + Send + Sync> Merkle<S> {
                 };
 
             // [parent] (-> [ExtNode]) -> [branch with v] -> [Leaf]
-            let mut children = [None; MAX_CHILDREN];
+            let mut children = [None; BranchNode::MAX_CHILDREN];
 
             children[idx] = leaf_address.into();
 
@@ -561,7 +561,7 @@ impl<S: ShaleStore<Node> + Send + Sync> Merkle<S> {
             };
 
             if let Some((idx, more, ext, val)) = info {
-                let mut chd = [None; MAX_CHILDREN];
+                let mut chd = [None; BranchNode::MAX_CHILDREN];
 
                 let c_ptr = if more {
                     u_ptr
@@ -1695,7 +1695,7 @@ mod tests {
     fn branch(value: Vec<u8>, encoded_child: Option<Vec<u8>>) -> Node {
         let children = Default::default();
         let value = Some(Data(value));
-        let mut children_encoded = <[Option<Vec<u8>>; MAX_CHILDREN]>::default();
+        let mut children_encoded = <[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>::default();
 
         if let Some(child) = encoded_child {
             children_encoded[0] = Some(child);

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -28,29 +28,6 @@ pub struct BranchNode {
     pub(crate) children_encoded: [Option<Vec<u8>>; MAX_CHILDREN],
 }
 
-enum BranchDataLength {
-    None,
-    Length(u32),
-}
-
-impl From<u32> for BranchDataLength {
-    fn from(value: u32) -> Self {
-        match value {
-            u32::MAX => BranchDataLength::None,
-            len => BranchDataLength::Length(len),
-        }
-    }
-}
-
-impl From<BranchDataLength> for u32 {
-    fn from(value: BranchDataLength) -> Self {
-        match value {
-            BranchDataLength::None => u32::MAX,
-            BranchDataLength::Length(len) => len,
-        }
-    }
-}
-
 impl Debug for BranchNode {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         write!(f, "[Branch")?;

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -4,14 +4,21 @@
 use super::{Data, Encoded, Node};
 use crate::{
     merkle::{PartialPath, TRIE_HASH_LEN},
-    shale::DiskAddress,
     shale::ShaleStore,
+    shale::{DiskAddress, Storable},
 };
 use bincode::{Error, Options};
-use std::fmt::{Debug, Error as FmtError, Formatter};
+use std::{
+    fmt::{Debug, Error as FmtError, Formatter},
+    io::{Cursor, Write},
+    mem::size_of,
+    ops::Deref,
+};
 
-pub const MAX_CHILDREN: usize = 16;
-pub const SIZE: usize = MAX_CHILDREN + 1;
+pub type DataLen = u32;
+pub type EncodedChildLen = u8;
+
+const MAX_CHILDREN: usize = 16;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct BranchNode {
@@ -19,6 +26,29 @@ pub struct BranchNode {
     pub(crate) children: [Option<DiskAddress>; MAX_CHILDREN],
     pub(crate) value: Option<Data>,
     pub(crate) children_encoded: [Option<Vec<u8>>; MAX_CHILDREN],
+}
+
+enum BranchDataLength {
+    None,
+    Length(u32),
+}
+
+impl From<u32> for BranchDataLength {
+    fn from(value: u32) -> Self {
+        match value {
+            u32::MAX => BranchDataLength::None,
+            len => BranchDataLength::Length(len),
+        }
+    }
+}
+
+impl From<BranchDataLength> for u32 {
+    fn from(value: BranchDataLength) -> Self {
+        match value {
+            BranchDataLength::None => u32::MAX,
+            BranchDataLength::Length(len) => len,
+        }
+    }
 }
 
 impl Debug for BranchNode {
@@ -50,11 +80,14 @@ impl Debug for BranchNode {
 }
 
 impl BranchNode {
+    pub const MAX_CHILDREN: usize = MAX_CHILDREN;
+    pub const MSIZE: usize = Self::MAX_CHILDREN + 1;
+
     pub fn new(
         _path: PartialPath,
-        chd: [Option<DiskAddress>; MAX_CHILDREN],
+        chd: [Option<DiskAddress>; Self::MAX_CHILDREN],
         value: Option<Vec<u8>>,
-        chd_encoded: [Option<Vec<u8>>; MAX_CHILDREN],
+        chd_encoded: [Option<Vec<u8>>; Self::MAX_CHILDREN],
     ) -> Self {
         BranchNode {
             // path,
@@ -68,19 +101,19 @@ impl BranchNode {
         &self.value
     }
 
-    pub fn chd(&self) -> &[Option<DiskAddress>; MAX_CHILDREN] {
+    pub fn chd(&self) -> &[Option<DiskAddress>; Self::MAX_CHILDREN] {
         &self.children
     }
 
-    pub fn chd_mut(&mut self) -> &mut [Option<DiskAddress>; MAX_CHILDREN] {
+    pub fn chd_mut(&mut self) -> &mut [Option<DiskAddress>; Self::MAX_CHILDREN] {
         &mut self.children
     }
 
-    pub fn chd_encode(&self) -> &[Option<Vec<u8>>; MAX_CHILDREN] {
+    pub fn chd_encode(&self) -> &[Option<Vec<u8>>; Self::MAX_CHILDREN] {
         &self.children_encoded
     }
 
-    pub fn chd_encoded_mut(&mut self) -> &mut [Option<Vec<u8>>; MAX_CHILDREN] {
+    pub fn chd_encoded_mut(&mut self) -> &mut [Option<Vec<u8>>; Self::MAX_CHILDREN] {
         &mut self.children_encoded
     }
 
@@ -109,7 +142,7 @@ impl BranchNode {
         let value = Some(data).filter(|data| !data.is_empty());
 
         // encode all children.
-        let mut chd_encoded: [Option<Vec<u8>>; MAX_CHILDREN] = Default::default();
+        let mut chd_encoded: [Option<Vec<u8>>; Self::MAX_CHILDREN] = Default::default();
 
         // we popped the last element, so their should only be NBRANCH items left
         for (i, chd) in items.into_iter().enumerate() {
@@ -122,7 +155,7 @@ impl BranchNode {
 
         Ok(BranchNode::new(
             path,
-            [None; MAX_CHILDREN],
+            [None; Self::MAX_CHILDREN],
             value,
             chd_encoded,
         ))
@@ -130,7 +163,7 @@ impl BranchNode {
 
     pub(super) fn encode<S: ShaleStore<Node>>(&self, store: &S) -> Vec<u8> {
         // TODO: add path to encoded node
-        let mut list = <[Encoded<Vec<u8>>; MAX_CHILDREN + 1]>::default();
+        let mut list = <[Encoded<Vec<u8>>; Self::MAX_CHILDREN + 1]>::default();
 
         for (i, c) in self.children.iter().enumerate() {
             match c {
@@ -170,7 +203,7 @@ impl BranchNode {
         }
 
         if let Some(Data(val)) = &self.value {
-            list[MAX_CHILDREN] =
+            list[Self::MAX_CHILDREN] =
                 Encoded::Data(bincode::DefaultOptions::new().serialize(val).unwrap());
         }
 
@@ -178,4 +211,60 @@ impl BranchNode {
             .serialize(list.as_slice())
             .unwrap()
     }
+}
+
+impl Storable for BranchNode {
+    fn serialized_len(&self) -> u64 {
+        let children_len = Self::MAX_CHILDREN as u64 * DiskAddress::MSIZE;
+        let data_len = optional_data_len::<DataLen, _>(self.value.as_deref());
+        let children_encoded_len = self.children_encoded.iter().fold(0, |len, child| {
+            len + optional_data_len::<EncodedChildLen, _>(child.as_ref())
+        });
+
+        children_len + data_len + children_encoded_len
+    }
+
+    fn serialize(&self, to: &mut [u8]) -> Result<(), crate::shale::ShaleError> {
+        let mut cursor = Cursor::new(to);
+
+        for child in &self.children {
+            let bytes = child.map(|addr| addr.to_le_bytes()).unwrap_or_default();
+            cursor.write_all(&bytes)?;
+        }
+
+        let (value_len, value) = self
+            .value
+            .as_ref()
+            .map(|val| (val.len() as DataLen, val.deref()))
+            .unwrap_or((DataLen::MAX, &[]));
+
+        cursor.write_all(&value_len.to_le_bytes())?;
+        cursor.write_all(value)?;
+
+        for child_encoded in &self.children_encoded {
+            let (child_len, child) = child_encoded
+                .as_ref()
+                .map(|child| (child.len() as EncodedChildLen, child.as_slice()))
+                .unwrap_or((EncodedChildLen::MIN, &[]));
+
+            cursor.write_all(&child_len.to_le_bytes())?;
+            cursor.write_all(child)?;
+        }
+
+        Ok(())
+    }
+
+    fn deserialize<T: crate::shale::CachedStore>(
+        _addr: usize,
+        _mem: &T,
+    ) -> Result<Self, crate::shale::ShaleError>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+}
+
+fn optional_data_len<Len, T: AsRef<[u8]>>(data: Option<T>) -> u64 {
+    size_of::<Len>() as u64 + data.as_ref().map_or(0, |data| data.as_ref().len() as u64)
 }

--- a/firewood/src/shale/disk_address.rs
+++ b/firewood/src/shale/disk_address.rs
@@ -30,6 +30,8 @@ impl DerefMut for DiskAddress {
 }
 
 impl DiskAddress {
+    pub(crate) const MSIZE: u64 = size_of::<Self>() as u64;
+
     /// Return a None DiskAddress
     pub fn null() -> Self {
         DiskAddress(None)
@@ -158,10 +160,6 @@ impl std::ops::BitAnd<usize> for DiskAddress {
     fn bitand(self, rhs: usize) -> Self::Output {
         (self.get() & rhs).into()
     }
-}
-
-impl DiskAddress {
-    const MSIZE: u64 = size_of::<Self>() as u64;
 }
 
 impl Storable for DiskAddress {


### PR DESCRIPTION
There is a code move here and well as some code changes. They are unfortunately in one commit. Breaking it up would mean re-implementing it and possibly introducing a bug. 

I will be doing the same thing with both leaf and extension nodes.

Upon reviewing my own code, I see that this is actually just serialization. There's a `todo!()` that will come later for deserialization. 

