### PR TITLE
rename node `path` fields to `partial_path`

### DIFF
--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -112,14 +112,14 @@ impl NodeType {
 
     pub fn path_mut(&mut self) -> &mut PartialPath {
         match self {
-            NodeType::Branch(u) => &mut u.path,
+            NodeType::Branch(u) => &mut u.partial_path,
             NodeType::Leaf(node) => &mut node.partial_path,
         }
     }
 
     pub fn set_path(&mut self, path: PartialPath) {
         match self {
-            NodeType::Branch(u) => u.path = path,
+            NodeType::Branch(u) => u.partial_path = path,
             NodeType::Leaf(node) => node.partial_path = path,
         }
     }
@@ -210,7 +210,7 @@ impl Node {
                 is_encoded_longer_than_hash_len: OnceLock::new(),
                 inner: NodeType::Branch(
                     BranchNode {
-                        path: vec![].into(),
+                        partial_path: vec![].into(),
                         children: [Some(DiskAddress::null()); BranchNode::MAX_CHILDREN],
                         value: Some(Data(Vec::new())),
                         children_encoded: Default::default(),
@@ -834,7 +834,7 @@ mod tests {
     ) {
         let leaf = NodeType::Leaf(LeafNode::new(PartialPath(vec![1, 2, 3]), Data(vec![4, 5])));
         let branch = NodeType::Branch(Box::new(BranchNode {
-            path: vec![].into(),
+            partial_path: vec![].into(),
             children: [Some(DiskAddress::from(1)); BranchNode::MAX_CHILDREN],
             value: Some(Data(vec![1, 2, 3])),
             children_encoded: std::array::from_fn(|_| Some(vec![1])),
@@ -918,7 +918,7 @@ mod tests {
         value: impl Into<Option<u8>>,
         children_encoded: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN],
     ) {
-        let path = PartialPath(path.iter().copied().map(|x| x & 0xf).collect());
+        let partial_path = PartialPath(path.iter().copied().map(|x| x & 0xf).collect());
 
         let mut children = children.into_iter().map(|x| {
             if x == 0 {
@@ -935,7 +935,7 @@ mod tests {
             .map(|x| Data(std::iter::repeat(x).take(x as usize).collect()));
 
         let node = Node::from_branch(BranchNode {
-            path,
+            partial_path,
             children,
             value,
             children_encoded,

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -62,13 +62,13 @@ impl BranchNode {
     pub const MSIZE: usize = Self::MAX_CHILDREN + 2;
 
     pub fn new(
-        path: PartialPath,
+        partial_path: PartialPath,
         chd: [Option<DiskAddress>; Self::MAX_CHILDREN],
         value: Option<Vec<u8>>,
         chd_encoded: [Option<Vec<u8>>; Self::MAX_CHILDREN],
     ) -> Self {
         BranchNode {
-            partial_path: path,
+            partial_path,
             children: chd,
             value: value.map(Data),
             children_encoded: chd_encoded,

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -23,7 +23,7 @@ const MAX_CHILDREN: usize = 16;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct BranchNode {
-    pub(crate) path: PartialPath,
+    pub(crate) partial_path: PartialPath,
     pub(crate) children: [Option<DiskAddress>; MAX_CHILDREN],
     pub(crate) value: Option<Data>,
     pub(crate) children_encoded: [Option<Vec<u8>>; MAX_CHILDREN],
@@ -32,7 +32,7 @@ pub struct BranchNode {
 impl Debug for BranchNode {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
         write!(f, "[Branch")?;
-        write!(f, r#" path="{:?}""#, self.path)?;
+        write!(f, r#" path="{:?}""#, self.partial_path)?;
 
         for (i, c) in self.children.iter().enumerate() {
             if let Some(c) = c {
@@ -68,7 +68,7 @@ impl BranchNode {
         chd_encoded: [Option<Vec<u8>>; Self::MAX_CHILDREN],
     ) -> Self {
         BranchNode {
-            path,
+            partial_path: path,
             children: chd,
             value: value.map(Data),
             children_encoded: chd_encoded,
@@ -176,7 +176,7 @@ impl BranchNode {
         }
 
         #[allow(clippy::unwrap_used)]
-        let path = from_nibbles(&self.path.encode()).collect::<Vec<_>>();
+        let path = from_nibbles(&self.partial_path.encode()).collect::<Vec<_>>();
 
         list[Self::MAX_CHILDREN + 1] = path;
 
@@ -194,7 +194,7 @@ impl Storable for BranchNode {
             len + optional_data_len::<EncodedChildLen, _>(child.as_ref())
         });
         let path_len_size = size_of::<PathLen>() as u64;
-        let path_len = self.path.serialized_len();
+        let path_len = self.partial_path.serialized_len();
 
         children_len + data_len + children_encoded_len + path_len_size + path_len
     }
@@ -202,7 +202,7 @@ impl Storable for BranchNode {
     fn serialize(&self, to: &mut [u8]) -> Result<(), crate::shale::ShaleError> {
         let mut cursor = Cursor::new(to);
 
-        let path: Vec<u8> = from_nibbles(&self.path.encode()).collect();
+        let path: Vec<u8> = from_nibbles(&self.partial_path.encode()).collect();
         cursor.write_all(&[path.len() as PathLen])?;
         cursor.write_all(&path)?;
 
@@ -358,7 +358,7 @@ impl Storable for BranchNode {
         }
 
         let node = BranchNode {
-            path,
+            partial_path: path,
             children,
             value,
             children_encoded,

--- a/firewood/src/merkle/node/leaf.rs
+++ b/firewood/src/merkle/node/leaf.rs
@@ -38,9 +38,9 @@ impl Debug for LeafNode {
 }
 
 impl LeafNode {
-    pub fn new<P: Into<PartialPath>, D: Into<Data>>(path: P, data: D) -> Self {
+    pub fn new<P: Into<PartialPath>, D: Into<Data>>(partial_path: P, data: D) -> Self {
         Self {
-            partial_path: path.into(),
+            partial_path: partial_path.into(),
             data: data.into(),
         }
     }

--- a/firewood/src/merkle/node/leaf.rs
+++ b/firewood/src/merkle/node/leaf.rs
@@ -22,26 +22,31 @@ type DataLen = u32;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct LeafNode {
-    pub(crate) path: PartialPath,
+    pub(crate) partial_path: PartialPath,
     pub(crate) data: Data,
 }
 
 impl Debug for LeafNode {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        write!(f, "[Leaf {:?} {}]", self.path, hex::encode(&*self.data))
+        write!(
+            f,
+            "[Leaf {:?} {}]",
+            self.partial_path,
+            hex::encode(&*self.data)
+        )
     }
 }
 
 impl LeafNode {
     pub fn new<P: Into<PartialPath>, D: Into<Data>>(path: P, data: D) -> Self {
         Self {
-            path: path.into(),
+            partial_path: path.into(),
             data: data.into(),
         }
     }
 
     pub const fn path(&self) -> &PartialPath {
-        &self.path
+        &self.partial_path
     }
 
     pub const fn data(&self) -> &Data {
@@ -53,7 +58,7 @@ impl LeafNode {
         bincode::DefaultOptions::new()
             .serialize(
                 [
-                    from_nibbles(&self.path.encode()).collect(),
+                    from_nibbles(&self.partial_path.encode()).collect(),
                     self.data.to_vec(),
                 ]
                 .as_slice(),
@@ -76,7 +81,7 @@ impl Meta {
 impl Storable for LeafNode {
     fn serialized_len(&self) -> u64 {
         let meta_len = size_of::<Meta>() as u64;
-        let path_len = self.path.serialized_len();
+        let path_len = self.partial_path.serialized_len();
         let data_len = self.data.len() as u64;
 
         meta_len + path_len + data_len
@@ -85,11 +90,11 @@ impl Storable for LeafNode {
     fn serialize(&self, to: &mut [u8]) -> Result<(), crate::shale::ShaleError> {
         let mut cursor = Cursor::new(to);
 
-        let path = &self.path.encode();
+        let path = &self.partial_path.encode();
         let path = from_nibbles(path);
         let data = &self.data;
 
-        let path_len = self.path.serialized_len() as PathLen;
+        let path_len = self.partial_path.serialized_len() as PathLen;
         let data_len = data.len() as DataLen;
 
         let meta = Meta { path_len, data_len };

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -333,7 +333,7 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
             let encoded_sub_proof = match child_node.inner() {
                 NodeType::Leaf(n) => {
                     break n
-                        .path
+                        .partial_path
                         .iter()
                         .copied()
                         .eq(key_nibbles) // all nibbles have to match
@@ -552,7 +552,7 @@ where
 
             #[allow(clippy::indexing_slicing)]
             NodeType::Leaf(n) => {
-                let path = &*n.path;
+                let path = &*n.partial_path;
 
                 [fork_left, fork_right] = [&left_chunks[index..], &right_chunks[index..]]
                     .map(|chunks| chunks.chunks(path.len()).next().unwrap_or_default())

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -342,7 +342,7 @@ impl<N: AsRef<[u8]> + Send> Proof<N> {
 
                 NodeType::Branch(n) => {
                     let paths_match = n
-                        .path
+                        .partial_path
                         .iter()
                         .copied()
                         .all(|nibble| Some(nibble) == key_nibbles.next());
@@ -420,7 +420,7 @@ fn locate_subproof(
             Ok((sub_proof.into(), key_nibbles))
         }
         NodeType::Branch(n) => {
-            let partial_path = &n.path.0;
+            let partial_path = &n.partial_path.0;
 
             let does_not_match = key_nibbles.size_hint().0 < partial_path.len()
                 || !partial_path
@@ -518,7 +518,7 @@ where
             NodeType::Branch(n) => {
                 // If either the key of left proof or right proof doesn't match with
                 // stop here, this is the forkpoint.
-                let path = &*n.path;
+                let path = &*n.partial_path;
 
                 if !path.is_empty() {
                     [fork_left, fork_right] = [&left_chunks[index..], &right_chunks[index..]]
@@ -597,7 +597,7 @@ where
             }
 
             let p = u_ref.as_ptr();
-            index += n.path.len();
+            index += n.partial_path.len();
 
             // Only one proof points to non-existent key.
             if fork_right.is_ne() {
@@ -741,8 +741,8 @@ fn unset_node_ref<K: AsRef<[u8]>, S: CachedStore, T: BinarySerde>(
 
     #[allow(clippy::indexing_slicing)]
     match &u_ref.inner() {
-        NodeType::Branch(n) if chunks[index..].starts_with(&n.path) => {
-            let index = index + n.path.len();
+        NodeType::Branch(n) if chunks[index..].starts_with(&n.partial_path) => {
+            let index = index + n.partial_path.len();
             let child_index = chunks[index] as usize;
 
             let node = n.chd()[child_index];
@@ -772,7 +772,7 @@ fn unset_node_ref<K: AsRef<[u8]>, S: CachedStore, T: BinarySerde>(
         }
 
         NodeType::Branch(n) => {
-            let cur_key = &n.path;
+            let cur_key = &n.partial_path;
 
             // Find the fork point, it's a non-existent branch.
             //

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -146,7 +146,7 @@ impl<'a, S: CachedStore, T> Stream for MerkleNodeStream<'a, S, T> {
                             let child = merkle.get_node(child_addr)?;
 
                             let partial_path = match child.inner() {
-                                NodeType::Branch(branch) => branch.path.iter().copied(),
+                                NodeType::Branch(branch) => branch.partial_path.iter().copied(),
                                 NodeType::Leaf(leaf) => leaf.partial_path.iter().copied(),
                             };
 
@@ -240,7 +240,7 @@ fn get_iterator_intial_state<'a, S: CachedStore, T>(
                 let child = merkle.get_node(child_addr)?;
 
                 let partial_key = match child.inner() {
-                    NodeType::Branch(branch) => &branch.path,
+                    NodeType::Branch(branch) => &branch.partial_path,
                     NodeType::Leaf(leaf) => &leaf.partial_path,
                 };
 
@@ -477,7 +477,7 @@ impl<'a, 'b, S: CachedStore, T> Iterator for PathIterator<'a, 'b, S, T> {
                 };
 
                 let partial_path = match node.inner() {
-                    NodeType::Branch(branch) => &branch.path,
+                    NodeType::Branch(branch) => &branch.partial_path,
                     NodeType::Leaf(leaf) => &leaf.partial_path,
                 };
 
@@ -810,14 +810,14 @@ mod tests {
         assert_eq!(key, vec![0x00].into_boxed_slice());
         let node = node.inner().as_branch().unwrap();
         assert!(node.value.is_none());
-        assert_eq!(node.path.to_vec(), vec![0x00, 0x00]);
+        assert_eq!(node.partial_path.to_vec(), vec![0x00, 0x00]);
 
         // Covers case of branch with value
         let (key, node) = stream.next().await.unwrap().unwrap();
         assert_eq!(key, vec![0x00, 0x00, 0x00].into_boxed_slice());
         let node = node.inner().as_branch().unwrap();
         assert_eq!(node.value.clone().unwrap().to_vec(), vec![0x00, 0x00, 0x00]);
-        assert_eq!(node.path.to_vec(), vec![0x00, 0x00, 0x00]);
+        assert_eq!(node.partial_path.to_vec(), vec![0x00, 0x00, 0x00]);
 
         // Covers case of leaf with partial path
         let (key, node) = stream.next().await.unwrap().unwrap();

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -144,7 +144,7 @@ impl<T: Storable> Obj<T> {
 impl Obj<Node> {
     pub fn into_inner(mut self) -> Node {
         let empty_node = LeafNode {
-            path: PartialPath(Vec::new()),
+            partial_path: PartialPath(Vec::new()),
             data: Vec::new().into(),
         };
 


### PR DESCRIPTION
This field represents a partial path, not the full path to this node. This PR renames the field to make this more clear.