### PR TITLE
Add Merkledb encoding schema

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -6,7 +6,7 @@
 use criterion::{criterion_group, criterion_main, profiler::Profiler, BatchSize, Criterion};
 use firewood::{
     db::{BatchOp, DbConfig},
-    merkle::{Merkle, MerkleWithEncoder, TrieHash, TRIE_HASH_LEN},
+    merkle::{MerkleWithEncoder, TrieHash, TRIE_HASH_LEN},
     shale::{
         cached::PlainMem,
         compact::{CompactHeader, CompactSpace},
@@ -104,7 +104,7 @@ fn bench_merkle<const N: usize>(criterion: &mut Criterion) {
                     )
                     .unwrap();
 
-                    let merkle: MerkleWithEncoder = Merkle::new(Box::new(store));
+                    let merkle = MerkleWithEncoder::new(Box::new(store));
                     let root = merkle.init_root().unwrap();
 
                     let keys: Vec<Vec<u8>> = repeat_with(|| {

--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -6,7 +6,7 @@
 use criterion::{criterion_group, criterion_main, profiler::Profiler, BatchSize, Criterion};
 use firewood::{
     db::{BatchOp, DbConfig},
-    merkle::{Merkle, TrieHash, TRIE_HASH_LEN},
+    merkle::{Bincode, Merkle, Node, TrieHash, TRIE_HASH_LEN},
     shale::{
         cached::PlainMem,
         compact::{CompactHeader, CompactSpace},
@@ -104,7 +104,8 @@ fn bench_merkle<const N: usize>(criterion: &mut Criterion) {
                     )
                     .unwrap();
 
-                    let merkle = Merkle::new(Box::new(store));
+                    let merkle: Merkle<CompactSpace<Node, PlainMem>, Bincode> =
+                        Merkle::new(Box::new(store));
                     let root = merkle.init_root().unwrap();
 
                     let keys: Vec<Vec<u8>> = repeat_with(|| {

--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -6,7 +6,7 @@
 use criterion::{criterion_group, criterion_main, profiler::Profiler, BatchSize, Criterion};
 use firewood::{
     db::{BatchOp, DbConfig},
-    merkle::{Bincode, Merkle, Node, TrieHash, TRIE_HASH_LEN},
+    merkle::{Merkle, MerkleWithEncoder, TrieHash, TRIE_HASH_LEN},
     shale::{
         cached::PlainMem,
         compact::{CompactHeader, CompactSpace},
@@ -104,8 +104,7 @@ fn bench_merkle<const N: usize>(criterion: &mut Criterion) {
                     )
                     .unwrap();
 
-                    let merkle: Merkle<CompactSpace<Node, PlainMem>, Bincode> =
-                        Merkle::new(Box::new(store));
+                    let merkle: MerkleWithEncoder = Merkle::new(Box::new(store));
                     let root = merkle.init_root().unwrap();
 
                     let keys: Vec<Vec<u8>> = repeat_with(|| {

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1501,17 +1501,15 @@ mod tests {
     #[test_case(leaf(Vec::new(), Vec::new()) ; "empty leaf encoding")]
     #[test_case(leaf(vec![1, 2, 3], vec![4, 5]) ; "leaf encoding")]
     #[test_case(branch(b"value".to_vec(), vec![1, 2, 3].into()) ; "branch with chd")]
-    #[test_case(branch(b"value".to_vec(), None); "branch without chd")]
-    #[test_case(branch(Vec::new(), None); "branch without value and chd")]
+    #[test_case(branch(Vec::new(), vec![1, 2, 3].into()); "branch without value")]
     fn node_encode_decode_plain_(node: Node) {
         let merkle = create_test_merkle::<PlainCodec>();
         let node_ref = merkle.put_node(node.clone()).unwrap();
         let encoded = merkle.encode(&node_ref).unwrap();
-        println!("encoded: {:?}", encoded);
-        // let new_node = Node::from(merkle.decode(encoded.as_ref()).unwrap());
-        // let new_node_hash = new_node.get_root_hash(merkle.store.as_ref());
-        // let expected_hash = node.get_root_hash(merkle.store.as_ref());
-        // assert_eq!(new_node_hash, expected_hash);
+        let new_node = Node::from(merkle.decode(encoded.as_ref()).unwrap());
+        let new_node_hash = new_node.get_root_hash(merkle.store.as_ref());
+        let expected_hash = node.get_root_hash(merkle.store.as_ref());
+        assert_eq!(new_node_hash, expected_hash);
     }
 
     #[test]

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1451,10 +1451,7 @@ mod tests {
         Merkle::new(store)
     }
 
-    pub(super) fn create_test_merkle<'de>() -> Merkle<CompactSpace<Node, DynamicMem>, Bincode>
-    where
-        EncodedNode<Bincode>: serde::Serialize + serde::Deserialize<'de>,
-    {
+    pub(super) fn create_test_merkle() -> Merkle<CompactSpace<Node, DynamicMem>, Bincode> {
         create_generic_test_merkle::<Bincode>()
     }
 
@@ -1512,7 +1509,8 @@ mod tests {
     #[test_case(leaf(Vec::new(), Vec::new()) ; "empty leaf encoding")]
     #[test_case(leaf(vec![1, 2, 3], vec![4, 5]) ; "leaf encoding")]
     #[test_case(branch(b"value".to_vec(), vec![1, 2, 3].into()) ; "branch with chd")]
-    #[test_case(branch(Vec::new(), vec![1, 2, 3].into()); "branch without value")]
+    #[test_case(branch(b"value".to_vec(), None); "branch without chd")]
+    #[test_case(branch(Vec::new(), None); "branch without value and chd")]
     fn node_encode_decode_plain(node: Node) {
         let merkle = create_test_merkle();
         let node_ref = merkle.put_node(node.clone()).unwrap();

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1451,7 +1451,7 @@ mod tests {
 
     fn branch(value: Vec<u8>, encoded_child: Option<Vec<u8>>) -> Node {
         let children = Default::default();
-        let value = Some(Data(value));
+        let value = Some(Data(value)).filter(|data| !data.is_empty());
         let mut children_encoded = <[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>::default();
 
         if let Some(child) = encoded_child {

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -10,7 +10,7 @@ use bitflags::bitflags;
 use enum_as_inner::EnumAsInner;
 use serde::{
     de::DeserializeOwned,
-    ser::{SerializeSeq, SerializeStruct},
+    ser::{SerializeSeq, SerializeTuple},
     Deserialize, Serialize,
 };
 use sha3::{Digest, Keccak256};
@@ -540,10 +540,10 @@ impl Serialize for EncodedNode<PlainCodec> {
             }
         };
 
-        let mut s = serializer.serialize_struct("", 3)?;
-        s.serialize_field("", &n.chd)?;
-        s.serialize_field("", &n.data)?;
-        s.serialize_field("", &n.path)?;
+        let mut s = serializer.serialize_tuple(3)?;
+        s.serialize_element(&n.chd)?;
+        s.serialize_element(&n.data)?;
+        s.serialize_element(&n.path)?;
         s.end()
     }
 }
@@ -569,7 +569,7 @@ impl<'de> Deserialize<'de> for EncodedNode<PlainCodec> {
             let value = node.data.map(Data).filter(|data| !data.is_empty());
 
             for (i, chd) in node.chd {
-                children[i as usize] = Some(chd).filter(|chd| !chd.is_empty());
+                children[i as usize] = Some(chd);
             }
 
             let node = EncodedNodeType::Branch {

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -520,14 +520,13 @@ impl Serialize for EncodedNode<PlainCodec> {
                 let chd: Vec<(u64, Vec<u8>)> = children
                     .iter()
                     .enumerate()
-                    .filter_map(|(i, c)| {
-                        c.as_ref().map(|c| {
-                            if c.len() >= TRIE_HASH_LEN {
-                                (i as u64, Keccak256::digest(c).to_vec())
-                            } else {
-                                (i as u64, c.to_vec())
-                            }
-                        })
+                    .filter_map(|(i, c)| c.as_ref().map(|c| (i as u64, c)))
+                    .map(|(i, c)| {
+                        if c.len() >= TRIE_HASH_LEN {
+                            (i, Keccak256::digest(c).to_vec())
+                        } else {
+                            (i, c.to_vec())
+                        }
                     })
                     .collect();
 
@@ -566,7 +565,7 @@ impl<'de> Deserialize<'de> for EncodedNode<PlainCodec> {
             Ok(Self::new(node))
         } else {
             let mut children: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN] = Default::default();
-            let value = node.data.map(Data).filter(|data| !data.is_empty());
+            let value = node.data.map(Data);
 
             for (i, chd) in node.chd {
                 children[i as usize] = Some(chd);

--- a/firewood/src/merkle/node/leaf.rs
+++ b/firewood/src/merkle/node/leaf.rs
@@ -9,7 +9,7 @@ use std::{
 
 use bincode::Options;
 
-use super::{BranchNode, Data, Encoded};
+use super::{Data, Encoded};
 use crate::{
     merkle::{from_nibbles, to_nibble_array, PartialPath},
     shale::{ShaleError::InvalidCacheView, Storable},
@@ -61,15 +61,6 @@ impl LeafNode {
                 .as_slice(),
             )
             .unwrap()
-    }
-
-    pub fn to_branch(self) -> BranchNode {
-        BranchNode::new(
-            self.path,
-            [None; BranchNode::MAX_CHILDREN],
-            Some(self.data.0),
-            Default::default(),
-        )
     }
 }
 

--- a/firewood/src/merkle/node/leaf.rs
+++ b/firewood/src/merkle/node/leaf.rs
@@ -9,7 +9,7 @@ use std::{
 
 use bincode::Options;
 
-use super::{Data, Encoded};
+use super::{BranchNode, Data, Encoded};
 use crate::{
     merkle::{from_nibbles, to_nibble_array, PartialPath},
     shale::{ShaleError::InvalidCacheView, Storable},
@@ -61,6 +61,15 @@ impl LeafNode {
                 .as_slice(),
             )
             .unwrap()
+    }
+
+    pub fn to_branch(self) -> BranchNode {
+        BranchNode::new(
+            self.path,
+            [None; BranchNode::MAX_CHILDREN],
+            Some(self.data.0),
+            Default::default(),
+        )
     }
 }
 


### PR DESCRIPTION
With pluggable encoding, implement the MerkleDB matching node encoding schema.

Closes #294. 
