### PR TITLE
Refactor stream implementation

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1181,7 +1181,8 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
             node_ref = self.get_node(next_ptr)?;
         }
 
-        // when we're done iterating over nibbles, check if the node we're at has a value
+        // We're done iterating over nibbles.
+        // Check if the node we're at has a value.
         let node_ref = match &node_ref.inner {
             NodeType::Branch(n) if n.value.as_ref().is_some() => Some(node_ref),
             NodeType::Leaf(n) if n.path.len() == 0 => Some(node_ref),

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -464,20 +464,6 @@ mod tests {
             }
         }
 
-        // let mut merkle = create_test_merkle();
-        // let root = merkle.init_root().unwrap();
-
-        // // Insert key-values in reverse order to ensure iterator
-        // // doesn't just return the keys in insertion order.
-        // for i in (0..=u8::MAX).rev() {
-        //     for j in (0..=u8::MAX).rev() {
-        //         let key = vec![i, j];
-        //         let value = vec![i, j];
-
-        //         merkle.insert(key, value, root).unwrap();
-        //     }
-        // }
-
         // Test with no start key
         let mut stream = merkle.iter(root);
         for i in 0..u8::MAX {
@@ -495,32 +481,6 @@ mod tests {
             }
         }
         check_stream_is_done(stream).await;
-
-        // Test with start key
-        for i in 0..=u8::MAX {
-            let mut stream = merkle.iter_from(root, vec![i].into_boxed_slice());
-            for j in 0..=u8::MAX {
-                let expected_key = vec![i, j];
-                let expected_value = vec![i, j];
-                assert_eq!(
-                    stream.next().await.unwrap().unwrap(),
-                    (expected_key.into_boxed_slice(), expected_value),
-                    "i: {}, j: {}",
-                    i,
-                    j,
-                );
-            }
-            if i == u8::MAX {
-                check_stream_is_done(stream).await;
-            } else {
-                assert_eq!(
-                    stream.next().await.unwrap().unwrap(),
-                    (vec![i + 1, 0].into_boxed_slice(), vec![i + 1, 0]),
-                    "i: {}",
-                    i,
-                );
-            }
-        }
     }
 
     #[tokio::test]

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -186,13 +186,9 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                                 matched_key_nibbles.extend(extension.path.iter());
                                 continue;
                             }
-                            // This is the last node in the path to the key.
-                            // That means that either this node's child is at [key]
-                            // or [key] is not in the trie.
-                            // Figure out whether the first iteration of [children_iter]
-                            // should be the child at [pos] or the child at [pos + 1].
 
-                            // Figure out if [extension]'s child is before, at or after [key].
+                            // Figure out whether we want to start iterating at [pos] or [pos + 1].
+                            // See if [extension]'s child is before, at or after [key].
                             let key_nibbles = Nibbles::<1>::new(key.as_ref()).into_iter();
 
                             // Unmatched portion of [key].
@@ -206,9 +202,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                                 let next_key_nibble = remaining_key.next();
 
                                 if next_key_nibble.is_none() {
-                                    // We ran out of nibbles of [key] so
-                                    // the extension node is after [key].
-                                    // We want to iterate over the extension node's child.
+                                    // We ran out of nibbles of [key] so [extension]'s child is after [key].
                                     let mut key_nibbles = matched_key_nibbles.clone();
                                     key_nibbles.push(*next_extension_nibble);
                                     key_nibbles.extend(extension_iter);

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -334,7 +334,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                         }
                     };
                 }
-                return Poll::Ready(None);
+                Poll::Ready(None)
             }
         }
     }
