### PR TITLE
rename `PartialPath` to `Path`

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1346,7 +1346,7 @@ pub const fn to_nibble_array(x: u8) -> [u8; 2] {
 /// Returns an iterator where each element is the result of combining
 /// 2 nibbles of `nibbles`. If `nibbles` is odd length, panics in
 /// debug mode and drops the final nibble in release mode.
-pub fn from_nibbles(nibbles: &[u8]) -> impl Iterator<Item = u8> + '_ {
+pub fn nibbles_to_bytes_iter(nibbles: &[u8]) -> impl Iterator<Item = u8> + '_ {
     debug_assert_eq!(nibbles.len() & 1, 0);
     #[allow(clippy::indexing_slicing)]
     nibbles.chunks_exact(2).map(|p| (p[0] << 4) | p[1])

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1343,9 +1343,9 @@ pub const fn to_nibble_array(x: u8) -> [u8; 2] {
     [x >> 4, x & 0b_0000_1111]
 }
 
-// given a set of nibbles, take each pair and convert this back into bytes
-// if an odd number of nibbles, in debug mode it panics. In release mode,
-// the final nibble is dropped
+/// Returns an iterator where each element is the result of combining
+/// 2 nibbles of `nibbles`. If `nibbles` is odd length, panics in
+/// debug mode and drops the final nibble in release mode.
 pub fn from_nibbles(nibbles: &[u8]) -> impl Iterator<Item = u8> + '_ {
     debug_assert_eq!(nibbles.len() & 1, 0);
     #[allow(clippy::indexing_slicing)]

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -20,7 +20,7 @@ mod trie_hash;
 
 pub use node::{
     BinarySerde, Bincode, BranchNode, Data, EncodedNode, EncodedNodeType, LeafNode, Node, NodeType,
-    PartialPath,
+    Path,
 };
 pub use proof::{Proof, ProofError};
 pub use stream::MerkleKeyValueStream;
@@ -161,7 +161,7 @@ where
                 children,
                 value,
             } => {
-                let path = PartialPath::decode(&path);
+                let path = Path::decode(&path);
                 let value = value.map(|v| v.0);
                 let branch = NodeType::Branch(
                     BranchNode::new(path, [None; BranchNode::MAX_CHILDREN], value, *children)
@@ -330,10 +330,8 @@ impl<S: CachedStore, T> Merkle<S, T> {
                                 (index[0], path.to_vec())
                             };
 
-                            let new_leaf = Node::from_leaf(LeafNode::new(
-                                PartialPath(new_leaf_path),
-                                Data(val),
-                            ));
+                            let new_leaf =
+                                Node::from_leaf(LeafNode::new(Path(new_leaf_path), Data(val)));
 
                             let new_leaf = self.put_node(new_leaf)?.as_ptr();
 
@@ -341,7 +339,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                             children[new_leaf_index as usize] = Some(new_leaf);
 
                             let new_branch = BranchNode {
-                                partial_path: PartialPath(overlap.shared.to_vec()),
+                                partial_path: Path(overlap.shared.to_vec()),
                                 children,
                                 value: n.data.clone().into(),
                                 children_encoded: Default::default(),
@@ -369,12 +367,12 @@ impl<S: CachedStore, T> Merkle<S, T> {
                                 .update_path_and_move_node_if_larger(
                                     (&mut parents, &mut deleted),
                                     node,
-                                    PartialPath(old_leaf_path.to_vec()),
+                                    Path(old_leaf_path.to_vec()),
                                 )?
                                 .as_ptr();
 
                             let mut new_branch = BranchNode {
-                                partial_path: PartialPath(new_branch_path),
+                                partial_path: Path(new_branch_path),
                                 children: [None; BranchNode::MAX_CHILDREN],
                                 value: Some(val.into()),
                                 children_encoded: Default::default(),
@@ -406,19 +404,17 @@ impl<S: CachedStore, T> Merkle<S, T> {
                                 .update_path_and_move_node_if_larger(
                                     (&mut parents, &mut deleted),
                                     node,
-                                    PartialPath(old_leaf_path.to_vec()),
+                                    Path(old_leaf_path.to_vec()),
                                 )?
                                 .as_ptr();
 
-                            let new_leaf = Node::from_leaf(LeafNode::new(
-                                PartialPath(new_leaf_path),
-                                Data(val),
-                            ));
+                            let new_leaf =
+                                Node::from_leaf(LeafNode::new(Path(new_leaf_path), Data(val)));
 
                             let new_leaf = self.put_node(new_leaf)?.as_ptr();
 
                             let mut new_branch = BranchNode {
-                                partial_path: PartialPath(new_branch_path),
+                                partial_path: Path(new_branch_path),
                                 children: [None; BranchNode::MAX_CHILDREN],
                                 value: None,
                                 children_encoded: Default::default(),
@@ -446,7 +442,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                             // create a new leaf
                             let leaf_ptr = self
                                 .put_node(Node::from_leaf(LeafNode::new(
-                                    PartialPath(key_nibbles.collect()),
+                                    Path(key_nibbles.collect()),
                                     Data(val),
                                 )))?
                                 .as_ptr();
@@ -501,7 +497,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                                 Some(ptr) => (node, ptr),
                                 None => {
                                     let new_leaf = Node::from_leaf(LeafNode::new(
-                                        PartialPath(new_leaf_path.to_vec()),
+                                        Path(new_leaf_path.to_vec()),
                                         Data(val),
                                     ));
 
@@ -532,12 +528,12 @@ impl<S: CachedStore, T> Merkle<S, T> {
                                 .update_path_and_move_node_if_larger(
                                     (&mut parents, &mut deleted),
                                     node,
-                                    PartialPath(old_branch_path.to_vec()),
+                                    Path(old_branch_path.to_vec()),
                                 )?
                                 .as_ptr();
 
                             let mut new_branch = BranchNode {
-                                partial_path: PartialPath(new_branch_path),
+                                partial_path: Path(new_branch_path),
                                 children: [None; BranchNode::MAX_CHILDREN],
                                 value: Some(val.into()),
                                 children_encoded: Default::default(),
@@ -571,19 +567,17 @@ impl<S: CachedStore, T> Merkle<S, T> {
                                 .update_path_and_move_node_if_larger(
                                     (&mut parents, &mut deleted),
                                     node,
-                                    PartialPath(old_branch_path.to_vec()),
+                                    Path(old_branch_path.to_vec()),
                                 )?
                                 .as_ptr();
 
-                            let new_leaf = Node::from_leaf(LeafNode::new(
-                                PartialPath(new_leaf_path),
-                                Data(val),
-                            ));
+                            let new_leaf =
+                                Node::from_leaf(LeafNode::new(Path(new_leaf_path), Data(val)));
 
                             let new_leaf = self.put_node(new_leaf)?.as_ptr();
 
                             let mut new_branch = BranchNode {
-                                partial_path: PartialPath(new_branch_path),
+                                partial_path: Path(new_branch_path),
                                 children: [None; BranchNode::MAX_CHILDREN],
                                 value: None,
                                 children_encoded: Default::default(),
@@ -631,7 +625,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                                     #[allow(clippy::indexing_slicing)]
                                     let idx = n.partial_path[0];
                                     #[allow(clippy::indexing_slicing)]
-                                    (n.partial_path = PartialPath(n.partial_path[1..].to_vec()));
+                                    (n.partial_path = Path(n.partial_path[1..].to_vec()));
                                     u.rehash();
 
                                     Some((idx, true, None, val))
@@ -728,7 +722,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                                 .chain(once(child_index as u8))
                                 .chain(child_path.0.iter().copied())
                                 .collect();
-                            *child_path = PartialPath(path);
+                            *child_path = Path(path);
 
                             child.rehash();
                         })?;
@@ -793,7 +787,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                                         .chain(child.partial_path.0.iter().copied())
                                         .collect();
 
-                                    child.partial_path = PartialPath(path);
+                                    child.partial_path = Path(path);
 
                                     Node::from_branch(child)
                                 }
@@ -805,7 +799,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                                         .chain(child.partial_path.0.iter().copied())
                                         .collect();
 
-                                    child.partial_path = PartialPath(path);
+                                    child.partial_path = Path(path);
 
                                     Node::from_leaf(child)
                                 }
@@ -821,7 +815,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                         // branch nodes shouldn't have no children
                         (0, Some(data), true) => {
                             let leaf = Node::from_leaf(LeafNode::new(
-                                PartialPath(branch.partial_path.0.clone()),
+                                Path(branch.partial_path.0.clone()),
                                 data.clone(),
                             ));
 
@@ -1215,7 +1209,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
         &'a self,
         (parents, to_delete): (&mut [(NodeObjRef, u8)], &mut Vec<DiskAddress>),
         mut node: NodeObjRef<'a>,
-        path: PartialPath,
+        path: Path,
     ) -> Result<NodeObjRef<'a>, MerkleError> {
         let write_result = node.write(|node| {
             node.inner_mut().set_path(path);
@@ -1402,7 +1396,7 @@ mod tests {
     use test_case::test_case;
 
     fn leaf(path: Vec<u8>, data: Vec<u8>) -> Node {
-        Node::from_leaf(LeafNode::new(PartialPath(path), Data(data)))
+        Node::from_leaf(LeafNode::new(Path(path), Data(data)))
     }
 
     #[test_case(vec![0x12, 0x34, 0x56], &[0x1, 0x2, 0x3, 0x4, 0x5, 0x6])]
@@ -1454,7 +1448,7 @@ mod tests {
     fn branch(path: &[u8], value: &[u8], encoded_child: Option<Vec<u8>>) -> Node {
         let (path, value) = (path.to_vec(), value.to_vec());
         let path = Nibbles::<0>::new(&path);
-        let path = PartialPath(path.into_iter().collect());
+        let path = Path(path.into_iter().collect());
 
         let children = Default::default();
         // TODO: Properly test empty data as a value
@@ -1476,7 +1470,7 @@ mod tests {
     fn branch_without_data(path: &[u8], encoded_child: Option<Vec<u8>>) -> Node {
         let path = path.to_vec();
         let path = Nibbles::<0>::new(&path);
-        let path = PartialPath(path.into_iter().collect());
+        let path = Path(path.into_iter().collect());
 
         let children = Default::default();
         // TODO: Properly test empty data as a value
@@ -2089,7 +2083,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let node = Node::from_leaf(LeafNode {
-            partial_path: PartialPath::from(path),
+            partial_path: Path::from(path),
             data: Data(data.clone()),
         });
 
@@ -2108,7 +2102,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let node = Node::from_leaf(LeafNode {
-            partial_path: PartialPath::from(path.clone()),
+            partial_path: Path::from(path.clone()),
             data: Data(data),
         });
 
@@ -2127,7 +2121,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let node = Node::from_branch(BranchNode {
-            partial_path: PartialPath::from(path.clone()),
+            partial_path: Path::from(path.clone()),
             children: Default::default(),
             value: Some(Data(data.clone())),
             children_encoded: Default::default(),
@@ -2148,7 +2142,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let node = Node::from_branch(BranchNode {
-            partial_path: PartialPath::from(path.clone()),
+            partial_path: Path::from(path.clone()),
             children: Default::default(),
             value: Some(Data(data)),
             children_encoded: Default::default(),
@@ -2171,7 +2165,7 @@ mod tests {
 
         // make sure that doubling the path length will fail on a normal write
         let write_result = node_ref.write(|node| {
-            node.inner_mut().set_path(PartialPath(new_path.clone()));
+            node.inner_mut().set_path(Path(new_path.clone()));
             node.inner_mut().set_data(Data(new_data.clone()));
             node.rehash();
         });
@@ -2185,7 +2179,7 @@ mod tests {
         let node = merkle.update_path_and_move_node_if_larger(
             (&mut parents, &mut to_delete),
             node_ref,
-            PartialPath(new_path.clone()),
+            Path(new_path.clone()),
         )?;
 
         assert_ne!(node.as_ptr(), addr);
@@ -2196,7 +2190,7 @@ mod tests {
             NodeType::Branch(branch) => (&branch.partial_path, branch.value.as_ref()),
         };
 
-        assert_eq!(path, &PartialPath(new_path));
+        assert_eq!(path, &Path(new_path));
         assert_eq!(data, Some(&Data(new_data)));
 
         Ok(())

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -33,7 +33,7 @@ mod partial_path;
 
 pub use branch::BranchNode;
 pub use leaf::{LeafNode, SIZE as LEAF_NODE_SIZE};
-pub use partial_path::PartialPath;
+pub use partial_path::Path;
 
 use crate::nibbles::Nibbles;
 
@@ -87,7 +87,7 @@ impl NodeType {
 
                 let decoded_key_nibbles = Nibbles::<0>::new(&decoded_key);
 
-                let cur_key_path = PartialPath::from_nibbles(decoded_key_nibbles.into_iter());
+                let cur_key_path = Path::from_nibbles(decoded_key_nibbles.into_iter());
 
                 let cur_key = cur_key_path.into_inner();
                 #[allow(clippy::unwrap_used)]
@@ -110,14 +110,14 @@ impl NodeType {
         }
     }
 
-    pub fn path_mut(&mut self) -> &mut PartialPath {
+    pub fn path_mut(&mut self) -> &mut Path {
         match self {
             NodeType::Branch(u) => &mut u.partial_path,
             NodeType::Leaf(node) => &mut node.partial_path,
         }
     }
 
-    pub fn set_path(&mut self, path: PartialPath) {
+    pub fn set_path(&mut self, path: Path) {
         match self {
             NodeType::Branch(u) => u.partial_path = path,
             NodeType::Leaf(node) => node.partial_path = path,
@@ -500,7 +500,7 @@ impl<T> EncodedNode<T> {
 pub enum EncodedNodeType {
     Leaf(LeafNode),
     Branch {
-        path: PartialPath,
+        path: Path,
         children: Box<[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>,
         value: Option<Data>,
     },
@@ -571,7 +571,7 @@ impl<'de> Deserialize<'de> for EncodedNode<PlainCodec> {
     {
         let EncodedBranchNode { chd, data, path } = Deserialize::deserialize(deserializer)?;
 
-        let path = PartialPath::from_nibbles(Nibbles::<0>::new(&path).into_iter());
+        let path = Path::from_nibbles(Nibbles::<0>::new(&path).into_iter());
 
         if chd.is_empty() {
             let data = if let Some(d) = data {
@@ -685,7 +685,7 @@ impl<'de> Deserialize<'de> for EncodedNode<Bincode> {
                         "incorrect encoded type for leaf node data",
                     ));
                 };
-                let path = PartialPath::from_nibbles(Nibbles::<0>::new(&path).into_iter());
+                let path = Path::from_nibbles(Nibbles::<0>::new(&path).into_iter());
                 let node = EncodedNodeType::Leaf(LeafNode {
                     partial_path: path,
                     data: Data(data),
@@ -695,7 +695,7 @@ impl<'de> Deserialize<'de> for EncodedNode<Bincode> {
 
             BranchNode::MSIZE => {
                 let path = items.pop().expect("length was checked above");
-                let path = PartialPath::from_nibbles(Nibbles::<0>::new(&path).into_iter());
+                let path = Path::from_nibbles(Nibbles::<0>::new(&path).into_iter());
 
                 let value = items.pop().expect("length was checked above");
                 let value = if value.is_empty() {
@@ -832,7 +832,7 @@ mod tests {
         encoded: impl Into<Option<Vec<u8>>>,
         is_encoded_longer_than_hash_len: impl Into<Option<bool>>,
     ) {
-        let leaf = NodeType::Leaf(LeafNode::new(PartialPath(vec![1, 2, 3]), Data(vec![4, 5])));
+        let leaf = NodeType::Leaf(LeafNode::new(Path(vec![1, 2, 3]), Data(vec![4, 5])));
         let branch = NodeType::Branch(Box::new(BranchNode {
             partial_path: vec![].into(),
             children: [Some(DiskAddress::from(1)); BranchNode::MAX_CHILDREN],
@@ -869,7 +869,7 @@ mod tests {
     )]
     fn leaf_node<Iter: Iterator<Item = u8>>(path: Iter, data: Iter) {
         let node = Node::from_leaf(LeafNode::new(
-            PartialPath(path.map(|x| x & 0xf).collect()),
+            Path(path.map(|x| x & 0xf).collect()),
             Data(data.collect()),
         ));
 
@@ -886,7 +886,7 @@ mod tests {
     #[test_case(&[0x0F,0x01,0x0F])]
     fn encoded_branch_node_bincode_serialize(path_nibbles: &[u8]) -> Result<(), Error> {
         let node = EncodedNode::<Bincode>::new(EncodedNodeType::Branch {
-            path: PartialPath(path_nibbles.to_vec()),
+            path: Path(path_nibbles.to_vec()),
             children: Default::default(),
             value: Some(Data(vec![1, 2, 3, 4])),
         });
@@ -918,7 +918,7 @@ mod tests {
         value: impl Into<Option<u8>>,
         children_encoded: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN],
     ) {
-        let partial_path = PartialPath(path.iter().copied().map(|x| x & 0xf).collect());
+        let partial_path = Path(path.iter().copied().map(|x| x & 0xf).collect());
 
         let mut children = children.into_iter().map(|x| {
             if x == 0 {

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     logger::trace,
-    merkle::from_nibbles,
+    merkle::nibbles_to_bytes_iter,
     shale::{compact::CompactSpace, disk_address::DiskAddress, CachedStore, ShaleError, Storable},
 };
 use bincode::{Error, Options};
@@ -524,7 +524,7 @@ impl Serialize for EncodedNode<PlainCodec> {
             EncodedNodeType::Leaf(n) => {
                 let data = Some(&*n.data);
                 let chd: Vec<(u64, Vec<u8>)> = Default::default();
-                let path: Vec<_> = from_nibbles(&n.partial_path.encode()).collect();
+                let path: Vec<_> = nibbles_to_bytes_iter(&n.partial_path.encode()).collect();
                 (chd, data, path)
             }
 
@@ -548,7 +548,7 @@ impl Serialize for EncodedNode<PlainCodec> {
 
                 let data = value.as_deref();
 
-                let path = from_nibbles(&path.encode()).collect();
+                let path = nibbles_to_bytes_iter(&path.encode()).collect();
 
                 (chd, data, path)
             }
@@ -612,7 +612,7 @@ impl Serialize for EncodedNode<Bincode> {
         match &self.node {
             EncodedNodeType::Leaf(n) => {
                 let list = [
-                    from_nibbles(&n.partial_path.encode()).collect(),
+                    nibbles_to_bytes_iter(&n.partial_path.encode()).collect(),
                     n.data.to_vec(),
                 ];
                 let mut seq = serializer.serialize_seq(Some(list.len()))?;
@@ -647,7 +647,7 @@ impl Serialize for EncodedNode<Bincode> {
                     list[BranchNode::MAX_CHILDREN] = val.clone();
                 }
 
-                let serialized_path = from_nibbles(&path.encode()).collect();
+                let serialized_path = nibbles_to_bytes_iter(&path.encode()).collect();
                 list[BranchNode::MAX_CHILDREN + 1] = serialized_path;
 
                 let mut seq = serializer.serialize_seq(Some(list.len()))?;

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -29,11 +29,11 @@ use std::{
 
 mod branch;
 mod leaf;
-mod partial_path;
+mod path;
 
 pub use branch::BranchNode;
 pub use leaf::{LeafNode, SIZE as LEAF_NODE_SIZE};
-pub use partial_path::Path;
+pub use path::Path;
 
 use crate::nibbles::Nibbles;
 

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -3,7 +3,7 @@
 
 use super::{Data, Node};
 use crate::{
-    merkle::{from_nibbles, to_nibble_array, Path},
+    merkle::{nibbles_to_bytes_iter, to_nibble_array, Path},
     nibbles::Nibbles,
     shale::{compact::CompactSpace, CachedStore, DiskAddress, ShaleError, Storable},
 };
@@ -176,7 +176,7 @@ impl BranchNode {
         }
 
         #[allow(clippy::unwrap_used)]
-        let path = from_nibbles(&self.partial_path.encode()).collect::<Vec<_>>();
+        let path = nibbles_to_bytes_iter(&self.partial_path.encode()).collect::<Vec<_>>();
 
         list[Self::MAX_CHILDREN + 1] = path;
 
@@ -202,7 +202,7 @@ impl Storable for BranchNode {
     fn serialize(&self, to: &mut [u8]) -> Result<(), crate::shale::ShaleError> {
         let mut cursor = Cursor::new(to);
 
-        let path: Vec<u8> = from_nibbles(&self.partial_path.encode()).collect();
+        let path: Vec<u8> = nibbles_to_bytes_iter(&self.partial_path.encode()).collect();
         cursor.write_all(&[path.len() as PathLen])?;
         cursor.write_all(&path)?;
 

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -3,7 +3,7 @@
 
 use super::{Data, Node};
 use crate::{
-    merkle::{from_nibbles, to_nibble_array, PartialPath},
+    merkle::{from_nibbles, to_nibble_array, Path},
     nibbles::Nibbles,
     shale::{compact::CompactSpace, CachedStore, DiskAddress, ShaleError, Storable},
 };
@@ -23,7 +23,7 @@ const MAX_CHILDREN: usize = 16;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct BranchNode {
-    pub(crate) partial_path: PartialPath,
+    pub(crate) partial_path: Path,
     pub(crate) children: [Option<DiskAddress>; MAX_CHILDREN],
     pub(crate) value: Option<Data>,
     pub(crate) children_encoded: [Option<Vec<u8>>; MAX_CHILDREN],
@@ -62,7 +62,7 @@ impl BranchNode {
     pub const MSIZE: usize = Self::MAX_CHILDREN + 2;
 
     pub fn new(
-        partial_path: PartialPath,
+        partial_path: Path,
         chd: [Option<DiskAddress>; Self::MAX_CHILDREN],
         value: Option<Vec<u8>>,
         chd_encoded: [Option<Vec<u8>>; Self::MAX_CHILDREN],
@@ -100,7 +100,7 @@ impl BranchNode {
 
         let path = items.pop().ok_or(Error::custom("Invalid Branch Node"))?;
         let path = Nibbles::<0>::new(&path);
-        let path = PartialPath::from_nibbles(path.into_iter());
+        let path = Path::from_nibbles(path.into_iter());
 
         // we've already validated the size, that's why we can safely unwrap
         #[allow(clippy::unwrap_used)]
@@ -271,7 +271,7 @@ impl Storable for BranchNode {
         addr += path_len as usize;
 
         let path: Vec<u8> = path.into_iter().flat_map(to_nibble_array).collect();
-        let path = PartialPath::decode(&path);
+        let path = Path::decode(&path);
 
         let node_raw =
             mem.get_view(addr, BRANCH_HEADER_SIZE)

--- a/firewood/src/merkle/node/leaf.rs
+++ b/firewood/src/merkle/node/leaf.rs
@@ -3,7 +3,7 @@
 
 use super::Data;
 use crate::{
-    merkle::{from_nibbles, PartialPath},
+    merkle::{from_nibbles, Path},
     nibbles::Nibbles,
     shale::{ShaleError::InvalidCacheView, Storable},
 };
@@ -22,7 +22,7 @@ type DataLen = u32;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct LeafNode {
-    pub(crate) partial_path: PartialPath,
+    pub(crate) partial_path: Path,
     pub(crate) data: Data,
 }
 
@@ -38,14 +38,14 @@ impl Debug for LeafNode {
 }
 
 impl LeafNode {
-    pub fn new<P: Into<PartialPath>, D: Into<Data>>(partial_path: P, data: D) -> Self {
+    pub fn new<P: Into<Path>, D: Into<Data>>(partial_path: P, data: D) -> Self {
         Self {
             partial_path: partial_path.into(),
             data: data.into(),
         }
     }
 
-    pub const fn path(&self) -> &PartialPath {
+    pub const fn path(&self) -> &Path {
         &self.partial_path
     }
 
@@ -138,7 +138,7 @@ impl Storable for LeafNode {
 
         let path = {
             let nibbles = Nibbles::<0>::new(path).into_iter();
-            PartialPath::from_nibbles(nibbles).0
+            Path::from_nibbles(nibbles).0
         };
 
         let data = Data(data.to_vec());

--- a/firewood/src/merkle/node/leaf.rs
+++ b/firewood/src/merkle/node/leaf.rs
@@ -3,7 +3,7 @@
 
 use super::Data;
 use crate::{
-    merkle::{from_nibbles, Path},
+    merkle::{nibbles_to_bytes_iter, Path},
     nibbles::Nibbles,
     shale::{ShaleError::InvalidCacheView, Storable},
 };
@@ -58,7 +58,7 @@ impl LeafNode {
         bincode::DefaultOptions::new()
             .serialize(
                 [
-                    from_nibbles(&self.partial_path.encode()).collect(),
+                    nibbles_to_bytes_iter(&self.partial_path.encode()).collect(),
                     self.data.to_vec(),
                 ]
                 .as_slice(),
@@ -91,7 +91,7 @@ impl Storable for LeafNode {
         let mut cursor = Cursor::new(to);
 
         let path = &self.partial_path.encode();
-        let path = from_nibbles(path);
+        let path = nibbles_to_bytes_iter(path);
         let data = &self.data;
 
         let path_len = self.partial_path.serialized_len() as PathLen;

--- a/firewood/src/merkle/node/path.rs
+++ b/firewood/src/merkle/node/path.rs
@@ -63,12 +63,12 @@ impl Path {
     // TODO: remove all non `Nibbles` usages and delete this function.
     // I also think `Path` could probably borrow instead of own data.
     //
-    /// returns a tuple of the decoded partial path and whether the path is terminal
+    /// Returns the decoded partial path
     pub fn decode(raw: &[u8]) -> Self {
         Self::from_iter(raw.iter().copied())
     }
 
-    /// returns a tuple of the decoded partial path and whether the path is terminal
+    /// Returns the decoded partial path
     pub fn from_nibbles<const N: usize>(nibbles: NibblesIterator<'_, N>) -> Self {
         Self::from_iter(nibbles)
     }

--- a/firewood/src/merkle/node/path.rs
+++ b/firewood/src/merkle/node/path.rs
@@ -63,12 +63,12 @@ impl Path {
     // TODO: remove all non `Nibbles` usages and delete this function.
     // I also think `Path` could probably borrow instead of own data.
     //
-    /// Returns the decoded partial path
+    /// Returns the decoded path.
     pub fn decode(raw: &[u8]) -> Self {
         Self::from_iter(raw.iter().copied())
     }
 
-    /// Returns the decoded partial path
+    /// Returns the decoded path.
     pub fn from_nibbles<const N: usize>(nibbles: NibblesIterator<'_, N>) -> Self {
         Self::from_iter(nibbles)
     }

--- a/firewood/src/merkle/node/path.rs
+++ b/firewood/src/merkle/node/path.rs
@@ -9,11 +9,12 @@ use std::{
 };
 
 // TODO: use smallvec
-/// PartialPath keeps a list of nibbles to represent a path on the Trie.
+/// Path is part or all of a node's path in the trie.
+/// Each element is a nibble.
 #[derive(PartialEq, Eq, Clone)]
-pub struct PartialPath(pub Vec<u8>);
+pub struct Path(pub Vec<u8>);
 
-impl Debug for PartialPath {
+impl Debug for Path {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         for nib in self.0.iter() {
             write!(f, "{:x}", *nib & 0xf)?;
@@ -22,20 +23,20 @@ impl Debug for PartialPath {
     }
 }
 
-impl std::ops::Deref for PartialPath {
+impl std::ops::Deref for Path {
     type Target = [u8];
     fn deref(&self) -> &[u8] {
         &self.0
     }
 }
 
-impl From<Vec<u8>> for PartialPath {
+impl From<Vec<u8>> for Path {
     fn from(value: Vec<u8>) -> Self {
         Self(value)
     }
 }
 
-impl PartialPath {
+impl Path {
     pub fn into_inner(self) -> Vec<u8> {
         self.0
     }
@@ -60,7 +61,7 @@ impl PartialPath {
     }
 
     // TODO: remove all non `Nibbles` usages and delete this function.
-    // I also think `PartialPath` could probably borrow instead of own data.
+    // I also think `Path` could probably borrow instead of own data.
     //
     /// returns a tuple of the decoded partial path and whether the path is terminal
     pub fn decode(raw: &[u8]) -> Self {
@@ -109,12 +110,12 @@ mod tests {
     #[test_case(&[1, 2])]
     #[test_case(&[1])]
     fn test_encoding(steps: &[u8]) {
-        let path = PartialPath(steps.to_vec());
+        let path = Path(steps.to_vec());
         let encoded = path.encode();
 
         assert_eq!(encoded.len(), path.serialized_len() as usize * 2);
 
-        let decoded = PartialPath::decode(&encoded);
+        let decoded = Path::decode(&encoded);
 
         assert_eq!(&&*decoded, &steps);
     }

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, RwLock, RwLockWriteGuard};
 
 use thiserror::Error;
 
-use crate::merkle::{LeafNode, Node, PartialPath};
+use crate::merkle::{LeafNode, Node, Path};
 
 pub mod cached;
 pub mod compact;
@@ -144,7 +144,7 @@ impl<T: Storable> Obj<T> {
 impl Obj<Node> {
     pub fn into_inner(mut self) -> Node {
         let empty_node = LeafNode {
-            partial_path: PartialPath(Vec::new()),
+            partial_path: Path(Vec::new()),
             data: Vec::new().into(),
         };
 


### PR DESCRIPTION
This type is just a bunch of nibbles -- it can actually be a full path too. (And we will use it as such in subsequent encoding/decoding changes.)

This PR also renames `from_nibbles` to `nibbles_to_bytes_iter` which I think is more clear.