### PR TITLE
Proposals are immutable

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -865,7 +865,7 @@ impl Db {
             m: Arc::clone(&self.inner),
             r: Arc::clone(&self.revisions),
             cfg: self.cfg.clone(),
-            rev,
+            rev: rev.into(),
             store,
             committed: Arc::new(Mutex::new(false)),
             root_hash,


### PR DESCRIPTION
We shouldn't keep the StoreRevMut around in the Proposal, especially now since you can't iterate on a mutable revision.