### PR TITLE
growth-ring: Add remaining lint checks

### DIFF
--- a/growth-ring/Cargo.toml
+++ b/growth-ring/Cargo.toml
@@ -35,4 +35,6 @@ crate-type = ["dylib", "rlib", "staticlib"]
 
 [lints.clippy]
 unwrap_used = "warn"
+indexing_slicing = "warn"
+explicit_deref_methods = "warn"
 missing_const_for_fn = "warn"

--- a/growth-ring/tests/common/mod.rs
+++ b/growth-ring/tests/common/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(clippy::indexing_slicing)]
 #[cfg(test)]
 use async_trait::async_trait;
 use futures::executor::block_on;

--- a/growth-ring/tests/rand_fail.rs
+++ b/growth-ring/tests/rand_fail.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(clippy::indexing_slicing)]
 #[cfg(test)]
 mod common;
 


### PR DESCRIPTION
Removed a couple of index dereferences and unwraps.

Unfortunately, there's one spot where it isn't easy to add the lint check, so there is a block that disables it. It's still a lot better having it in most of the project and not in this block. (search for TODO: not allowed for the spot).

Rewriting the loop to be more idiomatic is probably the right move here, but that's outside the scope of this fix.