### PR TITLE
Pin minor versions, not bugfix versions

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -16,41 +16,43 @@ homepage = "https://avalabs.org"
 readme = "../README.md"
 
 [dependencies]
-aquamarine = "0.5.0"
-async-trait = "0.1.57"
-bytemuck = { version = "1.13.1", features = ["derive"] }
-enum-as-inner = "0.6.0"
+aquamarine = "0.5"
+async-trait = "0.1"
+bytemuck = { version = "1.13", features = ["derive"] }
+enum-as-inner = "0.6"
 growth-ring = { version = "0.0.4", path = "../growth-ring" }
 libaio = {version = "0.0.4", path = "../libaio" }
-futures = "0.3.24"
-hex = "0.4.3"
-lru = "0.12.0"
-metered = "0.9.0"
-nix = {version = "0.27.1", features = ["fs", "uio"]}
-parking_lot = "0.12.1"
+futures = "0.3"
+hex = "0.4"
+lru = "0.12"
+metered = "0.9"
+nix = {version = "0.27", features = ["fs", "uio"]}
+parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
-sha3 = "0.10.2"
-thiserror = "1.0.38"
-tokio = { version = "1.21.1", features = ["rt", "sync", "macros", "rt-multi-thread"] }
-typed-builder = "0.18.0"
-bincode = "1.3.3"
-bitflags = { version = "2.4.1", features = ["bytemuck"] }
-env_logger = { version = "0.11.0", optional = true }
-log = { version = "0.4.20", optional = true }
+sha3 = "0.10"
+thiserror = "1.0"
+tokio = { version = "1.21", features = ["rt", "sync", "macros", "rt-multi-thread"] }
+typed-builder = "0.18"
+bincode = "1.3"
+bitflags = { version = "2.4", features = ["bytemuck"] }
+env_logger = { version = "0.11", optional = true }
+log = { version = "0.4", optional = true }
+stacktrace = "0.2"
+backtrace = "0.3"
 
 [features]
 logger = ["dep:env_logger", "log"]
 
 [dev-dependencies]
-criterion = {version = "0.5.1", features = ["async_tokio"]}
-keccak-hasher = "0.15.3"
-rand = "0.8.5"
-triehash = "0.8.4"
-assert_cmd = "2.0.7"
-predicates = "3.0.1"
-clap = { version = "4.3.1", features = ['derive'] }
-test-case = "3.1.0"
-pprof = { version = "0.13.0", features = ["flamegraph"] }
+criterion = {version = "0.5", features = ["async_tokio"]}
+keccak-hasher = "0.15"
+rand = "0.8"
+triehash = "0.8"
+assert_cmd = "2.0"
+predicates = "3.0"
+clap = { version = "4.3", features = ['derive'] }
+test-case = "3.1"
+pprof = { version = "0.13", features = ["flamegraph"] }
 
 [[bench]]
 name = "hashops"

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -18,7 +18,7 @@ readme = "../README.md"
 [dependencies]
 aquamarine = "0.5"
 async-trait = "0.1"
-bytemuck = { version = "1.13", features = ["derive"] }
+bytemuck = { version = "1.14", features = ["derive"] }
 enum-as-inner = "0.6"
 growth-ring = { version = "0.0.4", path = "../growth-ring" }
 libaio = {version = "0.0.4", path = "../libaio" }
@@ -31,7 +31,7 @@ parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10"
 thiserror = "1.0"
-tokio = { version = "1.21", features = ["rt", "sync", "macros", "rt-multi-thread"] }
+tokio = { version = "1.36", features = ["rt", "sync", "macros", "rt-multi-thread"] }
 typed-builder = "0.18"
 bincode = "1.3"
 bitflags = { version = "2.4", features = ["bytemuck"] }
@@ -49,9 +49,9 @@ keccak-hasher = "0.15"
 rand = "0.8"
 triehash = "0.8"
 assert_cmd = "2.0"
