### PR TITLE
use bytemuck for metadata

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1.0.38"
 tokio = { version = "1.21.1", features = ["rt", "sync", "macros", "rt-multi-thread"] }
 typed-builder = "0.18.0"
 bincode = "1.3.3"
-bitflags = "2.4.1"
+bitflags = { version = "2.4.1", features = ["bytemuck"] }
 env_logger = { version = "0.10.1", optional = true }
 log = { version = "0.4.20", optional = true }
 

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -1,13 +1,14 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::logger::trace;
 use crate::{
+    logger::trace,
     merkle::from_nibbles,
     shale::{disk_address::DiskAddress, CachedStore, ShaleError, ShaleStore, Storable},
 };
 use bincode::{Error, Options};
 use bitflags::bitflags;
+use bytemuck::{CheckedBitPattern, NoUninit, Pod, Zeroable};
 use enum_as_inner::EnumAsInner;
 use serde::{
     de::DeserializeOwned,
@@ -213,6 +214,8 @@ impl From<NodeType> for Node {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, Pod, Zeroable)]
+    #[repr(transparent)]
     struct NodeAttributes: u8 {
         const ROOT_HASH_VALID      = 0b001;
         const IS_ENCODED_BIG_VALID = 0b010;
@@ -315,14 +318,13 @@ impl Node {
     }
 }
 
-const ENCODED_MAX_LEN: usize = TRIE_HASH_LEN;
-
-#[repr(C)]
+#[derive(Clone, Copy, CheckedBitPattern, NoUninit)]
+#[repr(C, packed)]
 struct Meta {
     root_hash: [u8; TRIE_HASH_LEN],
     attrs: NodeAttributes,
-    encoded_len: [u8; size_of::<u64>()],
-    encoded: [u8; ENCODED_MAX_LEN],
+    encoded_len: u64,
+    encoded: [u8; TRIE_HASH_LEN],
     type_id: NodeTypeId,
 }
 
