### PR TITLE
Clippy Warning fix with latest rust upgrade

### DIFF
--- a/firewood/src/storage/mod.rs
+++ b/firewood/src/storage/mod.rs
@@ -629,15 +629,9 @@ impl CachedStore for StoreRevMut {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 /// A zero-filled in memory store which can serve as a plain base to overlay deltas on top.
-pub struct ZeroStore(Arc<()>);
-
-impl Default for ZeroStore {
-    fn default() -> Self {
-        Self(Arc::new(()))
-    }
-}
+pub struct ZeroStore(());
 
 impl MemStoreR for ZeroStore {
     fn get_slice(&self, _: u64, length: u64) -> Option<Vec<u8>> {

--- a/growth-ring/tests/common/mod.rs
+++ b/growth-ring/tests/common/mod.rs
@@ -614,7 +614,7 @@ impl PaintingSim {
         state: &mut WalStoreEmulState,
         canvas: &mut Canvas,
         wal: WalLoader,
-        ops: &Vec<PaintStrokes>,
+        ops: &[PaintStrokes],
         ringid_map: &HashMap<WalRingId, usize>,
     ) -> bool {
         if ops.is_empty() {


### PR DESCRIPTION
After upgrade rust version, the following shown as clippy warning.