### PR TITLE
Add an upgrade check to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,13 @@
 
 version: 2
 updates:
-  - package-ecosystem: cargo
+  - package-ecosystem: "cargo"
+    versioning-strategy: "increase"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "daily"
       time: "05:00"
-      timezone: America/Los_Angeles
+      timezone: "America/Los_Angeles"
     open-pull-requests-limit: 10
     allow:
-      - dependency-type: all
+      - dependency-type: "all"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,10 @@ jobs:
         run: cargo fmt -- --check
       - name: Clippy
         run: cargo clippy --tests --examples --benches --all-features -- -D warnings
+      - name: Cargo Edit
+        run: cargo install cargo-edit
+      - name: Cargo upgrade
+        run: cargo upgrade --locked || echo "::warning dependencies are out of date"
 
   test:
     needs: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: Cargo Edit
         run: cargo install cargo-edit
       - name: Cargo upgrade
-        run: cargo upgrade --locked || echo "::warning file=Cargo.toml,line=1,col=1::dependencies are out of date"
+        run: cargo upgrade --locked
 
   test:
     needs: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          # We can do this now because we use specific verison and update with Dependabot
+          # We can do this now because we use specific version and update with Dependabot
           # but if we make the deps any less specifc, we'll have to fix
           key: ${{ runner.os }}-deps-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/*.rs') }}
           # start from the previous set of cached dependencies
@@ -104,7 +104,7 @@ jobs:
       - name: Cargo Edit
         run: cargo install cargo-edit
       - name: Cargo upgrade
-        run: cargo upgrade --locked || echo "::warning dependencies are out of date"
+        run: cargo upgrade --locked || echo "::warning file=Cargo.toml,line=1,col=1::dependencies are out of date"
 
   test:
     needs: build

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -17,25 +17,25 @@ readme = "../README.md"
 
 [dependencies]
 aquamarine = "0.5.0"
-async-trait = "0.1.57"
-bytemuck = { version = "1.13.1", features = ["derive"] }
+async-trait = "0.1.77"
+bytemuck = { version = "1.14.2", features = ["derive"] }
 enum-as-inner = "0.6.0"
 growth-ring = { version = "0.0.4", path = "../growth-ring" }
 libaio = {version = "0.0.4", path = "../libaio" }
-futures = "0.3.24"
+futures = "0.3.30"
 hex = "0.4.3"
-lru = "0.12.0"
+lru = "0.12.2"
 metered = "0.9.0"
 nix = {version = "0.27.1", features = ["fs", "uio"]}
 parking_lot = "0.12.1"
 serde = { version = "1.0", features = ["derive"] }
-sha3 = "0.10.2"
-thiserror = "1.0.38"
-tokio = { version = "1.21.1", features = ["rt", "sync", "macros", "rt-multi-thread"] }
-typed-builder = "0.18.0"
+sha3 = "0.10.8"
+thiserror = "1.0.56"
+tokio = { version = "1.35.0", features = ["rt", "sync", "macros", "rt-multi-thread"] }
+typed-builder = "0.18.1"
 bincode = "1.3.3"
-bitflags = { version = "2.4.1", features = ["bytemuck"] }
-env_logger = { version = "0.11.0", optional = true }
+bitflags = { version = "2.4.2", features = ["bytemuck"] }
+env_logger = { version = "0.11.1", optional = true }
 log = { version = "0.4.20", optional = true }
 
 [features]
@@ -46,10 +46,10 @@ criterion = {version = "0.5.1", features = ["async_tokio"]}
 keccak-hasher = "0.15.3"
 rand = "0.8.5"
 triehash = "0.8.4"
-assert_cmd = "2.0.7"
-predicates = "3.0.1"
-clap = { version = "4.3.1", features = ['derive'] }
-test-case = "3.1.0"
+assert_cmd = "2.0.13"
+predicates = "3.1.0"
+clap = { version = "4.4.18", features = ['derive'] }
+test-case = "3.3.1"
 pprof = { version = "0.13.0", features = ["flamegraph"] }
 
 [[bench]]

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -31,7 +31,7 @@ parking_lot = "0.12.1"
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10.8"
 thiserror = "1.0.56"
-tokio = { version = "1.35.0", features = ["rt", "sync", "macros", "rt-multi-thread"] }
+tokio = { version = "1.36.0", features = ["rt", "sync", "macros", "rt-multi-thread"] }
 typed-builder = "0.18.1"
 bincode = "1.3.3"
 bitflags = { version = "2.4.2", features = ["bytemuck"] }

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -5,16 +5,16 @@ edition = "2021"
 
 [dependencies]
 firewood = { version = "0.0.4", path = "../firewood" }
-clap = { version = "4.0.29", features = ["cargo", "derive"] }
-anyhow = "1.0.66"
-env_logger = "0.11.0"
-log = "0.4.17"
-tokio = { version = "1.33.0", features = ["full"] }
-futures-util = "0.3.29"
+clap = { version = "4.4.18", features = ["cargo", "derive"] }
+anyhow = "1.0.79"
+env_logger = "0.11.1"
+log = "0.4.20"
+tokio = { version = "1.36.0", features = ["full"] }
+futures-util = "0.3.30"
 
 [dev-dependencies]
-assert_cmd = "2.0.7"
-predicates = "3.0.1"
+assert_cmd = "2.0.13"
+predicates = "3.1.0"
 serial_test = "3.0.0"
 
 [lints.rust]

--- a/growth-ring/Cargo.toml
+++ b/growth-ring/Cargo.toml
@@ -9,24 +9,24 @@ description = "Simple and modular write-ahead-logging implementation."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lru = "0.12.0"
+lru = "0.12.2"
 scan_fmt = "0.2.6"
-regex = "1.6.0"
-async-trait = "0.1.57"
-futures = "0.3.24"
+regex = "1.10.3"
+async-trait = "0.1.77"
+futures = "0.3.30"
 nix = {version = "0.27.1", features = ["fs", "uio"]}
-libc = "0.2.133"
-bytemuck = {version = "1.13.1", features = ["derive"]}
-thiserror = "1.0.40"
-tokio = { version = "1.28.1", features = ["fs", "io-util", "sync"] }
+libc = "0.2.153"
+bytemuck = {version = "1.14.2", features = ["derive"]}
+thiserror = "1.0.56"
+tokio = { version = "1.36.0", features = ["fs", "io-util", "sync"] }
 crc32fast = "1.3.2"
 
 [dev-dependencies]
 hex = "0.4.3"
 rand = "0.8.5"
-indexmap = "2.2.1"
-tokio = { version = "1.28.1", features = ["tokio-macros", "rt", "macros"] }
-test-case = "3.1.0"
+indexmap = "2.2.2"
+tokio = { version = "1.36.0", features = ["tokio-macros", "rt", "macros"] }
+test-case = "3.3.1"
 
 [lib]
 name = "growthring"

--- a/grpc-testtool/Cargo.toml
+++ b/grpc-testtool/Cargo.toml
@@ -17,21 +17,21 @@ bench = false
 
 [dependencies]
 firewood = { version = "0.0.4", path = "../firewood" }
-prost = "0.12.0"
-thiserror = "1.0.47"
-tokio = { version = "1.32.0", features = ["sync", "rt-multi-thread"] }
-tonic = { version = "0.10.0", features = ["tls"] }
-tracing = { version = "0.1.16" }
-clap = { version = "4.4.11", features = ["derive"] }
+prost = "0.12.3"
+thiserror = "1.0.56"
+tokio = { version = "1.36.0", features = ["sync", "rt-multi-thread"] }
+tonic = { version = "0.10.2", features = ["tls"] }
+tracing = { version = "0.1.40" }
+clap = { version = "4.4.18", features = ["derive"] }
 tempdir = "0.3.7"
 log = "0.4.20"
-env_logger = "0.11.0"
-chrono = "0.4.31"
-serde_json = "1.0.108"
-serde = { version = "1.0.193", features = ["derive"] }
+env_logger = "0.11.1"
+chrono = "0.4.33"
+serde_json = "1.0.113"
+serde = { version = "1.0.196", features = ["derive"] }
 
 [build-dependencies]
-tonic-build = "0.10.0"
+tonic-build = "0.10.2"
 
 [lints.rust]
 unsafe_code = "deny"

--- a/libaio/Cargo.toml
+++ b/libaio/Cargo.toml
@@ -10,12 +10,12 @@ description = "Straightforward Linux AIO using Futures/async/await."
 emulated-failure = []
 
 [dependencies]
-libc = "0.2.133"
+libc = "0.2.153"
 parking_lot = "0.12.1"
-crossbeam-channel = "0.5.6"
+crossbeam-channel = "0.5.11"
 
 [dev-dependencies]
-futures = "0.3.24"
+futures = "0.3.30"
 
 [lib]
 name = "aiofut"


### PR DESCRIPTION
This PR adds a check to validate that nothing can be upgraded. Example output (tested with outdated version of tokio):
```
Run cargo upgrade --locked
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking virtual workspace's dependencies
    Checking firewood's dependencies
name  old req compatible latest new req
====  ======= ========== ====== =======
    Checking fwdctl's dependencies
tokio 1.35.0  1.36.0     1.36.0 1.36.0 
    Checking growth-ring's dependencies
    Checking libaio's dependencies
    Checking rpc's dependencies
Error: cannot upgrade due to `--locked`
Error: Process completed with exit code 1.
```