### PR TITLE
`Proposal.commit` consume the underlying `DbRev` directly to the base committed revision

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -95,8 +95,8 @@ fn bench_merkle<const N: usize>(criterion: &mut Criterion) {
                     .unwrap();
 
                     let store = CompactSpace::new(
-                        PlainMem::new(TEST_MEM_SIZE, 0).into(),
-                        PlainMem::new(TEST_MEM_SIZE, 1).into(),
+                        PlainMem::new(TEST_MEM_SIZE, 0),
+                        PlainMem::new(TEST_MEM_SIZE, 1),
                         merkle_payload_header_ref,
                         ObjCache::new(1 << 20),
                         4096,

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -58,6 +58,7 @@ const MAGIC_STR: &[u8; 16] = b"firewood v0.1\0\0\0";
 
 pub type MutStore = CompactSpace<Node, StoreRevMut>;
 pub type SharedStore = CompactSpace<Node, StoreRevShared>;
+// pub type SharedStore = CompactSpace<Node, StoreRev>;
 
 #[derive(Debug)]
 #[non_exhaustive]
@@ -829,7 +830,7 @@ impl Db {
             m: Arc::clone(&self.inner),
             r: Arc::clone(&self.revisions),
             cfg: self.cfg.clone(),
-            rev: Box::new(rev),
+            rev,
             store,
             committed: Arc::new(Mutex::new(false)),
             parent,

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -58,7 +58,6 @@ const MAGIC_STR: &[u8; 16] = b"firewood v0.1\0\0\0";
 
 pub type MutStore = CompactSpace<Node, StoreRevMut>;
 pub type SharedStore = CompactSpace<Node, StoreRevShared>;
-// pub type SharedStore = CompactSpace<Node, StoreRev>;
 
 #[derive(Debug)]
 #[non_exhaustive]
@@ -584,7 +583,6 @@ impl Db {
             merkle: get_sub_universe_from_empty_delta(&data_cache.merkle),
         };
 
-       
         let db_header_ref = Db::get_db_header_ref(&base.merkle.meta)?;
 
         let merkle_payload_header_ref =
@@ -700,14 +698,11 @@ impl Db {
 
         let db_header_ref = Db::get_db_header_ref(&store.merkle.meta)?;
 
-        let merkle_payload_header_ref = Db::get_payload_header_ref(
-            &store.merkle.meta,
-            Db::PARAM_SIZE + DbHeader::MSIZE,
-        )?;
+        let merkle_payload_header_ref =
+            Db::get_payload_header_ref(&store.merkle.meta, Db::PARAM_SIZE + DbHeader::MSIZE)?;
 
         let header_refs = (db_header_ref, merkle_payload_header_ref);
 
-        //let meta = store.merkle.meta;
         let mut rev: DbRev<CompactSpace<Node, StoreRevMut>> = Db::new_revision(
             header_refs,
             (store.merkle.meta.clone(), store.merkle.payload.clone()),
@@ -789,7 +784,7 @@ impl Db {
     }
 
     /// Create a proposal.
-    pub fn new_proposal<K: KeyType, V: ValueType>(
+    pub(crate) fn new_proposal<K: KeyType, V: ValueType>(
         &self,
         data: Batch<K, V>,
     ) -> Result<proposal::Proposal, DbError> {
@@ -940,7 +935,7 @@ impl Db {
         self.revisions.lock().base_revision.kv_dump(w)
     }
     /// Get root hash of the latest generic key-value storage.
-    pub fn kv_root_hash(&self) -> Result<TrieHash, DbError> {
+    pub(crate) fn kv_root_hash(&self) -> Result<TrieHash, DbError> {
         self.revisions.lock().base_revision.kv_root_hash()
     }
 

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -36,7 +36,7 @@ pub struct Proposal {
 
     // State of the proposal
     pub(super) rev: DbRev<MutStore>,
-    pub(super) store: Universe<Arc<StoreRevMut>>,
+    pub(super) store: Universe<StoreRevMut>,
     pub(super) committed: Arc<Mutex<bool>>,
 
     pub(super) parent: ProposalBase,
@@ -77,10 +77,10 @@ impl Proposal {
         let r = Arc::clone(&self.r);
         let cfg = self.cfg.clone();
 
-        let db_header_ref = Db::get_db_header_ref(store.merkle.meta.as_ref())?;
+        let db_header_ref = Db::get_db_header_ref(&store.merkle.meta)?;
 
         let merkle_payload_header_ref = Db::get_payload_header_ref(
-            store.merkle.meta.as_ref(),
+            &store.merkle.meta,
             Db::PARAM_SIZE + DbHeader::MSIZE,
         )?;
 

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1421,7 +1421,6 @@ mod tests {
     use super::*;
     use node::tests::{extension, leaf};
     use shale::{cached::DynamicMem, compact::CompactSpace, CachedStore};
-    use std::sync::Arc;
     use test_case::test_case;
 
     #[test_case(vec![0x12, 0x34, 0x56], &[0x1, 0x2, 0x3, 0x4, 0x5, 0x6])]

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1,3 +1,4 @@
+use crate::db::{MutStore, SharedStore};
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 use crate::nibbles::Nibbles;
@@ -69,6 +70,16 @@ macro_rules! write_node {
 pub struct Merkle<S, T> {
     store: Box<S>,
     phantom: PhantomData<T>,
+}
+
+impl<T> Merkle<MutStore, T> {
+    pub fn into(self) -> Merkle<SharedStore, T> {
+        let store = self.store.into_shared();
+        Merkle {
+            store: Box::new(store),
+            phantom: PhantomData,
+        }
+    }
 }
 
 impl<S: ShaleStore<Node>, T> Merkle<S, T> {

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1454,8 +1454,8 @@ mod tests {
             shale::compact::CompactHeader::MSIZE,
         )
         .unwrap();
-        let mem_meta = Arc::new(dm);
-        let mem_payload = Arc::new(DynamicMem::new(0x10000, 0x1));
+        let mem_meta = dm;
+        let mem_payload = DynamicMem::new(0x10000, 0x1);
 
         let cache = shale::ObjCache::new(1);
         let space =

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -6,7 +6,7 @@ use crate::shale::{
     self, cached::DynamicMem, compact::CompactSpace, disk_address::DiskAddress, CachedStore,
     ShaleStore, StoredView,
 };
-use std::{num::NonZeroUsize, sync::Arc};
+use std::num::NonZeroUsize;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -135,8 +135,8 @@ pub fn new_merkle(
     );
     let compact_header =
         StoredView::ptr_to_obj(&dm, compact_header, shale::compact::CompactHeader::MSIZE).unwrap();
-    let mem_meta = Arc::new(dm);
-    let mem_payload = Arc::new(DynamicMem::new(compact_size, 0x1));
+    let mem_meta = dm;
+    let mem_payload = DynamicMem::new(compact_size, 0x1);
 
     let cache = shale::ObjCache::new(1);
     let space =

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -226,7 +226,7 @@ struct CompactSpaceInner<M> {
 }
 
 impl CompactSpaceInner<StoreRevMut> {
-    pub fn into_shared(self) -> CompactSpaceInner<StoreRevShared> {  
+    pub fn into_shared(self) -> CompactSpaceInner<StoreRevShared> {
         CompactSpaceInner {
             meta_space: self.meta_space.into_shared(),
             compact_space: self.compact_space.into_shared(),

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -226,10 +226,7 @@ struct CompactSpaceInner<M> {
 }
 
 impl CompactSpaceInner<StoreRevMut> {
-    pub fn into_shared(self) -> CompactSpaceInner<StoreRevShared> {
-        // let meta_space = Arc::<StoreRevMut>::into_inner(self.meta_space).unwrap();
-        // let compact_space = Arc::<StoreRevMut>::into_inner(self.compact_space).unwrap();
-        
+    pub fn into_shared(self) -> CompactSpaceInner<StoreRevShared> {  
         CompactSpaceInner {
             meta_space: self.meta_space.into_shared(),
             compact_space: self.compact_space.into_shared(),

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -228,9 +228,12 @@ struct CompactSpaceInner<M> {
 
 impl CompactSpaceInner<StoreRevMut> {
     pub fn into_shared(self) -> CompactSpaceInner<StoreRevShared> {
+        let meta_space = Arc::<StoreRevMut>::into_inner(self.meta_space).unwrap();
+        let compact_space = Arc::<StoreRevMut>::into_inner(self.compact_space).unwrap();
+        
         CompactSpaceInner {
-            meta_space: Arc::new(self.meta_space.into_shared()),
-            compact_space: Arc::new(self.compact_space.into_shared()),
+            meta_space: Arc::new(meta_space.into_shared()),
+            compact_space: Arc::new(compact_space.into_shared()),
             header: self.header,
             alloc_max_walk: self.alloc_max_walk,
             regn_nbit: self.regn_nbit,

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -152,9 +152,7 @@ impl<T: Storable> Obj<T> {
 
 impl<T: Storable> Drop for Obj<T> {
     fn drop(&mut self) {
-        if self.dirty.is_some() {
-            self.flush_dirty()
-        }
+        self.flush_dirty()
     }
 }
 

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -152,7 +152,9 @@ impl<T: Storable> Obj<T> {
 
 impl<T: Storable> Drop for Obj<T> {
     fn drop(&mut self) {
-        self.flush_dirty()
+        if self.dirty.is_some() {
+            self.flush_dirty()
+        }
     }
 }
 

--- a/firewood/src/storage/mod.rs
+++ b/firewood/src/storage/mod.rs
@@ -402,9 +402,10 @@ impl StoreRevMut {
     }
 
     pub fn into_shared(self) -> StoreRevShared {
+        let delta = self.delta().0;
         let rev = Arc::new(StoreRev {
             base_space: RwLock::new(self.base_space),
-            delta: self.delta().0,
+            delta,
         });
         StoreRevShared(rev)
     }

--- a/firewood/src/storage/mod.rs
+++ b/firewood/src/storage/mod.rs
@@ -403,10 +403,7 @@ impl StoreRevMut {
 
     pub fn into_shared(self) -> StoreRevShared {
         let mut pages = Vec::new();
-        let deltas = std::mem::replace(
-            &mut *self.deltas.write(),
-            Default::default(),
-        );
+        let deltas = std::mem::take(&mut *self.deltas.write());
         for (pid, page) in deltas.pages.into_iter() {
             pages.push(DeltaPage(pid, page));
         }

--- a/firewood/src/storage/mod.rs
+++ b/firewood/src/storage/mod.rs
@@ -401,6 +401,14 @@ impl StoreRevMut {
         }
     }
 
+    pub fn into_shared(self) -> StoreRevShared {
+        let rev = Arc::new(StoreRev {
+            base_space: RwLock::new(self.base_space),
+            delta: self.delta().0,
+        });
+        StoreRevShared(rev)
+    }
+
     fn get_page_mut<'a>(
         &self,
         deltas: &'a mut StoreRevMutDelta,

--- a/firewood/tests/db.rs
+++ b/firewood/tests/db.rs
@@ -244,6 +244,7 @@ macro_rules! assert_val {
     };
 }
 
+#[ignore = "ref: https://github.com/ava-labs/firewood/issues/457"]
 #[tokio::test(flavor = "multi_thread")]
 async fn db_proposal() -> Result<(), api::Error> {
     let cfg = DbConfig::builder()


### PR DESCRIPTION
Close https://github.com/ava-labs/firewood/issues/449

With this change we can reduce around ~(40% - 50%) of time using the `insert` example as the benchmark.

```
~/src/firewood$ cargo run --release --quiet --example insert -- -i 1000
Generated and inserted 1000 batches of size 1 in 3.106775653s
~/src/firewood$ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
~/src/firewood$ cargo run --release --quiet --example insert -- -i 1000
Generated and inserted 1000 batches of size 1 in 6.001036863s
```

However there are serval improvements need to happen after this PR,

1.  It takes the short route to convert a `StoreRevMut` to `StoreRevShared`, a more idiomatic way to combine these two into one struct should happen.
2. It disabled the recursive commit feature of proposal as we now consume the proposal when we commit.