### PR TITLE
dont panic on error during disk buffer creation

### DIFF
--- a/firewood/src/v2/db.rs
+++ b/firewood/src/v2/db.rs
@@ -17,6 +17,7 @@ use crate::{db::DbError, v2::api};
 impl From<DbError> for api::Error {
     fn from(value: DbError) -> Self {
         match value {
+            DbError::Aio(e) => api::Error::InternalError(Box::new(e)),
             DbError::InvalidParams => api::Error::InternalError(Box::new(value)),
             DbError::Merkle(e) => api::Error::InternalError(Box::new(e)),
             DbError::System(e) => api::Error::IO(e.into()),

--- a/libaio/Cargo.toml
+++ b/libaio/Cargo.toml
@@ -13,6 +13,7 @@ emulated-failure = []
 libc = "0.2.153"
 parking_lot = "0.12.1"
 crossbeam-channel = "0.5.11"
+thiserror = "1.0.57"
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/libaio/src/lib.rs
+++ b/libaio/src/lib.rs
@@ -49,16 +49,21 @@ use std::sync::{
     atomic::{AtomicPtr, AtomicUsize, Ordering},
     Arc,
 };
+use thiserror::Error;
 
 const LIBAIO_EAGAIN: libc::c_int = -libc::EAGAIN;
 const LIBAIO_ENOMEM: libc::c_int = -libc::ENOMEM;
 const LIBAIO_ENOSYS: libc::c_int = -libc::ENOSYS;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Error)]
 pub enum AioError {
+    #[error("maxevents is too large")]
     MaxEventsTooLarge,
+    #[error("low kernel resources")]
     LowKernelRes,
+    #[error("not supported")]
     NotSupported,
+    #[error("other aio error")]
     OtherError,
 }
 


### PR DESCRIPTION
Adds handling for errors from `DiskBuffer::new` instead of panicking. To do this, we add an enum variant `Aio` on `DbError`  and `AioError` on `ProofError` (followed existing naming conventions)