### PR TITLE
dont panic on invalid `DiskAddress` length

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -218,10 +218,7 @@ impl Storable for DbHeader {
         Ok(Self {
             kv_root: root_bytes
                 .try_into()
-                .map_err(|_| ShaleError::InvalidAddressLength {
-                    expected: Self::MSIZE,
-                    found: root_bytes.len() as u64,
-                })?,
+                .expect("Self::MSIZE > DiskAddress:MSIZE"),
         })
     }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -219,7 +219,7 @@ impl Storable for DbHeader {
             kv_root: root_bytes
                 .try_into()
                 .map_err(|_| ShaleError::InvalidAddressLength {
-                    expected: DiskAddress::MSIZE,
+                    expected: Self::MSIZE,
                     found: root_bytes.len() as u64,
                 })?,
         })

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -218,7 +218,7 @@ impl Storable for DbHeader {
         Ok(Self {
             kv_root: root_bytes
                 .try_into()
-                .expect("Self::MSIZE > DiskAddress:MSIZE"),
+                .expect("Self::MSIZE == DiskAddress:MSIZE"),
         })
     }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -206,14 +206,22 @@ impl DbHeader {
 
 impl Storable for DbHeader {
     fn deserialize<T: CachedStore>(addr: usize, mem: &T) -> Result<Self, shale::ShaleError> {
-        let raw = mem
+        let root_bytes = mem
             .get_view(addr, Self::MSIZE)
             .ok_or(ShaleError::InvalidCacheView {
                 offset: addr,
                 size: Self::MSIZE,
             })?;
+        let root_bytes = root_bytes.as_deref();
+        let root_bytes = root_bytes.as_slice();
+
         Ok(Self {
-            kv_root: raw.as_deref().as_slice().into(),
+            kv_root: root_bytes
+                .try_into()
+                .map_err(|_| ShaleError::InvalidAddressLength {
+                    expected: DiskAddress::MSIZE,
+                    found: root_bytes.len() as u64,
+                })?,
         })
     }
 

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -201,13 +201,21 @@ impl Storable for CompactSpaceHeader {
                 size: Self::MSIZE,
             })?;
         #[allow(clippy::indexing_slicing)]
-        let meta_space_tail = raw.as_deref()[..8].try_into().unwrap();
+        let meta_space_tail = raw.as_deref()[..8]
+            .try_into()
+            .expect("Self::MSIZE = 4 * DiskAddress::MSIZE");
         #[allow(clippy::indexing_slicing)]
-        let data_space_tail = raw.as_deref()[8..16].try_into().unwrap();
+        let data_space_tail = raw.as_deref()[8..16]
+            .try_into()
+            .expect("Self::MSIZE = 4 * DiskAddress::MSIZE");
         #[allow(clippy::indexing_slicing)]
-        let base_addr = raw.as_deref()[16..24].try_into().unwrap();
+        let base_addr = raw.as_deref()[16..24]
+            .try_into()
+            .expect("Self::MSIZE = 4 * DiskAddress::MSIZE");
         #[allow(clippy::indexing_slicing)]
-        let alloc_addr = raw.as_deref()[24..].try_into().unwrap();
+        let alloc_addr = raw.as_deref()[24..]
+            .try_into()
+            .expect("Self::MSIZE = 4 * DiskAddress::MSIZE");
         Ok(Self {
             meta_space_tail,
             data_space_tail,

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -201,13 +201,13 @@ impl Storable for CompactSpaceHeader {
                 size: Self::MSIZE,
             })?;
         #[allow(clippy::indexing_slicing)]
-        let meta_space_tail = raw.as_deref()[..8].into();
+        let meta_space_tail = raw.as_deref()[..8].try_into().unwrap();
         #[allow(clippy::indexing_slicing)]
-        let data_space_tail = raw.as_deref()[8..16].into();
+        let data_space_tail = raw.as_deref()[8..16].try_into().unwrap();
         #[allow(clippy::indexing_slicing)]
-        let base_addr = raw.as_deref()[16..24].into();
+        let base_addr = raw.as_deref()[16..24].try_into().unwrap();
         #[allow(clippy::indexing_slicing)]
-        let alloc_addr = raw.as_deref()[24..].into();
+        let alloc_addr = raw.as_deref()[24..].try_into().unwrap();
         Ok(Self {
             meta_space_tail,
             data_space_tail,
@@ -631,7 +631,7 @@ impl<T: Storable + Debug + 'static, M: CachedStore> CompactSpace<T, M> {
         #[allow(clippy::unwrap_used)]
         if ptr < DiskAddress::from(CompactSpaceHeader::MSIZE as usize) {
             return Err(ShaleError::InvalidAddressLength {
-                expected: DiskAddress::from(CompactSpaceHeader::MSIZE as usize),
+                expected: CompactSpaceHeader::MSIZE,
                 found: ptr.0.map(|inner| inner.get()).unwrap_or_default() as u64,
             });
         }

--- a/firewood/src/shale/disk_address.rs
+++ b/firewood/src/shale/disk_address.rs
@@ -75,11 +75,13 @@ impl From<[u8; 8]> for DiskAddress {
 /// Convert from a slice of bytes to a DiskAddress
 /// panics if the slice isn't 8 bytes; used for
 /// serialization from disk
-impl From<&[u8]> for DiskAddress {
-    fn from(value: &[u8]) -> Self {
+impl TryFrom<&[u8]> for DiskAddress {
+    type Error = std::array::TryFromSliceError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         #[allow(clippy::unwrap_used)]
-        let bytes: [u8; 8] = value.try_into().unwrap();
-        bytes.into()
+        let bytes: [u8; 8] = value.try_into()?;
+        Ok(bytes.into())
     }
 }
 

--- a/firewood/src/shale/mod.rs
+++ b/firewood/src/shale/mod.rs
@@ -28,7 +28,7 @@ pub enum ShaleError {
         error: &'static str,
     },
     #[error("invalid address length expected: {expected:?} found: {found:?})")]
-    InvalidAddressLength { expected: DiskAddress, found: u64 },
+    InvalidAddressLength { expected: u64, found: u64 },
     #[error("invalid node type")]
     InvalidNodeType,
     #[error("invalid node metadata")]


### PR DESCRIPTION
Replaces `impl From<&[u8]> for DiskAddress {` with `impl TryFrom<&[u8]> for DiskAddress {` so we don't panic if we try to get a `DiskAddress` `From` a [u8] with an unexpected length