### PR TITLE
add support for start key argument in fwdctl dump command

### DIFF
--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -9,7 +9,6 @@ use firewood::{
 use futures_util::StreamExt;
 use log;
 use std::borrow::Cow;
-use std::num::ParseIntError;
 
 #[derive(Debug, Args)]
 pub struct Options {
@@ -60,12 +59,6 @@ fn u8_to_string(data: &[u8]) -> Cow<'_, str> {
     String::from_utf8_lossy(data)
 }
 
-fn key_parser(s: &str) -> Result<Box<[u8]>, ParseIntError> {
-    let mut result = Vec::with_capacity(s.len() / 2);
-    let mut iter = s.chars().peekable();
-    while iter.peek().is_some() {
-        let chunk = iter.by_ref().take(2).collect::<String>();
-        result.push(u8::from_str_radix(&chunk, 16)?);
-    }
-    Ok(result.into_boxed_slice())
+fn key_parser(s: &str) -> Result<Box<[u8]>, std::io::Error> {
+    return Ok(Box::from(s.as_bytes()));
 }

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -27,10 +27,9 @@ pub struct Options {
     #[arg(
         required = false,
         value_name = "START_KEY",
-        default_value_t = String::from(""),
         help = "Start dumping from this key (inclusive)."
     )]
-    pub start_key: String,
+    pub start_key: Option<String>,
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
@@ -42,10 +41,9 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     let db = Db::new(opts.db.clone(), &cfg.build()).await?;
     let latest_hash = db.root_hash().await?;
     let latest_rev = db.revision(latest_hash).await?;
-    let start_key_bytes = opts.start_key.as_bytes();
-    let start_key = match start_key_bytes.is_empty() {
-        true => Box::new([]),
-        false => start_key_bytes.to_vec().into_boxed_slice(),
+    let start_key = match &opts.start_key {
+        Some(key) => key.as_bytes().to_vec().into_boxed_slice(),
+        None => Box::new([]),
     };
     let mut stream = latest_rev.stream_from(start_key);
     loop {

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -1,6 +1,8 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use std::borrow::Cow;
+
 use clap::Args;
 use firewood::{
     db::{Db, DbConfig, WalConfig},
@@ -8,7 +10,6 @@ use firewood::{
 };
 use futures_util::StreamExt;
 use log;
-use std::borrow::Cow;
 
 #[derive(Debug, Args)]
 pub struct Options {


### PR DESCRIPTION
Adds a new optional `START_KEY` argument. The `START_KEY` is not expected to be hex. The string is turned into bytes with `.as_bytes()`. Tested manually and it works.