### PR TITLE
remove `EncodedNodeType`

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -117,7 +117,7 @@ where
             NodeType::Leaf(n) => {
                 let children: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN] = Default::default();
                 EncodedNode {
-                    path: n.partial_path.clone(),
+                    partial_path: n.partial_path.clone(),
                     children: Box::new(children),
                     value: Some(n.data.0.clone()), // TODO implement into?
                     phantom: PhantomData,
@@ -151,7 +151,7 @@ where
                     None
                 };
                 EncodedNode {
-                    path,
+                    partial_path: path,
                     children,
                     value: value,
                     phantom: PhantomData,
@@ -184,7 +184,8 @@ where
         //         Ok(branch)
         //     }
         // }
-        let path = PartialPath::decode(&encoded.path);
+
+        let path = PartialPath::decode(&encoded.partial_path);
         Ok(NodeType::Branch(
             BranchNode::new(
                 path,

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -119,7 +119,7 @@ where
                 EncodedNode {
                     partial_path: n.partial_path.clone(),
                     children: Box::new(children),
-                    value: Some(n.data.0.clone()), // TODO implement into?
+                    value: n.data.clone().into(),
                     phantom: PhantomData,
                 }
             }

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -117,9 +117,9 @@ where
             NodeType::Leaf(n) => {
                 let children: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN] = Default::default();
                 EncodedNode {
-                    path: n.partial_path,
+                    path: n.partial_path.clone(),
                     children: Box::new(children),
-                    value: Some(n.data.0), // TODO implement into?
+                    value: Some(n.data.0.clone()), // TODO implement into?
                     phantom: PhantomData,
                 }
             }
@@ -145,7 +145,7 @@ where
                     .try_into()
                     .expect("MAX_CHILDREN will always be yielded");
 
-                let value = if let Some(v) = n.value {
+                let value = if let Some(v) = &n.value {
                     Some(v.0.clone())
                 } else {
                     None
@@ -185,18 +185,15 @@ where
         //     }
         // }
         let path = PartialPath::decode(&encoded.path);
-        let value = value.map(|v| v.0);
-        let branch = NodeType::Branch(
+        Ok(NodeType::Branch(
             BranchNode::new(
                 path,
                 [None; BranchNode::MAX_CHILDREN],
-                value,
+                encoded.value,
                 *encoded.children,
             )
             .into(),
-        );
-
-        Ok()
+        ))
     }
 }
 

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -509,13 +509,6 @@ impl<T> PartialEq for EncodedNode<T> {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct EncodedBranchNode {
-    chd: Vec<(u64, Vec<u8>)>,
-    data: Option<Vec<u8>>,
-    path: Vec<u8>,
-}
-
 // Note that the serializer passed in should always be the same type as T in EncodedNode<T>.
 impl Serialize for EncodedNode<PlainCodec> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -536,14 +529,14 @@ impl Serialize for EncodedNode<PlainCodec> {
             })
             .collect();
 
-        let data = self.value.as_deref();
+        let value = self.value.as_deref();
 
         let path: Vec<u8> = from_nibbles(&self.partial_path.encode()).collect();
 
         let mut s = serializer.serialize_tuple(3)?;
 
         s.serialize_element(&chd)?;
-        s.serialize_element(&data)?;
+        s.serialize_element(&value)?;
         s.serialize_element(&path)?;
 
         s.end()
@@ -555,11 +548,11 @@ impl<'de> Deserialize<'de> for EncodedNode<PlainCodec> {
     where
         D: serde::Deserializer<'de>,
     {
-        let EncodedBranchNode {
-            chd,
-            data: value,
-            path,
-        } = Deserialize::deserialize(deserializer)?;
+        let chd: Vec<(u64, Vec<u8>)>;
+        let value: Option<Vec<u8>>;
+        let path: Vec<u8>;
+
+        (chd, value, path) = Deserialize::deserialize(deserializer)?;
 
         let path = PartialPath::from_nibbles(Nibbles::<0>::new(&path).into_iter());
 

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -483,28 +483,22 @@ impl Storable for Node {
 }
 
 pub struct EncodedNode<T> {
-    pub(crate) node: EncodedNodeType,
+    pub(crate) path: PartialPath,
+    pub(crate) children: Box<[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>,
+    pub(crate) value: Option<Vec<u8>>,
     pub(crate) phantom: PhantomData<T>,
 }
 
-impl<T> EncodedNode<T> {
-    pub const fn new(node: EncodedNodeType) -> Self {
-        Self {
-            node,
-            phantom: PhantomData,
-        }
-    }
-}
-
-#[derive(Debug, PartialEq)]
-pub enum EncodedNodeType {
-    Leaf(LeafNode),
-    Branch {
-        path: PartialPath,
-        children: Box<[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>,
-        value: Option<Data>,
-    },
-}
+// TODO remove
+// #[derive(Debug, PartialEq)]
+// pub enum EncodedNodeType {
+//     Leaf(LeafNode),
+//     Branch {
+//         path: PartialPath,
+//         children: Box<[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>,
+//         value: Option<Data>,
+//     },
+// }
 
 // TODO: probably can merge with `EncodedNodeType`.
 #[derive(Debug, Deserialize)]

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -56,9 +56,9 @@ impl std::ops::Deref for Data {
     }
 }
 
-impl Into<Option<Vec<u8>>> for Data {
-    fn into(self) -> Option<Vec<u8>> {
-        Some(self.0)
+impl From<Data> for Option<Vec<u8>> {
+    fn from(val: Data) -> Self {
+        Some(val.0)
     }
 }
 

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -482,9 +482,14 @@ impl Storable for Node {
     }
 }
 
+/// Contains the fields that we include in a node's hash.
+/// If this is a leaf node, `children` is empty and `value` is Some.
+/// If this is a branch node, `children` is non-empty.
 #[derive(Debug)]
 pub struct EncodedNode<T> {
     pub(crate) partial_path: PartialPath,
+    /// If a child is None, it doesn't exist.
+    /// If it's Some, it's the value or value hash of the child.
     pub(crate) children: Box<[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>,
     pub(crate) value: Option<Vec<u8>>,
     pub(crate) phantom: PhantomData<T>,
@@ -602,8 +607,6 @@ impl Serialize for EncodedNode<Bincode> {
 
         seq.end()
     }
-    // }
-    //}
 }
 
 impl<'de> Deserialize<'de> for EncodedNode<Bincode> {

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -56,6 +56,12 @@ impl std::ops::Deref for Data {
     }
 }
 
+impl Into<Option<Vec<u8>>> for Data {
+    fn into(self) -> Option<Vec<u8>> {
+        Some(self.0)
+    }
+}
+
 impl From<Vec<u8>> for Data {
     fn from(v: Vec<u8>) -> Self {
         Self(v)


### PR DESCRIPTION
Once again removing types I don't think we really need. Removes `EncodedNodeType` and `EncodedBranchNode` (which we kind of abused. It wasn't always a branch node.)

I think this code more cleanly aligns with merkledb now.