### PR TITLE
Write panics to the log

### DIFF
--- a/grpc-testtool/Cargo.toml
+++ b/grpc-testtool/Cargo.toml
@@ -26,6 +26,7 @@ tempdir = "0.3.7"
 log = "0.4.20"
 env_logger = "0.10.1"
 chrono = "0.4.31"
+log-panics = { version = "2.1.0", features = ["backtrace", "with-backtrace"] }
 
 [build-dependencies]
 tonic-build = "0.10.0"


### PR DESCRIPTION
The orchestrator does not save the standard output of this executable, it expects everything to be logged. We have two options here, one is to just write the panics to the log (which is now a required option) and the other is to redirect stderr into the log. I went with the former, since I want to see the "starting up" message if I run it interactively.

This could be a little better -- we could both write it to the log and then render the panic to stderr, but that doesn't seem possible with the log_panic crate.