### PR TITLE
always use 'value' instead of 'data' to describe the thing inside nodes

### DIFF
--- a/firewood/examples/insert.rs
+++ b/firewood/examples/insert.rs
@@ -21,7 +21,7 @@ struct Args {
     #[arg(short, long, default_value = "1-64", value_parser = string_to_range)]
     keylen: RangeInclusive<usize>,
     #[arg(short, long, default_value = "32", value_parser = string_to_range)]
-    datalen: RangeInclusive<usize>,
+    valuelen: RangeInclusive<usize>,
     #[arg(short, long, default_value_t = 1)]
     batch_size: usize,
     #[arg(short, long, default_value_t = 100)]
@@ -65,7 +65,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     for _ in 0..args.number_of_batches {
         let keylen = rng.gen_range(args.keylen.clone());
-        let datalen = rng.gen_range(args.datalen.clone());
+        let valuelen = rng.gen_range(args.valuelen.clone());
         let batch: Batch<Vec<u8>, Vec<u8>> = (0..keys)
             .map(|_| {
                 (
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         .collect::<Vec<u8>>(),
                     rng.borrow_mut()
                         .sample_iter(&Alphanumeric)
-                        .take(datalen)
+                        .take(valuelen)
                         .collect::<Vec<u8>>(),
                 )
             })

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1324,7 +1324,7 @@ impl<'a, S: CachedStore, T> RefMut<'a, S, T> {
                 |u| {
                     #[allow(clippy::unwrap_used)]
                     modify(match &mut u.inner {
-                        NodeType::Branch(n) => &mut n.value.as_mut().unwrap(),
+                        NodeType::Branch(n) => n.value.as_mut().unwrap(),
                         NodeType::Leaf(n) => &mut n.data,
                     });
                     u.rehash()

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -117,7 +117,7 @@ where
                 EncodedNode {
                     partial_path: n.partial_path.clone(),
                     children: Box::new(children),
-                    value: n.data.clone().into(),
+                    value: n.value.clone().into(),
                     phantom: PhantomData,
                 }
             }
@@ -318,9 +318,9 @@ impl<S: CachedStore, T> Merkle<S, T> {
 
                     #[allow(clippy::indexing_slicing)]
                     match (overlap.unique_a.len(), overlap.unique_b.len()) {
-                        // same node, overwrite the data
+                        // same node, overwrite the value
                         (0, 0) => {
-                            self.update_data_and_move_node_if_larger(
+                            self.update_value_and_move_node_if_larger(
                                 (&mut parents, &mut deleted),
                                 node,
                                 val,
@@ -344,7 +344,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                             let new_branch = BranchNode {
                                 partial_path: Path(overlap.shared.to_vec()),
                                 children,
-                                value: n.data.clone().into(),
+                                value: n.value.clone().into(),
                                 children_encoded: Default::default(),
                             };
 
@@ -472,9 +472,9 @@ impl<S: CachedStore, T> Merkle<S, T> {
 
                     #[allow(clippy::indexing_slicing)]
                     match (overlap.unique_a.len(), overlap.unique_b.len()) {
-                        // same node, overwrite the data
+                        // same node, overwrite the value
                         (0, 0) => {
-                            self.update_data_and_move_node_if_larger(
+                            self.update_value_and_move_node_if_larger(
                                 (&mut parents, &mut deleted),
                                 node,
                                 val,
@@ -619,7 +619,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                             }
                             NodeType::Leaf(n) => {
                                 if n.partial_path.len() == 0 {
-                                    n.data = val;
+                                    n.value = val;
 
                                     None
                                 } else {
@@ -684,7 +684,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
 
         let mut deleted = Vec::new();
 
-        let data = {
+        let value = {
             let (node, mut parents) =
                 self.get_node_and_parents_by_key(self.get_node(root)?, key)?;
 
@@ -692,22 +692,21 @@ impl<S: CachedStore, T> Merkle<S, T> {
                 return Ok(None);
             };
 
-            let data = match &node.inner {
+            let value = match &node.inner {
                 NodeType::Branch(branch) => {
-                    let data = branch.value.clone();
-                    let children = branch.children;
-
-                    if data.is_none() {
+                    let value = branch.value.clone();
+                    if value.is_none() {
                         return Ok(None);
                     }
 
-                    let children: Vec<_> = children
+                    let children: Vec<_> = branch
+                        .children
                         .iter()
                         .enumerate()
                         .filter_map(|(i, child)| child.map(|child| (i, child)))
                         .collect();
 
-                    // don't change the sentinal node
+                    // don't change the sentinel node
                     if children.len() == 1 && !parents.is_empty() {
                         let branch_path = &branch.partial_path.0;
 
@@ -738,11 +737,11 @@ impl<S: CachedStore, T> Merkle<S, T> {
                         })?
                     }
 
-                    data
+                    value
                 }
 
                 NodeType::Leaf(n) => {
-                    let data = Some(n.data.clone());
+                    let value = Some(n.value.clone());
 
                     // TODO: handle unwrap better
                     deleted.push(node.as_ptr());
@@ -767,7 +766,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                         .collect();
 
                     match (children.len(), &branch.value, !parents.is_empty()) {
-                        // node is invalid, all single-child nodes should have data
+                        // node is invalid, all single-child nodes should have a value
                         (1, None, true) => {
                             let parent_path = &branch.partial_path.0;
 
@@ -814,10 +813,10 @@ impl<S: CachedStore, T> Merkle<S, T> {
                         }
 
                         // branch nodes shouldn't have no children
-                        (0, Some(data), true) => {
+                        (0, Some(value), true) => {
                             let leaf = Node::from_leaf(LeafNode::new(
                                 Path(branch.partial_path.0.clone()),
-                                data.clone(),
+                                value.clone(),
                             ));
 
                             let leaf = self.put_node(leaf)?.as_ptr();
@@ -829,7 +828,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                         _ => parent.write(|parent| parent.rehash())?,
                     }
 
-                    data
+                    value
                 }
             };
 
@@ -837,14 +836,14 @@ impl<S: CachedStore, T> Merkle<S, T> {
                 parent.write(|u| u.rehash())?;
             }
 
-            data
+            value
         };
 
         for ptr in deleted.into_iter() {
             self.free_node(ptr)?;
         }
 
-        Ok(data)
+        Ok(value)
     }
 
     fn remove_tree_(
@@ -1146,7 +1145,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
 
         // transpose the Option<Result<T, E>> to Result<Option<T>, E>
         // If this is an error, the ? operator will return it
-        let Some((first_key, first_data)) = first_result.transpose()? else {
+        let Some((first_key, first_value)) = first_result.transpose()? else {
             // nothing returned, either the trie is empty or the key wasn't found
             return Ok(None);
         };
@@ -1156,7 +1155,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
             .map_err(|e| api::Error::InternalError(Box::new(e)))?;
         let limit = limit.map(|old_limit| old_limit - 1);
 
-        let mut middle = vec![(first_key.into_vec(), first_data)];
+        let mut middle = vec![(first_key.into_vec(), first_value)];
 
         // we stop streaming if either we hit the limit or the key returned was larger
         // than the largest key requested
@@ -1220,16 +1219,16 @@ impl<S: CachedStore, T> Merkle<S, T> {
         self.move_node_if_write_failed((parents, to_delete), node, write_result)
     }
 
-    /// Try to update the [NodeObjRef]'s data/value in-place. If the update fails because the node can no longer fit at its old address,
+    /// Try to update the [NodeObjRef]'s value in-place. If the update fails because the node can no longer fit at its old address,
     /// then the old address is marked for deletion and the [Node] (with its update) is inserted at a new address.
-    fn update_data_and_move_node_if_larger<'a>(
+    fn update_value_and_move_node_if_larger<'a>(
         &'a self,
         (parents, to_delete): (&mut [(NodeObjRef, u8)], &mut Vec<DiskAddress>),
         mut node: NodeObjRef<'a>,
-        data: Vec<u8>,
+        value: Vec<u8>,
     ) -> Result<NodeObjRef, MerkleError> {
         let write_result = node.write(|node| {
-            node.inner_mut().set_data(data);
+            node.inner_mut().set_value(value);
             node.rehash();
         });
 
@@ -1285,7 +1284,7 @@ impl<'a> std::ops::Deref for Ref<'a> {
     fn deref(&self) -> &[u8] {
         match &self.0.inner {
             NodeType::Branch(n) => n.value.as_ref().unwrap(),
-            NodeType::Leaf(n) => &n.data,
+            NodeType::Leaf(n) => &n.value,
         }
     }
 }
@@ -1324,7 +1323,7 @@ impl<'a, S: CachedStore, T> RefMut<'a, S, T> {
                     #[allow(clippy::unwrap_used)]
                     modify(match &mut u.inner {
                         NodeType::Branch(n) => n.value.as_mut().unwrap(),
-                        NodeType::Leaf(n) => &mut n.data,
+                        NodeType::Leaf(n) => &mut n.value,
                     });
                     u.rehash()
                 },
@@ -1396,8 +1395,8 @@ mod tests {
     use shale::{cached::InMemLinearStore, CachedStore};
     use test_case::test_case;
 
-    fn leaf(path: Vec<u8>, data: Vec<u8>) -> Node {
-        Node::from_leaf(LeafNode::new(Path(path), data))
+    fn leaf(path: Vec<u8>, value: Vec<u8>) -> Node {
+        Node::from_leaf(LeafNode::new(Path(path), value))
     }
 
     #[test_case(vec![0x12, 0x34, 0x56], &[0x1, 0x2, 0x3, 0x4, 0x5, 0x6])]
@@ -1467,13 +1466,13 @@ mod tests {
         })
     }
 
-    fn branch_without_data(path: &[u8], encoded_child: Option<Vec<u8>>) -> Node {
+    fn branch_without_value(path: &[u8], encoded_child: Option<Vec<u8>>) -> Node {
         let path = path.to_vec();
         let path = Nibbles::<0>::new(&path);
         let path = Path(path.into_iter().collect());
 
         let children = Default::default();
-        // TODO: Properly test empty data as a value
+        // TODO: Properly test empty value
         let value = None;
         let mut children_encoded = <[Option<Vec<u8>>; BranchNode::MAX_CHILDREN]>::default();
 
@@ -1493,7 +1492,7 @@ mod tests {
     #[test_case(leaf(vec![1, 2, 3], vec![4, 5]) ; "leaf encoding")]
     #[test_case(branch(b"", b"value", vec![1, 2, 3].into()) ; "branch with chd")]
     #[test_case(branch(b"", b"value", None); "branch without chd")]
-    #[test_case(branch_without_data(b"", None); "branch without value and chd")]
+    #[test_case(branch_without_value(b"", None); "branch without value and chd")]
     #[test_case(branch(b"", b"", None); "branch without path value or children")]
     #[test_case(branch(b"", b"value", None) ; "branch with value")]
     #[test_case(branch(&[2], b"", None); "branch with path")]
@@ -2074,7 +2073,7 @@ mod tests {
     #[test]
     fn update_leaf_with_larger_path() -> Result<(), MerkleError> {
         let path = vec![0x00];
-        let data = vec![0x00];
+        let value = vec![0x00];
 
         let double_path = path
             .clone()
@@ -2084,35 +2083,35 @@ mod tests {
 
         let node = Node::from_leaf(LeafNode {
             partial_path: Path::from(path),
-            data: data.clone(),
+            value: value.clone(),
         });
 
-        check_node_update(node, double_path, data)
+        check_node_update(node, double_path, value)
     }
 
     #[test]
-    fn update_leaf_with_larger_data() -> Result<(), MerkleError> {
+    fn update_leaf_with_larger_value() -> Result<(), MerkleError> {
         let path = vec![0x00];
-        let data = vec![0x00];
+        let value = vec![0x00];
 
-        let double_data = data
+        let double_value = value
             .clone()
             .into_iter()
-            .chain(data.clone())
+            .chain(value.clone())
             .collect::<Vec<_>>();
 
         let node = Node::from_leaf(LeafNode {
             partial_path: Path::from(path.clone()),
-            data,
+            value,
         });
 
-        check_node_update(node, path, double_data)
+        check_node_update(node, path, double_value)
     }
 
     #[test]
     fn update_branch_with_larger_path() -> Result<(), MerkleError> {
         let path = vec![0x00];
-        let data = vec![0x00];
+        let value = vec![0x00];
 
         let double_path = path
             .clone()
@@ -2123,38 +2122,38 @@ mod tests {
         let node = Node::from_branch(BranchNode {
             partial_path: Path::from(path.clone()),
             children: Default::default(),
-            value: Some(data.clone()),
+            value: Some(value.clone()),
             children_encoded: Default::default(),
         });
 
-        check_node_update(node, double_path, data)
+        check_node_update(node, double_path, value)
     }
 
     #[test]
-    fn update_branch_with_larger_data() -> Result<(), MerkleError> {
+    fn update_branch_with_larger_value() -> Result<(), MerkleError> {
         let path = vec![0x00];
-        let data = vec![0x00];
+        let value = vec![0x00];
 
-        let double_data = data
+        let double_value = value
             .clone()
             .into_iter()
-            .chain(data.clone())
+            .chain(value.clone())
             .collect::<Vec<_>>();
 
         let node = Node::from_branch(BranchNode {
             partial_path: Path::from(path.clone()),
             children: Default::default(),
-            value: Some(data),
+            value: Some(value),
             children_encoded: Default::default(),
         });
 
-        check_node_update(node, path, double_data)
+        check_node_update(node, path, double_value)
     }
 
     fn check_node_update(
         node: Node,
         new_path: Vec<u8>,
-        new_data: Vec<u8>,
+        new_value: Vec<u8>,
     ) -> Result<(), MerkleError> {
         let merkle = create_test_merkle();
         let root = merkle.init_root()?;
@@ -2166,7 +2165,7 @@ mod tests {
         // make sure that doubling the path length will fail on a normal write
         let write_result = node_ref.write(|node| {
             node.inner_mut().set_path(Path(new_path.clone()));
-            node.inner_mut().set_data(new_data.clone());
+            node.inner_mut().set_value(new_value.clone());
             node.rehash();
         });
 
@@ -2185,13 +2184,13 @@ mod tests {
         assert_ne!(node.as_ptr(), addr);
         assert_eq!(&to_delete[0], &addr);
 
-        let (path, data) = match node.inner() {
-            NodeType::Leaf(leaf) => (&leaf.partial_path, Some(&leaf.data)),
+        let (path, value) = match node.inner() {
+            NodeType::Leaf(leaf) => (&leaf.partial_path, Some(&leaf.value)),
             NodeType::Branch(branch) => (&branch.partial_path, branch.value.as_ref()),
         };
 
         assert_eq!(path, &Path(new_path));
-        assert_eq!(data, Some(&new_data));
+        assert_eq!(value, Some(&new_value));
 
         Ok(())
     }

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -167,12 +167,12 @@ where
         }
 
         Ok(NodeType::Branch(
-            BranchNode::new(
-                encoded.partial_path,
-                [None; BranchNode::MAX_CHILDREN],
-                encoded.value,
-                *encoded.children,
-            )
+            BranchNode {
+                partial_path: encoded.partial_path,
+                children: [None; BranchNode::MAX_CHILDREN],
+                value: encoded.value,
+                children_encoded: *encoded.children,
+            }
             .into(),
         ))
     }

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -141,11 +141,10 @@ where
                     .try_into()
                     .expect("MAX_CHILDREN will always be yielded");
 
-                let value = n.value.as_ref().map(|v| v.clone());
                 EncodedNode {
                     partial_path: n.partial_path.clone(),
                     children,
-                    value,
+                    value: n.value.clone(),
                     phantom: PhantomData,
                 }
             }
@@ -378,7 +377,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                             let mut new_branch = BranchNode {
                                 partial_path: Path(new_branch_path),
                                 children: [None; BranchNode::MAX_CHILDREN],
-                                value: Some(val.into()),
+                                value: Some(val),
                                 children_encoded: Default::default(),
                             };
 
@@ -538,7 +537,7 @@ impl<S: CachedStore, T> Merkle<S, T> {
                             let mut new_branch = BranchNode {
                                 partial_path: Path(new_branch_path),
                                 children: [None; BranchNode::MAX_CHILDREN],
-                                value: Some(val.into()),
+                                value: Some(val),
                                 children_encoded: Default::default(),
                             };
 

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -46,29 +46,6 @@ bitflags! {
     }
 }
 
-// TODO remove
-// #[derive(Debug, PartialEq, Eq, Clone)]
-// pub struct Data(pub(super) Vec<u8>);
-
-// impl std::ops::Deref for Data {
-//     type Target = [u8];
-//     fn deref(&self) -> &[u8] {
-//         &self.0
-//     }
-// }
-
-// impl From<Vec<u8>> for Data {
-//     fn from(v: Vec<u8>) -> Self {
-//         Self(v)
-//     }
-// }
-
-// impl Data {
-//     pub fn into_inner(self) -> Vec<u8> {
-//         self.0
-//     }
-// }
-
 #[derive(PartialEq, Eq, Clone, Debug, EnumAsInner)]
 pub enum NodeType {
     Branch(Box<BranchNode>),

--- a/firewood/src/merkle/node.rs
+++ b/firewood/src/merkle/node.rs
@@ -69,9 +69,9 @@ impl NodeType {
 
                 let cur_key = cur_key_path.into_inner();
                 #[allow(clippy::unwrap_used)]
-                let data: Vec<u8> = items.next().unwrap();
+                let value: Vec<u8> = items.next().unwrap();
 
-                Ok(NodeType::Leaf(LeafNode::new(cur_key, data)))
+                Ok(NodeType::Leaf(LeafNode::new(cur_key, value)))
             }
             // TODO: add path
             BranchNode::MSIZE => Ok(NodeType::Branch(BranchNode::decode(buf)?.into())),
@@ -102,10 +102,10 @@ impl NodeType {
         }
     }
 
-    pub fn set_data(&mut self, data: Vec<u8>) {
+    pub fn set_value(&mut self, value: Vec<u8>) {
         match self {
-            NodeType::Branch(u) => u.value = Some(data),
-            NodeType::Leaf(node) => node.data = data,
+            NodeType::Branch(u) => u.value = Some(value),
+            NodeType::Leaf(node) => node.value = value,
         }
     }
 }
@@ -598,9 +598,9 @@ impl<'de> Deserialize<'de> for EncodedNode<Bincode> {
                         "incorrect encoded type for leaf node path",
                     ));
                 };
-                let Some(data) = items.next() else {
+                let Some(value) = items.next() else {
                     return Err(D::Error::custom(
-                        "incorrect encoded type for leaf node data",
+                        "incorrect encoded type for leaf node value",
                     ));
                 };
                 let path = Path::from_nibbles(Nibbles::<0>::new(&path).into_iter());
@@ -608,7 +608,7 @@ impl<'de> Deserialize<'de> for EncodedNode<Bincode> {
                 Ok(Self {
                     partial_path: path,
                     children: children.into(),
-                    value: Some(data),
+                    value: Some(value),
                     phantom: PhantomData,
                 })
             }
@@ -779,10 +779,10 @@ mod tests {
         (0..0, 0..15, 0..16, 0..31, 0..32),
         [0..0, 0..16, 0..32]
     )]
-    fn leaf_node<Iter: Iterator<Item = u8>>(path: Iter, data: Iter) {
+    fn leaf_node<Iter: Iterator<Item = u8>>(path: Iter, value: Iter) {
         let node = Node::from_leaf(LeafNode::new(
             Path(path.map(|x| x & 0xf).collect()),
-            data.collect::<Vec<u8>>(),
+            value.collect::<Vec<u8>>(),
         ));
 
         check_node_encoding(node);

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -61,7 +61,8 @@ impl BranchNode {
     pub const MAX_CHILDREN: usize = MAX_CHILDREN;
     pub const MSIZE: usize = Self::MAX_CHILDREN + 2;
 
-    pub fn new(
+    // TODO remove
+    pub const fn new(
         partial_path: Path,
         chd: [Option<DiskAddress>; Self::MAX_CHILDREN],
         value: Option<Vec<u8>>,

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -61,21 +61,6 @@ impl BranchNode {
     pub const MAX_CHILDREN: usize = MAX_CHILDREN;
     pub const MSIZE: usize = Self::MAX_CHILDREN + 2;
 
-    // TODO remove
-    pub const fn new(
-        partial_path: Path,
-        chd: [Option<DiskAddress>; Self::MAX_CHILDREN],
-        value: Option<Vec<u8>>,
-        chd_encoded: [Option<Vec<u8>>; Self::MAX_CHILDREN],
-    ) -> Self {
-        BranchNode {
-            partial_path,
-            children: chd,
-            value,
-            children_encoded: chd_encoded,
-        }
-    }
-
     pub const fn value(&self) -> &Option<Vec<u8>> {
         &self.value
     }
@@ -118,12 +103,12 @@ impl BranchNode {
             (chd_encoded[i] = Some(chd).filter(|data| !data.is_empty()));
         }
 
-        Ok(BranchNode::new(
-            path,
-            [None; Self::MAX_CHILDREN],
+        Ok(BranchNode {
+            partial_path: path,
+            children: [None; Self::MAX_CHILDREN],
             value,
-            chd_encoded,
-        ))
+            children_encoded: chd_encoded,
+        })
     }
 
     pub(super) fn encode<S: CachedStore>(&self, store: &CompactSpace<Node, S>) -> Vec<u8> {

--- a/firewood/src/merkle/node/branch.rs
+++ b/firewood/src/merkle/node/branch.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use super::{Data, Node};
+use super::Node;
 use crate::{
     merkle::{from_nibbles, to_nibble_array, PartialPath},
     nibbles::Nibbles,
@@ -25,7 +25,7 @@ const MAX_CHILDREN: usize = 16;
 pub struct BranchNode {
     pub(crate) partial_path: PartialPath,
     pub(crate) children: [Option<DiskAddress>; MAX_CHILDREN],
-    pub(crate) value: Option<Data>,
+    pub(crate) value: Option<Vec<u8>>,
     pub(crate) children_encoded: [Option<Vec<u8>>; MAX_CHILDREN],
 }
 
@@ -70,12 +70,12 @@ impl BranchNode {
         BranchNode {
             partial_path,
             children: chd,
-            value: value.map(Data),
+            value,
             children_encoded: chd_encoded,
         }
     }
 
-    pub const fn value(&self) -> &Option<Data> {
+    pub const fn value(&self) -> &Option<Vec<u8>> {
         &self.value
     }
 
@@ -171,7 +171,7 @@ impl BranchNode {
         }
 
         #[allow(clippy::unwrap_used)]
-        if let Some(Data(val)) = &self.value {
+        if let Some(val) = &self.value {
             list[Self::MAX_CHILDREN] = val.clone();
         }
 
@@ -312,7 +312,7 @@ impl Storable for BranchNode {
 
                 addr += len as usize;
 
-                Some(Data(data.as_deref()))
+                Some(data.as_deref())
             }
             None => None,
         };

--- a/firewood/src/merkle/node/leaf.rs
+++ b/firewood/src/merkle/node/leaf.rs
@@ -1,7 +1,6 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use super::Data;
 use crate::{
     merkle::{from_nibbles, PartialPath},
     nibbles::Nibbles,
@@ -23,7 +22,7 @@ type DataLen = u32;
 #[derive(PartialEq, Eq, Clone)]
 pub struct LeafNode {
     pub(crate) partial_path: PartialPath,
-    pub(crate) data: Data,
+    pub(crate) data: Vec<u8>,
 }
 
 impl Debug for LeafNode {
@@ -38,7 +37,7 @@ impl Debug for LeafNode {
 }
 
 impl LeafNode {
-    pub fn new<P: Into<PartialPath>, D: Into<Data>>(partial_path: P, data: D) -> Self {
+    pub fn new<P: Into<PartialPath>, D: Into<Vec<u8>>>(partial_path: P, data: D) -> Self {
         Self {
             partial_path: partial_path.into(),
             data: data.into(),
@@ -49,7 +48,7 @@ impl LeafNode {
         &self.partial_path
     }
 
-    pub const fn data(&self) -> &Data {
+    pub const fn data(&self) -> &Vec<u8> {
         &self.data
     }
 
@@ -141,7 +140,7 @@ impl Storable for LeafNode {
             PartialPath::from_nibbles(nibbles).0
         };
 
-        let data = Data(data.to_vec());
+        let data = data.to_vec();
 
         Ok(Self::new(path, data))
     }

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -434,7 +434,7 @@ fn locate_subproof(
             let Some(index) = key_nibbles.next().map(|nib| nib as usize) else {
                 let encoded = n.value;
 
-                let sub_proof = encoded.map(|encoded| SubProof::Data(encoded));
+                let sub_proof = encoded.map(SubProof::Data);
 
                 return Ok((sub_proof, key_nibbles));
             };

--- a/firewood/src/merkle/proof.rs
+++ b/firewood/src/merkle/proof.rs
@@ -434,7 +434,7 @@ fn locate_subproof(
             let Some(index) = key_nibbles.next().map(|nib| nib as usize) else {
                 let encoded = n.value;
 
-                let sub_proof = encoded.map(|encoded| SubProof::Data(encoded.into_inner()));
+                let sub_proof = encoded.map(|encoded| SubProof::Data(encoded));
 
                 return Ok((sub_proof, key_nibbles));
             };

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -381,7 +381,7 @@ impl<'a, S: CachedStore, T> Stream for MerkleKeyValueStream<'a, S, T> {
                                 Poll::Ready(Some(Ok((key, value))))
                             }
                             NodeType::Leaf(leaf) => {
-                                let value = leaf.data.to_vec();
+                                let value = leaf.value.to_vec();
                                 Poll::Ready(Some(Ok((key, value))))
                             }
                         },
@@ -635,7 +635,7 @@ mod tests {
         };
 
         assert_eq!(key, vec![0x01, 0x03, 0x03, 0x07].into_boxed_slice());
-        assert_eq!(node.inner().as_leaf().unwrap().data, vec![0x42]);
+        assert_eq!(node.inner().as_leaf().unwrap().value, vec![0x42]);
 
         assert!(stream.next().is_none());
     }
@@ -683,7 +683,7 @@ mod tests {
             vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x0F].into_boxed_slice()
         );
         assert_eq!(
-            node.inner().as_leaf().unwrap().data,
+            node.inner().as_leaf().unwrap().value,
             vec![0x00, 0x00, 0x00, 0x0FF],
         );
 
@@ -753,7 +753,7 @@ mod tests {
         let (key, node) = stream.next().await.unwrap().unwrap();
 
         assert_eq!(key, vec![0x00].into_boxed_slice());
-        assert_eq!(node.inner().as_leaf().unwrap().data.to_vec(), vec![0x00]);
+        assert_eq!(node.inner().as_leaf().unwrap().value.to_vec(), vec![0x00]);
 
         check_stream_is_done(stream).await;
     }
@@ -823,26 +823,26 @@ mod tests {
         let (key, node) = stream.next().await.unwrap().unwrap();
         assert_eq!(key, vec![0x00, 0x00, 0x00, 0x01].into_boxed_slice());
         let node = node.inner().as_leaf().unwrap();
-        assert_eq!(node.clone().data.to_vec(), vec![0x00, 0x00, 0x00, 0x01]);
+        assert_eq!(node.clone().value.to_vec(), vec![0x00, 0x00, 0x00, 0x01]);
         assert_eq!(node.partial_path.to_vec(), vec![0x01]);
 
         let (key, node) = stream.next().await.unwrap().unwrap();
         assert_eq!(key, vec![0x00, 0x00, 0x00, 0xFF].into_boxed_slice());
         let node = node.inner().as_leaf().unwrap();
-        assert_eq!(node.clone().data.to_vec(), vec![0x00, 0x00, 0x00, 0xFF]);
+        assert_eq!(node.clone().value.to_vec(), vec![0x00, 0x00, 0x00, 0xFF]);
         assert_eq!(node.partial_path.to_vec(), vec![0x0F]);
 
         let (key, node) = stream.next().await.unwrap().unwrap();
         assert_eq!(key, vec![0x00, 0xD0, 0xD0].into_boxed_slice());
         let node = node.inner().as_leaf().unwrap();
-        assert_eq!(node.clone().data.to_vec(), vec![0x00, 0xD0, 0xD0]);
+        assert_eq!(node.clone().value.to_vec(), vec![0x00, 0xD0, 0xD0]);
         assert_eq!(node.partial_path.to_vec(), vec![0x00, 0x0D, 0x00]); // 0x0D00 becomes 0xDO
 
         // Covers case of leaf with no partial path
         let (key, node) = stream.next().await.unwrap().unwrap();
         assert_eq!(key, vec![0x00, 0xFF].into_boxed_slice());
         let node = node.inner().as_leaf().unwrap();
-        assert_eq!(node.clone().data.to_vec(), vec![0x00, 0xFF]);
+        assert_eq!(node.clone().value.to_vec(), vec![0x00, 0xFF]);
         assert_eq!(node.partial_path.to_vec(), vec![0x0F]);
 
         check_stream_is_done(stream).await;
@@ -857,7 +857,7 @@ mod tests {
         let (key, node) = stream.next().await.unwrap().unwrap();
         assert_eq!(key, vec![0x00, 0xD0, 0xD0].into_boxed_slice());
         assert_eq!(
-            node.inner().as_leaf().unwrap().clone().data.to_vec(),
+            node.inner().as_leaf().unwrap().clone().value.to_vec(),
             vec![0x00, 0xD0, 0xD0]
         );
 
@@ -865,7 +865,7 @@ mod tests {
         let (key, node) = stream.next().await.unwrap().unwrap();
         assert_eq!(key, vec![0x00, 0xFF].into_boxed_slice());
         assert_eq!(
-            node.inner().as_leaf().unwrap().clone().data.to_vec(),
+            node.inner().as_leaf().unwrap().clone().value.to_vec(),
             vec![0x00, 0xFF]
         );
 
@@ -881,7 +881,7 @@ mod tests {
         let (key, node) = stream.next().await.unwrap().unwrap();
         assert_eq!(key, vec![0x00, 0xD0, 0xD0].into_boxed_slice());
         assert_eq!(
-            node.inner().as_leaf().unwrap().clone().data.to_vec(),
+            node.inner().as_leaf().unwrap().clone().value.to_vec(),
             vec![0x00, 0xD0, 0xD0]
         );
 
@@ -889,7 +889,7 @@ mod tests {
         let (key, node) = stream.next().await.unwrap().unwrap();
         assert_eq!(key, vec![0x00, 0xFF].into_boxed_slice());
         assert_eq!(
-            node.inner().as_leaf().unwrap().clone().data.to_vec(),
+            node.inner().as_leaf().unwrap().clone().value.to_vec(),
             vec![0x00, 0xFF]
         );
 
@@ -1039,7 +1039,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn key_value_root_with_empty_data() {
+    async fn key_value_root_with_empty_value() {
         let mut merkle = create_test_merkle();
         let root = merkle.init_root().unwrap();
 

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -670,7 +670,7 @@ mod tests {
         );
         assert_eq!(
             node.inner().as_branch().unwrap().value,
-            Some(vec![0x00, 0x00, 0x00].into()),
+            Some(vec![0x00, 0x00, 0x00]),
         );
 
         let (key, node) = match stream.next() {
@@ -718,7 +718,7 @@ mod tests {
         );
         assert_eq!(
             node.inner().as_branch().unwrap().value,
-            Some(vec![0x00, 0x00, 0x00].into()),
+            Some(vec![0x00, 0x00, 0x00]),
         );
 
         assert!(stream.next().is_none());

--- a/firewood/src/merkle/stream.rs
+++ b/firewood/src/merkle/stream.rs
@@ -635,7 +635,7 @@ mod tests {
         };
 
         assert_eq!(key, vec![0x01, 0x03, 0x03, 0x07].into_boxed_slice());
-        assert_eq!(node.inner().as_leaf().unwrap().data, vec![0x42].into());
+        assert_eq!(node.inner().as_leaf().unwrap().data, vec![0x42]);
 
         assert!(stream.next().is_none());
     }
@@ -684,7 +684,7 @@ mod tests {
         );
         assert_eq!(
             node.inner().as_leaf().unwrap().data,
-            vec![0x00, 0x00, 0x00, 0x0FF].into(),
+            vec![0x00, 0x00, 0x00, 0x0FF],
         );
 
         assert!(stream.next().is_none());

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -145,7 +145,7 @@ impl Obj<Node> {
     pub fn into_inner(mut self) -> Node {
         let empty_node = LeafNode {
             partial_path: Path(Vec::new()),
-            data: Vec::new().into(),
+            data: Vec::new(),
         };
 
         std::mem::replace(&mut self.value.item, Node::from_leaf(empty_node))

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -145,7 +145,7 @@ impl Obj<Node> {
     pub fn into_inner(mut self) -> Node {
         let empty_node = LeafNode {
             partial_path: Path(Vec::new()),
-            data: Vec::new(),
+            value: Vec::new(),
         };
 
         std::mem::replace(&mut self.value.item, Node::from_leaf(empty_node))

--- a/firewood/tests/merkle.rs
+++ b/firewood/tests/merkle.rs
@@ -946,8 +946,8 @@ fn test_empty_value_range_proof() -> Result<(), ProofError> {
     // Create a new entry with a slightly modified key
     let mid_index = items.len() / 2;
     let key = increase_key(items[mid_index - 1].0);
-    let empty_data: [u8; 20] = [0; 20];
-    items.splice(mid_index..mid_index, [(&key, &empty_data)].iter().cloned());
+    let empty_value: [u8; 20] = [0; 20];
+    items.splice(mid_index..mid_index, [(&key, &empty_value)].iter().cloned());
 
     let start = 1;
     let end = items.len() - 1;
@@ -982,8 +982,8 @@ fn test_all_elements_empty_value_range_proof() -> Result<(), ProofError> {
     // Create a new entry with a slightly modified key
     let mid_index = items.len() / 2;
     let key = increase_key(items[mid_index - 1].0);
-    let empty_data: [u8; 20] = [0; 20];
-    items.splice(mid_index..mid_index, [(&key, &empty_data)].iter().cloned());
+    let empty_value: [u8; 20] = [0; 20];
+    items.splice(mid_index..mid_index, [(&key, &empty_value)].iter().cloned());
 
     let start = 0;
     let end = items.len() - 1;
@@ -1049,12 +1049,12 @@ fn test_bloadted_range_proof() -> Result<(), ProofError> {
     let mut items = Vec::new();
     for i in 0..100_u32 {
         let mut key: [u8; 32] = [0; 32];
-        let mut data: [u8; 20] = [0; 20];
+        let mut value: [u8; 20] = [0; 20];
         for (index, d) in i.to_be_bytes().iter().enumerate() {
             key[index] = *d;
-            data[index] = *d;
+            value[index] = *d;
         }
-        items.push((key, data));
+        items.push((key, value));
     }
     let merkle = merkle_build_test(items.clone(), 0x10000, 0x10000)?;
 
@@ -1085,18 +1085,18 @@ fn fixed_and_pseudorandom_data(random_count: u32) -> HashMap<[u8; 32], [u8; 20]>
     let mut items: HashMap<[u8; 32], [u8; 20]> = HashMap::new();
     for i in 0..100_u32 {
         let mut key: [u8; 32] = [0; 32];
-        let mut data: [u8; 20] = [0; 20];
+        let mut value: [u8; 20] = [0; 20];
         for (index, d) in i.to_be_bytes().iter().enumerate() {
             key[index] = *d;
-            data[index] = *d;
+            value[index] = *d;
         }
-        items.insert(key, data);
+        items.insert(key, value);
 
         let mut more_key: [u8; 32] = [0; 32];
         for (index, d) in (i + 10).to_be_bytes().iter().enumerate() {
             more_key[index] = *d;
         }
-        items.insert(more_key, data);
+        items.insert(more_key, value);
     }
 
     // read FIREWOOD_TEST_SEED from the environment. If it's there, parse it into a u64.


### PR DESCRIPTION
It's confusing that sometimes we call the thing inside of a node / the thing we map a key to as "data" and other times as "value". This PR changes usages of "data" in this context to "value" so that we're not using 2 different terms for the same thing. It also matches merkledb.