### PR TITLE
Fix upcoming clippy lint

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -889,9 +889,7 @@ impl Db {
                 .position(|trie_hash| &trie_hash == root_hash));
         }
 
-        let Some(nback) = nback else {
-            return None;
-        };
+        let nback = nback?;
 
         let rlen = revisions.inner.len();
         if rlen < nback {


### PR DESCRIPTION
Nightly reports this:

```
warning: this `let...else` may be rewritten with the `?` operator
   --> firewood/src/db.rs:891:9
    |
891 | /         let Some(nback) = nback else {
892 | |             return None;
893 | |         };
    | |__________^ help: replace it with: `let nback = nback?;`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
    = note: `#[warn(clippy::question_mark)]` on by default
```