### PR TITLE
Make sure free space has a writeable CachedStore

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -68,7 +68,7 @@ impl Profiler for FlamegraphProfiler {
 fn bench_trie_hash(criterion: &mut Criterion) {
     let mut to = [1u8; TRIE_HASH_LEN];
     let mut store = DynamicMem::new(TRIE_HASH_LEN as u64, 0u8);
-    store.write(0, &*ZERO_HASH);
+    store.write(0, &*ZERO_HASH).expect("write should succeed");
 
     #[allow(clippy::unwrap_used)]
     criterion

--- a/firewood/benches/shale-bench.rs
+++ b/firewood/benches/shale-bench.rs
@@ -67,7 +67,7 @@ fn get_view<C: CachedStore>(b: &mut Bencher, mut cached: C) {
 
         let offset = rng.gen_range(0..BENCH_MEM_SIZE - len);
 
-        cached.write(offset, rdata);
+        cached.write(offset, rdata).expect("write should succeed");
         #[allow(clippy::unwrap_used)]
         let view = cached
             .get_view(offset, rdata.len().try_into().unwrap())

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -225,7 +225,7 @@ impl Proposal {
                 .resize(max_revisions, TrieHash([0; TRIE_HASH_LEN]));
         }
 
-        rev_inner.root_hash_staging.write(0, &hash.0);
+        rev_inner.root_hash_staging.write(0, &hash.0)?;
         let (root_hash_redo, root_hash_wal) = rev_inner.root_hash_staging.delta();
 
         // schedule writes to the disk

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1423,7 +1423,8 @@ mod tests {
                 std::num::NonZeroUsize::new(RESERVED).unwrap(),
             ))
             .unwrap(),
-        );
+        )
+        .unwrap();
         let compact_header = shale::StoredView::ptr_to_obj(
             &dm,
             compact_header,

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -942,7 +942,7 @@ mod tests {
         node.serialize(&mut bytes).expect("node should serialize");
 
         let mut mem = PlainMem::new(serialized_len, 0);
-        mem.write(0, &bytes);
+        mem.write(0, &bytes).expect("write should succed");
 
         let mut hydrated_node = Node::deserialize(0, &mem).expect("node should deserialize");
 

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -63,7 +63,8 @@ where
                 NonZeroUsize::new(RESERVED).unwrap(),
             ))
             .unwrap(),
-        );
+        )
+        .expect("write should succeed");
         #[allow(clippy::unwrap_used)]
         let compact_header =
             StoredView::ptr_to_obj(&dm, compact_header, shale::compact::CompactHeader::MSIZE)

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -726,7 +726,8 @@ mod tests {
                 reserved.0.unwrap(),
             ))
             .unwrap(),
-        );
+        )
+        .unwrap();
         let compact_header =
             StoredView::ptr_to_obj(&dm, compact_header, CompactHeader::MSIZE).unwrap();
         let mem_meta = dm;

--- a/firewood/src/shale/plainmem.rs
+++ b/firewood/src/shale/plainmem.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Arc, RwLock},
 };
 
-use super::{CachedStore, CachedView, SendSyncDerefMut, SpaceId};
+use super::{CachedStore, CachedView, SendSyncDerefMut, ShaleError, SpaceId};
 
 /// in-memory vector-based implementation for [CachedStore] for testing
 // built on [ShaleStore](super::ShaleStore) in memory, without having to write
@@ -54,16 +54,21 @@ impl CachedStore for PlainMem {
         }))
     }
 
-    fn write(&mut self, offset: usize, change: &[u8]) {
+    fn write(&mut self, offset: usize, change: &[u8]) -> Result<(), ShaleError> {
         let length = change.len();
         #[allow(clippy::unwrap_used)]
         let mut vect = self.space.deref().write().unwrap();
         #[allow(clippy::indexing_slicing)]
         vect.as_mut_slice()[offset..offset + length].copy_from_slice(change);
+        Ok(())
     }
 
     fn id(&self) -> SpaceId {
         self.id
+    }
+
+    fn is_writeable(&self) -> bool {
+        true
     }
 }
 

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -711,14 +711,14 @@ mod tests {
         let change = b"this is a test";
 
         // write to the in memory buffer not to disk
-        mut_store.write(0, change);
+        mut_store.write(0, change).unwrap();
         assert_eq!(mut_store.id(), STATE_SPACE);
 
         // mutate the in memory buffer.
         let change = b"this is another test";
 
         // write to the in memory buffer (ash) not yet to disk
-        mut_store.write(0, change);
+        mut_store.write(0, change).unwrap();
         assert_eq!(mut_store.id(), STATE_SPACE);
 
         // wal should have no records.
@@ -789,7 +789,7 @@ mod tests {
         let hash: [u8; HASH_SIZE] = sha3::Keccak256::digest(data).into();
 
         // write to the in memory buffer (ash) not yet to disk
-        mut_store.write(0, &hash);
+        mut_store.write(0, &hash).unwrap();
         assert_eq!(mut_store.id(), STATE_SPACE);
 
         // wal should have no records.
@@ -871,7 +871,7 @@ mod tests {
         // mutate the in memory buffer.
         let data = b"this is a test";
         let hash: [u8; HASH_SIZE] = sha3::Keccak256::digest(data).into();
-        block_in_place(|| store.write(0, &hash));
+        block_in_place(|| store.write(0, &hash)).unwrap();
         assert_eq!(store.id(), STATE_SPACE);
 
         let another_data = b"this is another test";
@@ -879,7 +879,7 @@ mod tests {
 
         // mutate the in memory buffer in another StoreRev new from the above.
         let mut another_store = StoreRevMut::new_from_other(&store);
-        block_in_place(|| another_store.write(32, &another_hash));
+        block_in_place(|| another_store.write(32, &another_hash)).unwrap();
         assert_eq!(another_store.id(), STATE_SPACE);
 
         // wal should have no records.
@@ -902,7 +902,7 @@ mod tests {
         assert_eq!(view.as_deref(), empty);
 
         // Overwrite the value from the beginning in the new store.  Only the new store should see the change.
-        another_store.write(0, &another_hash);
+        another_store.write(0, &another_hash).unwrap();
         let view = another_store.get_view(0, HASH_SIZE as u64).unwrap();
         assert_eq!(view.as_deref(), another_hash);
         let view = store.get_view(0, HASH_SIZE as u64).unwrap();


### PR DESCRIPTION
The database header was backed by a StoreRevShared on new revisions, which meant that writes to the database header were not persisted. This happens because the merkle meta and payloads were backed by a `StoreRevShared`. The write method on `StoreRevShared` was a no-op.

This change prevents this problem from reappearing in several ways:
 - The `CachedStore` trait now has an `is_writeable` method to indicate whether writes should be allowed to this cache. This is only tested when debug mode is active, and ends out throwing the error earlier to make finding errant writes easier. Otherwise, this gets flushed when it goes out of scope, which can happen a lot later.
 - The `write` method of CachedStore now returns a `ShaleError`. These always return `Ok` except for the `StoreRevShared` implementation, which always returns an error.

Once these changes were made, it found the free space management bugs which are fixed in this change.