@@ -331,28 +333,31 @@ impl Meta {
 }
 
 mod type_id {
+    use super::{CheckedBitPattern, NoUninit, NodeType};
     use crate::shale::ShaleError;
 
-    const BRANCH: u8 = 0;
-    const LEAF: u8 = 1;
-    const EXTENSION: u8 = 2;
-
+    #[derive(Clone, Copy, CheckedBitPattern, NoUninit)]
     #[repr(u8)]
     pub enum NodeTypeId {
-        Branch = BRANCH,
-        Leaf = LEAF,
-        Extension = EXTENSION,
+        Branch = 0,
+        Leaf = 1,
+        Extension = 2,
     }
 
     impl TryFrom<u8> for NodeTypeId {
         type Error = ShaleError;
 
         fn try_from(value: u8) -> Result<Self, Self::Error> {
-            match value {
-                BRANCH => Ok(Self::Branch),
-                LEAF => Ok(Self::Leaf),
-                EXTENSION => Ok(Self::Extension),
-                _ => Err(ShaleError::InvalidNodeType),
+            bytemuck::checked::try_cast::<_, Self>(value).map_err(|_| ShaleError::InvalidNodeType)
+        }
+    }
+
+    impl From<&NodeType> for NodeTypeId {
+        fn from(node_type: &NodeType) -> Self {
+            match node_type {
+                NodeType::Branch(_) => NodeTypeId::Branch,
+                NodeType::Leaf(_) => NodeTypeId::Leaf,
+                NodeType::Extension(_) => NodeTypeId::Extension,
             }
         }
     }
@@ -368,46 +373,34 @@ impl Storable for Node {
                     offset,
                     size: Meta::SIZE as u64,
                 })?;
+        let meta_raw = meta_raw.as_deref();
+
+        let meta = bytemuck::checked::try_from_bytes::<Meta>(&meta_raw)
+            .map_err(|_| ShaleError::InvalidNodeMeta)?;
+
+        let Meta {
+            root_hash,
+            attrs,
+            encoded_len,
+            encoded,
+            type_id,
+        } = *meta;
 
         trace!("[{mem:p}] Deserializing node at {offset}");
 
         let offset = offset + Meta::SIZE;
 
-        #[allow(clippy::indexing_slicing)]
-        let attrs = NodeAttributes::from_bits_retain(meta_raw.as_deref()[TRIE_HASH_LEN]);
-
         let root_hash = if attrs.contains(NodeAttributes::ROOT_HASH_VALID) {
-            Some(TrieHash(
-                #[allow(clippy::indexing_slicing)]
-                meta_raw.as_deref()[..TRIE_HASH_LEN]
-                    .try_into()
-                    .expect("invalid slice"),
-            ))
+            Some(TrieHash(root_hash))
         } else {
             None
         };
 
-        let mut start_index = TRIE_HASH_LEN + 1;
-        let end_index = start_index + size_of::<u64>();
-        #[allow(clippy::indexing_slicing)]
-        let encoded_len = u64::from_le_bytes(
-            meta_raw.as_deref()[start_index..end_index]
-                .try_into()
-                .expect("invalid slice"),
-        );
-
-        start_index = end_index;
-        let mut encoded: Option<Vec<u8>> = None;
-        if encoded_len > 0 {
-            #[allow(clippy::indexing_slicing)]
-            let value: Vec<u8> =
-                meta_raw.as_deref()[start_index..start_index + encoded_len as usize].into();
-            encoded = Some(value);
-        }
-
-        start_index += ENCODED_MAX_LEN;
-        #[allow(clippy::indexing_slicing)]
-        let type_id: NodeTypeId = meta_raw.as_deref()[start_index].try_into()?;
+        let encoded = if encoded_len > 0 {
+            Some(encoded.iter().take(encoded_len as usize).copied().collect())
+        } else {
+            None
+        };
 
         let is_encoded_longer_than_hash_len =
             if attrs.contains(NodeAttributes::IS_ENCODED_BIG_VALID) {
@@ -451,10 +444,7 @@ impl Storable for Node {
     fn serialized_len(&self) -> u64 {
         Meta::SIZE as u64
             + match &self.inner {
-                NodeType::Branch(n) => {
-                    // TODO: add path
-                    n.serialized_len()
-                }
+                NodeType::Branch(n) => n.serialized_len(),
                 NodeType::Extension(n) => n.serialized_len(),
                 NodeType::Leaf(n) => n.serialized_len(),
             }
@@ -462,76 +452,75 @@ impl Storable for Node {
 
     fn serialize(&self, to: &mut [u8]) -> Result<(), ShaleError> {
         trace!("[{self:p}] Serializing node");
-        let mut cur = Cursor::new(to);
+        let mut cursor = Cursor::new(to);
 
-        let mut attrs = match self.root_hash.get() {
-            Some(h) => {
-                cur.write_all(&h.0)?;
-                NodeAttributes::ROOT_HASH_VALID
-            }
-            None => {
-                cur.write_all(&[0; 32])?;
-                NodeAttributes::empty()
-            }
+        let root_hash = self.root_hash.get().map(|hash| hash.0);
+        let encoded = self.encoded.get();
+        let encoded_len = encoded.map(Vec::len).map(|len| len as u64);
+
+        let mut attrs = match (encoded_len, self.is_encoded_longer_than_hash_len.get()) {
+            // the raw encoded-node is longer than a hash
+            (None, Some(true)) => NodeAttributes::LONG,
+            (Some(len), _) if len > TRIE_HASH_LEN as u64 => NodeAttributes::LONG,
+            //
+            (Some(_), _) | (None, Some(false)) => NodeAttributes::IS_ENCODED_BIG_VALID,
+            (None, None) => NodeAttributes::empty(),
         };
 
-        let mut encoded_len: u64 = 0;
-        let mut encoded = None;
-        if let Some(b) = self.encoded.get() {
-            attrs.insert(if b.len() > TRIE_HASH_LEN {
-                NodeAttributes::LONG
-            } else {
-                encoded_len = b.len() as u64;
-                encoded = Some(b);
-                NodeAttributes::IS_ENCODED_BIG_VALID
-            });
-        } else if let Some(b) = self.is_encoded_longer_than_hash_len.get() {
-            attrs.insert(if *b {
-                NodeAttributes::LONG
-            } else {
-                NodeAttributes::IS_ENCODED_BIG_VALID
-            });
+        if root_hash.is_some() {
+            attrs.insert(NodeAttributes::ROOT_HASH_VALID);
         }
 
-        #[allow(clippy::unwrap_used)]
-        cur.write_all(&[attrs.bits()]).unwrap();
+        let root_hash = root_hash.unwrap_or_default();
 
-        cur.write_all(&encoded_len.to_le_bytes())?;
-        if let Some(encoded) = encoded {
-            cur.write_all(encoded)?;
-            let remaining_len = ENCODED_MAX_LEN - encoded_len as usize;
-            cur.write_all(&vec![0; remaining_len])?;
-        } else {
-            cur.write_all(&[0; ENCODED_MAX_LEN])?;
-        }
+        let (encoded_len, encoded) = {
+            let encoded_len = encoded_len.filter(|len| *len <= TRIE_HASH_LEN as u64);
+            let encoded = std::array::from_fn({
+                let mut iter = encoded_len
+                    .and_then(|_| encoded)
+                    .map(Vec::as_slice)
+                    .unwrap_or_default()
+                    .iter()
+                    .copied();
+
+                move |_| iter.next().unwrap_or_default()
+            });
+
+            (encoded_len.unwrap_or_default(), encoded)
+        };
+
+        let type_id = NodeTypeId::from(&self.inner);
+
+        let meta = Meta {
+            root_hash,
+            attrs,
+            encoded_len,
+            encoded,
+            type_id,
+        };
+
+        cursor.write_all(bytemuck::bytes_of(&meta))?;
 
         match &self.inner {
             NodeType::Branch(n) => {
-                // TODO: add path
-                cur.write_all(&[type_id::NodeTypeId::Branch as u8])?;
-
-                let pos = cur.position() as usize;
+                let pos = cursor.position() as usize;
 
                 #[allow(clippy::indexing_slicing)]
-                n.serialize(&mut cur.get_mut()[pos..])
+                n.serialize(&mut cursor.get_mut()[pos..])
             }
 
             NodeType::Extension(n) => {
-                cur.write_all(&[type_id::NodeTypeId::Extension as u8])?;
-
-                let pos = cur.position() as usize;
+                let pos = cursor.position() as usize;
 
                 #[allow(clippy::indexing_slicing)]
-                n.serialize(&mut cur.get_mut()[pos..])
+                n.serialize(&mut cursor.get_mut()[pos..])
             }
 
             NodeType::Leaf(n) => {
-                cur.write_all(&[type_id::NodeTypeId::Leaf as u8])?;
-
-                let pos = cur.position() as usize;
+                let pos = cursor.position() as usize;
 
                 #[allow(clippy::indexing_slicing)]
-                n.serialize(&mut cur.get_mut()[pos..])
+                n.serialize(&mut cursor.get_mut()[pos..])
             }
         }
     }

--- a/firewood/src/merkle/node/leaf.rs
+++ b/firewood/src/merkle/node/leaf.rs
@@ -1,18 +1,18 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use std::{
-    fmt::{Debug, Error as FmtError, Formatter},
-    io::{Cursor, Read, Write},
-    mem::size_of,
-};
-
-use bincode::Options;
-
 use super::{Data, Encoded};
 use crate::{
-    merkle::{from_nibbles, to_nibble_array, PartialPath},
+    merkle::{from_nibbles, PartialPath},
+    nibbles::Nibbles,
     shale::{ShaleError::InvalidCacheView, Storable},
+};
+use bincode::Options;
+use bytemuck::{Pod, Zeroable};
+use std::{
+    fmt::{Debug, Error as FmtError, Formatter},
+    io::{Cursor, Write},
+    mem::size_of,
 };
 
 pub const SIZE: usize = 2;
@@ -33,9 +33,6 @@ impl Debug for LeafNode {
 }
 
 impl LeafNode {
-    const PATH_LEN_SIZE: u64 = size_of::<PathLen>() as u64;
-    const DATA_LEN_SIZE: u64 = size_of::<DataLen>() as u64;
-
     pub fn new<P: Into<PartialPath>, D: Into<Data>>(path: P, data: D) -> Self {
         Self {
             path: path.into(),
@@ -65,66 +62,68 @@ impl LeafNode {
     }
 }
 
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C, packed)]
+struct Meta {
+    path_len: PathLen,
+    data_len: DataLen,
+}
+
+impl Meta {
+    const SIZE: usize = size_of::<Self>();
+}
+
 impl Storable for LeafNode {
     fn serialized_len(&self) -> u64 {
-        let path_len_size = size_of::<PathLen>() as u64;
+        let meta_len = size_of::<Meta>() as u64;
         let path_len = self.path.serialized_len();
-        let data_len_size = size_of::<DataLen>() as u64;
         let data_len = self.data.len() as u64;
 
-        path_len_size + path_len + data_len_size + data_len
+        meta_len + path_len + data_len
     }
 
     fn serialize(&self, to: &mut [u8]) -> Result<(), crate::shale::ShaleError> {
         let mut cursor = Cursor::new(to);
 
-        let path: Vec<u8> = from_nibbles(&self.path.encode(true)).collect();
+        let path = &self.path.encode(true);
+        let path = from_nibbles(&path);
+        let data = &self.data;
 
-        cursor.write_all(&[path.len() as PathLen])?;
+        let path_len = self.path.serialized_len() as PathLen;
+        let data_len = data.len() as DataLen;
 
-        let data_len = self.data.len() as DataLen;
-        cursor.write_all(&data_len.to_le_bytes())?;
+        let meta = Meta { path_len, data_len };
 
-        cursor.write_all(&path)?;
-        cursor.write_all(&self.data)?;
+        cursor.write_all(bytemuck::bytes_of(&meta))?;
+
+        for nibble in path {
+            cursor.write_all(&[nibble])?;
+        }
+
+        cursor.write_all(data)?;
 
         Ok(())
     }
 
     fn deserialize<T: crate::shale::CachedStore>(
-        mut offset: usize,
+        offset: usize,
         mem: &T,
     ) -> Result<Self, crate::shale::ShaleError>
     where
         Self: Sized,
     {
-        let header_size = Self::PATH_LEN_SIZE + Self::DATA_LEN_SIZE;
-
         let node_header_raw = mem
-            .get_view(offset, header_size)
+            .get_view(offset, Meta::SIZE as u64)
             .ok_or(InvalidCacheView {
                 offset,
-                size: header_size,
+                size: Meta::SIZE as u64,
             })?
             .as_deref();
 
-        offset += header_size as usize;
+        let offset = offset + Meta::SIZE as usize;
+        let Meta { path_len, data_len } = *bytemuck::from_bytes(&node_header_raw);
+        let size = path_len as u64 + data_len as u64;
 
-        let mut cursor = Cursor::new(node_header_raw);
-
-        let path_len = {
-            let mut buf = [0u8; Self::PATH_LEN_SIZE as usize];
-            cursor.read_exact(buf.as_mut())?;
-            PathLen::from_le_bytes(buf) as u64
-        };
-
-        let data_len = {
-            let mut buf = [0u8; Self::DATA_LEN_SIZE as usize];
-            cursor.read_exact(buf.as_mut())?;
-            DataLen::from_le_bytes(buf) as u64
-        };
-
-        let size = path_len + data_len;
         let remainder = mem
             .get_view(offset, size)
             .ok_or(InvalidCacheView { offset, size })?
@@ -133,8 +132,8 @@ impl Storable for LeafNode {
         let (path, data) = remainder.split_at(path_len as usize);
 
         let path = {
-            let nibbles: Vec<u8> = path.iter().copied().flat_map(to_nibble_array).collect();
-            PartialPath::decode(&nibbles).0
+            let nibbles = Nibbles::<0>::new(&path).into_iter();
+            PartialPath::from_nibbles(nibbles).0
         };
 
         let data = Data(data.to_vec());

--- a/firewood/src/merkle/node/partial_path.rs
+++ b/firewood/src/merkle/node/partial_path.rs
@@ -68,25 +68,23 @@ impl PartialPath {
     //
     /// returns a tuple of the decoded partial path and whether the path is terminal
     pub fn decode(raw: &[u8]) -> (Self, bool) {
-        let mut raw = raw.iter().copied();
-        let flags = Flags::from_bits_retain(raw.next().unwrap_or_default());
-
-        if !flags.contains(Flags::ODD_LEN) {
-            let _ = raw.next();
-        }
-
-        (Self(raw.collect()), flags.contains(Flags::TERMINAL))
+        Self::from_iter(raw.iter().copied())
     }
 
     /// returns a tuple of the decoded partial path and whether the path is terminal
-    pub fn from_nibbles<const N: usize>(mut nibbles: NibblesIterator<'_, N>) -> (Self, bool) {
-        let flags = Flags::from_bits_retain(nibbles.next().unwrap_or_default());
+    pub fn from_nibbles<const N: usize>(nibbles: NibblesIterator<'_, N>) -> (Self, bool) {
+        Self::from_iter(nibbles)
+    }
+
+    /// Assumes all bytes are nibbles, prefer to use `from_nibbles` instead.
+    fn from_iter<Iter: Iterator<Item = u8>>(mut iter: Iter) -> (Self, bool) {
+        let flags = Flags::from_bits_retain(iter.next().unwrap_or_default());
 
         if !flags.contains(Flags::ODD_LEN) {
-            let _ = nibbles.next();
+            let _ = iter.next();
         }
 
-        (Self(nibbles.collect()), flags.contains(Flags::TERMINAL))
+        (Self(iter.collect()), flags.contains(Flags::TERMINAL))
     }
 
     pub(super) fn serialized_len(&self) -> u64 {

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -30,6 +30,8 @@ pub enum ShaleError {
     InvalidAddressLength { expected: DiskAddress, found: u64 },
     #[error("invalid node type")]
     InvalidNodeType,
+    #[error("invalid node metadata")]
+    InvalidNodeMeta,
     #[error("failed to create view: offset: {offset:?} size: {size:?}")]
     InvalidCacheView { offset: usize, size: u64 },
     #[error("io error: {0}")]


### PR DESCRIPTION
These code changes are from my suggestions [here](https://github.com/ava-labs/firewood/pull/487#event-11447833272) (on @xinifinity's PR). 

Using a stack-based struct allows for simplified serialization and deserialization and leaves less room for error compared to manually dealing with lengths. 

It would further be beneficial to refactor both `Extension` and `Branch` nodes such that all their metadata is stored in one chunk at the start of the serialized bytes. However, changing either type of branch is a little more involved and beyond the scope of this PR

- Use bytemuck for node-metadata
- Use bytemuck for leaf-node serialization