-predicates = "3.0"
-clap = { version = "4.3", features = ['derive'] }
-test-case = "3.1"
+predicates = "3.1"
+clap = { version = "4.4", features = ['derive'] }
+test-case = "3.3"
 pprof = { version = "0.13", features = ["flamegraph"] }
 
 [[bench]]

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -5,17 +5,17 @@ edition = "2021"
 
 [dependencies]
 firewood = { version = "0.0.4", path = "../firewood" }
-clap = { version = "4.0.29", features = ["cargo", "derive"] }
-anyhow = "1.0.66"
-env_logger = "0.11.0"
-log = "0.4.17"
-tokio = { version = "1.33.0", features = ["full"] }
-futures-util = "0.3.29"
+clap = { version = "4.0", features = ["cargo", "derive"] }
+anyhow = "1.0"
+env_logger = "0.11"
+log = "0.4"
+tokio = { version = "1.33", features = ["full"] }
+futures-util = "0.3"
 
 [dev-dependencies]
-assert_cmd = "2.0.7"
-predicates = "3.0.1"
-serial_test = "3.0.0"
+assert_cmd = "2.0"
+predicates = "3.0"
+serial_test = "3.0"
 
 [lints.rust]
 unsafe_code = "deny"

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -5,16 +5,16 @@ edition = "2021"
 
 [dependencies]
 firewood = { version = "0.0.4", path = "../firewood" }
-clap = { version = "4.0", features = ["cargo", "derive"] }
+clap = { version = "4.4", features = ["cargo", "derive"] }
 anyhow = "1.0"
 env_logger = "0.11"
 log = "0.4"
-tokio = { version = "1.33", features = ["full"] }
+tokio = { version = "1.36", features = ["full"] }
 futures-util = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2.0"
-predicates = "3.0"
+predicates = "3.1"
 serial_test = "3.0"
 
 [lints.rust]

--- a/growth-ring/Cargo.toml
+++ b/growth-ring/Cargo.toml
@@ -11,22 +11,22 @@ description = "Simple and modular write-ahead-logging implementation."
 [dependencies]
 lru = "0.12"
 scan_fmt = "0.2"
-regex = "1.6"
+regex = "1.10"
 async-trait = "0.1"
 futures = "0.3"
 nix = {version = "0.27", features = ["fs", "uio"]}
 libc = "0.2"
-bytemuck = {version = "1.13", features = ["derive"]}
+bytemuck = {version = "1.14", features = ["derive"]}
 thiserror = "1.0"
-tokio = { version = "1.28", features = ["fs", "io-util", "sync"] }
+tokio = { version = "1.36", features = ["fs", "io-util", "sync"] }
 crc32fast = "1.3"
 
 [dev-dependencies]
 hex = "0.4"
 rand = "0.8"
 indexmap = "2.2"
-tokio = { version = "1.28", features = ["tokio-macros", "rt", "macros"] }
-test-case = "3.1.0"
+tokio = { version = "1.36", features = ["tokio-macros", "rt", "macros"] }
+test-case = "3.3.1"
 
 [lib]
 name = "growthring"

--- a/growth-ring/Cargo.toml
+++ b/growth-ring/Cargo.toml
@@ -9,23 +9,23 @@ description = "Simple and modular write-ahead-logging implementation."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lru = "0.12.0"
-scan_fmt = "0.2.6"
-regex = "1.6.0"
-async-trait = "0.1.57"
-futures = "0.3.24"
-nix = {version = "0.27.1", features = ["fs", "uio"]}
-libc = "0.2.133"
-bytemuck = {version = "1.13.1", features = ["derive"]}
-thiserror = "1.0.40"
-tokio = { version = "1.28.1", features = ["fs", "io-util", "sync"] }
-crc32fast = "1.3.2"
+lru = "0.12"
+scan_fmt = "0.2"
+regex = "1.6"
+async-trait = "0.1"
+futures = "0.3"
+nix = {version = "0.27", features = ["fs", "uio"]}
+libc = "0.2"
+bytemuck = {version = "1.13", features = ["derive"]}
+thiserror = "1.0"
+tokio = { version = "1.28", features = ["fs", "io-util", "sync"] }
+crc32fast = "1.3"
 
 [dev-dependencies]
