### PR TITLE
Orchestrator interface changes

### DIFF
--- a/grpc-testtool/Cargo.toml
+++ b/grpc-testtool/Cargo.toml
@@ -26,7 +26,8 @@ tempdir = "0.3.7"
 log = "0.4.20"
 env_logger = "0.10.1"
 chrono = "0.4.31"
-log-panics = { version = "2.1.0", features = ["backtrace", "with-backtrace"] }
+serde_json = "1.0.108"
+serde = { version = "1.0.193", features = ["derive"] }
 
 [build-dependencies]
 tonic-build = "0.10.0"

--- a/grpc-testtool/Cargo.toml
+++ b/grpc-testtool/Cargo.toml
@@ -21,6 +21,8 @@ prost = "0.12.0"
 thiserror = "1.0.47"
 tokio = { version = "1.32.0", features = ["sync", "rt-multi-thread"] }
 tonic = { version = "0.10.0", features = ["tls"] }
+tracing = { version = "0.1.16" }
+tracing-subscriber = { version = "0.3", features = ["tracing-log", "fmt", "env-filter"] }
 clap = { version = "4.4.11", features = ["derive"] }
 tempdir = "0.3.7"
 log = "0.4.20"

--- a/grpc-testtool/src/bin/process-server.rs
+++ b/grpc-testtool/src/bin/process-server.rs
@@ -84,8 +84,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .filter(None, args.log_level)
         .init();
 
+    tracing_subscriber::fmt::init();
+
     // log to the file and to stderr
-    eprintln!("Database-Server listening on: {}", args.grpc_port);
     info!("Starting up: Listening on {}", args.grpc_port);
 
     let svc = Arc::new(
@@ -100,6 +101,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // TODO: graceful shutdown
     Ok(Server::builder()
+        .trace_fn(|_m| tracing::debug_span!("process-server"))
         .add_service(RpcServer::from_arc(svc.clone()))
         .add_service(SyncServer::from_arc(svc.clone()))
         .add_service(ProcessServerServiceServer::from_arc(svc.clone()))

--- a/grpc-testtool/src/bin/process-server.rs
+++ b/grpc-testtool/src/bin/process-server.rs
@@ -3,81 +3,71 @@
 
 use chrono::Local;
 use clap::Parser;
-use env_logger::{Builder, Target};
+use env_logger::Builder;
 use log::{info, LevelFilter};
 use rpc::{
     process_server::process_server_service_server::ProcessServerServiceServer,
     rpcdb::database_server::DatabaseServer as RpcServer, sync::db_server::DbServer as SyncServer,
     DatabaseService,
 };
+use serde::Deserialize;
 use std::{
     error::Error,
     io::Write,
     net::{IpAddr::V4, Ipv4Addr},
     path::PathBuf,
+    str::FromStr,
     sync::Arc,
 };
-use tempdir::TempDir;
 use tonic::transport::Server;
+
+#[derive(Clone, Debug, Deserialize)]
+struct Options {
+    #[serde(default = "Options::history_length_default")]
+    history_length: u32,
+}
+
+impl Options {
+    // used in two cases:
+    //  serde deserializes Options and there was no history_length
+    // OR
+    //  Options was not present
+    const fn history_length_default() -> u32 {
+        100
+    }
+}
+
+impl FromStr for Options {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s).map_err(|e| format!("error parsing options: {}", e))
+    }
+}
 
 /// A GRPC server that can be plugged into the generic testing framework for merkledb
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 struct Opts {
-    #[arg(short = 'g', long, default_value_t = 10000)]
+    #[arg(short, long)]
     //// Port gRPC server listens on
     grpc_port: u16,
 
-    #[arg(short = 'G', long, default_value_t = 10001)]
-    /// Port gRPC gateway server, which HTTP requests can be made to
-    _gateway_port: u16,
-
-    #[arg(short = 'l', long, default_value = temp_path())]
-    log_dir: PathBuf,
-
-    #[arg(short = 'L', long, default_value_t = LevelFilter::Info)]
-    log_level: LevelFilter,
-
-    #[arg(short = 'b', long)]
-    _branch_factor: Option<u16>,
-
-    #[arg(short = 'p', long)]
-    _process_name: String,
-
-    #[arg(short = 'd')]
+    #[arg(short, long)]
     db_dir: PathBuf,
 
-    #[arg(short = 'H')]
-    _history_length: Option<u32>,
+    #[arg(short, long, default_value_t = LevelFilter::Info)]
+    log_level: LevelFilter,
 
-    #[arg(short = 'N')]
-    _node_cache_size: Option<u32>,
-}
-
-fn temp_path() -> clap::builder::OsStr {
-    let tmpdir = TempDir::new("process-server").expect("unable to create temporary directory");
-    // we leak because we want the temporary directory to stick around forever (emulating what happens in golang)
-    Box::leak(Box::new(tmpdir.into_path())).as_os_str().into()
+    #[arg(short, long)]
+    config: Option<Options>,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // parse command line options
     let args = Opts::parse();
-
-    match std::fs::create_dir_all(&args.log_dir) {
-        Ok(()) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
-        Err(e) => panic!("Unable to create directory\n{}", e),
-    }
-
-    // set up the log file
-    let logfile = std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .append(true)
-        .open(args.log_dir.join("server.log"))?;
 
     // configure the logger
     Builder::new()
@@ -91,19 +81,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
             )
         })
         .format_target(true)
