### PR TITLE
remove dead code from bincode deserialize of EncodedNode

### DIFF
--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -747,26 +747,13 @@ impl<'de> Deserialize<'de> for EncodedNode<Bincode> {
                 let mut children: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN] = Default::default();
 
                 for (i, chd) in items.into_iter().enumerate() {
-                    if i == len - 1 {
-                        let data = match chd {
-                            Encoded::Raw(data) => Err(D::Error::custom(format!(
-                                "incorrect encoded type for branch node value {:?}",
-                                data
-                            )))?,
-                            Encoded::Data(data) => Bincode::deserialize(data.as_ref())
-                                .map_err(|e| D::Error::custom(format!("bincode error: {e}")))?,
-                        };
-                        // Extract the value of the branch node and set to None if it's an empty Vec
-                        value = Some(Data(data)).filter(|data| !data.is_empty());
-                    } else {
-                        let chd = match chd {
-                            Encoded::Raw(chd) => chd,
-                            Encoded::Data(chd) => Bincode::deserialize(chd.as_ref())
-                                .map_err(|e| D::Error::custom(format!("bincode error: {e}")))?,
-                        };
-                        #[allow(clippy::indexing_slicing)]
-                        (children[i] = Some(chd).filter(|chd| !chd.is_empty()));
-                    }
+                    let chd = match chd {
+                        Encoded::Raw(chd) => chd,
+                        Encoded::Data(chd) => Bincode::deserialize(chd.as_ref())
+                            .map_err(|e| D::Error::custom(format!("bincode error: {e}")))?,
+                    };
+                    #[allow(clippy::indexing_slicing)]
+                    (children[i] = Some(chd).filter(|chd| !chd.is_empty()));
                 }
 
                 let node = EncodedNodeType::Branch {


### PR DESCRIPTION
This code is dead. If we're executing this code, `len == BranchNode::MSIZE` (i.e. `len == 18`) and we have already popped two elements from items. So 15 the maximum that `i` reaches during this iteration. `i` will never `== len - 1 == 17`.