### PR TITLE
remove `ShaleStore` trait

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -6,7 +6,7 @@
 use criterion::{criterion_group, criterion_main, profiler::Profiler, BatchSize, Criterion};
 use firewood::{
     db::{BatchOp, DbConfig},
-    merkle::{Bincode, Merkle, Node, TrieHash, TRIE_HASH_LEN},
+    merkle::{Bincode, Merkle, TrieHash, TRIE_HASH_LEN},
     shale::{
         cached::InMemLinearStore,
         compact::{CompactHeader, CompactSpace},
@@ -113,7 +113,7 @@ fn bench_merkle<const N: usize>(criterion: &mut Criterion) {
                     )
                     .unwrap();
 
-                    let merkle = MerkleWithEncoder::new(Box::new(store));
+                    let merkle = MerkleWithEncoder::new(store);
                     #[allow(clippy::unwrap_used)]
                     let root = merkle.init_root().unwrap();
 

--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -20,7 +20,7 @@ use pprof::ProfilerGuard;
 use rand::{distributions::Alphanumeric, rngs::StdRng, Rng, SeedableRng};
 use std::{fs::File, iter::repeat_with, os::raw::c_int, path::Path, sync::Arc};
 
-pub type MerkleWithEncoder = Merkle<CompactSpace<Node, InMemLinearStore>, Bincode>;
+pub type MerkleWithEncoder = Merkle<InMemLinearStore, Bincode>;
 
 const ZERO_HASH: TrieHash = TrieHash([0u8; TRIE_HASH_LEN]);
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -25,7 +25,7 @@ use crate::{
         self,
         compact::{CompactSpace, CompactSpaceHeader},
         disk_address::DiskAddress,
-        CachedStore, Obj, ShaleError, ShaleStore, SpaceId, Storable, StoredView,
+        CachedStore, Obj, ShaleError, SpaceId, Storable, StoredView,
     },
 };
 use aiofut::AioError;

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -9,7 +9,7 @@ pub use crate::{
 use crate::{
     file,
     merkle::{
-        Bincode, Key, Merkle, MerkleError, MerkleKeyValueStream, Node, Proof, ProofError, TrieHash,
+        Bincode, Key, Merkle, MerkleError, MerkleKeyValueStream, Proof, ProofError, TrieHash,
         TRIE_HASH_LEN,
     },
     storage::{
@@ -22,10 +22,8 @@ use crate::{
 use crate::{
     merkle,
     shale::{
-        self,
-        compact::{CompactSpace, CompactSpaceHeader},
-        disk_address::DiskAddress,
-        CachedStore, Obj, ShaleError, SpaceId, Storable, StoredView,
+        self, compact::CompactSpaceHeader, disk_address::DiskAddress, CachedStore, Obj, ShaleError,
+        SpaceId, Storable, StoredView,
     },
 };
 use aiofut::AioError;

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -393,12 +393,7 @@ impl<A: CachedStore> DbRev<A> {
 }
 
 impl DbRev<StoreRevMut> {
-    fn borrow_split(
-        &mut self,
-    ) -> (
-        &mut shale::Obj<DbHeader>,
-        &mut Merkle<CompactSpace<Node, StoreRevMut>, Bincode>,
-    ) {
+    fn borrow_split(&mut self) -> (&mut shale::Obj<DbHeader>, &mut Merkle<StoreRevMut, Bincode>) {
         (&mut self.header, &mut self.merkle)
     }
 
@@ -742,7 +737,7 @@ impl Db {
 
         let header_refs = (db_header_ref, merkle_payload_header_ref);
 
-        let mut rev: DbRev<CompactSpace<Node, StoreRevMut>> = Db::new_revision(
+        let mut rev: DbRev<StoreRevMut> = Db::new_revision(
             header_refs,
             (store.merkle.meta.clone(), store.merkle.payload.clone()),
             self.payload_regn_nbit,
@@ -779,7 +774,7 @@ impl Db {
         payload_regn_nbit: u64,
         payload_max_walk: u64,
         cfg: &DbRevConfig,
-    ) -> Result<DbRev<CompactSpace<Node, K>>, DbError> {
+    ) -> Result<DbRev<K>, DbError> {
         // TODO: This should be a compile time check
         const DB_OFFSET: u64 = Db::PARAM_SIZE;
         let merkle_offset = DB_OFFSET + DbHeader::MSIZE;
@@ -802,7 +797,7 @@ impl Db {
         )
         .unwrap();
 
-        let merkle = Merkle::new(Box::new(merkle_space));
+        let merkle = Merkle::new(merkle_space);
 
         if db_header_ref.kv_root.is_null() {
             let mut err = Ok(());

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -60,8 +60,9 @@ const SPACE_RESERVED: u64 = 0x1000;
 
 const MAGIC_STR: &[u8; 16] = b"firewood v0.1\0\0\0";
 
-pub type MutStore = CompactSpace<Node, StoreRevMut>;
-pub type SharedStore = CompactSpace<Node, StoreRevShared>;
+// TODO remove
+// pub type MutStore = CompactSpace<Node, StoreRevMut>;
+// pub type SharedStore = CompactSpace<Node, StoreRevShared>;
 
 #[derive(Debug)]
 #[non_exhaustive]

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -3,12 +3,12 @@
 
 use super::{
     get_sub_universe_from_deltas, Db, DbConfig, DbError, DbHeader, DbInner, DbRev, DbRevInner,
-    MutStore, SharedStore, Universe, MERKLE_META_SPACE, MERKLE_PAYLOAD_SPACE, ROOT_HASH_SPACE,
+    Universe, MERKLE_META_SPACE, MERKLE_PAYLOAD_SPACE, ROOT_HASH_SPACE,
 };
 use crate::merkle::{Bincode, MerkleKeyValueStream, Node, Proof};
 use crate::shale::compact::CompactSpace;
 use crate::shale::CachedStore;
-use crate::storage;
+use crate::storage::{self, StoreRevShared};
 use crate::{
     merkle::{TrieHash, TRIE_HASH_LEN},
     storage::{buffer::BufferWrite, AshRecord, StoreRevMut},
@@ -27,11 +27,11 @@ use tokio::task::block_in_place;
 pub struct Proposal {
     // State of the Db
     pub(super) m: Arc<RwLock<DbInner>>,
-    pub(super) r: Arc<Mutex<DbRevInner<SharedStore>>>,
+    pub(super) r: Arc<Mutex<DbRevInner<StoreRevShared>>>,
     pub(super) cfg: DbConfig,
 
     // State of the proposal
-    pub(super) rev: DbRev<MutStore>,
+    pub(super) rev: DbRev<StoreRevMut>,
     pub(super) store: Universe<StoreRevMut>,
     pub(super) committed: Arc<Mutex<bool>>,
     pub(super) root_hash: TrieHash,
@@ -41,7 +41,7 @@ pub struct Proposal {
 
 pub enum ProposalBase {
     Proposal(Arc<Proposal>),
-    View(Arc<DbRev<SharedStore>>),
+    View(Arc<DbRev<StoreRevShared>>),
 }
 
 #[async_trait]
@@ -259,7 +259,7 @@ impl Proposal {
 }
 
 impl Proposal {
-    pub const fn get_revision(&self) -> &DbRev<MutStore> {
+    pub const fn get_revision(&self) -> &DbRev<StoreRevMut> {
         &self.rev
     }
 }

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -266,7 +266,7 @@ impl Proposal {
 
 #[async_trait]
 impl api::DbView for Proposal {
-    type Stream<'a> = MerkleKeyValueStream<'a, CompactSpace<Node, storage::StoreRevMut>, Bincode>;
+    type Stream<'a> = MerkleKeyValueStream<'a, storage::StoreRevMut, Bincode>;
 
     async fn root_hash(&self) -> Result<api::HashKey, api::Error> {
         self.get_revision()

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -5,8 +5,7 @@ use super::{
     get_sub_universe_from_deltas, Db, DbConfig, DbError, DbHeader, DbInner, DbRev, DbRevInner,
     Universe, MERKLE_META_SPACE, MERKLE_PAYLOAD_SPACE, ROOT_HASH_SPACE,
 };
-use crate::merkle::{Bincode, MerkleKeyValueStream, Node, Proof};
-use crate::shale::compact::CompactSpace;
+use crate::merkle::{Bincode, MerkleKeyValueStream, Proof};
 use crate::shale::CachedStore;
 use crate::storage::{self, StoreRevShared};
 use crate::{

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::merkle::{Bincode, MerkleKeyValueStream, Proof};
 use crate::shale::CachedStore;
-use crate::storage::{self, StoreRevShared};
+use crate::storage::StoreRevShared;
 use crate::{
     merkle::{TrieHash, TRIE_HASH_LEN},
     storage::{buffer::BufferWrite, AshRecord, StoreRevMut},
@@ -265,7 +265,7 @@ impl Proposal {
 
 #[async_trait]
 impl api::DbView for Proposal {
-    type Stream<'a> = MerkleKeyValueStream<'a, storage::StoreRevMut, Bincode>;
+    type Stream<'a> = MerkleKeyValueStream<'a, StoreRevMut, Bincode>;
 
     async fn root_hash(&self) -> Result<api::HashKey, api::Error> {
         self.get_revision()

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -79,8 +79,7 @@
 //!
 //! - Persistent item storage stash: `CompactStore` in `shale` defines a pool of typed objects that are
 //!   persisted on disk but also made accessible in memory transparently. It is built on top of `CachedStore`
-//!   by defining how "items" of the given type are laid out, allocated and recycled throughout their
-//!   lifecycles (there is a disk-friendly, malloc-style kind of basic implementation in `shale` crate).
+//!   and defines how "items" of a given type are laid out, allocated and recycled throughout their lifecycles.
 //!
 //! - Data structure: in Firewood, one trie is maintained by invoking `CompactStore` (see `src/merkle.rs`).
 //!   The data structure code is totally unaware of how its objects (i.e., nodes) are organized or

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -77,19 +77,18 @@
 //!   that is mirrored to the disk. In reality, the linear space will be chunked into files under a
 //!   directory, but the user does not have to even know about this.
 //!
-//! - Persistent item storage stash: `ShaleStore` trait from `shale` defines a pool of typed
-//!   objects that are persisted on disk but also made accessible in memory transparently. It is
-//!   built on top of `CachedStore` by defining how "items" of the given type are laid out, allocated
-//!   and recycled throughout their life cycles (there is a disk-friendly, malloc-style kind of
-//!   basic implementation in `shale` crate, but one can always define their own `ShaleStore`).
+//! - Persistent item storage stash: `CompactStore` in `shale` defines a pool of typed objects that are
+//!   persisted on disk but also made accessible in memory transparently. It is built on top of `CachedStore`
+//!   by defining how "items" of the given type are laid out, allocated and recycled throughout their
+//!   lifecycles (there is a disk-friendly, malloc-style kind of basic implementation in `shale` crate).
 //!
-//! - Data structure: in Firewood, one trie is maintained by invoking `ShaleStore` (see `src/merkle.rs`).
+//! - Data structure: in Firewood, one trie is maintained by invoking `CompactStore` (see `src/merkle.rs`).
 //!   The data structure code is totally unaware of how its objects (i.e., nodes) are organized or
 //!   persisted on disk. It is as if they're just in memory, which makes it much easier to write
 //!   and maintain the code.
 //!
 //! Given the abstraction, one can easily realize the fact that the actual data that affect the
-//! state of the data structure (trie) is what the linear space (`CachedStore`) keeps track of, that is,
+//! state of the data structure (trie) is what the linear space (`CachedStore`) keeps track of. That is,
 //! a flat but conceptually large byte vector. In other words, given a valid byte vector as the
 //! content of the linear space, the higher level data structure can be *uniquely* determined, there
 //! is nothing more (except for some auxiliary data that are kept for performance reasons, such as caching)
@@ -97,8 +96,7 @@
 //! separate the logical data from its physical representation, greatly simplifies the storage
 //! management, and allows reusing the code. It is still a very versatile abstraction, as in theory
 //! any persistent data could be stored this way -- sometimes you need to swap in a different
-//! `ShaleStore` or `CachedStore` implementation, but without having to touch the code for the persisted
-//! data structure.
+//! `CachedStore` implementation, but without having to touch the code for the persisted data structure.
 //!
 //! ## Page-based Shadowing and Revisions
 //!

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -78,7 +78,7 @@ impl<C> From<Merkle<StoreRevMut, C>> for Merkle<StoreRevShared, C> {
     fn from(value: Merkle<StoreRevMut, C>) -> Self {
         let store = value.store.into();
         Merkle {
-            store: Box::new(store),
+            store: store,
             phantom: PhantomData,
         }
     }

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -78,7 +78,7 @@ impl<C> From<Merkle<StoreRevMut, C>> for Merkle<StoreRevShared, C> {
     fn from(value: Merkle<StoreRevMut, C>) -> Self {
         let store = value.store.into();
         Merkle {
-            store: store,
+            store,
             phantom: PhantomData,
         }
     }
@@ -1395,7 +1395,7 @@ impl<'a, T: PartialEq> PrefixOverlap<'a, T> {
 mod tests {
     use super::*;
     use crate::merkle::node::PlainCodec;
-    use shale::{cached::InMemLinearStore, compact::CompactSpace, CachedStore};
+    use shale::{cached::InMemLinearStore, CachedStore};
     use test_case::test_case;
 
     fn leaf(path: Vec<u8>, data: Vec<u8>) -> Node {

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -212,7 +212,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
             .children[0];
         Ok(if let Some(root) = root {
             let mut node = self.get_node(root)?;
-            let res = *node.get_root_hash(&self.store); // TODO what should turbofin param be?
+            let res = *node.get_root_hash(&self.store);
             #[allow(clippy::unwrap_used)]
             if node.is_dirty() {
                 node.write(|_| {}).unwrap();

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1290,7 +1290,7 @@ impl<'a> std::ops::Deref for Ref<'a> {
     }
 }
 
-impl<'a, S: CachedStore, T> RefMut<'a, S, T> {
+impl<'a, S, T> RefMut<'a, S, T> {
     fn new(ptr: DiskAddress, parents: ParentAddresses, merkle: &'a mut Merkle<S, T>) -> Self {
         Self {
             ptr,
@@ -1298,7 +1298,9 @@ impl<'a, S: CachedStore, T> RefMut<'a, S, T> {
             merkle,
         }
     }
+}
 
+impl<'a, S: CachedStore, T> RefMut<'a, S, T> {
     #[allow(clippy::unwrap_used)]
     pub fn get(&self) -> Ref {
         Ref(self.merkle.get_node(self.ptr).unwrap())

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -104,7 +104,7 @@ where
     C: BinarySerde,
     EncodedNode<C>: serde::Serialize + serde::Deserialize<'de>,
 {
-    pub fn new(store: CompactSpace<Node, A>) -> Self {
+    pub const fn new(store: CompactSpace<Node, A>) -> Self {
         Self {
             store,
             phantom: PhantomData,
@@ -190,7 +190,7 @@ impl<A: CachedStore, C> Merkle<A, C> {
             .map(|node| node.as_ptr())
     }
 
-    pub fn get_store(&self) -> &CompactSpace<Node, A> {
+    pub const fn get_store(&self) -> &CompactSpace<Node, A> {
         &self.store
     }
 

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -190,10 +190,6 @@ impl<S: CachedStore, T> Merkle<S, T> {
             .map(|node| node.as_ptr())
     }
 
-    pub const fn get_store(&self) -> &CompactSpace<Node, S> {
-        &self.store
-    }
-
     pub fn empty_root() -> &'static TrieHash {
         static V: OnceLock<TrieHash> = OnceLock::new();
         #[allow(clippy::unwrap_used)]

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -2,7 +2,7 @@ use crate::db::{MutStore, SharedStore};
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 use crate::nibbles::Nibbles;
-use crate::shale::{self, disk_address::DiskAddress, ObjWriteSizeError, ShaleError, ShaleStore};
+use crate::shale::{self, disk_address::DiskAddress, ObjWriteSizeError, ShaleError};
 use crate::v2::api;
 use futures::{StreamExt, TryStreamExt};
 use sha3::Digest;

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1066,7 +1066,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
 
         // Get the hashes of the nodes.
         for node in nodes.into_iter() {
-            let encoded = <&[u8]>::clone(&node.get_encoded(&self.store));
+            let encoded = node.get_encoded(&self.store);
             let hash: [u8; TRIE_HASH_LEN] = sha3::Keccak256::digest(encoded).into();
             proofs.insert(hash, encoded.to_vec());
         }

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -4,7 +4,7 @@
 use crate::{
     logger::trace,
     merkle::from_nibbles,
-    shale::{disk_address::DiskAddress, CachedStore, ShaleError, Storable},
+    shale::{compact::CompactSpace, disk_address::DiskAddress, CachedStore, ShaleError, Storable},
 };
 use bincode::{Error, Options};
 use bitflags::bitflags;
@@ -103,7 +103,7 @@ impl NodeType {
         }
     }
 
-    pub fn encode<S: ShaleStore<Node>>(&self, store: &S) -> Vec<u8> {
+    pub fn encode<A>(&self, store: &CompactSpace<Node, A>) -> Vec<u8> {
         match &self {
             NodeType::Leaf(n) => n.encode(),
             NodeType::Branch(n) => n.encode(store),
@@ -223,18 +223,18 @@ impl Node {
         })
     }
 
-    pub(super) fn get_encoded<S: ShaleStore<Node>>(&self, store: &S) -> &[u8] {
-        self.encoded.get_or_init(|| self.inner.encode::<S>(store))
+    pub(super) fn get_encoded<A>(&self, store: &CompactSpace<Node, A>) -> &[u8] {
+        self.encoded.get_or_init(|| self.inner.encode(store))
     }
 
-    pub(super) fn get_root_hash<S: ShaleStore<Node>>(&self, store: &S) -> &TrieHash {
+    pub(super) fn get_root_hash<A>(&self, store: &CompactSpace<Node, A>) -> &TrieHash {
         self.root_hash.get_or_init(|| {
             self.set_dirty(true);
-            TrieHash(Keccak256::digest(self.get_encoded::<S>(store)).into())
+            TrieHash(Keccak256::digest(self.get_encoded(store)).into())
         })
     }
 
-    fn is_encoded_longer_than_hash_len<S: ShaleStore<Node>>(&self, store: &S) -> bool {
+    fn is_encoded_longer_than_hash_len<A>(&self, store: &CompactSpace<Node, A>) -> bool {
         *self
             .is_encoded_longer_than_hash_len
             .get_or_init(|| self.get_encoded(store).len() >= TRIE_HASH_LEN)

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -103,7 +103,7 @@ impl NodeType {
         }
     }
 
-    pub fn encode<A: CachedStore>(&self, store: &CompactSpace<Node, A>) -> Vec<u8> {
+    pub fn encode<S: CachedStore>(&self, store: &CompactSpace<Node, S>) -> Vec<u8> {
         match &self {
             NodeType::Leaf(n) => n.encode(),
             NodeType::Branch(n) => n.encode(store),
@@ -223,20 +223,20 @@ impl Node {
         })
     }
 
-    pub(super) fn get_encoded<A: CachedStore>(&self, store: &CompactSpace<Node, A>) -> &[u8] {
+    pub(super) fn get_encoded<S: CachedStore>(&self, store: &CompactSpace<Node, S>) -> &[u8] {
         self.encoded.get_or_init(|| self.inner.encode(store))
     }
 
-    pub(super) fn get_root_hash<A: CachedStore>(&self, store: &CompactSpace<Node, A>) -> &TrieHash {
+    pub(super) fn get_root_hash<S: CachedStore>(&self, store: &CompactSpace<Node, S>) -> &TrieHash {
         self.root_hash.get_or_init(|| {
             self.set_dirty(true);
             TrieHash(Keccak256::digest(self.get_encoded(store)).into())
         })
     }
 
-    fn is_encoded_longer_than_hash_len<A: CachedStore>(
+    fn is_encoded_longer_than_hash_len<S: CachedStore>(
         &self,
-        store: &CompactSpace<Node, A>,
+        store: &CompactSpace<Node, S>,
     ) -> bool {
         *self
             .is_encoded_longer_than_hash_len

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -103,7 +103,7 @@ impl NodeType {
         }
     }
 
-    pub fn encode<A>(&self, store: &CompactSpace<Node, A>) -> Vec<u8> {
+    pub fn encode<A: CachedStore>(&self, store: &CompactSpace<Node, A>) -> Vec<u8> {
         match &self {
             NodeType::Leaf(n) => n.encode(),
             NodeType::Branch(n) => n.encode(store),
@@ -223,18 +223,21 @@ impl Node {
         })
     }
 
-    pub(super) fn get_encoded<A>(&self, store: &CompactSpace<Node, A>) -> &[u8] {
+    pub(super) fn get_encoded<A: CachedStore>(&self, store: &CompactSpace<Node, A>) -> &[u8] {
         self.encoded.get_or_init(|| self.inner.encode(store))
     }
 
-    pub(super) fn get_root_hash<A>(&self, store: &CompactSpace<Node, A>) -> &TrieHash {
+    pub(super) fn get_root_hash<A: CachedStore>(&self, store: &CompactSpace<Node, A>) -> &TrieHash {
         self.root_hash.get_or_init(|| {
             self.set_dirty(true);
             TrieHash(Keccak256::digest(self.get_encoded(store)).into())
         })
     }
 
-    fn is_encoded_longer_than_hash_len<A>(&self, store: &CompactSpace<Node, A>) -> bool {
+    fn is_encoded_longer_than_hash_len<A: CachedStore>(
+        &self,
+        store: &CompactSpace<Node, A>,
+    ) -> bool {
         *self
             .is_encoded_longer_than_hash_len
             .get_or_init(|| self.get_encoded(store).len() >= TRIE_HASH_LEN)

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -4,7 +4,7 @@
 use crate::{
     logger::trace,
     merkle::from_nibbles,
-    shale::{disk_address::DiskAddress, CachedStore, ShaleError, ShaleStore, Storable},
+    shale::{disk_address::DiskAddress, CachedStore, ShaleError, Storable},
 };
 use bincode::{Error, Options};
 use bitflags::bitflags;

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -5,7 +5,7 @@ use super::{Data, Node};
 use crate::{
     merkle::{from_nibbles, to_nibble_array, PartialPath},
     nibbles::Nibbles,
-    shale::{DiskAddress, ShaleError, ShaleStore, Storable},
+    shale::{DiskAddress, ShaleError, Storable},
 };
 use bincode::{Error, Options};
 use serde::de::Error as DeError;

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -125,7 +125,7 @@ impl BranchNode {
         ))
     }
 
-    pub(super) fn encode<A: CachedStore>(&self, store: &CompactSpace<Node, A>) -> Vec<u8> {
+    pub(super) fn encode<S: CachedStore>(&self, store: &CompactSpace<Node, S>) -> Vec<u8> {
         // path + children + value
         let mut list = <[Vec<u8>; Self::MSIZE]>::default();
 

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -5,7 +5,7 @@ use super::{Data, Node};
 use crate::{
     merkle::{from_nibbles, to_nibble_array, PartialPath},
     nibbles::Nibbles,
-    shale::{DiskAddress, ShaleError, Storable},
+    shale::{compact::CompactSpace, DiskAddress, ShaleError, Storable},
 };
 use bincode::{Error, Options};
 use serde::de::Error as DeError;
@@ -125,7 +125,7 @@ impl BranchNode {
         ))
     }
 
-    pub(super) fn encode<S: ShaleStore<Node>>(&self, store: &S) -> Vec<u8> {
+    pub(super) fn encode<A>(&self, store: &CompactSpace<Node, A>) -> Vec<u8> {
         // path + children + value
         let mut list = <[Vec<u8>; Self::MSIZE]>::default();
 
@@ -136,9 +136,9 @@ impl BranchNode {
                     let mut c_ref = store.get_item(*c).unwrap();
 
                     #[allow(clippy::unwrap_used)]
-                    if c_ref.is_encoded_longer_than_hash_len::<S>(store) {
+                    if c_ref.is_encoded_longer_than_hash_len(store) {
                         #[allow(clippy::indexing_slicing)]
-                        (list[i] = c_ref.get_root_hash::<S>(store).to_vec());
+                        (list[i] = c_ref.get_root_hash(store).to_vec());
 
                         // See struct docs for ordering requirements
                         if c_ref.is_dirty() {
@@ -146,7 +146,7 @@ impl BranchNode {
                             c_ref.set_dirty(false);
                         }
                     } else {
-                        let child_encoded = c_ref.get_encoded::<S>(store);
+                        let child_encoded = c_ref.get_encoded(store);
                         #[allow(clippy::indexing_slicing)]
                         (list[i] = child_encoded.to_vec());
                     }

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -5,7 +5,7 @@ use super::{Data, Node};
 use crate::{
     merkle::{from_nibbles, to_nibble_array, PartialPath},
     nibbles::Nibbles,
-    shale::{compact::CompactSpace, DiskAddress, ShaleError, Storable},
+    shale::{compact::CompactSpace, CachedStore, DiskAddress, ShaleError, Storable},
 };
 use bincode::{Error, Options};
 use serde::de::Error as DeError;
@@ -125,7 +125,7 @@ impl BranchNode {
         ))
     }
 
-    pub(super) fn encode<A>(&self, store: &CompactSpace<Node, A>) -> Vec<u8> {
+    pub(super) fn encode<A: CachedStore>(&self, store: &CompactSpace<Node, A>) -> Vec<u8> {
         // path + children + value
         let mut list = <[Vec<u8>; Self::MSIZE]>::default();
 

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -270,17 +270,17 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
     /// necessary nodes will be resolved and leave the remaining as hashnode.
     ///
     /// The given edge proof is allowed to be an existent or non-existent proof.
-    fn proof_to_path<K, T>(
+    fn proof_to_path<K, C>(
         &self,
         key: K,
         root_hash: HashKey,
-        in_mem_merkle: &mut InMemoryMerkle<T>,
+        in_mem_merkle: &mut InMemoryMerkle<C>,
         allow_non_existent_node: bool,
     ) -> Result<Option<Vec<u8>>, ProofError>
     where
         K: AsRef<[u8]>,
-        T: BinarySerde,
-        EncodedNode<T>: serde::Serialize + serde::de::DeserializeOwned,
+        C: BinarySerde,
+        EncodedNode<C>: serde::Serialize + serde::de::DeserializeOwned,
     {
         // Start with the sentinel root
         let sentinel = in_mem_merkle.get_sentinel_address();
@@ -384,8 +384,8 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
     }
 }
 
-fn decode_subproof<'a, S: ShaleStore<Node>, T, N: AsRef<[u8]>>(
-    merkle: &'a Merkle<S, T>,
+fn decode_subproof<'a, S: ShaleStore<Node>, C, N: AsRef<[u8]>>(
+    merkle: &'a Merkle<S, C>,
     proofs_map: &HashMap<HashKey, N>,
     child_hash: &HashKey,
 ) -> Result<NodeObjRef<'a>, ProofError> {
@@ -714,8 +714,8 @@ where
 //     keep the entire branch and return.
 //   - the fork point is a shortnode, the shortnode is excluded in the range,
 //     unset the entire branch.
-fn unset_node_ref<K: AsRef<[u8]>, S: ShaleStore<Node> + Send + Sync, T: BinarySerde>(
-    merkle: &Merkle<S, T>,
+fn unset_node_ref<K: AsRef<[u8]>, S: ShaleStore<Node> + Send + Sync, C: BinarySerde>(
+    merkle: &Merkle<S, C>,
     parent: DiskAddress,
     node: Option<DiskAddress>,
     key: K,

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -4,8 +4,8 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-use crate::shale::ObjWriteSizeError;
 use crate::shale::{disk_address::DiskAddress, ShaleError};
+use crate::shale::{CachedStore, ObjWriteSizeError};
 use crate::v2::api::HashKey;
 use aiofut::AioError;
 use nix::errno::Errno;
@@ -384,8 +384,8 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
     }
 }
 
-fn decode_subproof<'a, S: ShaleStore<Node>, C, N: AsRef<[u8]>>(
-    merkle: &'a Merkle<S, C>,
+fn decode_subproof<'a, A: CachedStore, C, N: AsRef<[u8]>>(
+    merkle: &'a Merkle<A, C>,
     proofs_map: &HashMap<HashKey, N>,
     child_hash: &HashKey,
 ) -> Result<NodeObjRef<'a>, ProofError> {
@@ -714,8 +714,8 @@ where
 //     keep the entire branch and return.
 //   - the fork point is a shortnode, the shortnode is excluded in the range,
 //     unset the entire branch.
-fn unset_node_ref<K: AsRef<[u8]>, S: ShaleStore<Node> + Send + Sync, C: BinarySerde>(
-    merkle: &Merkle<S, C>,
+fn unset_node_ref<K: AsRef<[u8]>, A: CachedStore, C: BinarySerde>(
+    merkle: &Merkle<A, C>,
     parent: DiskAddress,
     node: Option<DiskAddress>,
     key: K,

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -270,17 +270,17 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
     /// necessary nodes will be resolved and leave the remaining as hashnode.
     ///
     /// The given edge proof is allowed to be an existent or non-existent proof.
-    fn proof_to_path<K, C>(
+    fn proof_to_path<K, T>(
         &self,
         key: K,
         root_hash: HashKey,
-        in_mem_merkle: &mut InMemoryMerkle<C>,
+        in_mem_merkle: &mut InMemoryMerkle<T>,
         allow_non_existent_node: bool,
     ) -> Result<Option<Vec<u8>>, ProofError>
     where
         K: AsRef<[u8]>,
-        C: BinarySerde,
-        EncodedNode<C>: serde::Serialize + serde::de::DeserializeOwned,
+        T: BinarySerde,
+        EncodedNode<T>: serde::Serialize + serde::de::DeserializeOwned,
     {
         // Start with the sentinel root
         let sentinel = in_mem_merkle.get_sentinel_address();
@@ -384,8 +384,8 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
     }
 }
 
-fn decode_subproof<'a, A: CachedStore, C, N: AsRef<[u8]>>(
-    merkle: &'a Merkle<A, C>,
+fn decode_subproof<'a, S: CachedStore, T, N: AsRef<[u8]>>(
+    merkle: &'a Merkle<S, T>,
     proofs_map: &HashMap<HashKey, N>,
     child_hash: &HashKey,
 ) -> Result<NodeObjRef<'a>, ProofError> {
@@ -714,8 +714,8 @@ where
 //     keep the entire branch and return.
 //   - the fork point is a shortnode, the shortnode is excluded in the range,
 //     unset the entire branch.
-fn unset_node_ref<K: AsRef<[u8]>, A: CachedStore, C: BinarySerde>(
-    merkle: &Merkle<A, C>,
+fn unset_node_ref<K: AsRef<[u8]>, S: CachedStore, T: BinarySerde>(
+    merkle: &Merkle<S, T>,
     parent: DiskAddress,
     node: Option<DiskAddress>,
     key: K,

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 
 use crate::shale::ObjWriteSizeError;
-use crate::shale::{disk_address::DiskAddress, ShaleError, ShaleStore};
+use crate::shale::{disk_address::DiskAddress, ShaleError};
 use crate::v2::api::HashKey;
 use aiofut::AioError;
 use nix::errno::Errno;

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -178,8 +178,8 @@ impl<'a, S: CachedStore, T> Stream for MerkleNodeStream<'a, S, T> {
 
 /// Returns the initial state for an iterator over the given `merkle` with root `root_node`
 /// which starts at `key`.
-fn get_iterator_intial_state<'a, A: CachedStore, C>(
-    merkle: &'a Merkle<A, C>,
+fn get_iterator_intial_state<'a, S: CachedStore, T>(
+    merkle: &'a Merkle<S, T>,
     root_node: DiskAddress,
     key: &[u8],
 ) -> Result<NodeStreamState<'a>, api::Error> {
@@ -290,18 +290,18 @@ fn get_iterator_intial_state<'a, A: CachedStore, C>(
 }
 
 #[derive(Debug)]
-enum MerkleKeyValueStreamState<'a, A, C> {
+enum MerkleKeyValueStreamState<'a, S, T> {
     /// The iterator state is lazily initialized when poll_next is called
     /// for the first time. The iteration start key is stored here.
     Uninitialized(Key),
     /// The iterator works by iterating over the nodes in the merkle trie
     /// and returning the key-value pairs for nodes that have values.
     Initialized {
-        node_iter: MerkleNodeStream<'a, A, C>,
+        node_iter: MerkleNodeStream<'a, S, T>,
     },
 }
 
-impl<'a, A, C> MerkleKeyValueStreamState<'a, A, C> {
+impl<'a, S, T> MerkleKeyValueStreamState<'a, S, T> {
     /// Returns a new iterator that will iterate over all the key-value pairs in `merkle`.
     fn new() -> Self {
         Self::Uninitialized(Box::new([]))
@@ -421,14 +421,14 @@ enum PathIteratorState<'a> {
 ///   remaining unmatched key, the node proves the non-existence of the key.
 /// Note that thi means that the last node's key isn't necessarily a prefix of
 /// the key we're traversing to.
-pub struct PathIterator<'a, 'b, S, C> {
+pub struct PathIterator<'a, 'b, S, T> {
     state: PathIteratorState<'b>,
-    merkle: &'a Merkle<S, C>,
+    merkle: &'a Merkle<S, T>,
 }
 
-impl<'a, 'b, A: CachedStore, C> PathIterator<'a, 'b, A, C> {
+impl<'a, 'b, S: CachedStore, T> PathIterator<'a, 'b, S, T> {
     pub(super) fn new(
-        merkle: &'a Merkle<A, C>,
+        merkle: &'a Merkle<S, T>,
         sentinel_node: NodeObjRef<'a>,
         key: &'b [u8],
     ) -> Self {

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -7,7 +7,7 @@ use crate::{
     shale::{CachedStore, DiskAddress},
     v2::api,
 };
-use futures::{stream::FusedStream, Stream};
+use futures::{stream::FusedStream, Stream, StreamExt};
 use std::task::Poll;
 use std::{cmp::Ordering, iter::once};
 
@@ -345,7 +345,7 @@ impl<'a, S, C> MerkleKeyValueStream<'a, S, C> {
     }
 }
 
-impl<'a, A, C> Stream for MerkleKeyValueStream<'a, A, C> {
+impl<'a, A: CachedStore, C> Stream for MerkleKeyValueStream<'a, A, C> {
     type Item = Result<(Key, Value), api::Error>;
 
     fn poll_next(

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -1,13 +1,13 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use super::{node::Node, BranchNode, Key, Merkle, MerkleError, NodeObjRef, NodeType, Value};
+use super::{BranchNode, Key, Merkle, MerkleError, NodeObjRef, NodeType, Value};
 use crate::{
     nibbles::{Nibbles, NibblesIterator},
     shale::{CachedStore, DiskAddress},
     v2::api,
 };
-use futures::{stream::FusedStream, Stream, StreamExt};
+use futures::{stream::FusedStream, Stream};
 use std::task::Poll;
 use std::{cmp::Ordering, iter::once};
 
@@ -582,10 +582,7 @@ use super::tests::create_test_merkle;
 #[cfg(test)]
 #[allow(clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
-    use crate::{
-        merkle::Bincode,
-        shale::{cached::InMemLinearStore, compact::CompactSpace},
-    };
+    use crate::{merkle::Bincode, shale::cached::InMemLinearStore};
 
     use super::*;
     use futures::StreamExt;
@@ -772,10 +769,7 @@ mod tests {
     ///
     /// Note the 0000 branch has no value and the F0F0
     /// The number next to each branch is the position of the child in the branch's children array.
-    fn created_populated_merkle() -> (
-        Merkle<CompactSpace<Node, InMemLinearStore>, Bincode>,
-        DiskAddress,
-    ) {
+    fn created_populated_merkle() -> (Merkle<InMemLinearStore, Bincode>, DiskAddress) {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
 

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -4,7 +4,7 @@
 use super::{node::Node, BranchNode, Key, Merkle, MerkleError, NodeObjRef, NodeType, Value};
 use crate::{
     nibbles::{Nibbles, NibblesIterator},
-    shale::{DiskAddress, ShaleStore},
+    shale::DiskAddress,
     v2::api,
 };
 use futures::{stream::FusedStream, Stream, StreamExt};

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -35,15 +35,15 @@ pub enum DataStoreError {
 
 // type InMemoryStore = CompactSpace<Node, InMemLinearStore>;
 
-pub struct InMemoryMerkle<C> {
+pub struct InMemoryMerkle<T> {
     root: DiskAddress,
-    merkle: Merkle<InMemLinearStore, C>,
+    merkle: Merkle<InMemLinearStore, T>,
 }
 
-impl<C> InMemoryMerkle<C>
+impl<T> InMemoryMerkle<T>
 where
-    C: BinarySerde,
-    EncodedNode<C>: serde::Serialize + serde::de::DeserializeOwned,
+    T: BinarySerde,
+    EncodedNode<T>: serde::Serialize + serde::de::DeserializeOwned,
 {
     pub fn new(meta_size: u64, compact_size: u64) -> Self {
         const RESERVED: usize = 0x1000;
@@ -102,7 +102,7 @@ where
     pub fn get_mut<K: AsRef<[u8]>>(
         &mut self,
         key: K,
-    ) -> Result<Option<RefMut<InMemLinearStore, C>>, DataStoreError> {
+    ) -> Result<Option<RefMut<InMemLinearStore, T>>, DataStoreError> {
         self.merkle
             .get_mut(key, self.root)
             .map_err(|_err| DataStoreError::GetError)
@@ -112,7 +112,7 @@ where
         self.root
     }
 
-    pub fn get_merkle_mut(&mut self) -> &mut Merkle<InMemLinearStore, C> {
+    pub fn get_merkle_mut(&mut self) -> &mut Merkle<InMemLinearStore, T> {
         &mut self.merkle
     }
 

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -33,8 +33,6 @@ pub enum DataStoreError {
     ProofEmptyKeyValuesError,
 }
 
-// type InMemoryStore = CompactSpace<Node, InMemLinearStore>;
-
 pub struct InMemoryMerkle<T> {
     root: DiskAddress,
     merkle: Merkle<InMemLinearStore, T>,

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -4,12 +4,9 @@
 use crate::{
     merkle::{
         proof::{Proof, ProofError},
-        BinarySerde, EncodedNode, Merkle, Node, Ref, RefMut, TrieHash,
+        BinarySerde, EncodedNode, Merkle, Ref, RefMut, TrieHash,
     },
-    shale::{
-        self, cached::InMemLinearStore, compact::CompactSpace, disk_address::DiskAddress,
-        CachedStore, StoredView,
-    },
+    shale::{self, cached::InMemLinearStore, disk_address::DiskAddress, CachedStore, StoredView},
 };
 use std::num::NonZeroUsize;
 use thiserror::Error;

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -38,15 +38,15 @@ pub enum DataStoreError {
 
 type InMemoryStore = CompactSpace<Node, InMemLinearStore>;
 
-pub struct InMemoryMerkle<T> {
+pub struct InMemoryMerkle<C> {
     root: DiskAddress,
-    merkle: Merkle<InMemoryStore, T>,
+    merkle: Merkle<InMemoryStore, C>,
 }
 
-impl<T> InMemoryMerkle<T>
+impl<C> InMemoryMerkle<C>
 where
-    T: BinarySerde,
-    EncodedNode<T>: serde::Serialize + serde::de::DeserializeOwned,
+    C: BinarySerde,
+    EncodedNode<C>: serde::Serialize + serde::de::DeserializeOwned,
 {
     pub fn new(meta_size: u64, compact_size: u64) -> Self {
         const RESERVED: usize = 0x1000;
@@ -105,7 +105,7 @@ where
     pub fn get_mut<K: AsRef<[u8]>>(
         &mut self,
         key: K,
-    ) -> Result<Option<RefMut<InMemoryStore, T>>, DataStoreError> {
+    ) -> Result<Option<RefMut<InMemoryStore, C>>, DataStoreError> {
         self.merkle
             .get_mut(key, self.root)
             .map_err(|_err| DataStoreError::GetError)
@@ -115,7 +115,7 @@ where
         self.root
     }
 
-    pub fn get_merkle_mut(&mut self) -> &mut Merkle<InMemoryStore, T> {
+    pub fn get_merkle_mut(&mut self) -> &mut Merkle<InMemoryStore, C> {
         &mut self.merkle
     }
 

--- a/firewood/src/merkle_util.rs
+++ b/firewood/src/merkle_util.rs
@@ -36,11 +36,11 @@ pub enum DataStoreError {
     ProofEmptyKeyValuesError,
 }
 
-type InMemoryStore = CompactSpace<Node, InMemLinearStore>;
+// type InMemoryStore = CompactSpace<Node, InMemLinearStore>;
 
 pub struct InMemoryMerkle<C> {
     root: DiskAddress,
-    merkle: Merkle<InMemoryStore, C>,
+    merkle: Merkle<InMemLinearStore, C>,
 }
 
 impl<C> InMemoryMerkle<C>
@@ -77,7 +77,7 @@ where
             shale::compact::CompactSpace::new(mem_meta, mem_payload, compact_header, cache, 10, 16)
                 .expect("CompactSpace init fail");
 
-        let merkle = Merkle::new(Box::new(space));
+        let merkle = Merkle::new(space);
         #[allow(clippy::unwrap_used)]
         let root = merkle.init_root().unwrap();
 
@@ -105,7 +105,7 @@ where
     pub fn get_mut<K: AsRef<[u8]>>(
         &mut self,
         key: K,
-    ) -> Result<Option<RefMut<InMemoryStore, C>>, DataStoreError> {
+    ) -> Result<Option<RefMut<InMemLinearStore, C>>, DataStoreError> {
         self.merkle
             .get_mut(key, self.root)
             .map_err(|_err| DataStoreError::GetError)
@@ -115,7 +115,7 @@ where
         self.root
     }
 
-    pub fn get_merkle_mut(&mut self) -> &mut Merkle<InMemoryStore, C> {
+    pub fn get_merkle_mut(&mut self) -> &mut Merkle<InMemLinearStore, C> {
         &mut self.merkle
     }
 

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -7,7 +7,7 @@ use crate::shale::ObjCache;
 use crate::storage::{StoreRevMut, StoreRevShared};
 
 use super::disk_address::DiskAddress;
-use super::{CachedStore, Obj, ObjRef, ShaleError, ShaleStore, Storable, StoredView};
+use super::{CachedStore, Obj, ObjRef, ShaleError, Storable, StoredView};
 use bytemuck::{Pod, Zeroable};
 use std::fmt::Debug;
 use std::io::{Cursor, Write};

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -569,9 +569,9 @@ impl<T: Storable, M: CachedStore> CompactSpace<T, M> {
     }
 }
 
-impl From<Box<CompactSpace<Node, StoreRevMut>>> for CompactSpace<Node, StoreRevShared> {
+impl From<CompactSpace<Node, StoreRevMut>> for CompactSpace<Node, StoreRevShared> {
     #[allow(clippy::unwrap_used)]
-    fn from(value: Box<CompactSpace<Node, StoreRevMut>>) -> Self {
+    fn from(value: CompactSpace<Node, StoreRevMut>) -> Self {
         let inner = value.inner.into_inner().unwrap();
         CompactSpace {
             inner: RwLock::new(inner.into()),

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -581,8 +581,7 @@ impl From<CompactSpace<Node, StoreRevMut>> for CompactSpace<Node, StoreRevShared
 }
 
 impl<T: Storable + Debug + 'static, M: CachedStore> CompactSpace<T, M> {
-    // TODO should this be pub?
-    pub fn put_item(&self, item: T, extra: u64) -> Result<ObjRef<'_, T>, ShaleError> {
+    pub(crate) fn put_item(&self, item: T, extra: u64) -> Result<ObjRef<'_, T>, ShaleError> {
         let size = item.serialized_len() + extra;
         #[allow(clippy::unwrap_used)]
         let addr = self.inner.write().unwrap().alloc(size)?;
@@ -611,17 +610,15 @@ impl<T: Storable + Debug + 'static, M: CachedStore> CompactSpace<T, M> {
         Ok(obj_ref)
     }
 
-    // TODO should this be pub?
     #[allow(clippy::unwrap_used)]
-    pub fn free_item(&mut self, ptr: DiskAddress) -> Result<(), ShaleError> {
+    pub(crate) fn free_item(&mut self, ptr: DiskAddress) -> Result<(), ShaleError> {
         let mut inner = self.inner.write().unwrap();
         self.obj_cache.pop(ptr);
         #[allow(clippy::unwrap_used)]
         inner.free(ptr.unwrap().get() as u64)
     }
 
-    // TODO should this be pub?
-    pub fn get_item(&self, ptr: DiskAddress) -> Result<ObjRef<'_, T>, ShaleError> {
+    pub(crate) fn get_item(&self, ptr: DiskAddress) -> Result<ObjRef<'_, T>, ShaleError> {
         let obj = self.obj_cache.get(ptr)?;
 
         #[allow(clippy::unwrap_used)]
@@ -649,9 +646,8 @@ impl<T: Storable + Debug + 'static, M: CachedStore> CompactSpace<T, M> {
         Ok(ObjRef::new(obj, cache))
     }
 
-    // TODO should this be pub?
     #[allow(clippy::unwrap_used)]
-    pub fn flush_dirty(&self) -> Option<()> {
+    pub(crate) fn flush_dirty(&self) -> Option<()> {
         let mut inner = self.inner.write().unwrap();
         inner.header.flush_dirty();
         // hold the write lock to ensure that both cache and header are flushed in-sync

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -580,7 +580,7 @@ impl From<CompactSpace<Node, StoreRevMut>> for CompactSpace<Node, StoreRevShared
     }
 }
 
-impl<T: Storable + Debug + 'static + PartialEq, M: CachedStore> CompactSpace<T, M> {
+impl<T: Storable + Debug + 'static, M: CachedStore> CompactSpace<T, M> {
     // TODO should this be pub?
     pub fn put_item(&self, item: T, extra: u64) -> Result<ObjRef<'_, T>, ShaleError> {
         let size = item.serialized_len() + extra;

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -580,7 +580,7 @@ impl From<CompactSpace<Node, StoreRevMut>> for CompactSpace<Node, StoreRevShared
     }
 }
 
-impl<T: Storable + Debug + 'static + PartialEq, M: CachedStore + Send + Sync> CompactSpace<T, M> {
+impl<T: Storable + Debug + 'static + PartialEq, M: CachedStore> CompactSpace<T, M> {
     // TODO should this be pub?
     pub fn put_item(&self, item: T, extra: u64) -> Result<ObjRef<'_, T>, ShaleError> {
         let size = item.serialized_len() + extra;

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -103,8 +103,7 @@ pub trait CachedStore: Debug + Send + Sync {
 
 /// A wrapper of `StoredView` to enable writes. The direct construction (by [Obj::from_stored_view]
 /// or [StoredView::ptr_to_obj]) could be useful for some unsafe access to a low-level item (e.g.
-/// headers/metadata at bootstrap or part of [ShaleStore] implementation) stored at a given [DiskAddress]
-/// . Users of [ShaleStore] implementation, however, will only use [ObjRef] for safeguarded access.
+/// headers/metadata at bootstrap) stored at a given [DiskAddress].
 #[derive(Debug)]
 pub struct Obj<T: Storable> {
     value: StoredView<T>,
@@ -182,7 +181,7 @@ impl<T: Storable> Deref for Obj<T> {
     }
 }
 
-/// User handle that offers read & write access to the stored [ShaleStore] item.
+/// User handle that offers read & write access to the stored items.
 #[derive(Debug)]
 pub struct ObjRef<'a, T: Storable> {
     inner: ManuallyDrop<Obj<T>>,
@@ -440,7 +439,7 @@ pub struct ObjCacheInner<T: Storable> {
     dirty: HashSet<DiskAddress>,
 }
 
-/// [ObjRef] pool that is used by [ShaleStore] implementation to construct [ObjRef]s.
+/// [ObjRef] pool that is used by [CompactSpace] to construct [ObjRef]s.
 #[derive(Debug)]
 pub struct ObjCache<T: Storable>(Arc<RwLock<ObjCacheInner<T>>>);
 

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -439,7 +439,7 @@ pub struct ObjCacheInner<T: Storable> {
     dirty: HashSet<DiskAddress>,
 }
 
-/// [ObjRef] pool that is used by [CompactSpace] to construct [ObjRef]s.
+/// [ObjRef] pool that is used by [compact::CompactSpace] to construct [ObjRef]s.
 #[derive(Debug)]
 pub struct ObjCache<T: Storable>(Arc<RwLock<ObjCacheInner<T>>>);
 

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -261,16 +261,16 @@ impl<'a, T: Storable> Drop for ObjRef<'a, T> {
 
 /// A persistent item storage backed by linear logical space. New items can be created and old
 /// items could be retrieved or dropped.
-pub trait ShaleStore<T: Storable + Debug> {
-    /// Dereference [DiskAddress] to a unique handle that allows direct access to the item in memory.
-    fn get_item(&'_ self, ptr: DiskAddress) -> Result<ObjRef<'_, T>, ShaleError>;
-    /// Allocate a new item.
-    fn put_item(&'_ self, item: T, extra: u64) -> Result<ObjRef<'_, T>, ShaleError>;
-    /// Free an item and recycle its space when applicable.
-    fn free_item(&mut self, item: DiskAddress) -> Result<(), ShaleError>;
-    /// Flush all dirty writes.
-    fn flush_dirty(&self) -> Option<()>;
-}
+// pub trait ShaleStore<T: Storable + Debug> {
+//     /// Dereference [DiskAddress] to a unique handle that allows direct access to the item in memory.
+//     fn get_item(&'_ self, ptr: DiskAddress) -> Result<ObjRef<'_, T>, ShaleError>;
+//     /// Allocate a new item.
+//     fn put_item(&'_ self, item: T, extra: u64) -> Result<ObjRef<'_, T>, ShaleError>;
+//     /// Free an item and recycle its space when applicable.
+//     fn free_item(&mut self, item: DiskAddress) -> Result<(), ShaleError>;
+//     /// Flush all dirty writes.
+//     fn flush_dirty(&self) -> Option<()>;
+// }
 
 /// A stored item type that can be decoded from or encoded to on-disk raw bytes. An efficient
 /// implementation could be directly transmuting to/from a POD struct. But sometimes necessary

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -259,19 +259,6 @@ impl<'a, T: Storable> Drop for ObjRef<'a, T> {
     }
 }
 
-/// A persistent item storage backed by linear logical space. New items can be created and old
-/// items could be retrieved or dropped.
-// pub trait ShaleStore<T: Storable + Debug> {
-//     /// Dereference [DiskAddress] to a unique handle that allows direct access to the item in memory.
-//     fn get_item(&'_ self, ptr: DiskAddress) -> Result<ObjRef<'_, T>, ShaleError>;
-//     /// Allocate a new item.
-//     fn put_item(&'_ self, item: T, extra: u64) -> Result<ObjRef<'_, T>, ShaleError>;
-//     /// Free an item and recycle its space when applicable.
-//     fn free_item(&mut self, item: DiskAddress) -> Result<(), ShaleError>;
-//     /// Flush all dirty writes.
-//     fn flush_dirty(&self) -> Option<()>;
-// }
-
 /// A stored item type that can be decoded from or encoded to on-disk raw bytes. An efficient
 /// implementation could be directly transmuting to/from a POD struct. But sometimes necessary
 /// compression/decompression is needed to reduce disk I/O and facilitate faster in-memory access.


### PR DESCRIPTION
Removes the `ShaleStore` trait and replaces its usage with `CompactSpace`, which was the only implementation of `ShaleStore`.