### PR TITLE
Centralize trie-traversal for proof generation

### DIFF
--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -55,6 +55,12 @@ impl From<Vec<u8>> for Data {
     }
 }
 
+impl Data {
+    pub fn into_inner(self) -> Vec<u8> {
+        self.0
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 enum Encoded<T> {
     Raw(T),

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -164,6 +164,11 @@ impl BranchNode {
                         list[i] = Encoded::Raw(child_encoded.to_vec());
                     }
                 }
+
+                // I'm not sure that this case makes sense. Why would there be an encoded child if there isn't a
+                // a disk-address in the same slot?
+                // TODO:
+                // change the data-structure children: [(Option<DiskAddress>, Option<Vec<u8>>); Self::MAX_CHILDREN]
                 None => {
                     // Check if there is already a calculated encoded value for the child, which
                     // can happen when manually constructing a trie from proof.

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -165,8 +165,10 @@ impl BranchNode {
                     }
                 }
 
-                // I'm not sure that this case makes sense. Why would there be an encoded child if there isn't a
-                // a disk-address in the same slot?
+                // TODO:
+                // we need a better solution for this. This is only used for reconstructing a
+                // merkle-tree in memory. The proper way to do it is to abstract a trait for nodes
+                // but that's a heavy lift.
                 // TODO:
                 // change the data-structure children: [(Option<DiskAddress>, Option<Vec<u8>>); Self::MAX_CHILDREN]
                 None => {

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -19,6 +19,8 @@ use crate::{
     merkle_util::{new_merkle, DataStoreError, MerkleSetup},
 };
 
+use super::TRIE_HASH_LEN;
+
 #[derive(Debug, Error)]
 pub enum ProofError {
     #[error("decoding error")]
@@ -91,15 +93,14 @@ impl From<DbError> for ProofError {
 #[derive(Clone, Debug)]
 pub struct Proof<N>(pub HashMap<HashKey, N>);
 
-/// SubProof contains the encoded value and the hash value of a node that maps
+/// `SubProof` contains the value or the hash of a node that maps
 /// to a single proof step. If reaches an end step during proof verification,
-/// the hash value will be none, and the encoded value will be the value of the
-/// node.
+/// the `SubProof` should be the `Value` variant.
 
 #[derive(Debug)]
-struct SubProof {
-    encoded: Vec<u8>,
-    hash: Option<[u8; 32]>,
+enum SubProof {
+    Data(Vec<u8>),
+    Hash([u8; TRIE_HASH_LEN]),
 }
 
 impl<N: AsRef<[u8]> + Send> Proof<N> {
@@ -130,14 +131,9 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
 
             cur_hash = match sub_proof {
                 // Return when reaching the end of the key.
-                Some(SubProof {
-                    encoded,
-                    hash: None,
-                }) if key_nibbles.is_empty() => return Ok(Some(encoded)),
+                Some(SubProof::Data(value)) if key_nibbles.is_empty() => return Ok(Some(value)),
                 // The trie doesn't contain the key.
-                Some(SubProof {
-                    hash: Some(hash), ..
-                }) => hash,
+                Some(SubProof::Hash(hash)) => hash,
                 _ => return Ok(None),
             };
         }
@@ -350,14 +346,16 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
                         let mut data = None;
 
                         // Decode the last subproof to get the value.
-                        if let Some(p_hash) = p.hash.as_ref() {
-                            let proof =
-                                proofs_map.get(p_hash).ok_or(ProofError::ProofNodeMissing)?;
+                        if let SubProof::Hash(p_hash) = p {
+                            let proof = proofs_map
+                                .get(&p_hash)
+                                .ok_or(ProofError::ProofNodeMissing)?;
 
                             chd_ptr = self.decode_node(merkle, cur_key, proof.as_ref(), true)?.0;
 
                             // Link the child to the parent based on the node type.
                             match &u_ref.inner() {
+                                // TODO: add path
                                 NodeType::Branch(n) if n.chd()[branch_index].is_none() => {
                                     // insert the leaf to the empty slot
                                     u_ref
@@ -407,8 +405,12 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
                             NodeType::Leaf(n) => {
                                 // Return the value on the node only when the key matches exactly
                                 // (e.g. the length path of subproof node is 0).
-                                if p.hash.is_none() || (p.hash.is_some() && n.path().len() == 0) {
-                                    data = Some(n.data().deref().to_vec());
+                                match p {
+                                    SubProof::Data(_) => data = Some(n.data().deref().to_vec()),
+                                    SubProof::Hash(_) if n.path().len() == 0 => {
+                                        data = Some(n.data().deref().to_vec())
+                                    }
+                                    _ => (),
                                 }
                             }
                             _ => (),
@@ -418,7 +420,7 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
                     }
 
                     // The trie doesn't contain the key.
-                    if p.hash.is_none() {
+                    let SubProof::Hash(hash) = p else {
                         return if allow_non_existent_node {
                             Ok(None)
                         } else {
@@ -426,7 +428,7 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
                         };
                     };
 
-                    cur_hash = p.hash.unwrap();
+                    cur_hash = hash;
                     cur_key = &chunks[key_index..];
                 }
             }
@@ -451,17 +453,17 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
             .put_node(Node::from(node))
             .map_err(ProofError::InvalidNode)?;
         let addr = new_node.as_ptr();
+
         match new_node.inner() {
             NodeType::Leaf(n) => {
                 let cur_key = n.path().0.as_ref();
+
                 if !key.contains_other(cur_key) {
                     return Ok((addr, None, 0));
                 }
 
-                let subproof = SubProof {
-                    encoded: n.data().to_vec(),
-                    hash: None,
-                };
+                let subproof = SubProof::Data(n.data().to_vec());
+
                 Ok((addr, subproof.into(), cur_key.len()))
             }
             NodeType::Extension(n) => {
@@ -510,10 +512,7 @@ fn locate_subproof(
 
             let encoded: Vec<u8> = n.data().to_vec();
 
-            let sub_proof = SubProof {
-                encoded,
-                hash: None,
-            };
+            let sub_proof = SubProof::Data(encoded);
 
             Ok((sub_proof.into(), key_nibbles))
         }
@@ -536,10 +535,7 @@ fn locate_subproof(
             let Some(index) = key_nibbles.next().map(|nib| nib as usize) else {
                 let encoded = n.value;
 
-                let sub_proof = encoded.map(|encoded| SubProof {
-                    encoded: encoded.into_inner(),
-                    hash: None,
-                });
+                let sub_proof = encoded.map(|encoded| SubProof::Data(encoded.into_inner()));
 
                 return Ok((sub_proof, key_nibbles));
             };
@@ -558,20 +554,14 @@ fn generate_subproof(encoded: Vec<u8>) -> Result<SubProof, ProofError> {
     match encoded.len() {
         0..=31 => {
             let sub_hash = sha3::Keccak256::digest(&encoded).into();
-            Ok(SubProof {
-                encoded,
-                hash: Some(sub_hash),
-            })
+            Ok(SubProof::Hash(sub_hash))
         }
 
         32 => {
             let sub_hash: &[u8] = &encoded;
             let sub_hash = sub_hash.try_into().unwrap();
 
-            Ok(SubProof {
-                encoded,
-                hash: Some(sub_hash),
-            })
+            Ok(SubProof::Hash(sub_hash))
         }
 
         len => Err(ProofError::DecodeError(Box::new(

--- a/firewood/tests/merkle.rs
+++ b/firewood/tests/merkle.rs
@@ -201,23 +201,6 @@ fn test_root_hash_random_deletions() -> Result<(), DataStoreError> {
 }
 
 #[test]
-fn test_one_element_proof() -> Result<(), DataStoreError> {
-    let items = vec![("k", "v")];
-    let merkle = merkle_build_test(items, 0x10000, 0x10000)?;
-    let key = "k";
-
-    let proof = merkle.prove(key)?;
-    assert!(!proof.0.is_empty());
-    assert!(proof.0.len() == 1);
-
-    let val = merkle.verify_proof(key, &proof)?;
-    assert!(val.is_some());
-    assert_eq!(&val.unwrap(), b"v");
-
-    Ok(())
-}
-
-#[test]
 fn test_proof() -> Result<(), DataStoreError> {
     let set = generate_random_data(500);
     let mut items = Vec::from_iter(set.iter());


### PR DESCRIPTION
Trie traversal has historically been re-implmented in every place that requires such logic. This makes it very difficult to implement any changes in the trie structure itself. Traversal has been partially centralized prior to this PR, but this _should_ finish the job.