-        .target(Target::Pipe(Box::new(logfile)))
         .filter(None, args.log_level)
         .init();
-
-    log_panics::Config::new()
-        .backtrace_mode(log_panics::BacktraceMode::Unresolved)
-        .install_panic_hook();
 
     // log to the file and to stderr
     eprintln!("Database-Server listening on: {}", args.grpc_port);
     info!("Starting up: Listening on {}", args.grpc_port);
 
-    let svc = Arc::new(DatabaseService::new(args.db_dir).await?);
+    let svc = Arc::new(
+        DatabaseService::new(
+            args.db_dir,
+            args.config
+                .map(|o| o.history_length)
+                .unwrap_or_else(Options::history_length_default),
+        )
+        .await?,
+    );
 
     // TODO: graceful shutdown
     Ok(Server::builder()

--- a/grpc-testtool/src/service.rs
+++ b/grpc-testtool/src/service.rs
@@ -1,7 +1,8 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use firewood::db::Db;
+use firewood::db::{Db, DbConfig};
+use firewood::storage::WalConfig;
 use firewood::v2::{api::Db as _, api::Error};
 
 use std::path::Path;
@@ -44,12 +45,15 @@ pub struct Database {
 }
 
 impl Database {
-    pub async fn new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+    pub async fn new<P: AsRef<Path>>(path: P, history_length: u32) -> Result<Self, Error> {
         // try to create the parents for this directory, but it's okay if it fails; it will get caught in Db::new
         std::fs::create_dir_all(&path).ok();
         // TODO: truncate should be false
         // see https://github.com/ava-labs/firewood/issues/418
-        let cfg = firewood::config::DbConfig::builder().truncate(true).build();
+        let cfg = DbConfig::builder()
+            .wal(WalConfig::builder().max_revisions(history_length).build())
+            .truncate(true)
+            .build();
 
         let db = Db::new(path, &cfg).await?;
 

--- a/grpc-testtool/src/service.rs
+++ b/grpc-testtool/src/service.rs
@@ -39,6 +39,8 @@ impl<T> IntoStatusResultExt<T> for Result<T, Error> {
         })
     }
 }
+
+#[derive(Debug)]
 pub struct Database {
     db: Db,
     iterators: Arc<Mutex<Iterators>>,
@@ -80,9 +82,10 @@ impl Database {
 }
 
 // TODO: implement Iterator
+#[derive(Debug)]
 struct Iter;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct Iterators {
     map: HashMap<u64, Iter>,
     next_id: AtomicU64,

--- a/grpc-testtool/src/service/db.rs
+++ b/grpc-testtool/src/service/db.rs
@@ -13,6 +13,7 @@ use tonic::{async_trait, Request, Response, Status};
 
 #[async_trait]
 impl DbServerTrait for Database {
+    #[tracing::instrument(level = "trace")]
     async fn get_merkle_root(
         &self,
         _request: Request<()>,
@@ -24,6 +25,7 @@ impl DbServerTrait for Database {
         Ok(Response::new(response))
     }
 
+    #[tracing::instrument(level = "trace")]
     async fn get_proof(
         &self,
         request: Request<GetProofRequest>,
@@ -34,6 +36,7 @@ impl DbServerTrait for Database {
         todo!()
     }
 
+    #[tracing::instrument(level = "trace")]
     async fn get_change_proof(
         &self,
         request: Request<GetChangeProofRequest>,
@@ -51,6 +54,7 @@ impl DbServerTrait for Database {
         todo!()
     }
 
+    #[tracing::instrument(level = "trace")]
     async fn verify_change_proof(
         &self,
         request: Request<VerifyChangeProofRequest>,
@@ -67,6 +71,7 @@ impl DbServerTrait for Database {
         todo!()
     }
 
+    #[tracing::instrument(level = "trace")]
     async fn commit_change_proof(
         &self,
         request: Request<CommitChangeProofRequest>,
@@ -76,6 +81,7 @@ impl DbServerTrait for Database {
         todo!()
     }
 
+    #[tracing::instrument(level = "trace")]
     async fn get_range_proof(
         &self,
         request: Request<GetRangeProofRequest>,
@@ -90,6 +96,7 @@ impl DbServerTrait for Database {
         todo!()
     }
 
+    #[tracing::instrument(level = "trace")]
     async fn commit_range_proof(
         &self,
         request: Request<CommitRangeProofRequest>,


### PR DESCRIPTION
 Changed to use --options so we don't have to parse all database specific options (we might add more to merkledb). This uses a json blob for options. We can parse additional ones as they become supported from the orchestrator.

Also added span-level tracing for debugging in a second commit. This required sprinkling `#[derive(Debug)]` on the components.