### PR TITLE
Implement iterator over nodes; refactor key-value iterator

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -328,7 +328,7 @@ impl<S: ShaleStore<Node> + Send + Sync> DbRev<S> {
         start_key: Box<[u8]>,
     ) -> merkle::MerkleKeyValueStream<'_, S, Bincode> {
         self.merkle
-            .key_value_iter_from(self.header.kv_root, start_key)
+            .key_value_iter_from_key(self.header.kv_root, start_key)
     }
 
     fn flush_dirty(&mut self) -> Option<()> {

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -320,14 +320,15 @@ impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
 
 impl<S: ShaleStore<Node> + Send + Sync> DbRev<S> {
     pub fn stream(&self) -> merkle::MerkleKeyValueStream<'_, S, Bincode> {
-        self.merkle.iter(self.header.kv_root)
+        self.merkle.key_value_iter(self.header.kv_root)
     }
 
     pub fn stream_from(
         &self,
         start_key: Box<[u8]>,
     ) -> merkle::MerkleKeyValueStream<'_, S, Bincode> {
-        self.merkle.iter_from(self.header.kv_root, start_key)
+        self.merkle
+            .key_value_iter_from(self.header.kv_root, start_key)
     }
 
     fn flush_dirty(&mut self) -> Option<()> {

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -319,14 +319,14 @@ impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
 }
 
 impl<S: ShaleStore<Node> + Send + Sync> DbRev<S> {
-    pub fn stream(&self) -> merkle::MerkleKeyValueStream2<'_, S, Bincode> {
+    pub fn stream(&self) -> merkle::MerkleKeyValueStream<'_, S, Bincode> {
         self.merkle.iter(self.header.kv_root)
     }
 
     pub fn stream_from(
         &self,
         start_key: Box<[u8]>,
-    ) -> merkle::MerkleKeyValueStream2<'_, S, Bincode> {
+    ) -> merkle::MerkleKeyValueStream<'_, S, Bincode> {
         self.merkle.iter_from(self.header.kv_root, start_key)
     }
 

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -25,8 +25,6 @@ pub use proof::{Proof, ProofError};
 pub use stream::MerkleKeyValueStream;
 pub use trie_hash::{TrieHash, TRIE_HASH_LEN};
 
-use self::stream::MerkleNodeStream;
-
 type NodeObjRef<'a> = shale::ObjRef<'a, Node>;
 type ParentRefs<'a> = Vec<(NodeObjRef<'a>, u8)>;
 type ParentAddresses = Vec<(DiskAddress, u8)>;
@@ -1727,20 +1725,6 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
         key: Box<[u8]>,
     ) -> MerkleKeyValueStream<'_, S, T> {
         MerkleKeyValueStream::from_key(self, root, key)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn node_iter(&self, root: DiskAddress) -> MerkleNodeStream<'_, S, T> {
-        MerkleNodeStream::new(self, root)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn node_iter_from(
-        &self,
-        root: DiskAddress,
-        key: Box<[u8]>,
-    ) -> MerkleNodeStream<'_, S, T> {
-        MerkleNodeStream::from_key(self, root, key)
     }
 
     pub(super) async fn range_proof<K: api::KeyType + Send + Sync>(

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -22,7 +22,7 @@ pub use node::{
     NodeType, PartialPath,
 };
 pub use proof::{Proof, ProofError};
-pub use stream::MerkleKeyValueStream2;
+pub use stream::MerkleKeyValueStream;
 pub use trie_hash::{TrieHash, TRIE_HASH_LEN};
 
 type NodeObjRef<'a> = shale::ObjRef<'a, Node>;
@@ -1715,16 +1715,16 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
         self.store.flush_dirty()
     }
 
-    pub(crate) fn iter(&self, root: DiskAddress) -> MerkleKeyValueStream2<'_, S, T> {
-        MerkleKeyValueStream2::new(self, root)
+    pub(crate) fn iter(&self, root: DiskAddress) -> MerkleKeyValueStream<'_, S, T> {
+        MerkleKeyValueStream::new(self, root)
     }
 
     pub(crate) fn iter_from(
         &self,
         root: DiskAddress,
         key: Box<[u8]>,
-    ) -> MerkleKeyValueStream2<'_, S, T> {
-        MerkleKeyValueStream2::from_key(self, root, key)
+    ) -> MerkleKeyValueStream<'_, S, T> {
+        MerkleKeyValueStream::from_key(self, root, key)
     }
 
     pub(super) async fn range_proof<K: api::KeyType + Send + Sync>(

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1721,7 +1721,7 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
         MerkleKeyValueStream::new(self, root)
     }
 
