### PR TITLE
Use fast crc32 crate instead in growth-ring

### DIFF
--- a/growth-ring/Cargo.toml
+++ b/growth-ring/Cargo.toml
@@ -9,7 +9,6 @@ description = "Simple and modular write-ahead-logging implementation."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crc = "3.0.0"
 lru = "0.12.0"
 scan_fmt = "0.2.6"
 regex = "1.6.0"
@@ -20,6 +19,7 @@ libc = "0.2.133"
 bytemuck = {version = "1.13.1", features = ["derive"]}
 thiserror = "1.0.40"
 tokio = { version = "1.28.1", features = ["fs", "io-util", "sync"] }
+crc32fast = "1.3.2"
 
 [dev-dependencies]
 hex = "0.4.3"


### PR DESCRIPTION
Closes https://github.com/ava-labs/firewood/issues/495.

While examine the flamegraph for inserts of large batch size I found the more number of batches, the more time it spent on crc32 checksum calculation in wal. e.g. for 5000 batches of insert of size 10 it took ~20% time. This PR updates to use a faster crc32 crate.

Before the change,
$ cargo run --release --quiet --example insert -- -n 5000 -b 10 -s 0
Generated and inserted 5000 batches of size 10 in 19.322914592s

flamegrah,
![flamegraph_5000_old](https://github.com/ava-labs/firewood/assets/113067541/05ff8127-934b-4bf0-820a-71f0fffe4510)


After,
cargo run --release --quiet --example insert -- -n 5000 -b 10 -s 0
Generated and inserted 5000 batches of size 10 in 14.522793177s
![flamegraph_5000](https://github.com/ava-labs/firewood/assets/113067541/e9be2f61-f192-4946-b259-583337d273a9)

 