### PR TITLE
update deps

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -18,7 +18,7 @@ readme = "../README.md"
 [dependencies]
 aquamarine = "0.5.0"
 async-trait = "0.1.77"
-bytemuck = { version = "1.14.2", features = ["derive"] }
+bytemuck = { version = "1.14.3", features = ["derive"] }
 enum-as-inner = "0.6.0"
 growth-ring = { version = "0.0.4", path = "../growth-ring" }
 libaio = {version = "0.0.4", path = "../libaio" }

--- a/growth-ring/Cargo.toml
+++ b/growth-ring/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1.77"
 futures = "0.3.30"
 nix = {version = "0.27.1", features = ["fs", "uio"]}
 libc = "0.2.153"
-bytemuck = {version = "1.14.2", features = ["derive"]}
+bytemuck = {version = "1.14.3", features = ["derive"]}
 thiserror = "1.0.56"
 tokio = { version = "1.36.0", features = ["fs", "io-util", "sync"] }
 crc32fast = "1.3.2"


### PR DESCRIPTION
dependabot hasn't made a PR for these yet so CI is failing on unrelated PRs

[Changelog](https://github.com/Lokathor/bytemuck/blob/main/changelog.md)

>The new std simd nightly features are apparently arch-specific. This adjusts the feature activation to be x86/ x86_64 only.
