### PR TITLE
Make `MerkleKeyValueStream` handle branches with values

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -3,16 +3,17 @@
 use crate::nibbles::Nibbles;
 use crate::shale::{self, disk_address::DiskAddress, ObjWriteError, ShaleError, ShaleStore};
 use crate::v2::api;
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::{StreamExt, TryStreamExt};
 use sha3::Digest;
 use std::{
     cmp::Ordering, collections::HashMap, future::ready, io::Write, iter::once, marker::PhantomData,
-    sync::OnceLock, task::Poll,
+    sync::OnceLock,
 };
 use thiserror::Error;
 
 mod node;
 pub mod proof;
+mod stream;
 mod trie_hash;
 
 pub use node::{
@@ -20,6 +21,8 @@ pub use node::{
     NodeType, PartialPath,
 };
 pub use proof::{Proof, ProofError};
+use stream::IteratorState;
+pub use stream::MerkleKeyValueStream;
 pub use trie_hash::{TrieHash, TRIE_HASH_LEN};
 
 type ObjRef<'a> = shale::ObjRef<'a, Node>;
@@ -1304,286 +1307,6 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
     }
 }
 
-enum IteratorState<'a> {
-    /// Start iterating at the beginning of the trie,
-    /// returning the lowest key/value pair first
-    StartAtBeginning,
-    /// Start iterating at the specified key
-    StartAtKey(Vec<u8>),
-    /// Continue iterating after the given last_node and parents
-    Iterating {
-        last_node: ObjRef<'a>,
-        parents: Vec<(ObjRef<'a>, u8)>,
-    },
-}
-impl IteratorState<'_> {
-    fn new<K: AsRef<[u8]>>(starting: Option<K>) -> Self {
-        match starting {
-            None => Self::StartAtBeginning,
-            Some(key) => Self::StartAtKey(key.as_ref().to_vec()),
-        }
-    }
-}
-
-// The default state is to start at the beginning
-impl<'a> Default for IteratorState<'a> {
-    fn default() -> Self {
-        Self::StartAtBeginning
-    }
-}
-
-/// A MerkleKeyValueStream iterates over keys/values for a merkle trie.
-/// This iterator is not fused. If you read past the None value, you start
-/// over at the beginning. If you need a fused iterator, consider using
-/// std::iter::fuse
-pub struct MerkleKeyValueStream<'a, S, T> {
-    key_state: IteratorState<'a>,
-    merkle_root: DiskAddress,
-    merkle: &'a Merkle<S, T>,
-}
-
-impl<'a, S: shale::ShaleStore<node::Node> + Send + Sync, T> Stream
-    for MerkleKeyValueStream<'a, S, T>
-{
-    type Item = Result<(Vec<u8>, Vec<u8>), api::Error>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        _cx: &mut std::task::Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
-        // Note that this sets the key_state to StartAtBeginning temporarily
-        let found_key = match std::mem::take(&mut self.key_state) {
-            IteratorState::StartAtBeginning => {
-                let root_node = self
-                    .merkle
-                    .get_node(self.merkle_root)
-                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
-                let mut last_node = root_node;
-                let mut parents = vec![];
-                let leaf = loop {
-                    match last_node.inner() {
-                        NodeType::Branch(branch) => {
-                            let Some((leftmost_position, leftmost_address)) = branch
-                                .children
-                                .iter()
-                                .enumerate()
-                                .filter_map(|(i, addr)| addr.map(|addr| (i, addr)))
-                                .next()
-                            else {
-                                // we already exhausted the branch node. This happens with an empty trie
-                                // ... or a corrupt one
-                                return if parents.is_empty() {
-                                    // empty trie
-                                    Poll::Ready(None)
-                                } else {
-                                    // branch with NO children, not at the top
-                                    Poll::Ready(Some(Err(api::Error::InternalError(Box::new(
-                                        MerkleError::ParentLeafBranch,
-                                    )))))
-                                };
-                            };
-
-                            let next = self
-                                .merkle
-                                .get_node(leftmost_address)
-                                .map_err(|e| api::Error::InternalError(Box::new(e)))?;
-
-                            parents.push((last_node, leftmost_position as u8));
-
-                            last_node = next;
-                        }
-                        NodeType::Leaf(leaf) => break leaf,
-                        NodeType::Extension(_) => todo!(),
-                    }
-                };
-
-                // last_node should have a leaf; compute the key and value
-                let current_key = key_from_parents_and_leaf(&parents, leaf);
-
-                self.key_state = IteratorState::Iterating { last_node, parents };
-
-                current_key
-            }
-            IteratorState::StartAtKey(key) => {
-                // TODO: support finding the next key after K
-                let root_node = self
-                    .merkle
-                    .get_node(self.merkle_root)
-                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
-
-                let (found_node, parents) = self
-                    .merkle
-                    .get_node_and_parents_by_key(root_node, &key)
-                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
-
-                let Some(last_node) = found_node else {
-                    return Poll::Ready(None);
-                };
-
-                let returned_key_value = match last_node.inner() {
-                    NodeType::Branch(branch) => (key, branch.value.to_owned().unwrap().to_vec()),
-                    NodeType::Leaf(leaf) => (key, leaf.data.to_vec()),
-                    NodeType::Extension(_) => todo!(),
-                };
-
-                self.key_state = IteratorState::Iterating { last_node, parents };
-
-                return Poll::Ready(Some(Ok(returned_key_value)));
-            }
-            IteratorState::Iterating {
-                last_node,
-                mut parents,
-            } => {
-                match last_node.inner() {
-                    NodeType::Branch(branch) => {
-                        // previously rendered the value from a branch node, so walk down to the first available child
-                        let Some((child_position, child_address)) = branch
-                            .children
-                            .iter()
-                            .enumerate()
-                            .filter_map(|(child_position, &addr)| {
-                                addr.map(|addr| (child_position, addr))
-                            })
-                            .next()
-                        else {
-                            // Branch node with no children?
-                            return Poll::Ready(Some(Err(api::Error::InternalError(Box::new(
-                                MerkleError::ParentLeafBranch,
-                            )))));
-                        };
-
-                        parents.push((last_node, child_position as u8)); // remember where we walked down from
-
-                        let current_node = self
-                            .merkle
-                            .get_node(child_address)
-                            .map_err(|e| api::Error::InternalError(Box::new(e)))?;
-
-                        let found_key = key_from_parents(&parents);
-
-                        self.key_state = IteratorState::Iterating {
-                            // continue iterating from here
-                            last_node: current_node,
-                            parents,
-                        };
-
-                        found_key
-                    }
-                    NodeType::Leaf(leaf) => {
-                        let mut next = parents.pop().map(|(node, position)| (node, Some(position)));
-                        loop {
-                            match next {
-                                None => return Poll::Ready(None),
-                                Some((parent, child_position)) => {
-                                    // Assume all parents are branch nodes
-                                    let children = parent.inner().as_branch().unwrap().chd();
-
-                                    // we use wrapping_add here because the value might be u8::MAX indicating that
-                                    // we want to go down branch
-                                    let start_position =
-                                        child_position.map(|pos| pos + 1).unwrap_or_default();
-
-                                    let Some((found_position, found_address)) = children
-                                        .iter()
-                                        .enumerate()
-                                        .skip(start_position as usize)
-                                        .filter_map(|(offset, addr)| {
-                                            addr.map(|addr| (offset as u8, addr))
-                                        })
-                                        .next()
-                                    else {
-                                        next = parents
-                                            .pop()
-                                            .map(|(node, position)| (node, Some(position)));
-                                        continue;
-                                    };
-
-                                    // we push (node, None) which will start at the beginning of the next branch node
-                                    let child = self
-                                        .merkle
-                                        .get_node(found_address)
-                                        .map(|node| (node, None))
-                                        .map_err(|e| api::Error::InternalError(Box::new(e)))?;
-
-                                    // stop_descending if:
-                                    //  - on a branch and it has a value; OR
-                                    //  - on a leaf
-                                    let stop_descending = match child.0.inner() {
-                                        NodeType::Branch(branch) => branch.value.is_some(),
-                                        NodeType::Leaf(_) => true,
-                                        NodeType::Extension(_) => todo!(),
-                                    };
-
-                                    next = Some(child);
-
-                                    parents.push((parent, found_position));
-
-                                    if stop_descending {
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        // recompute current_key
-                        // TODO: Can we keep current_key updated as we walk the tree instead of building it from the top all the time?
-                        let current_key = key_from_parents_and_leaf(&parents, leaf);
-
-                        self.key_state = IteratorState::Iterating {
-                            last_node: next.unwrap().0,
-                            parents,
-                        };
-
-                        current_key
-                    }
-
-                    NodeType::Extension(_) => todo!(),
-                }
-            }
-        };
-
-        // figure out the value to return from the state
-        // if we get here, we're sure to have something to return
-        // TODO: It's possible to return a reference to the data since the last_node is
-        // saved in the iterator
-        let return_value = match &self.key_state {
-            IteratorState::Iterating {
-                last_node,
-                parents: _,
-            } => {
-                let value = match last_node.inner() {
-                    NodeType::Branch(branch) => branch.value.to_owned().unwrap().to_vec(),
-                    NodeType::Leaf(leaf) => leaf.data.to_vec(),
-                    NodeType::Extension(_) => todo!(),
-                };
-
-                (found_key, value)
-            }
-            _ => unreachable!(),
-        };
-
-        Poll::Ready(Some(Ok(return_value)))
-    }
-}
-
-/// Compute a key from a set of parents
-fn key_from_parents(parents: &[(ObjRef, u8)]) -> Vec<u8> {
-    parents[1..]
-        .chunks_exact(2)
-        .map(|parents| (parents[0].1 << 4) + parents[1].1)
-        .collect::<Vec<u8>>()
-}
-fn key_from_parents_and_leaf(parents: &[(ObjRef, u8)], leaf: &LeafNode) -> Vec<u8> {
-    let mut iter = parents[1..]
-        .iter()
-        .map(|parent| parent.1)
-        .chain(leaf.path.to_vec());
-    let mut data = Vec::with_capacity(iter.size_hint().0);
-    while let (Some(hi), Some(lo)) = (iter.next(), iter.next()) {
-        data.push((hi << 4) + lo);
-    }
-    data
-}
-
 fn set_parent(new_chd: DiskAddress, parents: &mut [(ObjRef, u8)]) {
     let (p_ref, idx) = parents.last_mut().unwrap();
     p_ref
@@ -1690,7 +1413,7 @@ mod tests {
         assert_eq!(n, nibbles);
     }
 
-    fn create_test_merkle() -> Merkle<CompactSpace<Node, DynamicMem>, Bincode> {
+    pub(super) fn create_test_merkle() -> Merkle<CompactSpace<Node, DynamicMem>, Bincode> {
         const RESERVED: usize = 0x1000;
 
         let mut dm = shale::cached::DynamicMem::new(0x10000, 0);

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -1,0 +1,334 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use super::{node::Node, LeafNode, Merkle, MerkleError, NodeType, ObjRef};
+use crate::{
+    shale::{DiskAddress, ShaleStore},
+    v2::api,
+};
+use futures::Stream;
+use std::task::Poll;
+
+pub(super) enum IteratorState<'a> {
+    /// Start iterating at the beginning of the trie,
+    /// returning the lowest key/value pair first
+    StartAtBeginning,
+    /// Start iterating at the specified key
+    StartAtKey(Vec<u8>),
+    /// Continue iterating after the given last_node and parents
+    Iterating {
+        last_node: ObjRef<'a>,
+        parents: Vec<(ObjRef<'a>, u8)>,
+    },
+}
+impl IteratorState<'_> {
+    pub(super) fn new<K: AsRef<[u8]>>(starting: Option<K>) -> Self {
+        match starting {
+            None => Self::StartAtBeginning,
+            Some(key) => Self::StartAtKey(key.as_ref().to_vec()),
+        }
+    }
+}
+
+// The default state is to start at the beginning
+impl<'a> Default for IteratorState<'a> {
+    fn default() -> Self {
+        Self::StartAtBeginning
+    }
+}
+
+/// A MerkleKeyValueStream iterates over keys/values for a merkle trie.
+/// This iterator is not fused. If you read past the None value, you start
+/// over at the beginning. If you need a fused iterator, consider using
+/// std::iter::fuse
+pub struct MerkleKeyValueStream<'a, S, T> {
+    pub(super) key_state: IteratorState<'a>,
+    pub(super) merkle_root: DiskAddress,
+    pub(super) merkle: &'a Merkle<S, T>,
+}
+
+impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'a, S, T> {
+    type Item = Result<(Vec<u8>, Vec<u8>), api::Error>;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        // Note that this sets the key_state to StartAtBeginning temporarily
+        let found_key = match std::mem::take(&mut self.key_state) {
+            IteratorState::StartAtBeginning => {
+                let root_node = self
+                    .merkle
+                    .get_node(self.merkle_root)
+                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+                let mut last_node = root_node;
+                let mut parents = vec![];
+                let leaf = loop {
+                    match last_node.inner() {
+                        NodeType::Branch(branch) => {
+                            let Some((leftmost_position, leftmost_address)) = branch
+                                .children
+                                .iter()
+                                .enumerate()
+                                .filter_map(|(i, addr)| addr.map(|addr| (i, addr)))
+                                .next()
+                            else {
+                                // we already exhausted the branch node. This happens with an empty trie
+                                // ... or a corrupt one
+                                return if parents.is_empty() {
+                                    // empty trie
+                                    Poll::Ready(None)
+                                } else {
+                                    // branch with NO children, not at the top
+                                    Poll::Ready(Some(Err(api::Error::InternalError(Box::new(
+                                        MerkleError::ParentLeafBranch,
+                                    )))))
+                                };
+                            };
+
+                            let next = self
+                                .merkle
+                                .get_node(leftmost_address)
+                                .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+
+                            parents.push((last_node, leftmost_position as u8));
+
+                            last_node = next;
+                        }
+                        NodeType::Leaf(leaf) => break leaf,
+                        NodeType::Extension(_) => todo!(),
+                    }
+                };
+
+                // last_node should have a leaf; compute the key and value
+                let current_key = key_from_parents_and_leaf(&parents, leaf);
+
+                self.key_state = IteratorState::Iterating { last_node, parents };
+
+                current_key
+            }
+            IteratorState::StartAtKey(key) => {
+                // TODO: support finding the next key after K
+                let root_node = self
+                    .merkle
+                    .get_node(self.merkle_root)
+                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+
+                let (found_node, parents) = self
+                    .merkle
+                    .get_node_and_parents_by_key(root_node, &key)
+                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+
+                let Some(last_node) = found_node else {
+                    return Poll::Ready(None);
+                };
+
+                let returned_key_value = match last_node.inner() {
+                    NodeType::Branch(branch) => (key, branch.value.to_owned().unwrap().to_vec()),
+                    NodeType::Leaf(leaf) => (key, leaf.data.to_vec()),
+                    NodeType::Extension(_) => todo!(),
+                };
+
+                self.key_state = IteratorState::Iterating { last_node, parents };
+
+                return Poll::Ready(Some(Ok(returned_key_value)));
+            }
+            IteratorState::Iterating {
+                last_node,
+                mut parents,
+            } => {
+                match last_node.inner() {
+                    NodeType::Branch(branch) => {
+                        // previously rendered the value from a branch node, so walk down to the first available child
+                        let Some((child_position, child_address)) = branch
+                            .children
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(child_position, &addr)| {
+                                addr.map(|addr| (child_position, addr))
+                            })
+                            .next()
+                        else {
+                            // Branch node with no children?
+                            return Poll::Ready(Some(Err(api::Error::InternalError(Box::new(
+                                MerkleError::ParentLeafBranch,
+                            )))));
+                        };
+
+                        parents.push((last_node, child_position as u8)); // remember where we walked down from
+
+                        let current_node = self
+                            .merkle
+                            .get_node(child_address)
+                            .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+
+                        let found_key = key_from_parents(&parents);
+
+                        self.key_state = IteratorState::Iterating {
+                            // continue iterating from here
+                            last_node: current_node,
+                            parents,
+                        };
+
+                        found_key
+                    }
+                    NodeType::Leaf(leaf) => {
+                        let mut next = parents.pop().map(|(node, position)| (node, Some(position)));
+                        loop {
+                            match next {
+                                None => return Poll::Ready(None),
+                                Some((parent, child_position)) => {
+                                    // Assume all parents are branch nodes
+                                    let children = parent.inner().as_branch().unwrap().chd();
+
+                                    // we use wrapping_add here because the value might be u8::MAX indicating that
+                                    // we want to go down branch
+                                    let start_position =
+                                        child_position.map(|pos| pos + 1).unwrap_or_default();
+
+                                    let Some((found_position, found_address)) = children
+                                        .iter()
+                                        .enumerate()
+                                        .skip(start_position as usize)
+                                        .filter_map(|(offset, addr)| {
+                                            addr.map(|addr| (offset as u8, addr))
+                                        })
+                                        .next()
+                                    else {
+                                        next = parents
+                                            .pop()
+                                            .map(|(node, position)| (node, Some(position)));
+                                        continue;
+                                    };
+
+                                    // we push (node, None) which will start at the beginning of the next branch node
+                                    let child = self
+                                        .merkle
+                                        .get_node(found_address)
+                                        .map(|node| (node, None))
+                                        .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+
+                                    // stop_descending if:
+                                    //  - on a branch and it has a value; OR
+                                    //  - on a leaf
+                                    let stop_descending = match child.0.inner() {
+                                        NodeType::Branch(branch) => branch.value.is_some(),
+                                        NodeType::Leaf(_) => true,
+                                        NodeType::Extension(_) => todo!(),
+                                    };
+
+                                    next = Some(child);
+
+                                    parents.push((parent, found_position));
+
+                                    if stop_descending {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        // recompute current_key
+                        // TODO: Can we keep current_key updated as we walk the tree instead of building it from the top all the time?
+                        let current_key = key_from_parents_and_leaf(&parents, leaf);
+
+                        self.key_state = IteratorState::Iterating {
+                            last_node: next.unwrap().0,
+                            parents,
+                        };
+
+                        current_key
+                    }
+
+                    NodeType::Extension(_) => todo!(),
+                }
+            }
+        };
+
+        // figure out the value to return from the state
+        // if we get here, we're sure to have something to return
+        // TODO: It's possible to return a reference to the data since the last_node is
+        // saved in the iterator
+        let return_value = match &self.key_state {
+            IteratorState::Iterating {
+                last_node,
+                parents: _,
+            } => {
+                let value = match last_node.inner() {
+                    NodeType::Branch(branch) => branch.value.to_owned().unwrap().to_vec(),
+                    NodeType::Leaf(leaf) => leaf.data.to_vec(),
+                    NodeType::Extension(_) => todo!(),
+                };
+
+                (found_key, value)
+            }
+            _ => unreachable!(),
+        };
+
+        Poll::Ready(Some(Ok(return_value)))
+    }
+}
+
+/// Compute a key from a set of parents
+fn key_from_parents(parents: &[(ObjRef, u8)]) -> Vec<u8> {
+    parents[1..]
+        .chunks_exact(2)
+        .map(|parents| (parents[0].1 << 4) + parents[1].1)
+        .collect::<Vec<u8>>()
+}
+fn key_from_parents_and_leaf(parents: &[(ObjRef, u8)], leaf: &LeafNode) -> Vec<u8> {
+    let mut iter = parents[1..]
+        .iter()
+        .map(|parent| parent.1)
+        .chain(leaf.path.to_vec());
+    let mut data = Vec::with_capacity(iter.size_hint().0);
+    while let (Some(hi), Some(lo)) = (iter.next(), iter.next()) {
+        data.push((hi << 4) + lo);
+    }
+    data
+}
+
+#[cfg(test)]
+use super::tests::create_test_merkle;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[ignore]
+    #[tokio::test]
+    async fn get_branch_and_leaf() {
+        let mut merkle = create_test_merkle();
+        let root = merkle.init_root().unwrap();
+
+        let first_leaf = &[0x00, 0x0f];
+        let second_leaf = &[0x00, 0x00];
+        let branch = &[0x00];
+
+        merkle
+            .insert(first_leaf, first_leaf.to_vec(), root)
+            .unwrap();
+        merkle
+            .insert(second_leaf, second_leaf.to_vec(), root)
+            .unwrap();
+
+        merkle.insert(branch, branch.to_vec(), root).unwrap();
+
+        let mut stream = merkle.get_iter(None::<&[u8]>, root).unwrap();
+
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            (branch.to_vec(), branch.to_vec())
+        );
+
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            (first_leaf.to_vec(), first_leaf.to_vec())
+        );
+
+        assert_eq!(
+            stream.next().await.unwrap().unwrap(),
+            (second_leaf.to_vec(), second_leaf.to_vec())
+        );
+    }
+}


### PR DESCRIPTION
This was not the easiest thing to implement. Once I got the tests passing, I went over it a few times. 

It actually looks like we should move the starting logic into the `get_iter` method, but I will leave that for another day. I honestly tried to make this a much smaller change, but there was no way to get it to work without re-writing everything. 

There are two commits here. The first one is the move (feel free to verify that all the tests pass with the pure move). The second is the addition of tests and changes in behaviour. 