-    pub(crate) fn key_value_iter_from(
+    pub(crate) fn key_value_iter_from_key(
         &self,
         root: DiskAddress,
         key: Box<[u8]>,
@@ -1766,7 +1766,9 @@ impl<S: ShaleStore<Node> + Send + Sync, T> Merkle<S, T> {
 
         let mut stream = match first_key {
             // TODO: fix the call-site to force the caller to do the allocation
-            Some(key) => self.key_value_iter_from(root, key.as_ref().to_vec().into_boxed_slice()),
+            Some(key) => {
+                self.key_value_iter_from_key(root, key.as_ref().to_vec().into_boxed_slice())
+            }
             None => self.key_value_iter(root),
         };
 

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -261,7 +261,7 @@ fn get_iterator_intial_state<S: ShaleStore<Node> + Send + Sync, T>(
                     }
                 };
 
-                for next_partial_key_nibble in partial_key.iter().copied() {
+                for next_partial_key_nibble in partial_key.iter() {
                     let Some(next_key_nibble) = unmatched_key_nibbles.next() else {
                         // Ran out of [key] nibbles so [child] is after [key]
                         branch_iter_stack.push(BranchIterator::Unvisited {
@@ -277,7 +277,7 @@ fn get_iterator_intial_state<S: ShaleStore<Node> + Send + Sync, T>(
                         return Ok(MerkleNodeStreamState::Initialized { branch_iter_stack });
                     };
 
-                    if next_partial_key_nibble > next_key_nibble {
+                    if next_partial_key_nibble > &next_key_nibble {
                         // The leaf's key and the key diverged, and the
                         // leaf is greater, so we can stop here.
                         branch_iter_stack.push(BranchIterator::Unvisited {
@@ -290,7 +290,7 @@ fn get_iterator_intial_state<S: ShaleStore<Node> + Send + Sync, T>(
                                 .collect(),
                         });
                         return Ok(MerkleNodeStreamState::Initialized { branch_iter_stack });
-                    } else if next_partial_key_nibble < next_key_nibble {
+                    } else if next_partial_key_nibble < &next_key_nibble {
                         // [child] is before [key]
                         return Ok(MerkleNodeStreamState::Initialized { branch_iter_stack });
                     }

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -190,10 +190,6 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
         .get_node(root_node)
         .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
-    // Invariant: This is `node`'s address at the start
-    // of each loop iteration.
-    let mut node_addr = root_node;
-
     // Invariant: [matched_key_nibbles] is the key of `node` at the start
     // of each loop iteration.
     let mut matched_key_nibbles = vec![];
@@ -275,7 +271,6 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                         // `child` is a prefix of `key`.
                         matched_key_nibbles.extend(partial_key.iter().copied());
                         node = child;
-                        node_addr = child_addr;
                     }
                     Ordering::Greater => {
                         // `child` is after `key`.
@@ -299,9 +294,6 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                 match comparison {
                     Ordering::Less | Ordering::Equal => {}
                     Ordering::Greater => {
-                        let node = merkle
-                            .get_node(node_addr)
-                            .map_err(|e| api::Error::InternalError(Box::new(e)))?;
                         // The leaf's key > `key`, so we can stop here.
                         iter_stack.push(IterationNode::Unvisited {
                             key: matched_key_nibbles

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -445,20 +445,6 @@ fn key_from_nibble_iter<Iter: Iterator<Item = u8>>(mut nibbles: Iter) -> Key {
     data.into_boxed_slice()
 }
 
-// CAUTION: only use with nibble iterators
-trait IntoBytes: Iterator<Item = u8> {
-    fn nibbles_into_bytes(&mut self) -> Vec<u8> {
-        let mut data = Vec::with_capacity(self.size_hint().0 / 2);
-
-        while let (Some(hi), Some(lo)) = (self.next(), self.next()) {
-            data.push((hi << 4) + lo);
-        }
-
-        data
-    }
-}
-impl<T: Iterator<Item = u8>> IntoBytes for T {}
-
 #[cfg(test)]
 use super::tests::create_test_merkle;
 
@@ -467,7 +453,6 @@ use super::tests::create_test_merkle;
 mod tests {
     use crate::{
         merkle::Bincode,
-        nibbles::Nibbles,
         shale::{cached::DynamicMem, compact::CompactSpace},
     };
 
@@ -1154,22 +1139,5 @@ mod tests {
     {
         assert!(stream.next().await.is_none());
         assert!(stream.is_terminated());
-    }
-
-    #[test]
-    fn remaining_bytes() {
-        let data = &[1];
-        let nib: Nibbles<'_, 0> = Nibbles::<0>::new(data);
-        let mut it = nib.into_iter();
-        assert_eq!(it.nibbles_into_bytes(), data.to_vec());
-    }
-
-    #[test]
-    fn remaining_bytes_off() {
-        let data = &[1];
-        let nib: Nibbles<'_, 0> = Nibbles::<0>::new(data);
-        let mut it = nib.into_iter();
-        it.next();
-        assert_eq!(it.nibbles_into_bytes(), vec![]);
     }
 }

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -231,14 +231,11 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                 // Figure out if the child at `next_unmatched_key_nibble` is a prefix of `key`.
                 // (i.e. if we should run this loop body again)
                 #[allow(clippy::indexing_slicing)]
-                let child_addr = match branch.children[next_unmatched_key_nibble as usize] {
-                    Some(c) => c,
-                    None => {
-                        // There is no child at `next_unmatched_key_nibble`.
-                        // We'll visit `node`'s first child at index > `next_unmatched_key_nibble`
-                        // first (if it exists).
-                        return Ok(NodeStreamState::Iterating { iter_stack });
-                    }
+                let Some(child_addr) = branch.children[next_unmatched_key_nibble as usize] else {
+                    // There is no child at `nib`.
+                    // We'll visit `node`'s first child at index > `nib`
+                    // first (if it exists).
+                    return Ok(NodeStreamState::Iterating { iter_stack });
                 };
 
                 matched_key_nibbles.push(next_unmatched_key_nibble);

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -263,7 +263,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                 };
 
                 let (comparison, new_unmatched_key_nibbles) =
-                    is_prefix(partial_key.iter(), unmatched_key_nibbles);
+                    compare_partial_path(partial_key.iter(), unmatched_key_nibbles);
                 unmatched_key_nibbles = new_unmatched_key_nibbles;
 
                 match comparison {
@@ -296,7 +296,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                 }
             }
             NodeType::Leaf(leaf) => {
-                let (comparison, _) = is_prefix(leaf.path.iter(), unmatched_key_nibbles);
+                let (comparison, _) = compare_partial_path(leaf.path.iter(), unmatched_key_nibbles);
 
                 match comparison {
                     Ordering::Less | Ordering::Equal => {}
@@ -436,7 +436,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
 /// * [Ordering::Greater] if the node is after the key.
 /// The second returned element is the unmatched portion of the key after the
 /// partial path has been matched.
-fn is_prefix<'a, I1, I2>(
+fn compare_partial_path<'a, I1, I2>(
     partial_path_iter: I1,
     mut unmatched_key_nibbles_iter: I2,
 ) -> (Ordering, I2)

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -192,7 +192,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
             match &node.inner {
                 NodeType::Branch(_) | NodeType::Leaf(_) => {
                     iter_stack.push(IterationNode::Unvisited {
-                        key: matched_key_nibbles.clone().into_boxed_slice(),
+                        key: Box::from(matched_key_nibbles),
                         node,
                     });
                 }
@@ -257,8 +257,8 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                         // `child` is after `key`.
                         let key = matched_key_nibbles
                             .iter()
+                            .chain(partial_key.iter())
                             .copied()
-                            .chain(partial_key.iter().copied())
                             .collect();
                         iter_stack.push(IterationNode::Unvisited { key, node: child });
 

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -182,7 +182,8 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleNodeStream<'a, S
     }
 }
 
-// TODO comment
+/// Returns the initial state for an iterator over the given `merkle` with root `root_node`
+/// which starts at `key`.
 fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
     merkle: &'a Merkle<S, T>,
     root_node: DiskAddress,

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -140,9 +140,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleNodeStream<'a, S
                                 continue;
                             };
 
-                            let child = merkle
-                                .get_node(child_addr)
-                                .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+                            let child = merkle.get_node(child_addr)?;
 
                             let partial_path = match child.inner() {
                                 NodeType::Branch(branch) => branch.path.iter().copied(),
@@ -186,9 +184,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
     key: &[u8],
 ) -> Result<NodeStreamState<'a>, api::Error> {
     // Invariant: `node`'s key is a prefix of `key`.
-    let mut node = merkle
-        .get_node(root_node)
-        .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+    let mut node = merkle.get_node(root_node)?;
 
     // Invariant: [matched_key_nibbles] is the key of `node` at the start
     // of each loop iteration.
@@ -247,9 +243,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
 
                 matched_key_nibbles.push(next_unmatched_key_nibble);
 
-                let child = merkle
-                    .get_node(child_addr)
-                    .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+                let child = merkle.get_node(child_addr)?;
 
                 let partial_key = match child.inner() {
                     NodeType::Branch(branch) => &branch.path,

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -107,7 +107,9 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleNodeStream<'a, S
                                     // `node` is a branch node. Visit its children next.
                                     iter_stack.push(IterationNode::Visited {
                                         key: key.clone(),
-                                        children_iter: Box::new(get_children_iter(branch)),
+                                        children_iter: Box::new(as_enumerated_children_iter(
+                                            branch,
+                                        )),
                                     });
                                 }
                                 NodeType::Leaf(_) => {}
@@ -212,7 +214,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                 iter_stack.push(IterationNode::Visited {
                     key: matched_key_nibbles.iter().copied().collect(),
                     children_iter: Box::new(
-                        get_children_iter(branch)
+                        as_enumerated_children_iter(branch)
                             .filter(move |(_, pos)| *pos > next_unmatched_key_nibble),
                     ),
                 });
@@ -427,7 +429,7 @@ where
 
 /// Returns an iterator that returns (child_addr, pos) for each non-empty child of `branch`,
 /// where `pos` is the position of the child in `branch`'s children array.
-fn get_children_iter(branch: &BranchNode) -> impl Iterator<Item = (DiskAddress, u8)> {
+fn as_enumerated_children_iter(branch: &BranchNode) -> impl Iterator<Item = (DiskAddress, u8)> {
     branch
         .children
         .into_iter()

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -16,13 +16,13 @@ type Value = Vec<u8>;
 
 /// Represents an ongoing iteration over a node and its children.
 enum IterationNode<'a> {
-    // This node has not been returned yet.
+    /// This node has not been returned yet.
     Unvisited {
         /// The key (as nibbles) of this node.
         key: Key,
         node: NodeObjRef<'a>,
     },
-    // This node has been returned. Track which child to visit next.
+    /// This node has been returned. Track which child to visit next.
     Visited {
         /// The key (as nibbles) of this node.
         key: Key,

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -56,9 +56,6 @@ impl NodeStreamState<'_> {
     }
 }
 
-/// Iterates over the nodes in `merkle, whose root is `merkle_root,
-/// in order of ascending key. For each, returns the key and the node.
-/// Note that the returned key is the raw key, not the key as nibbles.
 pub struct MerkleNodeStream<'a, S, T> {
     state: NodeStreamState<'a>,
     merkle_root: DiskAddress,

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -275,8 +275,8 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                     // `child` is after `key`.
                     let key = matched_key_nibbles
                         .iter()
+                        .chain(leaf.path.iter())
                         .copied()
-                        .chain(leaf.path.iter().copied())
                         .collect();
                     iter_stack.push(IterationNode::Unvisited { key, node });
                 }

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -60,6 +60,8 @@ pub struct MerkleNodeStream<'a, S, T> {
 
 impl<'a, S: ShaleStore<Node> + Send + Sync, T> FusedStream for MerkleNodeStream<'a, S, T> {
     fn is_terminated(&self) -> bool {
+        // The top of `iter_stack` is the next node to return.
+        // If `iter_stack` is empty, there are no more nodes to visit.
         matches!(&self.state, NodeStreamState::Iterating { iter_stack } if iter_stack.is_empty())
     }
 }

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -122,7 +122,9 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleNodeStream<'a, S
                                     });
                                 }
                                 NodeType::Leaf(_) => {}
-                                NodeType::Extension(_) => panic!("extension nodes shouldn't exist"),
+                                NodeType::Extension(_) => {
+                                    unreachable!("extension nodes shouldn't exist")
+                                }
                             }
 
                             let key = key_from_nibble_iter(key.iter().copied().skip(1));
@@ -138,7 +140,6 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleNodeStream<'a, S
                                 continue;
                             };
 
-                            // Visit the child next.
                             let child = merkle
                                 .get_node(child_addr)
                                 .map_err(|e| api::Error::InternalError(Box::new(e)))?;
@@ -147,7 +148,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleNodeStream<'a, S
                                 NodeType::Branch(branch) => branch.path.iter().copied(),
                                 NodeType::Leaf(leaf) => leaf.path.iter().copied(),
                                 NodeType::Extension(_) => {
-                                    panic!("extension nodes shouldn't exist")
+                                    unreachable!("extension nodes shouldn't exist")
                                 }
                             };
 
@@ -208,7 +209,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                     });
                 }
                 NodeType::Extension(_) => {
-                    panic!("extension nodes shouldn't exist")
+                    unreachable!("extension nodes shouldn't exist")
                 }
             }
 
@@ -251,7 +252,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                     NodeType::Branch(branch) => &branch.path,
                     NodeType::Leaf(leaf) => &leaf.path,
                     NodeType::Extension(_) => {
-                        panic!("extension nodes shouldn't exist")
+                        unreachable!("extension nodes shouldn't exist")
                     }
                 };
 
@@ -299,7 +300,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                 return Ok(NodeStreamState::Iterating { iter_stack });
             }
             NodeType::Extension(_) => {
-                panic!("extension nodes shouldn't exist")
+                unreachable!("extension nodes shouldn't exist")
             }
         };
     }
