### PR TITLE
Persist `is_encoded_longer_than_hash_len` property of a Node

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -830,6 +830,9 @@ impl Db {
                 }
             }
         })?;
+
+        // Calculated the root hash before flushing so it can be persisted.
+        let root_hash = rev.kv_root_hash()?;
         #[allow(clippy::unwrap_used)]
         rev.flush_dirty().unwrap();
 
@@ -841,6 +844,7 @@ impl Db {
             rev,
             store,
             committed: Arc::new(Mutex::new(false)),
+            root_hash,
             parent,
         })
     }


### PR DESCRIPTION
Closes https://github.com/ava-labs/firewood/issues/472

This PR ensures we store `is_encoded_longer_than_hash_len` property of a Node and reload when reading a node from disk, so that the persisted root hash can be used. It also ensures root hash calculation is done before we flushing the writes in a proposal so it can be persisted.

With this change, the performance of small key insertion with large number of batches dramatically improved. For example with 1000 batches of size 10, dropped from 27s to 1s.  Before,
```
$ cargo run --release --quiet --example insert -- -b 10 -n 1000 -s 0
Generated and inserted 1000 batches of size 10 in 27.246639082s
```

After,
```
$ cargo run --release --quiet --example insert -- -b 10 -n 1000 -s 0
Generated and inserted 1000 batches of size 10 in 1.521389874s
```