### PR TITLE
Fix the demo example in `growth-ring`

### DIFF
--- a/growth-ring/Cargo.toml
+++ b/growth-ring/Cargo.toml
@@ -26,7 +26,7 @@ strum_macros = "0.26.1"
 hex = "0.4.3"
 rand = "0.8.5"
 indexmap = "2.2.3"
-tokio = { version = "1.36.0", features = ["tokio-macros", "rt", "macros"] }
+tokio = { version = "1.36.0", features = ["tokio-macros", "rt", "macros", "rt-multi-thread"] }
 test-case = "3.3.1"
 
 [lib]

--- a/growth-ring/examples/demo1.rs
+++ b/growth-ring/examples/demo1.rs
@@ -31,7 +31,8 @@ fn recover(payload: WalBytes, ringid: WalRingId) -> Result<(), WalError> {
     Ok(())
 }
 
-fn main() -> Result<(), WalError> {
+#[tokio::main]
+async fn main() -> Result<(), WalError> {
     let wal_dir = "./wal_demo1";
     let mut rng = rand::rngs::StdRng::seed_from_u64(0);
     let mut loader = WalLoader::new();


### PR DESCRIPTION
WIP not ready for review.

Currently, the demo example in `growth-ring` failed with `there is no reactor running, must be called from the context of a Tokio 1.x runtime` error.