### PR TITLE
Delay block in place

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -281,7 +281,7 @@ pub struct DbRev<S> {
 #[async_trait]
 impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
     async fn root_hash(&self) -> Result<api::HashKey, api::Error> {
-        block_in_place(|| self.merkle.root_hash(self.header.kv_root))
+        self.merkle.root_hash(self.header.kv_root)
             .map(|h| *h)
             .map_err(|e| api::Error::IO(std::io::Error::new(ErrorKind::Other, e)))
     }
@@ -414,7 +414,7 @@ impl api::Db for Db {
     type Proposal = proposal::Proposal;
 
     async fn revision(&self, root_hash: HashKey) -> Result<Arc<Self::Historical>, api::Error> {
-        let rev = block_in_place(|| self.get_revision(&TrieHash(root_hash)));
+        let rev = self.get_revision(&TrieHash(root_hash));
         if let Some(rev) = rev {
             Ok(Arc::new(rev.rev))
         } else {
@@ -425,7 +425,7 @@ impl api::Db for Db {
     }
 
     async fn root_hash(&self) -> Result<HashKey, api::Error> {
-        block_in_place(|| self.kv_root_hash())
+        self.kv_root_hash()
             .map(|hash| hash.0)
             .map_err(Into::into)
     }
@@ -434,7 +434,7 @@ impl api::Db for Db {
         &self,
         batch: api::Batch<K, V>,
     ) -> Result<Self::Proposal, api::Error> {
-        block_in_place(|| self.new_proposal(batch)).map_err(Into::into)
+        self.new_proposal(batch).map_err(Into::into)
     }
 }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -281,7 +281,8 @@ pub struct DbRev<S> {
 #[async_trait]
 impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
     async fn root_hash(&self) -> Result<api::HashKey, api::Error> {
-        self.merkle.root_hash(self.header.kv_root)
+        self.merkle
+            .root_hash(self.header.kv_root)
             .map(|h| *h)
             .map_err(|e| api::Error::IO(std::io::Error::new(ErrorKind::Other, e)))
     }
@@ -425,9 +426,7 @@ impl api::Db for Db {
     }
 
     async fn root_hash(&self) -> Result<HashKey, api::Error> {
-        self.kv_root_hash()
-            .map(|hash| hash.0)
-            .map_err(Into::into)
+        self.kv_root_hash().map(|hash| hash.0).map_err(Into::into)
     }
 
     async fn propose<K: KeyType, V: ValueType>(

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -15,7 +15,6 @@ use crate::{
 use async_trait::async_trait;
 use parking_lot::{Mutex, RwLock};
 use std::{io::ErrorKind, sync::Arc};
-use tokio::task::block_in_place;
 
 pub use crate::v2::api::{Batch, BatchOp};
 
@@ -49,15 +48,14 @@ impl crate::v2::api::Proposal for Proposal {
 
     #[allow(clippy::unwrap_used)]
     async fn commit(self: Arc<Self>) -> Result<(), api::Error> {
-        let proposal = Arc::<Proposal>::into_inner(self).unwrap();
-        block_in_place(|| proposal.commit_sync().map_err(Into::into))
+        block_in_place(|| self.commit_sync().map_err(Into::into))
     }
 
     async fn propose<K: api::KeyType, V: api::ValueType>(
         self: Arc<Self>,
         data: api::Batch<K, V>,
     ) -> Result<Self::Proposal, api::Error> {
-        block_in_place(|| self.propose_sync(data)).map_err(Into::into)
+        self.propose_sync(data).map_err(Into::into)
     }
 }
 

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 use async_trait::async_trait;
 use parking_lot::{Mutex, RwLock};
-use tokio::task::block_in_place;
 use std::{io::ErrorKind, sync::Arc};
+use tokio::task::block_in_place;
 
 pub use crate::v2::api::{Batch, BatchOp};
 

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use parking_lot::{Mutex, RwLock};
+use tokio::task::block_in_place;
 use std::{io::ErrorKind, sync::Arc};
 
 pub use crate::v2::api::{Batch, BatchOp};
@@ -48,7 +49,8 @@ impl crate::v2::api::Proposal for Proposal {
 
     #[allow(clippy::unwrap_used)]
     async fn commit(self: Arc<Self>) -> Result<(), api::Error> {
-        block_in_place(|| self.commit_sync().map_err(Into::into))
+        let proposal = Arc::<Proposal>::into_inner(self).unwrap();
+        block_in_place(|| proposal.commit_sync().map_err(Into::into))
     }
 
     async fn propose<K: api::KeyType, V: api::ValueType>(

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -623,7 +623,7 @@ impl DiskBufferRequester {
             .send(BufferCmd::CollectAsh(nrecords, resp_tx))
             .map_err(StoreError::Send)
             .ok();
-        resp_rx.blocking_recv().map_err(StoreError::Receive)
+        block_in_place(|| resp_rx.blocking_recv().map_err(StoreError::Receive))
     }
 
     /// Register a cached space to the buffer.

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -20,6 +20,7 @@ use growthring::{
     walerror::WalError,
     WalFileImpl, WalStoreImpl,
 };
+use tokio::task::block_in_place;
 use tokio::{
     sync::{
         mpsc,
@@ -588,7 +589,7 @@ impl DiskBufferRequester {
             .map_err(StoreError::Send)
             .ok();
         #[allow(clippy::unwrap_used)]
-        resp_rx.blocking_recv().unwrap()
+        block_in_place(move || resp_rx.blocking_recv().unwrap())
     }
 
     /// Sends a batch of writes to the buffer.


### PR DESCRIPTION
We can delay calling `block_in_place` until we actually block. This results in a small performance gain, probably more noticeable when we start doing reads in parallel.

Before:
```
Your branch is up to date with 'origin/main'.
❯ cargo run --quiet --release --example insert -- -i 1000 -s 1
Generated and inserted 1000 batches of size 1 in 5.022415705s
❯ cargo run --quiet --release --example insert -- -i 1000 -s 1
Generated and inserted 1000 batches of size 1 in 5.410185903s
❯ cargo run --quiet --release --example insert -- -i 1000 -s 1
Generated and inserted 1000 batches of size 1 in 5.059761131s
```

After
```
❯ cargo run --quiet --release --example insert -- -i 1000 -s 1
Generated and inserted 1000 batches of size 1 in 4.911608567s
❯ cargo run --quiet --release --example insert -- -i 1000 -s 1
Generated and inserted 1000 batches of size 1 in 4.906468629s
❯ cargo run --quiet --release --example insert -- -i 1000 -s 1
Generated and inserted 1000 batches of size 1 in 4.918876902s
```