### PR TITLE
Don't `Box` the children!

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -116,7 +116,7 @@ where
                 let children: [Option<Vec<u8>>; BranchNode::MAX_CHILDREN] = Default::default();
                 EncodedNode {
                     partial_path: n.partial_path.clone(),
-                    children: Box::new(children),
+                    children,
                     value: n.value.clone().into(),
                     phantom: PhantomData,
                 }
@@ -171,7 +171,7 @@ where
                 partial_path: encoded.partial_path,
                 children: [None; BranchNode::MAX_CHILDREN],
                 value: encoded.value,
-                children_encoded: *encoded.children,
+                children_encoded: encoded.children,
             }
             .into(),
         ))


### PR DESCRIPTION
An enum was converted into a struct. The `Box` wrapper arguably wasn't necessary for the enum since the `Branch` variant was so much more common, but in any case, this definitely is not needed for the new struct.

