### PR TITLE
Add nibbles_into_bytes for an arbitrary iterator

### DIFF
--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -287,11 +287,27 @@ fn key_from_parents_and_leaf(parents: &[(ObjRef, u8)], leaf: &LeafNode) -> Vec<u
     data
 }
 
+// CAUTION: only use with nibble iterators
+trait IntoBytes: Iterator<Item = u8> {
+    fn nibbles_into_bytes(&mut self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(self.size_hint().0 / 2);
+
+        while let (Some(hi), Some(lo)) = (self.next(), self.next()) {
+            data.push((hi << 4) + lo);
+        }
+
+        data
+    }
+}
+impl<T: Iterator<Item = u8>> IntoBytes for T {}
+
 #[cfg(test)]
 use super::tests::create_test_merkle;
 
 #[cfg(test)]
 mod tests {
+    use crate::nibbles::Nibbles;
+
     use super::*;
     use futures::StreamExt;
     use test_case::test_case;
@@ -411,5 +427,22 @@ mod tests {
         let done = stream.next().await;
 
         assert!(done.is_none());
+    }
+
+    #[test]
+    fn remaining_bytes() {
+        let data = &[1];
+        let nib: Nibbles<'_, 0> = Nibbles::<0>::new(data);
+        let mut it = nib.into_iter();
+        assert_eq!(it.nibbles_into_bytes(), data.to_vec());
+    }
+
+    #[test]
+    fn remaining_bytes_off() {
+        let data = &[1];
+        let nib: Nibbles<'_, 0> = Nibbles::<0>::new(data);
+        let mut it = nib.into_iter();
+        it.next();
+        assert_eq!(it.nibbles_into_bytes(), vec![]);
     }
 }

--- a/firewood/src/nibbles.rs
+++ b/firewood/src/nibbles.rs
@@ -140,23 +140,8 @@ impl<'a, const LEADING_ZEROES: usize> DoubleEndedIterator for NibblesIterator<'a
     }
 }
 
-pub(crate) trait IntoBytes: Iterator<Item = u8> {
-    fn nibbles_into_bytes(&mut self) -> Vec<u8> {
-        let mut data = Vec::with_capacity(self.size_hint().0 / 2);
-
-        while let (Some(hi), Some(lo)) = (self.next(), self.next()) {
-            data.push((hi << 4) + lo);
-        }
-
-        data
-    }
-}
-impl<T: Iterator<Item = u8>> IntoBytes for T {}
-
 #[cfg(test)]
 mod test {
-    use crate::nibbles::IntoBytes;
-
     use super::Nibbles;
     static TEST_BYTES: [u8; 4] = [0xdeu8, 0xad, 0xbe, 0xef];
 
@@ -264,22 +249,5 @@ mod test {
         assert_eq!(it.next(), Some(1));
         assert!(it.is_empty());
         assert_eq!(it.size_hint(), (0, Some(0)));
-    }
-
-    #[test]
-    fn remaining_bytes() {
-        let data = &[1];
-        let nib: Nibbles<'_, 0> = Nibbles::<0>(data);
-        let mut it = nib.into_iter();
-        assert_eq!(it.nibbles_into_bytes(), data.to_vec());
-    }
-
-    #[test]
-    fn remaining_bytes_off() {
-        let data = &[1];
-        let nib: Nibbles<'_, 0> = Nibbles::<0>(data);
-        let mut it = nib.into_iter();
-        it.next();
-        assert_eq!(it.nibbles_into_bytes(), vec![]);
     }
 }

--- a/firewood/src/nibbles.rs
+++ b/firewood/src/nibbles.rs
@@ -123,6 +123,7 @@ impl<'a, const LEADING_ZEROES: usize> NibblesIterator<'a, LEADING_ZEROES> {
     pub fn is_empty(&self) -> bool {
         self.head == self.tail
     }
+
 }
 
 impl<'a, const LEADING_ZEROES: usize> DoubleEndedIterator for NibblesIterator<'a, LEADING_ZEROES> {
@@ -140,8 +141,23 @@ impl<'a, const LEADING_ZEROES: usize> DoubleEndedIterator for NibblesIterator<'a
     }
 }
 
+pub(crate) trait IntoBytes : Iterator<Item = u8> {
+    fn nibbles_into_bytes(&mut self) -> Vec<u8> {
+        let mut data = Vec::with_capacity(self.size_hint().0 / 2);
+
+        while let (Some(hi), Some(lo)) = (self.next(), self.next()) {
+            data.push((hi << 4) + lo);
+        }
+    
+        data    
+    }
+}
+impl<T: Iterator<Item = u8>> IntoBytes for T {}
+
 #[cfg(test)]
 mod test {
+    use crate::nibbles::IntoBytes;
+
     use super::Nibbles;
     static TEST_BYTES: [u8; 4] = [0xdeu8, 0xad, 0xbe, 0xef];
 
@@ -249,5 +265,22 @@ mod test {
         assert_eq!(it.next(), Some(1));
         assert!(it.is_empty());
         assert_eq!(it.size_hint(), (0, Some(0)));
+    }
+
+    #[test]
+    fn remaining_bytes() {
+        let data = &[1];
+        let nib: Nibbles<'_, 0> = Nibbles::<0>(data);
+        let mut it = nib.into_iter();
+        assert_eq!(it.nibbles_into_bytes(), data.to_vec());
+    }
+
+    #[test]
+    fn remaining_bytes_off() {
+        let data = &[1];
+        let nib: Nibbles<'_, 0> = Nibbles::<0>(data);
+        let mut it = nib.into_iter();
+        it.next();
+        assert_eq!(it.nibbles_into_bytes(), vec![]);
     }
 }

--- a/firewood/src/nibbles.rs
+++ b/firewood/src/nibbles.rs
@@ -123,7 +123,6 @@ impl<'a, const LEADING_ZEROES: usize> NibblesIterator<'a, LEADING_ZEROES> {
     pub fn is_empty(&self) -> bool {
         self.head == self.tail
     }
-
 }
 
 impl<'a, const LEADING_ZEROES: usize> DoubleEndedIterator for NibblesIterator<'a, LEADING_ZEROES> {
@@ -141,15 +140,15 @@ impl<'a, const LEADING_ZEROES: usize> DoubleEndedIterator for NibblesIterator<'a
     }
 }
 
-pub(crate) trait IntoBytes : Iterator<Item = u8> {
+pub(crate) trait IntoBytes: Iterator<Item = u8> {
     fn nibbles_into_bytes(&mut self) -> Vec<u8> {
         let mut data = Vec::with_capacity(self.size_hint().0 / 2);
 
         while let (Some(hi), Some(lo)) = (self.next(), self.next()) {
             data.push((hi << 4) + lo);
         }
-    
-        data    
+
+        data
     }
 }
 impl<T: Iterator<Item = u8>> IntoBytes for T {}


### PR DESCRIPTION
This method is useful for converting nibbles back into their corresponding bytes.

Added some simple tests, both in the success case and the failure case.