### PR TITLE
Use the typed encoder, not always Bincode

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -144,7 +144,7 @@ where
             }
         };
 
-        Bincode::serialize(&encoded).map_err(|e| MerkleError::BinarySerdeError(e.to_string()))
+        T::serialize(&encoded).map_err(|e| MerkleError::BinarySerdeError(e.to_string()))
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
When we switch to PlainCodec, we shouldn't be calling the Bincode encoder; always use the one from the trait.