### PR TITLE
Logging in firewood, initial version

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ There are several examples, in the examples directory, that simulate real world
 use-cases. Try running them via the command-line, via `cargo run --release
 --example simple`.
 
+## Logging
+
+If you want logging, enable the `logging` feature flag, and then set RUST\_LOG accordingly.
+See the documentation for [env\_logger](https://docs.rs/env_logger/latest/env_logger/) for specifics.
+We currently have very few logging statements, but this is useful for print-style debugging.
+
 ## Release
 
 See the [release documentation](./RELEASE.md) for detailed information on how to release Firewood.

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -35,6 +35,11 @@ tokio = { version = "1.21.1", features = ["rt", "sync", "macros", "rt-multi-thre
 typed-builder = "0.18.0"
 bincode = "1.3.3"
 bitflags = "2.4.1"
+env_logger = { version = "0.10.1", optional = true }
+log = { version = "0.4.20", optional = true }
+
+[features]
+logger = ["dep:env_logger", "log"]
 
 [dev-dependencies]
 criterion = {version = "0.5.1", features = ["async_tokio"]}

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -465,6 +465,11 @@ impl Db {
             let _ = tokio::fs::remove_dir_all(db_path.as_ref()).await;
         }
 
+        #[cfg(feature = "logger")]
+        // initialize the logger, but ignore if this fails. This could fail because the calling
+        // library already initialized the logger or if you're opening a second database
+        let _ = env_logger::try_init();
+
         block_in_place(|| Db::new_internal(db_path, cfg.clone()))
             .map_err(|e| api::Error::InternalError(Box::new(e)))
     }

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -195,4 +195,5 @@ pub mod nibbles;
 // TODO: shale should not be pub, but there are integration test dependencies :(
 pub mod shale;
 
+pub mod logger;
 pub mod v2;

--- a/firewood/src/logger.rs
+++ b/firewood/src/logger.rs
@@ -6,7 +6,7 @@
 // static shortcut
 
 #[cfg(feature = "logger")]
-pub use log::{trace, debug, info, warn, error};
+pub use log::{debug, error, info, trace, warn};
 
 #[cfg(not(feature = "logger"))]
 pub use noop_logger::{debug, error, info, trace, warn};

--- a/firewood/src/logger.rs
+++ b/firewood/src/logger.rs
@@ -1,0 +1,87 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+#[cfg(feature = "logger")]
+#[macro_export]
+macro_rules! trace {
+    // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
+    // trace!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => (log::log!(target: $target, log::Level::Trace, $($arg)+));
+
+    // trace!("a {} event", "log")
+    ($($arg:tt)+) => (log::log!(log::Level::Trace, $($arg)+))
+}
+#[cfg(not(feature = "logger"))]
+#[macro_export]
+macro_rules! trace {
+    (target: $target:expr, $($arg:tt)+) => {};
+    ($($arg:tt)+) => {};
+}
+
+#[cfg(feature = "logger")]
+#[macro_export]
+macro_rules! debug {
+    // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
+    // trace!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => (log::log!(target: $target, log::Level::Debug, $($arg)+));
+
+    // trace!("a {} event", "log")
+    ($($arg:tt)+) => (log::log!(log::Level::Debug, $($arg)+))
+}
+#[cfg(not(feature = "logger"))]
+#[macro_export]
+macro_rules! debug {
+    (target: $target:expr, $($arg:tt)+) => {};
+    ($($arg:tt)+) => {};
+}
+
+#[cfg(feature = "logger")]
+#[macro_export]
+macro_rules! info {
+    // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
+    // trace!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => (log::log!(target: $target, log::Level::Info, $($arg)+));
+
+    // trace!("a {} event", "log")
+    ($($arg:tt)+) => (log::log!(log::Level::Info, $($arg)+))
+}
+#[cfg(not(feature = "logger"))]
+#[macro_export]
+macro_rules! info {
+    (target: $target:expr, $($arg:tt)+) => {};
+    ($($arg:tt)+) => {};
+}
+
+#[cfg(feature = "logger")]
+#[macro_export]
+macro_rules! warn {
+    // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
+    // trace!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => (log::log!(target: $target, log::Level::Warn, $($arg)+));
+
+    // trace!("a {} event", "log")
+    ($($arg:tt)+) => (log::log!(log::Level::Warn, $($arg)+))
+}
+#[cfg(not(feature = "logger"))]
+#[macro_export]
+macro_rules! warn {
+    (target: $target:expr, $($arg:tt)+) => {};
+    ($($arg:tt)+) => {};
+}
+
+#[cfg(feature = "logger")]
+#[macro_export]
+macro_rules! error {
+    // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
+    // trace!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => (log::log!(target: $target, log::Level::Error, $($arg)+));
+
+    // trace!("a {} event", "log")
+    ($($arg:tt)+) => (log::log!(log::Level::Error, $($arg)+))
+}
+#[cfg(not(feature = "logger"))]
+#[macro_export]
+macro_rules! error {
+    (target: $target:expr, $($arg:tt)+) => {};
+    ($($arg:tt)+) => {};
+}

--- a/firewood/src/logger.rs
+++ b/firewood/src/logger.rs
@@ -1,87 +1,26 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#[cfg(feature = "logger")]
-#[macro_export]
-macro_rules! trace {
-    // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
-    // trace!(target: "my_target", "a {} event", "log")
-    (target: $target:expr, $($arg:tt)+) => (log::log!(target: $target, log::Level::Trace, $($arg)+));
-
-    // trace!("a {} event", "log")
-    ($($arg:tt)+) => (log::log!(log::Level::Trace, $($arg)+))
-}
-#[cfg(not(feature = "logger"))]
-#[macro_export]
-macro_rules! trace {
-    (target: $target:expr, $($arg:tt)+) => {};
-    ($($arg:tt)+) => {};
-}
+// Supports making the logging operations a true runtime no-op
+// Since we're a library, we can't really use the logging level
+// static shortcut
 
 #[cfg(feature = "logger")]
-#[macro_export]
-macro_rules! debug {
-    // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
-    // trace!(target: "my_target", "a {} event", "log")
-    (target: $target:expr, $($arg:tt)+) => (log::log!(target: $target, log::Level::Debug, $($arg)+));
+pub use log::{trace, debug, info, warn, error};
 
-    // trace!("a {} event", "log")
-    ($($arg:tt)+) => (log::log!(log::Level::Debug, $($arg)+))
-}
 #[cfg(not(feature = "logger"))]
-#[macro_export]
-macro_rules! debug {
-    (target: $target:expr, $($arg:tt)+) => {};
-    ($($arg:tt)+) => {};
-}
+pub use noop_logger::{debug, error, info, trace, warn};
 
-#[cfg(feature = "logger")]
-#[macro_export]
-macro_rules! info {
-    // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
-    // trace!(target: "my_target", "a {} event", "log")
-    (target: $target:expr, $($arg:tt)+) => (log::log!(target: $target, log::Level::Info, $($arg)+));
-
-    // trace!("a {} event", "log")
-    ($($arg:tt)+) => (log::log!(log::Level::Info, $($arg)+))
-}
 #[cfg(not(feature = "logger"))]
-#[macro_export]
-macro_rules! info {
-    (target: $target:expr, $($arg:tt)+) => {};
-    ($($arg:tt)+) => {};
-}
+mod noop_logger {
+    #[macro_export]
+    macro_rules! noop {
+        ($(target: $a:expr,)? $b:tt) => {};
+    }
 
-#[cfg(feature = "logger")]
-#[macro_export]
-macro_rules! warn {
-    // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
-    // trace!(target: "my_target", "a {} event", "log")
-    (target: $target:expr, $($arg:tt)+) => (log::log!(target: $target, log::Level::Warn, $($arg)+));
-
-    // trace!("a {} event", "log")
-    ($($arg:tt)+) => (log::log!(log::Level::Warn, $($arg)+))
-}
-#[cfg(not(feature = "logger"))]
-#[macro_export]
-macro_rules! warn {
-    (target: $target:expr, $($arg:tt)+) => {};
-    ($($arg:tt)+) => {};
-}
-
-#[cfg(feature = "logger")]
-#[macro_export]
-macro_rules! error {
-    // trace!(target: "my_target", key1 = 42, key2 = true; "a {} event", "log")
-    // trace!(target: "my_target", "a {} event", "log")
-    (target: $target:expr, $($arg:tt)+) => (log::log!(target: $target, log::Level::Error, $($arg)+));
-
-    // trace!("a {} event", "log")
-    ($($arg:tt)+) => (log::log!(log::Level::Error, $($arg)+))
-}
-#[cfg(not(feature = "logger"))]
-#[macro_export]
-macro_rules! error {
-    (target: $target:expr, $($arg:tt)+) => {};
-    ($($arg:tt)+) => {};
+    pub use noop as debug;
+    pub use noop as error;
+    pub use noop as info;
+    pub use noop as trace;
+    pub use noop as warn;
 }

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::trace;
+use crate::logger::trace;
 use crate::{
     merkle::from_nibbles,
     shale::{disk_address::DiskAddress, CachedStore, ShaleError, ShaleStore, Storable},

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use crate::trace;
 use crate::{
     merkle::from_nibbles,
     shale::{disk_address::DiskAddress, CachedStore, ShaleError, ShaleStore, Storable},
@@ -8,7 +9,6 @@ use crate::{
 use bincode::{Error, Options};
 use bitflags::bitflags;
 use enum_as_inner::EnumAsInner;
-use log::debug;
 use serde::{
     de::DeserializeOwned,
     ser::{SerializeSeq, SerializeTuple},
@@ -360,8 +360,7 @@ impl Storable for Node {
                     size: Meta::SIZE as u64,
                 })?;
 
-        #[cfg(feature = "logger")]
-        debug!("[{mem:p}] Deserializing node at {offset}");
+        trace!("[{mem:p}] Deserializing node at {offset}");
 
         let offset = offset + Meta::SIZE;
 
@@ -431,7 +430,7 @@ impl Storable for Node {
     }
 
     fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
-        debug!("[{self:p}] Serializing node");
+        trace!("[{self:p}] Serializing node");
         let mut cur = Cursor::new(to);
 
         let mut attrs = match self.root_hash.get() {

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -13,6 +13,9 @@ use std::io::{Cursor, Write};
 use std::num::NonZeroUsize;
 use std::sync::RwLock;
 
+#[cfg(feature = "logger")]
+use log::debug;
+
 #[derive(Debug)]
 pub struct CompactHeader {
     payload_size: u64,
@@ -561,6 +564,8 @@ impl<T: Storable, M: CachedStore> CompactSpace<T, M> {
             }),
             obj_cache,
         };
+        #[cfg(logger)]
+        debug!("[{cs:p} New cache");
         Ok(cs)
     }
 }
@@ -583,6 +588,9 @@ impl<T: Storable + Debug + 'static + PartialEq, M: CachedStore + Send + Sync> Sh
         let size = item.serialized_len() + extra;
         #[allow(clippy::unwrap_used)]
         let addr = self.inner.write().unwrap().alloc(size)?;
+
+        #[cfg(feature = "logger")]
+        debug!("{self:p} New item at {addr} size {size}");
 
         #[allow(clippy::unwrap_used)]
         let obj = {

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -13,8 +13,7 @@ use std::io::{Cursor, Write};
 use std::num::NonZeroUsize;
 use std::sync::RwLock;
 
-#[cfg(feature = "logger")]
-use log::debug;
+use crate::trace;
 
 #[derive(Debug)]
 pub struct CompactHeader {
@@ -564,8 +563,6 @@ impl<T: Storable, M: CachedStore> CompactSpace<T, M> {
             }),
             obj_cache,
         };
-        #[cfg(logger)]
-        debug!("[{cs:p} New cache");
         Ok(cs)
     }
 }
@@ -589,8 +586,7 @@ impl<T: Storable + Debug + 'static + PartialEq, M: CachedStore + Send + Sync> Sh
         #[allow(clippy::unwrap_used)]
         let addr = self.inner.write().unwrap().alloc(size)?;
 
-        #[cfg(feature = "logger")]
-        debug!("{self:p} New item at {addr} size {size}");
+        trace!("{self:p} New item at {addr} size {size}");
 
         #[allow(clippy::unwrap_used)]
         let obj = {

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -13,7 +13,7 @@ use std::io::{Cursor, Write};
 use std::num::NonZeroUsize;
 use std::sync::RwLock;
 
-use crate::trace;
+use crate::logger::trace;
 
 #[derive(Debug)]
 pub struct CompactHeader {

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -586,7 +586,7 @@ impl<T: Storable + Debug + 'static + PartialEq, M: CachedStore + Send + Sync> Sh
         #[allow(clippy::unwrap_used)]
         let addr = self.inner.write().unwrap().alloc(size)?;
 
-        trace!("{self:p} New item at {addr} size {size}");
+        trace!("{self:p} put_item at {addr} size {size}");
 
         #[allow(clippy::unwrap_used)]
         let obj = {


### PR DESCRIPTION
Needed logging for easy reporting of frequency of serialization and deserialization, so added some logging framework, behind a feature flag.

Also a tiny change to remove mutability of offset when deserializing, which arguably could have been done in a different commit.