@@ -396,7 +397,9 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                                 let value = leaf.data.to_vec();
                                 Poll::Ready(Some(Ok((key, value))))
                             }
-                            NodeType::Extension(_) => panic!("extension nodes shouldn't exist"),
+                            NodeType::Extension(_) => {
+                                unreachable!("extension nodes shouldn't exist")
+                            }
                         },
                         Some(Err(e)) => Poll::Ready(Some(Err(e))),
                         None => Poll::Ready(None),

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -492,7 +492,7 @@ mod tests {
     async fn key_value_iterate_empty() {
         let merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
-        let stream = merkle.key_value_iter_from(root, b"x".to_vec().into_boxed_slice());
+        let stream = merkle.key_value_iter_from_key(root, b"x".to_vec().into_boxed_slice());
         check_stream_is_done(stream).await;
     }
 
@@ -671,7 +671,7 @@ mod tests {
         }
 
         let mut stream = match start {
-            Some(start) => merkle.key_value_iter_from(root, start.to_vec().into_boxed_slice()),
+            Some(start) => merkle.key_value_iter_from_key(root, start.to_vec().into_boxed_slice()),
             None => merkle.key_value_iter(root),
         };
 
@@ -733,7 +733,7 @@ mod tests {
 
         // Test with start key
         for i in 0..=u8::MAX {
-            let mut stream = merkle.key_value_iter_from(root, vec![i].into_boxed_slice());
+            let mut stream = merkle.key_value_iter_from_key(root, vec![i].into_boxed_slice());
             for j in 0..=u8::MAX {
                 let expected_key = vec![i, j];
                 let expected_value = vec![i, j];
@@ -865,7 +865,8 @@ mod tests {
             merkle.insert(key, key.to_vec(), root).unwrap();
         }
 
-        let mut stream = merkle.key_value_iter_from(root, vec![intermediate].into_boxed_slice());
+        let mut stream =
+            merkle.key_value_iter_from_key(root, vec![intermediate].into_boxed_slice());
 
         let first_expected = key_values[1].as_slice();
         let first = stream.next().await.unwrap().unwrap();
@@ -912,7 +913,7 @@ mod tests {
         let start = keys.iter().position(|key| key[0] == branch_path).unwrap();
         let keys = &keys[start..];
 
-        let mut stream = merkle.key_value_iter_from(root, vec![branch_path].into_boxed_slice());
+        let mut stream = merkle.key_value_iter_from_key(root, vec![branch_path].into_boxed_slice());
 
         for key in keys {
             let next = stream.next().await.unwrap().unwrap();
@@ -961,7 +962,7 @@ mod tests {
         let start = keys.iter().position(|key| key == &branch_key).unwrap();
         let keys = &keys[start..];
 
-        let mut stream = merkle.key_value_iter_from(root, branch_key.into_boxed_slice());
+        let mut stream = merkle.key_value_iter_from_key(root, branch_key.into_boxed_slice());
 
         for key in keys {
             let next = stream.next().await.unwrap().unwrap();
@@ -992,7 +993,7 @@ mod tests {
 
         let keys = &keys[(missing as usize)..];
 
-        let mut stream = merkle.key_value_iter_from(root, vec![missing].into_boxed_slice());
+        let mut stream = merkle.key_value_iter_from_key(root, vec![missing].into_boxed_slice());
 
         for key in keys {
             let next = stream.next().await.unwrap().unwrap();
@@ -1019,7 +1020,7 @@ mod tests {
             merkle.insert(&key, key.clone(), root).unwrap();
         });
 
-        let stream = merkle.key_value_iter_from(root, vec![start_key].into_boxed_slice());
+        let stream = merkle.key_value_iter_from_key(root, vec![start_key].into_boxed_slice());
 
         check_stream_is_done(stream).await;
     }
@@ -1042,7 +1043,7 @@ mod tests {
             })
             .collect();
 
-        let mut stream = merkle.key_value_iter_from(root, vec![start_key].into_boxed_slice());
+        let mut stream = merkle.key_value_iter_from_key(root, vec![start_key].into_boxed_slice());
 
         for key in keys {
             let next = stream.next().await.unwrap().unwrap();
@@ -1075,7 +1076,7 @@ mod tests {
 
         let keys = &keys[((missing >> 4) as usize)..];
 
-        let mut stream = merkle.key_value_iter_from(root, vec![missing].into_boxed_slice());
+        let mut stream = merkle.key_value_iter_from_key(root, vec![missing].into_boxed_slice());
 
         for key in keys {
             let next = stream.next().await.unwrap().unwrap();
@@ -1094,7 +1095,7 @@ mod tests {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
         merkle.insert(key.clone(), key, root).unwrap();
-        let stream = merkle.key_value_iter_from(root, greater_key.into_boxed_slice());
+        let stream = merkle.key_value_iter_from_key(root, greater_key.into_boxed_slice());
 
         check_stream_is_done(stream).await;
     }
@@ -1120,7 +1121,7 @@ mod tests {
 
         let keys = &keys[((greatest >> 4) as usize)..];
 
-        let mut stream = merkle.key_value_iter_from(root, vec![greatest].into_boxed_slice());
+        let mut stream = merkle.key_value_iter_from_key(root, vec![greatest].into_boxed_slice());
 
         for key in keys {
             let next = stream.next().await.unwrap().unwrap();

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -19,11 +19,11 @@ enum BranchIterator {
     Unvisited {
         address: DiskAddress,
         /// The nibbles of the key at this branch node.
-        key: Box<[u8]>,
+        key: Key,
     },
     Visited {
         /// The nibbles of the key at this branch node.
-        key: Box<[u8]>,
+        key: Key,
         /// Returns the non-empty children of this node and their positions
         /// in the node's children array .
         children_iter: Box<dyn Iterator<Item = (DiskAddress, u8)> + Send>,

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -164,10 +164,6 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleNodeStream<'a, S
                             // There may be more children of this node to visit.
                             iter_stack.push(iter_node);
 
-                            let child = merkle
-                                .get_node(child_addr)
-                                .map_err(|e| api::Error::InternalError(Box::new(e)))?;
-
                             iter_stack.push(IterationNode::Unvisited {
                                 key: child_key,
                                 node: child,

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -379,6 +379,8 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                         Some(Ok((key, node))) => match node.inner() {
                             NodeType::Branch(branch) => {
                                 let Some(value) = branch.value.as_ref() else {
+                                    // This node doesn't have a value to return.
+                                    // Continue to the next node.
                                     return self.poll_next(_cx);
                                 };
 

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -152,6 +152,8 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleNodeStream<'a, S
                                 }
                             };
 
+                            // The child's key is its parent's key, followed by the child's index,
+                            // followed by the child's partial path (if any).
                             let child_key: Box<[u8]> = key
                                 .iter()
                                 .copied()

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -266,6 +266,10 @@ fn get_iterator_intial_state<S: ShaleStore<Node> + Send + Sync, T>(
                         // Ran out of [key] nibbles so [child] is after [key]
                         branch_iter_stack.push(BranchIterator::Unvisited {
                             address: child_addr,
+                            // TODO is there a way to just drain [partial_key]
+                            // into [matched_key_nibbles]? Then we could append
+                            // each matched nibble as we go instead of using
+                            // extend.
                             key: matched_key_nibbles
                                 .clone()
                                 .iter()

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -58,7 +58,7 @@ impl MerkleNodeStreamState {
     }
 }
 
-/// Iterates over the nodes in [merkle], whose root is [merkle_root],
+/// Iterates over the nodes in `merkle, whose root is `merkle_root,
 /// in order of ascending key. For each, returns the key and the node.
 pub struct MerkleNodeStream<'a, S, T> {
     state: MerkleNodeStreamState,
@@ -73,7 +73,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> FusedStream for MerkleNodeStream<
 }
 
 impl<'a, S, T> MerkleNodeStream<'a, S, T> {
-    /// Returns a new iterator that will iterate over all the nodes in [merkle].
+    /// Returns a new iterator that will iterate over all the nodes in `merkle`.
     #[allow(dead_code)] // TODO should we remove this function?
     pub(super) fn new(merkle: &'a Merkle<S, T>, merkle_root: DiskAddress) -> Self {
         Self {
@@ -83,8 +83,8 @@ impl<'a, S, T> MerkleNodeStream<'a, S, T> {
         }
     }
 
-    /// Returns a new iterator that will iterate over all the nodes in [merkle]
-    /// with keys greater than or equal to [key].
+    /// Returns a new iterator that will iterate over all the nodes in `merkle`
+    /// with keys greater than or equal to `key`.
     pub(super) fn from_key(merkle: &'a Merkle<S, T>, merkle_root: DiskAddress, key: Key) -> Self {
         Self {
             state: MerkleNodeStreamState::with_key(key),
@@ -339,14 +339,14 @@ enum MerkleKeyValueStreamState<'a, S, T> {
 }
 
 impl<'a, S, T> MerkleKeyValueStreamState<'a, S, T> {
-    /// Returns a new iterator that will iterate over all the key-value pairs in [merkle].
+    /// Returns a new iterator that will iterate over all the key-value pairs in `merkle`.
     #[allow(dead_code)] // TODO should we remove this function?
     fn new() -> Self {
         Self::Uninitialized(vec![].into_boxed_slice())
     }
 
-    /// Returns a new iterator that will iterate over all the key-value pairs in [merkle]
-    /// with keys greater than or equal to [key].
+    /// Returns a new iterator that will iterate over all the key-value pairs in `merkle`
+    /// with keys greater than or equal to `key`.
     fn with_key(key: Key) -> Self {
         Self::Uninitialized(key)
     }
@@ -467,8 +467,8 @@ where
     (Ordering::Equal, unmatched_key_nibbles_iter)
 }
 
-/// Returns an iterator that returns (child_addr, pos) for each non-empty child of [branch],
-/// where [pos] is the position of the child in [branch]'s children array.
+/// Returns an iterator that returns (child_addr, pos) for each non-empty child of `branch`,
+/// where `pos` is the position of the child in `branch`'s children array.
 fn get_children_iter(branch: &BranchNode) -> impl Iterator<Item = (DiskAddress, u8)> {
     branch
         .children

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -111,12 +111,14 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleNodeStream<'a, S
                 while let Some(mut branch_iter) = branch_iter_stack.pop() {
                     match branch_iter {
                         BranchIterator::Unvisited { address, key } => {
+                            // We haven't returned this node yet
                             let node = merkle
                                 .get_node(address)
                                 .map_err(|e| api::Error::InternalError(Box::new(e)))?;
 
                             match node.inner() {
                                 NodeType::Branch(branch) => {
+                                    // [node] is a branch node. Visit its children next.
                                     branch_iter_stack.push(BranchIterator::Visited {
                                         key: key.clone(),
                                         children_iter: Box::new(get_children_iter(branch)),
@@ -140,6 +142,8 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleNodeStream<'a, S
 
                             let mut child_key: Vec<u8> =
                                 key.iter().copied().chain(once(pos)).collect();
+
+                            // There may be more children of this node to visit
 
                             branch_iter_stack.push(branch_iter);
 

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -322,7 +322,7 @@ enum MerkleKeyValueStreamState<'a, S, T> {
 impl<'a, S, T> MerkleKeyValueStreamState<'a, S, T> {
     /// Returns a new iterator that will iterate over all the key-value pairs in `merkle`.
     fn new() -> Self {
-        Self::Uninitialized(vec![].into_boxed_slice())
+        Self::Uninitialized(Box::new([]))
     }
 
     /// Returns a new iterator that will iterate over all the key-value pairs in `merkle`

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -290,15 +290,13 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                 if compare_partial_path(leaf.path.iter(), unmatched_key_nibbles).0
                     == Ordering::Greater
                 {
-                    // The leaf's key > `key`, so we can stop here.
-                    iter_stack.push(IterationNode::Unvisited {
-                        key: matched_key_nibbles
-                            .iter()
-                            .copied()
-                            .chain(leaf.path.iter().copied())
-                            .collect(),
-                        node,
-                    });
+                    // `child` is after `key`.
+                    let key = matched_key_nibbles
+                        .iter()
+                        .copied()
+                        .chain(leaf.path.iter().copied())
+                        .collect();
+                    iter_stack.push(IterationNode::Unvisited { key, node });
                 }
                 return Ok(NodeStreamState::Iterating { iter_stack });
             }

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -279,10 +279,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                             .copied()
                             .chain(partial_key.iter().copied())
                             .collect();
-                        iter_stack.push(IterationNode::Unvisited {
-                            key: key,
-                            node: child,
-                        });
+                        iter_stack.push(IterationNode::Unvisited { key, node: child });
 
                         return Ok(MerkleNodeStreamState::Initialized { iter_stack });
                     }

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -511,7 +511,7 @@ mod tests {
     use test_case::test_case;
 
     #[tokio::test]
-    async fn iterate_empty() {
+    async fn key_value_iterate_empty() {
         let merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
         let stream = merkle.key_value_iter_from(root, b"x".to_vec().into_boxed_slice());
@@ -523,7 +523,7 @@ mod tests {
     #[test_case(Some(&[128u8]); "Starting in middle")]
     #[test_case(Some(&[u8::MAX]); "Starting at last key")]
     #[tokio::test]
-    async fn iterate_many(start: Option<&[u8]>) {
+    async fn key_value_iterate_many(start: Option<&[u8]>) {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
 
@@ -553,14 +553,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fused_empty() {
+    async fn key_value_fused_empty() {
         let merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
         check_stream_is_done(merkle.key_value_iter(root)).await;
     }
 
     #[tokio::test]
-    async fn table_test() {
+    async fn key_value_table_test() {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
 
@@ -621,7 +621,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fused_full() {
+    async fn key_value_fused_full() {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
 
@@ -652,7 +652,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn root_with_empty_data() {
+    async fn key_value_root_with_empty_data() {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
 
@@ -667,7 +667,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_branch_and_leaf() {
+    async fn key_value_get_branch_and_leaf() {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
 
@@ -706,7 +706,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_at_key_not_in_trie() {
+    async fn key_value_start_at_key_not_in_trie() {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
 
@@ -745,7 +745,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_at_key_on_branch_with_no_value() {
+    async fn key_value_start_at_key_on_branch_with_no_value() {
         let sibling_path = 0x00;
         let branch_path = 0x0f;
         let children = 0..=0x0f;
@@ -787,7 +787,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_at_key_on_branch_with_value() {
+    async fn key_value_start_at_key_on_branch_with_value() {
         let sibling_path = 0x00;
         let branch_path = 0x0f;
         let branch_key = vec![branch_path];
@@ -836,7 +836,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_at_key_on_extension() {
+    async fn key_value_start_at_key_on_extension() {
         let missing = 0x0a;
         let children = (0..=0x0f).filter(|x| *x != missing);
         let mut merkle = create_test_merkle();
@@ -867,7 +867,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_at_key_overlapping_with_extension_but_greater() {
+    async fn key_value_start_at_key_overlapping_with_extension_but_greater() {
         let start_key = 0x0a;
         let shared_path = 0x09;
         // 0x0900, 0x0901, ... 0x0a0f
@@ -887,7 +887,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_at_key_overlapping_with_extension_but_smaller() {
+    async fn key_value_start_at_key_overlapping_with_extension_but_smaller() {
         let start_key = 0x00;
         let shared_path = 0x09;
         // 0x0900, 0x0901, ... 0x0a0f
@@ -917,7 +917,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_at_key_between_siblings() {
+    async fn key_value_start_at_key_between_siblings() {
         let missing = 0xaa;
         let children = (0..=0xf)
             .map(|val| (val << 4) + val) // 0x00, 0x11, ... 0xff
@@ -950,7 +950,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_at_key_greater_than_all_others_leaf() {
+    async fn key_value_start_at_key_greater_than_all_others_leaf() {
         let key = vec![0x00];
         let greater_key = vec![0xff];
         let mut merkle = create_test_merkle();
@@ -962,7 +962,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn start_at_key_greater_than_all_others_branch() {
+    async fn key_value_start_at_key_greater_than_all_others_branch() {
         let greatest = 0xff;
         let children = (0..=0xf)
             .map(|val| (val << 4) + val) // 0x00, 0x11, ... 0xff

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -48,6 +48,7 @@ enum MerkleNodeStreamState {
 }
 
 impl MerkleNodeStreamState {
+    #[allow(dead_code)] // TODO should we remove this function?
     fn new() -> Self {
         Self::Uninitialized(vec![].into_boxed_slice())
     }
@@ -73,6 +74,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> FusedStream for MerkleNodeStream<
 
 impl<'a, S, T> MerkleNodeStream<'a, S, T> {
     /// Returns a new iterator that will iterate over all the nodes in [merkle].
+    #[allow(dead_code)] // TODO should we remove this function?
     pub(super) fn new(merkle: &'a Merkle<S, T>, merkle_root: DiskAddress) -> Self {
         Self {
             state: MerkleNodeStreamState::new(),
@@ -203,8 +205,7 @@ fn get_iterator_intial_state<S: ShaleStore<Node> + Send + Sync, T>(
     // of each loop iteration.
     let mut matched_key_nibbles = vec![];
 
-    let mut unmatched_key_nibbles: crate::nibbles::NibblesIterator<'_, 1> =
-        Nibbles::<1>::new(key.as_ref()).into_iter();
+    let mut unmatched_key_nibbles = Nibbles::<1>::new(key).into_iter();
 
     let mut iter_stack: Vec<IterationNode> = vec![];
 
@@ -341,6 +342,7 @@ enum MerkleKeyValueStreamState<'a, S, T> {
 
 impl<'a, S, T> MerkleKeyValueStreamState<'a, S, T> {
     /// Returns a new iterator that will iterate over all the key-value pairs in [merkle].
+    #[allow(dead_code)] // TODO should we remove this function?
     fn new() -> Self {
         Self::Uninitialized(vec![].into_boxed_slice())
     }
@@ -417,11 +419,11 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
                                     };
 
                                     let value = value.to_vec();
-                                    return Poll::Ready(Some(Ok((key, value))));
+                                    Poll::Ready(Some(Ok((key, value))))
                                 }
                                 NodeType::Leaf(leaf) => {
                                     let value = leaf.data.to_vec();
-                                    return Poll::Ready(Some(Ok((key, value))));
+                                    Poll::Ready(Some(Ok((key, value))))
                                 }
                                 NodeType::Extension(_) => panic!("extension nodes shouldn't exist"),
                             }
@@ -464,7 +466,7 @@ where
         }
     }
 
-    return (Ordering::Equal, unmatched_key_nibbles_iter);
+    (Ordering::Equal, unmatched_key_nibbles_iter)
 }
 
 /// Returns an iterator that returns (child_addr, pos) for each non-empty child of [branch],

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -205,6 +205,7 @@ fn get_iterator_intial_state<S: ShaleStore<Node> + Send + Sync, T>(
         // [nib] is the first nibble after [matched_key_nibbles].
         let Some(nib) = key_nibbles.next() else {
             // The invariant tells us [node] is a prefix of [key].
+            // There is no more [key] left so [node] must be at [key].
             match &node.inner {
                 NodeType::Branch(_) | NodeType::Leaf(_) => {
                     branch_iter_stack.push(BranchIterator::Unvisited {

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -456,6 +456,8 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
     }
 }
 
+/// Returns an iterator that returns (child_addr, pos) for each non-empty child of [branch],
+/// where [pos] is the position of the child in [branch]'s children array.
 fn get_children_iter(branch: &BranchNode) -> impl Iterator<Item = (DiskAddress, u8)> {
     branch
         .children

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -382,7 +382,6 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream<'
 
         match state {
             MerkleKeyValueStreamState::Uninitialized(key) => {
-                // TODO how to not clone here?
                 let iter = MerkleNodeStream::from_key(merkle, *merkle_root, key.clone());
                 self.state = MerkleKeyValueStreamState::Initialized { node_iter: iter };
                 self.poll_next(_cx)

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -279,12 +279,13 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                     }
                     Ordering::Greater => {
                         // `child` is after `key`.
+                        let key = matched_key_nibbles
+                            .iter()
+                            .copied()
+                            .chain(partial_key.iter().copied())
+                            .collect();
                         iter_stack.push(IterationNode::Unvisited {
-                            key: matched_key_nibbles
-                                .iter()
-                                .copied()
-                                .chain(partial_key.iter().copied())
-                                .collect(),
+                            key: key,
                             node: child,
                         });
 

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -289,21 +289,18 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                 }
             }
             NodeType::Leaf(leaf) => {
-                let (comparison, _) = compare_partial_path(leaf.path.iter(), unmatched_key_nibbles);
-
-                match comparison {
-                    Ordering::Less | Ordering::Equal => {}
-                    Ordering::Greater => {
-                        // The leaf's key > `key`, so we can stop here.
-                        iter_stack.push(IterationNode::Unvisited {
-                            key: matched_key_nibbles
-                                .iter()
-                                .copied()
-                                .chain(leaf.path.iter().copied())
-                                .collect(),
-                            node,
-                        });
-                    }
+                if compare_partial_path(leaf.path.iter(), unmatched_key_nibbles).0
+                    == Ordering::Greater
+                {
+                    // The leaf's key > `key`, so we can stop here.
+                    iter_stack.push(IterationNode::Unvisited {
+                        key: matched_key_nibbles
+                            .iter()
+                            .copied()
+                            .chain(leaf.path.iter().copied())
+                            .collect(),
+                        node,
+                    });
                 }
                 return Ok(MerkleNodeStreamState::Initialized { iter_stack });
             }

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -279,9 +279,6 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                     }
                     Ordering::Greater => {
                         // `child` is after `key`.
-                        let child = merkle
-                            .get_node(child_addr)
-                            .map_err(|e| api::Error::InternalError(Box::new(e)))?;
                         iter_stack.push(IterationNode::Unvisited {
                             key: matched_key_nibbles
                                 .iter()

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -405,8 +405,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream2<
             }
             MerkleKeyValueStreamState::Initialized { iter } => match iter.poll_next_unpin(_cx) {
                 Poll::Ready(node) => match node {
-                    Some(key_and_node) => {
-                        let (key, node) = key_and_node?;
+                    Some(Ok((key, node))) => {
                         let key = key_from_nibble_iter(key.iter().copied().skip(1));
 
                         match node.inner() {
@@ -425,6 +424,7 @@ impl<'a, S: ShaleStore<Node> + Send + Sync, T> Stream for MerkleKeyValueStream2<
                             NodeType::Extension(_) => panic!("extension nodes shouldn't exist"),
                         }
                     }
+                    Some(Err(e)) => Poll::Ready(Some(Err(e))),
                     None => Poll::Ready(None),
                 },
                 Poll::Pending => Poll::Pending,

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -563,6 +563,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn table_test() {
+        let mut merkle = create_test_merkle();
+        let root = merkle.init_root().unwrap();
+
+        // Insert key-values in reverse order to ensure iterator
+        // doesn't just return the keys in insertion order.
+        for i in (0..=u8::MAX).rev() {
+            for j in (0..=u8::MAX).rev() {
+                let key = vec![i, j];
+                let value = vec![i, j];
+
+                merkle.insert(key, value, root).unwrap();
+            }
+        }
+
+        // Test with no start key
+        let mut stream = merkle.iter(root);
+        for i in 0..=u8::MAX {
+            for j in 0..=u8::MAX {
+                let expected_key = vec![i, j];
+                let expected_value = vec![i, j];
+
+                assert_eq!(
+                    stream.next().await.unwrap().unwrap(),
+                    (expected_key.into_boxed_slice(), expected_value),
+                    "i: {}, j: {}",
+                    i,
+                    j,
+                );
+            }
+        }
+        check_stream_is_done(stream).await;
+
+        // Test with start key
+        for i in 0..=u8::MAX {
+            let mut stream = merkle.iter_from(root, vec![i].into_boxed_slice());
+            for j in 0..=u8::MAX {
+                let expected_key = vec![i, j];
+                let expected_value = vec![i, j];
+                assert_eq!(
+                    stream.next().await.unwrap().unwrap(),
+                    (expected_key.into_boxed_slice(), expected_value),
+                    "i: {}, j: {}",
+                    i,
+                    j,
+                );
+            }
+            if i == u8::MAX {
+                check_stream_is_done(stream).await;
+            } else {
+                assert_eq!(
+                    stream.next().await.unwrap().unwrap(),
+                    (vec![i + 1, 0].into_boxed_slice(), vec![i + 1, 0]),
+                    "i: {}",
+                    i,
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn fused_full() {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -474,27 +474,6 @@ fn key_from_nibble_iter<Iter: Iterator<Item = u8>>(mut nibbles: Iter) -> Key {
     data.into_boxed_slice()
 }
 
-mod helper_types {
-    use std::ops::Not;
-
-    #[must_use]
-    pub(super) struct MustUse<T>(T);
-
-    impl<T> From<T> for MustUse<T> {
-        fn from(t: T) -> Self {
-            Self(t)
-        }
-    }
-
-    impl<T: Not> Not for MustUse<T> {
-        type Output = T::Output;
-
-        fn not(self) -> Self::Output {
-            self.0.not()
-        }
-    }
-}
-
 // CAUTION: only use with nibble iterators
 trait IntoBytes: Iterator<Item = u8> {
     fn nibbles_into_bytes(&mut self) -> Vec<u8> {

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -221,8 +221,8 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                 // (i.e. if we should run this loop body again)
                 #[allow(clippy::indexing_slicing)]
                 let Some(child_addr) = branch.children[next_unmatched_key_nibble as usize] else {
-                    // There is no child at `nib`.
-                    // We'll visit `node`'s first child at index > `nib`
+                    // There is no child at `next_unmatched_key_nibble`.
+                    // We'll visit `node`'s first child at index > `next_unmatched_key_nibble`
                     // first (if it exists).
                     return Ok(NodeStreamState::Iterating { iter_stack });
                 };

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -225,7 +225,7 @@ fn get_iterator_intial_state<'a, S: ShaleStore<Node> + Send + Sync, T>(
                 // so all children of `node` with a position > `next_unmatched_key_nibble`
                 // should be visited since they are after `key`.
                 iter_stack.push(IterationNode::Visited {
-                    key: matched_key_nibbles.clone().into_boxed_slice(),
+                    key: matched_key_nibbles.iter().copied().collect(),
                     children_iter: Box::new(
                         get_children_iter(branch)
                             .filter(move |(_, pos)| *pos > next_unmatched_key_nibble),

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use crate::merkle::MerkleError;
 pub use crate::merkle::Proof;
 use async_trait::async_trait;
 use std::{fmt::Debug, sync::Arc};
@@ -82,6 +83,13 @@ pub enum Error {
 
     #[error("Range too small")]
     RangeTooSmall,
+}
+
+impl From<MerkleError> for Error {
+    fn from(err: MerkleError) -> Self {
+        // TODO: do a better job
+        Error::InternalError(Box::new(err))
+    }
 }
 
 /// A range proof, consisting of a proof of the first key and the last key,

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -82,15 +82,6 @@ pub enum Error {
 
     #[error("Range too small")]
     RangeTooSmall,
-
-    #[error("Child not found")]
-    ChildNotFound,
-
-    #[error("Sentinel node is an extension node; should be a branch node")]
-    SentinelNodeIsExtension,
-
-    #[error("Extension node has non-branch child")]
-    InvalidExtensionChild,
 }
 
 /// A range proof, consisting of a proof of the first key and the last key,


### PR DESCRIPTION
alternate implementation to #499.

This PR implements an iterator over nodes. The iterator can be configured to start at a given key. Uses this node iterator to refactor the key-value iterator implementation.
