### PR TITLE
Move proof to be a sub-module of merkle

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -8,14 +8,13 @@ pub use crate::{
 };
 use crate::{
     file,
-    merkle::{Merkle, MerkleError, Node, TrieHash, TRIE_HASH_LEN},
-    proof::ProofError,
+    merkle::{Merkle, MerkleError, Node, Proof, ProofError, TrieHash, TRIE_HASH_LEN},
     storage::{
         buffer::{DiskBuffer, DiskBufferRequester},
         CachedSpace, MemStoreR, SpaceWrite, StoreConfig, StoreDelta, StoreRevMut, StoreRevShared,
         ZeroStore, PAGE_SIZE_NBIT,
     },
-    v2::api::{self, HashKey, KeyType, Proof, ValueType},
+    v2::api::{self, HashKey, KeyType, ValueType},
 };
 use crate::{
     merkle,

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -6,6 +6,7 @@ use super::{
     DbHeader, DbInner, DbRev, DbRevInner, SharedStore, Store, Universe, MERKLE_META_SPACE,
     MERKLE_PAYLOAD_SPACE, ROOT_HASH_SPACE,
 };
+use crate::merkle::Proof;
 use crate::shale::CachedStore;
 use crate::{
     merkle::{TrieHash, TRIE_HASH_LEN},
@@ -285,7 +286,7 @@ impl api::DbView for Proposal {
         Ok(self.get_revision().kv_get(key))
     }
 
-    async fn single_key_proof<K>(&self, key: K) -> Result<Option<api::Proof<Vec<u8>>>, api::Error>
+    async fn single_key_proof<K>(&self, key: K) -> Result<Option<Proof<Vec<u8>>>, api::Error>
     where
         K: api::KeyType,
     {

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -188,7 +188,6 @@ pub mod db;
 pub(crate) mod file;
 pub mod merkle;
 pub mod merkle_util;
-pub mod proof;
 pub mod storage;
 
 pub mod config;

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1,8 +1,8 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
+use crate::nibbles::Nibbles;
 use crate::shale::{self, disk_address::DiskAddress, ObjWriteError, ShaleError, ShaleStore};
 use crate::v2::api;
-use crate::{nibbles::Nibbles, v2::api::Proof};
 use futures::{Stream, StreamExt, TryStreamExt};
 use sha3::Digest;
 use std::{
@@ -12,9 +12,11 @@ use std::{
 use thiserror::Error;
 
 mod node;
+pub mod proof;
 mod trie_hash;
 
 pub use node::{BranchNode, Data, ExtNode, LeafNode, Node, NodeType, PartialPath};
+pub use proof::{Proof, ProofError};
 pub use trie_hash::{TrieHash, TRIE_HASH_LEN};
 
 type ObjRef<'a> = shale::ObjRef<'a, Node>;

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -2,9 +2,11 @@
 // See the file LICENSE.md for licensing terms.
 
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::ops::Deref;
 
 use crate::shale::{disk_address::DiskAddress, ShaleError, ShaleStore};
+use crate::v2::api::HashKey;
 use nix::errno::Errno;
 use sha3::Digest;
 use thiserror::Error;
@@ -15,7 +17,6 @@ use crate::{
     db::DbError,
     merkle::{to_nibble_array, Merkle, MerkleError, Node, NodeType},
     merkle_util::{new_merkle, DataStoreError, MerkleSetup},
-    v2::api::Proof,
 };
 
 #[derive(Debug, Error)]
@@ -83,6 +84,12 @@ impl From<DbError> for ProofError {
         }
     }
 }
+
+/// A proof that a single key is present
+///
+/// The generic N represents the storage for the node data
+#[derive(Clone, Debug)]
+pub struct Proof<N>(pub HashMap<HashKey, N>);
 
 /// SubProof contains the encoded value and the hash value of a node that maps
 /// to a single proof step. If reaches an end step during proof verification,

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -1,14 +1,10 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use crate::merkle::{Merkle, Node, Proof, ProofError, Ref, RefMut, TrieHash};
 use crate::shale::{
     self, cached::DynamicMem, compact::CompactSpace, disk_address::DiskAddress, CachedStore,
     ShaleStore, StoredView,
-};
-use crate::{
-    merkle::{Merkle, Node, Ref, RefMut, TrieHash},
-    proof::ProofError,
-    v2::api::Proof,
 };
 use std::{num::NonZeroUsize, sync::Arc};
 use thiserror::Error;

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -1,9 +1,9 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
-
+pub use crate::merkle::Proof;
 use async_trait::async_trait;
+use std::{fmt::Debug, sync::Arc};
 
 /// A `KeyType` is something that can be xcast to a u8 reference,
 /// and can be sent and shared across threads. References with
@@ -85,12 +85,6 @@ pub struct RangeProof<K, V> {
     pub last_key_proof: Proof<Vec<u8>>,
     pub middle: Vec<(K, V)>,
 }
-
-/// A proof that a single key is present
-///
-/// The generic N represents the storage for the node data
-#[derive(Clone, Debug)]
-pub struct Proof<N>(pub HashMap<HashKey, N>);
 
 /// The database interface, which includes a type for a static view of
 /// the database (the DbView). The most common implementation of the DbView

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -1,12 +1,13 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use std::sync::Arc;
-
+use super::{
+    api::{Batch, Db, DbView, Error, HashKey, KeyType, RangeProof, ValueType},
+    propose::{Proposal, ProposalBase},
+};
+use crate::merkle::Proof;
 use async_trait::async_trait;
-
-use super::api::{Batch, Db, DbView, Error, HashKey, KeyType, Proof, RangeProof, ValueType};
-use super::propose::{Proposal, ProposalBase};
+use std::sync::Arc;
 
 /// An EmptyDb is a simple implementation of api::Db
 /// that doesn't store any data. It contains a single

--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 
-use crate::v2::api;
+use crate::{merkle::Proof, v2::api};
 
 use super::api::{KeyType, ValueType};
 
@@ -124,7 +124,7 @@ impl<T: api::DbView + Send + Sync> api::DbView for Proposal<T> {
     async fn single_key_proof<K: KeyType>(
         &self,
         _key: K,
-    ) -> Result<Option<api::Proof<Vec<u8>>>, api::Error> {
+    ) -> Result<Option<Proof<Vec<u8>>>, api::Error> {
         todo!()
     }
 

--- a/firewood/tests/merkle.rs
+++ b/firewood/tests/merkle.rs
@@ -2,12 +2,10 @@
 // See the file LICENSE.md for licensing terms.
 
 use firewood::{
-    merkle::Node,
+    merkle::{Node, Proof, ProofError},
     merkle_util::{new_merkle, DataStoreError, MerkleSetup},
-    proof::ProofError,
     // TODO: we should not be using shale from an integration test
     shale::{cached::DynamicMem, compact::CompactSpace},
-    v2::api::Proof,
 };
 use rand::Rng;
 use std::collections::HashMap;


### PR DESCRIPTION
Proofs only make sense in the context of a merkle-tree, therefore they should be a submodule of the merkle module.

