### PR TITLE
Fix `serialized_len` in Node

### DIFF
--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -416,7 +416,6 @@ impl Storable for Node {
 
     fn serialized_len(&self) -> u64 {
         Meta::SIZE as u64
-            + 1
             + match &self.inner {
                 NodeType::Branch(n) => {
                     // TODO: add path


### PR DESCRIPTION
Now there is an extra byte added to `serialized_len` in Node, which the tests happen to pass because the extra byte is not used.