### PR TITLE
Only call `Obj.flush_dirty` in `drop` if it is actually dirty

### DIFF
--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -149,7 +149,9 @@ impl<T: Storable> Obj<T> {
 
 impl<T: Storable> Drop for Obj<T> {
     fn drop(&mut self) {
-        self.flush_dirty()
+        if self.dirty.is_some() {
+            self.flush_dirty()
+        }
     }
 }
 

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -134,15 +134,13 @@ impl<T: Storable> Obj<T> {
     }
 
     pub fn flush_dirty(&mut self) {
-        if !self.value.is_mem_mapped() {
-            if let Some(new_value_len) = self.dirty.take() {
-                let mut new_value = vec![0; new_value_len as usize];
-                // TODO: log error
-                self.value.write_mem_image(&mut new_value).unwrap();
-                let offset = self.value.get_offset();
-                let bx: &mut dyn CachedStore = self.value.get_mut_mem_store();
-                bx.write(offset, &new_value);
-            }
+        if let Some(new_value_len) = self.dirty.take() {
+            let mut new_value = vec![0; new_value_len as usize];
+            // TODO: log error
+            self.value.write_mem_image(&mut new_value).unwrap();
+            let offset = self.value.get_offset();
+            let bx: &mut dyn CachedStore = self.value.get_mut_mem_store();
+            bx.write(offset, &new_value);
         }
     }
 }
@@ -234,9 +232,6 @@ pub trait Storable {
     fn deserialize<T: CachedStore>(addr: usize, mem: &T) -> Result<Self, ShaleError>
     where
         Self: Sized;
-    fn is_mem_mapped(&self) -> bool {
-        false
-    }
 }
 
 pub fn to_dehydrated(item: &dyn Storable) -> Result<Vec<u8>, ShaleError> {
@@ -304,9 +299,6 @@ impl<T: Storable> StoredView<T> {
 
     fn write(&mut self) -> &mut T {
         &mut self.decoded
-    }
-    fn is_mem_mapped(&self) -> bool {
-        self.decoded.is_mem_mapped()
     }
 }
 

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -134,6 +134,11 @@ impl<T: Storable> Obj<T> {
     }
 
     pub fn flush_dirty(&mut self) {
+        // faster than calling `self.dirty.take()` on a `None`
+        if self.dirty.is_none() {
+            return;
+        }
+
         if let Some(new_value_len) = self.dirty.take() {
             let mut new_value = vec![0; new_value_len as usize];
             // TODO: log error
@@ -147,9 +152,7 @@ impl<T: Storable> Obj<T> {
 
 impl<T: Storable> Drop for Obj<T> {
     fn drop(&mut self) {
-        if self.dirty.is_some() {
-            self.flush_dirty()
-        }
+        self.flush_dirty()
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/ava-labs/firewood/issues/448.

After the change, according to the flamegraph of `insert` example using [sync API](https://github.com/ava-labs/firewood/commit/bfbd148dbefe49d232c55963a4afb91d89a8e868), ~3% time reduced in `drop_in_place` call and ~2% in `flush_dirty`.

Before 
![insert_sync_flamegraph_before](https://github.com/ava-labs/firewood/assets/113067541/9f690be2-0b70-4ea9-8ab3-5638827af145)

After
![insert_sync_flamegraph_after](https://github.com/ava-labs/firewood/assets/113067541/6aadb1ab-71bf-4b4a-8e2f-62b4eddac45b)

The flamegraph is generated using `cargo flamegraph --example insert-sync
` the default is to use `release` profile