-hex = "0.4.3"
-rand = "0.8.5"
-indexmap = "2.2.1"
-tokio = { version = "1.28.1", features = ["tokio-macros", "rt", "macros"] }
+hex = "0.4"
+rand = "0.8"
+indexmap = "2.2"
+tokio = { version = "1.28", features = ["tokio-macros", "rt", "macros"] }
 test-case = "3.1.0"
 
 [lib]

--- a/grpc-testtool/Cargo.toml
+++ b/grpc-testtool/Cargo.toml
@@ -17,9 +17,9 @@ bench = false
 
 [dependencies]
 firewood = { version = "0.0.4", path = "../firewood" }
-prost = "0.12.0"
-thiserror = "1.0.47"
-tokio = { version = "1.32", features = ["sync", "rt-multi-thread"] }
+prost = "0.12.3"
+thiserror = "1.0.56"
+tokio = { version = "1.36", features = ["sync", "rt-multi-thread"] }
 tonic = { version = "0.10", features = ["tls"] }
 tracing = { version = "0.1" }
 clap = { version = "4.4", features = ["derive"] }
@@ -31,7 +31,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-tonic-build = "0.10.0"
+tonic-build = "0.10.2"
 
 [lints.rust]
 unsafe_code = "deny"

--- a/grpc-testtool/Cargo.toml
+++ b/grpc-testtool/Cargo.toml
@@ -19,16 +19,16 @@ bench = false
 firewood = { version = "0.0.4", path = "../firewood" }
 prost = "0.12.0"
 thiserror = "1.0.47"
-tokio = { version = "1.32.0", features = ["sync", "rt-multi-thread"] }
-tonic = { version = "0.10.0", features = ["tls"] }
-tracing = { version = "0.1.16" }
-clap = { version = "4.4.11", features = ["derive"] }
-tempdir = "0.3.7"
-log = "0.4.20"
-env_logger = "0.11.0"
-chrono = "0.4.31"
-serde_json = "1.0.108"
-serde = { version = "1.0.193", features = ["derive"] }
+tokio = { version = "1.32", features = ["sync", "rt-multi-thread"] }
+tonic = { version = "0.10", features = ["tls"] }
+tracing = { version = "0.1" }
+clap = { version = "4.4", features = ["derive"] }
+tempdir = "0.3"
+log = "0.4"
+env_logger = "0.11"
+chrono = "0.4"
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
 tonic-build = "0.10.0"

--- a/libaio/Cargo.toml
+++ b/libaio/Cargo.toml
@@ -10,12 +10,12 @@ description = "Straightforward Linux AIO using Futures/async/await."
 emulated-failure = []
 
 [dependencies]
-libc = "0.2.153"
-parking_lot = "0.12.1"
-crossbeam-channel = "0.5.11"
+libc = "0.2"
+parking_lot = "0.12"
+crossbeam-channel = "0.5"
 
 [dev-dependencies]
-futures = "0.3.30"
+futures = "0.3"
 
 [lib]
 name = "aiofut"

--- a/libaio/Cargo.toml
+++ b/libaio/Cargo.toml
@@ -10,12 +10,12 @@ description = "Straightforward Linux AIO using Futures/async/await."
 emulated-failure = []
 
 [dependencies]
-libc = "0.2.133"
+libc = "0.2.153"
 parking_lot = "0.12.1"
-crossbeam-channel = "0.5.6"
+crossbeam-channel = "0.5.11"
 
 [dev-dependencies]
-futures = "0.3.24"
+futures = "0.3.30"
 
 [lib]
 name = "aiofut"


### PR DESCRIPTION
[Cargo dependency rules](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html) say:

> The string "0.1.12" is a version requirement. Although it looks like a specific version of the time crate, it actually specifies a range of versions and allows SemVer compatible updates. An update is allowed if the new version number does not modify the left-most non-zero number in the major, minor, patch grouping. In this case, if we ran cargo update time, cargo should update us to version 0.1.13 if it is the latest 0.1.z release, but would not update us to 0.2.0. If instead we had specified the version string as 1.0, cargo should update to 1.1 if it is the latest 1.y release, but not 2.0. The version 0.0.x is not considered compatible with any other version.