@@ -493,8 +493,8 @@ mod tests {
         // doesn't just return the keys in insertion order.
         for i in (0..u8::MAX).rev() {
             for j in (0..u8::MAX).rev() {
-                let key = vec![i as u8, j as u8];
-                let value = vec![i as u8, j as u8];
+                let key = vec![i, j];
+                let value = vec![i, j];
 
                 merkle.insert(key, value, root).unwrap();
             }
@@ -504,8 +504,8 @@ mod tests {
 
         for i in 0..u8::MAX {
             for j in 0..u8::MAX {
-                let expected_key = vec![i as u8, j as u8];
-                let expected_value = vec![i as u8, j as u8];
+                let expected_key = vec![i, j];
+                let expected_value = vec![i, j];
 
                 assert_eq!(
                     stream.next().await.unwrap().unwrap(),
@@ -529,18 +529,18 @@ mod tests {
         // doesn't just return the keys in insertion order.
         for i in (0..=u8::MAX).rev() {
             for j in (0..=u8::MAX).rev() {
-                let key = vec![i as u8, j as u8];
-                let value = vec![i as u8, j as u8];
+                let key = vec![i, j];
+                let value = vec![i, j];
 
                 merkle.insert(key, value, root).unwrap();
             }
         }
 
         for i in 0..=u8::MAX {
-            let mut stream = merkle.iter_from(root, vec![i as u8].into_boxed_slice());
+            let mut stream = merkle.iter_from(root, vec![i].into_boxed_slice());
             for j in 0..=u8::MAX {
-                let expected_key = vec![i as u8, j as u8];
-                let expected_value = vec![i as u8, j as u8];
+                let expected_key = vec![i, j];
+                let expected_value = vec![i, j];
                 assert_eq!(
                     stream.next().await.unwrap().unwrap(),
                     (expected_key.into_boxed_slice(), expected_value),
@@ -554,10 +554,7 @@ mod tests {
             } else {
                 assert_eq!(
                     stream.next().await.unwrap().unwrap(),
-                    (
-                        vec![i as u8 + 1, 0].into_boxed_slice(),
-                        vec![i as u8 + 1, 0]
-                    ),
+                    (vec![i + 1, 0].into_boxed_slice(), vec![i + 1, 0]),
                     "i: {}",
                     i,
                 );

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -364,7 +364,7 @@ fn key_from_nibble_iter<Iter: Iterator<Item = u8>>(mut nibbles: Iter) -> Key {
 mod helper_types {
     use std::ops::Not;
 
-    /// TODO how can we use enums instead of Box<dyn Trait>?
+    /// TODO how can we use enums instead of `Box<dyn Trait>`?
     /// Enums enable stack-based dynamic-dispatch as opposed to heap-based `Box<dyn Trait>`.
     /// This helps us with match arms that return different types that implement the same trait.
     /// It's possible that [rust-lang/rust#63065](https://github.com/rust-lang/rust/issues/63065) will make this unnecessary.

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -217,10 +217,12 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                                 };
 
                                 match next_extension_nibble.cmp(&next_key_nibble) {
-                                    std::cmp::Ordering::Equal => (), // The nibbles match; check the next one.
-                                    std::cmp::Ordering::Less => break, // [extension]'s child is before [key]. Skip it.
+                                    // The nibbles match; check the next one.
+                                    std::cmp::Ordering::Equal => (),
+                                    // [extension]'s child is before [key]. Skip it.
+                                    std::cmp::Ordering::Less => break,
+                                    // [extension]'s child is after [key]. Visit it.
                                     std::cmp::Ordering::Greater => {
-                                        // [extension]'s child is after [key]. Visit it.
                                         let child = merkle
                                             .get_node(extension.chd())
                                             .map_err(|e| api::Error::InternalError(Box::new(e)))?;

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -90,24 +90,45 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                     .get_node(*merkle_root)
                     .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
-                let mut path_to_key = vec![];
+                let mut node_iter_stack: Vec<NodeIterator> = vec![];
+                node_iter_stack.push(NodeIterator {
+                    key: vec![],
+                    children_iter: Box::new(get_children_iter(
+                        root_node.inner().as_branch().unwrap(),
+                    )),
+                });
 
-                let node_at_key = merkle
-                    .get_node_by_key_with_callbacks(
-                        root_node,
-                        &key,
-                        |node_addr, i| path_to_key.push((node_addr, i)),
-                        |_, _| {},
-                    )
-                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+                self.key_state = IteratorState::Iterating { node_iter_stack };
 
-                let mut path_to_key = path_to_key
-                    .into_iter()
-                    .map(|(node, pos)| merkle.get_node(node).map(|node| (node, pos)))
-                    .collect::<Result<Vec<_>, _>>()
-                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+                self.poll_next(_cx)
 
-                todo!()
+                // let mut path_to_key = vec![];
+
+                // let node_at_key = merkle
+                //     .get_node_by_key_with_callbacks(
+                //         root_node,
+                //         &key,
+                //         |node_addr, i| path_to_key.push((node_addr, i)),
+                //         |_, _| {},
+                //     )
+                //     .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+
+                // let mut path_to_key = path_to_key
+                //     .into_iter()
+                //     .map(|(node, pos)| merkle.get_node(node).map(|node| (node, pos)))
+                //     .collect::<Result<Vec<_>, _>>()
+                //     .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+
+                // let remaining_key = key.iter();
+
+                // let mut node_iter_stack: Vec<NodeIterator> = vec![];
+
+                // loop {
+                //     let Some((node, pos)) = path_to_key.first() else {
+                //         break;
+                //     };
+                //     path_to_key.remove(0);
+                // }
 
                 // // TODO remove
                 // TODO remove

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -56,7 +56,7 @@ pub struct MerkleKeyValueStream<'a, S, T> {
 fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
     merkle: &'a Merkle<S, T>,
     root_node: DiskAddress,
-    key: &mut Box<[u8]>,
+    key: &Box<[u8]>,
 ) -> Result<IteratorState, api::Error> {
     let root_node = merkle
         .get_node(root_node)

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -375,8 +375,6 @@ use super::tests::create_test_merkle;
 #[cfg(test)]
 #[allow(clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
-    use std::vec;
-
     use crate::nibbles::Nibbles;
 
     use super::*;

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -125,7 +125,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                     .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
                 // Tracks how much of the key has been traversed so far.
-                let mut matched_key_nibbles: Vec<u8> = vec![];
+                let mut matched_key_nibbles = vec![];
 
                 while let Some((node, pos)) = path_to_key.pop_front() {
                     match node.inner() {

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -13,12 +13,24 @@ use std::task::Poll;
 type Key = Box<[u8]>;
 type Value = Vec<u8>;
 
-struct NodeIterator<F>
+struct NodeIterator<I>
 where
-    F: FnMut() -> Option<DiskAddress>,
+    I: Iterator<Item = DiskAddress>,
 {
     partial_path: PartialPath,
-    children_iter: F,
+    children_iter: I,
+}
+
+impl<I> NodeIterator<I>
+where
+    I: Iterator<Item = DiskAddress>,
+{
+    fn new(partial_path: PartialPath, children_iter: I) -> Self {
+        NodeIterator {
+            partial_path,
+            children_iter,
+        }
+    }
 }
 
 enum IteratorState {

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -114,7 +114,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                 // with [key], where [index] is the next nibble in the key.
                 let mut path_to_key = vec![];
 
-                let node_at_key = merkle
+                merkle
                     .get_node_by_key_with_callbacks(
                         root_node,
                         &key,

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -103,8 +103,9 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
 
                 let mut branch_iter_stack: Vec<BranchIterator> = vec![];
 
-                // (disk address, index) for each node we visit along the path to the node
-                // with [key], where [index] is the next nibble in the key.
+                // (disk address, index) for each node we visit along the path to
+                // [key], where [index] is the next nibble in the key after the node
+                // at [disk address].
                 let mut path_to_key = vec![];
 
                 // Populate [path_to_key].

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -127,11 +127,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                 // Tracks how much of the key has been traversed so far.
                 let mut matched_key_nibbles: Vec<u8> = vec![];
 
-                loop {
-                    let Some((node, pos)) = path_to_key.pop_front() else {
-                        break;
-                    };
-
+                while let Some((node, pos)) = path_to_key.pop_front() {
                     match node.inner() {
                         NodeType::Leaf(_) => (),
                         NodeType::Branch(branch) => {

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -466,8 +466,8 @@ mod tests {
 
         // Test with no start key
         let mut stream = merkle.iter(root);
-        for i in 0..u8::MAX {
-            for j in 0..u8::MAX {
+        for i in 0..=u8::MAX {
+            for j in 0..=u8::MAX {
                 let expected_key = vec![i, j];
                 let expected_value = vec![i, j];
 

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -170,7 +170,7 @@ fn get_iterator_intial_state<S: ShaleStore<Node> + Send + Sync, T>(
 
                         let Some(prev_index) = key_nibbles.pop() else {
                             return Err(api::Error::InternalError(Box::new(
-                                api::Error::ExtensionNodeAtRoot,
+                                api::Error::SentinelNodeIsExtension,
                             )));
                         };
                         let iter = std::iter::once((extension.chd(), prev_index));

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -14,10 +14,10 @@ type Key = Box<[u8]>;
 type Value = Vec<u8>;
 
 struct BranchIterator {
-    // The nibbles of the key at this node.
+    /// The nibbles of the key at this node.
     key_nibbles: Vec<u8>,
-    // Returns the non-empty children of this node
-    // and their positions in the node's children array.
+    /// Returns the non-empty children of this node
+    /// and their positions in the node's children array.
     children_iter: Box<dyn Iterator<Item = (DiskAddress, u8)> + Send>,
 }
 
@@ -26,11 +26,11 @@ enum IteratorState {
     StartAtKey(Key),
     /// Continue iterating after the last node in the `visited_node_path`
     Iterating {
-        // Each element is an iterator over a branch node we've visited
-        // along our traversal of the key-value pairs in the trie.
-        // We pop an iterator off the stack and call next on it to
-        // get the next child node to visit. When an iterator is empty,
-        // we pop it off the stack and go back up to its parent.
+        /// Each element is an iterator over a branch node we've visited
+        /// along our traversal of the key-value pairs in the trie.
+        /// We pop an iterator off the stack and call next on it to
+        /// get the next child node to visit. When an iterator is empty,
+        /// we pop it off the stack and go back up to its parent.
         branch_iter_stack: Vec<BranchIterator>,
     },
 }
@@ -162,7 +162,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                                     .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
                                 let comparer = if child.is_none() {
-                                    // The child doesn't exist; we don't need to iterator over this index.
+                                    // The child doesn't exist; we don't need to iterate over [pos].
                                     |a: &u8, b: &u8| a > b
                                 } else {
                                     // The child does exist; the first key to iterate over must be at [pos].

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -3,7 +3,6 @@
 
 use super::{node::Node, BranchNode, Merkle, NodeType};
 use crate::{
-    merkle::NodeObjRef,
     nibbles::Nibbles,
     shale::{DiskAddress, ShaleStore},
     v2::api,
@@ -119,7 +118,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                     .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
                 // Convert (address, index) pairs to (node, index) pairs.
-                let mut path_to_key: VecDeque<(NodeObjRef<'a>, u8)> = path_to_key
+                let mut path_to_key = path_to_key
                     .into_iter()
                     .map(|(node, pos)| merkle.get_node(node).map(|node| (node, pos)))
                     .collect::<Result<VecDeque<_>, _>>()

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -449,14 +449,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn no_start_key() {
+    async fn table_test() {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
 
         // Insert key-values in reverse order to ensure iterator
         // doesn't just return the keys in insertion order.
-        for i in (0..u8::MAX).rev() {
-            for j in (0..u8::MAX).rev() {
+        for i in (0..=u8::MAX).rev() {
+            for j in (0..=u8::MAX).rev() {
                 let key = vec![i, j];
                 let value = vec![i, j];
 
@@ -481,24 +481,8 @@ mod tests {
             }
         }
         check_stream_is_done(stream).await;
-    }
 
-    #[tokio::test]
-    async fn with_start_key() {
-        let mut merkle = create_test_merkle();
-        let root = merkle.init_root().unwrap();
-
-        // Insert key-values in reverse order to ensure iterator
-        // doesn't just return the keys in insertion order.
-        for i in (0..=u8::MAX).rev() {
-            for j in (0..=u8::MAX).rev() {
-                let key = vec![i, j];
-                let value = vec![i, j];
-
-                merkle.insert(key, value, root).unwrap();
-            }
-        }
-
+        // Test with start key
         for i in 0..=u8::MAX {
             let mut stream = merkle.iter_from(root, vec![i].into_boxed_slice());
             for j in 0..=u8::MAX {

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -168,15 +168,15 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                                         key_nibbles: key_nibbles_so_far.clone(),
                                         children_iter: Box::new(children_iter),
                                     });
-                                    break;
-                                }
-                                let children_iter = get_children_iter(branch)
-                                    .filter(move |(_, child_pos)| child_pos >= &pos);
+                                } else {
+                                    let children_iter = get_children_iter(branch)
+                                        .filter(move |(_, child_pos)| child_pos >= &pos);
 
-                                branch_iter_stack.push(BranchIterator {
-                                    key_nibbles: key_nibbles_so_far.clone(),
-                                    children_iter: Box::new(children_iter),
-                                });
+                                    branch_iter_stack.push(BranchIterator {
+                                        key_nibbles: key_nibbles_so_far.clone(),
+                                        children_iter: Box::new(children_iter),
+                                    });
+                                }
                             }
 
                             key_nibbles_so_far.push(pos);

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -311,7 +311,11 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                                 .get_node(extension.chd())
                                 .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
-                            let branch = child.inner().as_branch().unwrap();
+                            let Some(branch) = child.inner().as_branch() else {
+                                return Poll::Ready(Some(Err(api::Error::InternalError(
+                                    Box::new(api::Error::InvalidExtensionChild),
+                                ))));
+                            };
                             let children_iter = get_children_iter(branch);
 
                             // TODO reduce cloning

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -119,7 +119,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
 
                 // Get each node in [path_to_key]. Mark the last node as being the last
                 // so we can use that information in the while loop below.
-                let mut path_to_key =
+                let path_to_key =
                     path_to_key
                         .into_iter()
                         .rev()
@@ -131,7 +131,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
 
                 let mut matched_key_nibbles = vec![];
 
-                while let Some(result) = path_to_key.next() {
+                for result in path_to_key {
                     let (is_last, (node, pos)) = match result {
                         Ok(result) => result,
                         Err(e) => {

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -150,10 +150,10 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
 
                             let comparer = if child.is_none() {
                                 // The child doesn't exist; we don't need to iterate over [pos].
-                                |a: &u8, b: &u8| a > b
+                                <u8 as PartialOrd>::gt
                             } else {
                                 // The child does exist; the first key to iterate over must be at [pos].
-                                |a: &u8, b: &u8| a >= b
+                                <u8 as PartialOrd>::ge
                             };
 
                             let children_iter = get_children_iter(branch)

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -89,6 +89,9 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                     .get_node(*merkle_root)
                     .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
+                // TODO implement this code path.
+                // Right now we always start iterating from the root.
+                // We need to populate the initial state of [node_iter_stack].
                 let mut node_iter_stack: Vec<NodeIterator> = vec![];
                 node_iter_stack.push(NodeIterator {
                     key_nibbles: vec![],

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -569,25 +569,29 @@ mod tests {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
 
-        for i in 0..256 {
-            let key = vec![i as u8];
-            let value = vec![0x00];
+        for i in (0..256).rev() {
+            for j in (0..256).rev() {
+                let key = vec![i as u8, j as u8];
+                let value = vec![0x00];
 
-            merkle
-                .insert(key.clone(), value.clone(), root.clone())
-                .unwrap();
+                merkle
+                    .insert(key.clone(), value.clone(), root.clone())
+                    .unwrap();
+            }
         }
 
         let mut stream = merkle.iter(root);
 
         for i in 0..256 {
-            let expected_key = vec![i as u8];
-            let expected_value = vec![0x00];
+            for j in 0..256 {
+                let expected_key = vec![i as u8, j as u8];
+                let expected_value = vec![0x00];
 
-            assert_eq!(
-                stream.next().await.unwrap().unwrap(),
-                (expected_key.into_boxed_slice(), expected_value),
-            );
+                assert_eq!(
+                    stream.next().await.unwrap().unwrap(),
+                    (expected_key.into_boxed_slice(), expected_value),
+                );
+            }
         }
 
         check_stream_is_done(stream).await;

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -361,52 +361,54 @@ fn key_from_nibble_iter<Iter: Iterator<Item = u8>>(mut nibbles: Iter) -> Key {
     data.into_boxed_slice()
 }
 
-mod helper_types {
-    use std::ops::Not;
+// This code should be either used or removed.
+// TODO how can we use Either instead of `Box<dyn Trait>`?
+// mod helper_types {
+//     use std::ops::Not;
 
-    /// TODO how can we use enums instead of `Box<dyn Trait>`?
-    /// Enums enable stack-based dynamic-dispatch as opposed to heap-based `Box<dyn Trait>`.
-    /// This helps us with match arms that return different types that implement the same trait.
-    /// It's possible that [rust-lang/rust#63065](https://github.com/rust-lang/rust/issues/63065) will make this unnecessary.
-    ///
-    /// And this can be replaced by the `either` crate from crates.io if we ever need more functionality.
-    pub(super) enum Either<T, U> {
-        Left(T),
-        Right(U),
-    }
+//
+//     /// Enums enable stack-based dynamic-dispatch as opposed to heap-based `Box<dyn Trait>`.
+//     /// This helps us with match arms that return different types that implement the same trait.
+//     /// It's possible that [rust-lang/rust#63065](https://github.com/rust-lang/rust/issues/63065) will make this unnecessary.
+//     ///
+//     /// And this can be replaced by the `either` crate from crates.io if we ever need more functionality.
+//     pub(super) enum Either<T, U> {
+//         Left(T),
+//         Right(U),
+//     }
 
-    impl<T, U> Iterator for Either<T, U>
-    where
-        T: Iterator,
-        U: Iterator<Item = T::Item>,
-    {
-        type Item = T::Item;
+//     impl<T, U> Iterator for Either<T, U>
+//     where
+//         T: Iterator,
+//         U: Iterator<Item = T::Item>,
+//     {
+//         type Item = T::Item;
 
-        fn next(&mut self) -> Option<Self::Item> {
-            match self {
-                Self::Left(left) => left.next(),
-                Self::Right(right) => right.next(),
-            }
-        }
-    }
+//         fn next(&mut self) -> Option<Self::Item> {
+//             match self {
+//                 Self::Left(left) => left.next(),
+//                 Self::Right(right) => right.next(),
+//             }
+//         }
+//     }
 
-    #[must_use]
-    pub(super) struct MustUse<T>(T);
+//     #[must_use]
+//     pub(super) struct MustUse<T>(T);
 
-    impl<T> From<T> for MustUse<T> {
-        fn from(t: T) -> Self {
-            Self(t)
-        }
-    }
+//     impl<T> From<T> for MustUse<T> {
+//         fn from(t: T) -> Self {
+//             Self(t)
+//         }
+//     }
 
-    impl<T: Not> Not for MustUse<T> {
-        type Output = T::Output;
+//     impl<T: Not> Not for MustUse<T> {
+//         type Output = T::Output;
 
-        fn not(self) -> Self::Output {
-            self.0.not()
-        }
-    }
-}
+//         fn not(self) -> Self::Output {
+//             self.0.not()
+//         }
+//     }
+// }
 
 // CAUTION: only use with nibble iterators
 trait IntoBytes: Iterator<Item = u8> {

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -82,6 +82,9 @@ pub enum Error {
 
     #[error("Range too small")]
     RangeTooSmall,
+
+    #[error("Child not found")]
+    ChildNotFound,
 }
 
 /// A range proof, consisting of a proof of the first key and the last key,

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -85,6 +85,9 @@ pub enum Error {
 
     #[error("Child not found")]
     ChildNotFound,
+
+    #[error("Extension node is at the root; should be branch node")]
+    InvalidPathToExtension,
 }
 
 /// A range proof, consisting of a proof of the first key and the last key,

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -86,8 +86,8 @@ pub enum Error {
     #[error("Child not found")]
     ChildNotFound,
 
-    #[error("Extension node is at the root; should be branch node")]
-    ExtensionNodeAtRoot,
+    #[error("Sentinel node is an extension node; should be a branch node")]
+    SentinelNodeIsExtension,
 
     #[error("Extension node has non-branch child")]
     InvalidExtensionChild,

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -87,7 +87,10 @@ pub enum Error {
     ChildNotFound,
 
     #[error("Extension node is at the root; should be branch node")]
-    InvalidPathToExtension,
+    ExtensionNodeAtRoot,
+
+    #[error("Extension node has non-branch child")]
+    InvalidExtensionChild,
 }
 
 /// A range proof, consisting of a proof of the first key and the last key,


### PR DESCRIPTION
This PR refactors the stream implementation. The iterator maintains a stack where each element represents an ongoing iteration of a branch node. In each iteration, the element at the top of the stack tells us which key-value pair to traverse next.

The special casing in the "setup" code that deals with branch/extension nodes which are the last element of `path_to_key` is kind of annoying and not ideal, but we can probably refactor this further if/when we implement a function that returns an iterator over all nodes on the path to a given key. 