### PR TITLE
Cargo upgrades

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -30,12 +30,12 @@ nix = {version = "0.27.1", features = ["fs", "uio"]}
 parking_lot = "0.12.1"
 serde = { version = "1.0", features = ["derive"] }
 sha3 = "0.10.8"
-thiserror = "1.0.56"
+thiserror = "1.0.57"
 tokio = { version = "1.36.0", features = ["rt", "sync", "macros", "rt-multi-thread"] }
 typed-builder = "0.18.1"
 bincode = "1.3.3"
 bitflags = { version = "2.4.2", features = ["bytemuck"] }
-env_logger = { version = "0.11.1", optional = true }
+env_logger = { version = "0.11.2", optional = true }
 log = { version = "0.4.20", optional = true }
 
 [features]

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 firewood = { version = "0.0.4", path = "../firewood" }
 clap = { version = "4.5.0", features = ["cargo", "derive"] }
 anyhow = "1.0.79"
-env_logger = "0.11.1"
+env_logger = "0.11.2"
 log = "0.4.20"
 tokio = { version = "1.36.0", features = ["full"] }
 futures-util = "0.3.30"

--- a/growth-ring/Cargo.toml
+++ b/growth-ring/Cargo.toml
@@ -17,14 +17,14 @@ futures = "0.3.30"
 nix = {version = "0.27.1", features = ["fs", "uio"]}
 libc = "0.2.153"
 bytemuck = {version = "1.14.3", features = ["derive"]}
-thiserror = "1.0.56"
+thiserror = "1.0.57"
 tokio = { version = "1.36.0", features = ["fs", "io-util", "sync"] }
-crc32fast = "1.3.2"
+crc32fast = "1.4.0"
 
 [dev-dependencies]
 hex = "0.4.3"
 rand = "0.8.5"
-indexmap = "2.2.2"
+indexmap = "2.2.3"
 tokio = { version = "1.36.0", features = ["tokio-macros", "rt", "macros"] }
 test-case = "3.3.1"
 

--- a/grpc-testtool/Cargo.toml
+++ b/grpc-testtool/Cargo.toml
@@ -18,15 +18,15 @@ bench = false
 [dependencies]
 firewood = { version = "0.0.4", path = "../firewood" }
 prost = "0.12.3"
-thiserror = "1.0.56"
+thiserror = "1.0.57"
 tokio = { version = "1.36.0", features = ["sync", "rt-multi-thread"] }
 tonic = { version = "0.11.0", features = ["tls"] }
 tracing = { version = "0.1.40" }
 clap = { version = "4.5.0", features = ["derive"] }
 tempdir = "0.3.7"
 log = "0.4.20"
-env_logger = "0.11.1"
-chrono = "0.4.33"
+env_logger = "0.11.2"
+chrono = "0.4.34"
 serde_json = "1.0.113"
 serde = { version = "1.0.196", features = ["derive"] }
 


### PR DESCRIPTION
Maybe a script can do this for me automatically :)

```
❯ cargo upgrade
    Updating 'https://github.com/rust-lang/crates.io-index' index
    Checking virtual workspace's dependencies
    Checking firewood's dependencies
name       old req compatible latest new req
====       ======= ========== ====== =======
thiserror  1.0.56  1.0.57     1.0.57 1.0.57
env_logger 0.11.1  0.11.2     0.11.2 0.11.2
    Checking fwdctl's dependencies
name       old req compatible latest new req
====       ======= ========== ====== =======
env_logger 0.11.1  0.11.2     0.11.2 0.11.2
    Checking growth-ring's dependencies
name      old req compatible latest new req
====      ======= ========== ====== =======
thiserror 1.0.56  1.0.57     1.0.57 1.0.57
crc32fast 1.3.2   1.4.0      1.4.0  1.4.0
indexmap  2.2.2   2.2.3      2.2.3  2.2.3
    Checking libaio's dependencies
    Checking rpc's dependencies
name       old req compatible latest new req
====       ======= ========== ====== =======
thiserror  1.0.56  1.0.57     1.0.57 1.0.57
env_logger 0.11.1  0.11.2     0.11.2 0.11.2
chrono     0.4.33  0.4.34     0.4.34 0.4.34
   Upgrading recursive dependencies
note: Re-run with `--incompatible` to upgrade incompatible version requirements
note: Re-run with `--verbose` to show more dependencies
  incompatible: keccak-hasher
  latest: 41 packages
```