### PR TITLE
Use test-matrix for testing encoding for storage

### DIFF
--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -218,7 +218,7 @@ impl Proposal {
         revisions.base_revision = Arc::new(rev.into());
 
         // update the rolling window of root hashes
-        revisions.root_hashes.push_front(hash.clone());
+        revisions.root_hashes.push_front(hash);
         if revisions.root_hashes.len() > max_revisions {
             revisions
                 .root_hashes

--- a/firewood/src/merkle/trie_hash.rs
+++ b/firewood/src/merkle/trie_hash.rs
@@ -10,7 +10,7 @@ use std::{
 pub const TRIE_HASH_LEN: usize = 32;
 const U64_TRIE_HASH_LEN: u64 = TRIE_HASH_LEN as u64;
 
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub struct TrieHash(pub [u8; TRIE_HASH_LEN]);
 
 impl std::ops::Deref for TrieHash {


### PR DESCRIPTION
Previously, we were combining the tests for encoding/decoding the lazily-computed node-data with the encoding/decoding of the actual inner-node. I've separated out testing of each.

The branch testing is a little complex for my liking but I just wanted to get something up. I'm open to suggestions that will keep the test inputs relatively terse. Maybe write functions that actually name the cases? 

Please leave a comment with your opinion.  

