### PR TITLE
Allow kv iterator to use any NodeSource (merkle, DbRev, Proposal)

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -283,7 +283,7 @@ pub struct DbRev<S> {
 
 #[async_trait]
 impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
-    type Stream<'a> = MerkleKeyValueStream<'a, S, Bincode> where Self: 'a;
+    type Stream<'a> = MerkleKeyValueStream<'a, Merkle<S, Bincode>> where Self: 'a;
 
     async fn root_hash(&self) -> Result<api::HashKey, api::Error> {
         self.merkle
@@ -336,11 +336,14 @@ impl<S: ShaleStore<Node> + Send + Sync> api::DbView for DbRev<S> {
 }
 
 impl<S: ShaleStore<Node> + Send + Sync> DbRev<S> {
-    pub fn stream(&self) -> merkle::MerkleKeyValueStream<'_, S, Bincode> {
+    pub fn stream(&self) -> merkle::MerkleKeyValueStream<'_, Merkle<S, Bincode>> {
         self.merkle.key_value_iter(self.header.kv_root)
     }
 
-    pub fn stream_from(&self, start_key: Key) -> merkle::MerkleKeyValueStream<'_, S, Bincode> {
+    pub fn stream_from(
+        &self,
+        start_key: Key,
+    ) -> merkle::MerkleKeyValueStream<'_, Merkle<S, Bincode>> {
         self.merkle
             .key_value_iter_from_key(self.header.kv_root, start_key)
     }
@@ -373,9 +376,9 @@ impl<S: ShaleStore<Node> + Send + Sync> DbRev<S> {
     }
 
     /// Verifies a range proof is valid for a set of keys.
-    pub fn verify_range_proof<N: AsRef<[u8]> + Send, K: AsRef<[u8]>, V: AsRef<[u8]>>(
+    pub fn verify_range_proof<NS: AsRef<[u8]> + Send, K: AsRef<[u8]>, V: AsRef<[u8]>>(
         &self,
-        proof: Proof<N>,
+        proof: Proof<NS>,
         first_key: K,
         last_key: K,
         keys: Vec<K>,

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -5,7 +5,7 @@ use super::{
     get_sub_universe_from_deltas, Db, DbConfig, DbError, DbHeader, DbInner, DbRev, DbRevInner,
     MutStore, SharedStore, Universe, MERKLE_META_SPACE, MERKLE_PAYLOAD_SPACE, ROOT_HASH_SPACE,
 };
-use crate::merkle::{Bincode, MerkleKeyValueStream, Node, Proof};
+use crate::merkle::{Bincode, Merkle, MerkleKeyValueStream, Node, Proof};
 use crate::shale::compact::CompactSpace;
 use crate::shale::CachedStore;
 use crate::storage;
@@ -266,7 +266,8 @@ impl Proposal {
 
 #[async_trait]
 impl api::DbView for Proposal {
-    type Stream<'a> = MerkleKeyValueStream<'a, CompactSpace<Node, storage::StoreRevMut>, Bincode>;
+    type Stream<'a> =
+        MerkleKeyValueStream<'a, Merkle<CompactSpace<Node, storage::StoreRevMut>, Bincode>>;
 
     async fn root_hash(&self) -> Result<api::HashKey, api::Error> {
         self.get_revision()

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -15,7 +15,7 @@ use crate::nibbles::Nibbles;
 use crate::nibbles::NibblesIterator;
 use crate::{
     db::DbError,
-    merkle::{to_nibble_array, Merkle, MerkleError, Node, NodeType},
+    merkle::{to_nibble_array, Merkle, MerkleError, Node, NodeSource, NodeType},
     merkle_util::{DataStoreError, InMemoryMerkle},
 };
 


### PR DESCRIPTION
Streaming just needs a source of nodes. Currently, the only node source
is a merkle. Future diffs will add a DbRev or a Proposal as a node
source, allowing these to be the backing storage for a
MerkleKeyValueStream.
