### PR TITLE
don't assume DiskAddress is 8 bytes in CompactSpaceHeader

### DIFF
--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -171,7 +171,11 @@ impl CompactSpaceHeaderSliced {
 }
 
 impl CompactSpaceHeader {
-    pub const MSIZE: u64 = 32;
+    pub const MSIZE: u64 = 4 * DiskAddress::MSIZE as u64;
+    const META_SPACE_TAIL_OFFSET: usize = 0;
+    const DATA_SPACE_TAIL_OFFSET: usize = DiskAddress::MSIZE as usize;
+    const BASE_ADDR_OFFSET: usize = 2 * DiskAddress::MSIZE as usize;
+    const ALLOC_ADDR_OFFSET: usize = 3 * DiskAddress::MSIZE as usize;
 
     pub const fn new(meta_base: NonZeroUsize, compact_base: NonZeroUsize) -> Self {
         Self {
@@ -184,10 +188,30 @@ impl CompactSpaceHeader {
 
     fn into_fields(r: Obj<Self>) -> Result<CompactSpaceHeaderSliced, ShaleError> {
         Ok(CompactSpaceHeaderSliced {
-            meta_space_tail: StoredView::slice(&r, 0, 8, r.meta_space_tail)?,
-            data_space_tail: StoredView::slice(&r, 8, 8, r.data_space_tail)?,
-            base_addr: StoredView::slice(&r, 16, 8, r.base_addr)?,
-            alloc_addr: StoredView::slice(&r, 24, 8, r.alloc_addr)?,
+            meta_space_tail: StoredView::slice(
+                &r,
+                Self::META_SPACE_TAIL_OFFSET,
+                DiskAddress::MSIZE,
+                r.meta_space_tail,
+            )?,
+            data_space_tail: StoredView::slice(
+                &r,
+                Self::DATA_SPACE_TAIL_OFFSET,
+                DiskAddress::MSIZE,
+                r.data_space_tail,
+            )?,
+            base_addr: StoredView::slice(
+                &r,
+                Self::BASE_ADDR_OFFSET,
+                DiskAddress::MSIZE,
+                r.base_addr,
+            )?,
+            alloc_addr: StoredView::slice(
+                &r,
+                Self::ALLOC_ADDR_OFFSET,
+                DiskAddress::MSIZE,
+                r.alloc_addr,
+            )?,
         })
     }
 }
@@ -201,13 +225,14 @@ impl Storable for CompactSpaceHeader {
                 size: Self::MSIZE,
             })?;
         #[allow(clippy::indexing_slicing)]
-        let meta_space_tail = raw.as_deref()[..8].into();
+        let meta_space_tail = raw.as_deref()[..Self::DATA_SPACE_TAIL_OFFSET].into();
         #[allow(clippy::indexing_slicing)]
-        let data_space_tail = raw.as_deref()[8..16].into();
+        let data_space_tail =
+            raw.as_deref()[Self::DATA_SPACE_TAIL_OFFSET..Self::BASE_ADDR_OFFSET].into();
         #[allow(clippy::indexing_slicing)]
-        let base_addr = raw.as_deref()[16..24].into();
+        let base_addr = raw.as_deref()[Self::BASE_ADDR_OFFSET..Self::ALLOC_ADDR_OFFSET].into();
         #[allow(clippy::indexing_slicing)]
-        let alloc_addr = raw.as_deref()[24..].into();
+        let alloc_addr = raw.as_deref()[Self::ALLOC_ADDR_OFFSET..].into();
         Ok(Self {
             meta_space_tail,
             data_space_tail,

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -171,7 +171,7 @@ impl CompactSpaceHeaderSliced {
 }
 
 impl CompactSpaceHeader {
-    pub const MSIZE: u64 = 4 * DiskAddress::MSIZE as u64;
+    pub const MSIZE: u64 = 4 * DiskAddress::MSIZE;
     const META_SPACE_TAIL_OFFSET: usize = 0;
     const DATA_SPACE_TAIL_OFFSET: usize = DiskAddress::MSIZE as usize;
     const BASE_ADDR_OFFSET: usize = 2 * DiskAddress::MSIZE as usize;

--- a/firewood/src/shale/disk_address.rs
+++ b/firewood/src/shale/disk_address.rs
@@ -48,7 +48,7 @@ impl DiskAddress {
     }
 
     /// Get the little endian bytes for a DiskAddress for storage
-    pub fn to_le_bytes(&self) -> [u8; 8] {
+    pub fn to_le_bytes(&self) -> [u8; Self::MSIZE as usize] {
         self.0.map(|v| v.get()).unwrap_or_default().to_le_bytes()
     }
 
@@ -67,7 +67,7 @@ impl From<usize> for DiskAddress {
 
 /// Convert from a serialized le_bytes to a DiskAddress
 impl From<[u8; 8]> for DiskAddress {
-    fn from(value: [u8; 8]) -> Self {
+    fn from(value: [u8; Self::MSIZE as usize]) -> Self {
         Self::from(usize::from_le_bytes(value))
     }
 }
@@ -78,7 +78,7 @@ impl From<[u8; 8]> for DiskAddress {
 impl From<&[u8]> for DiskAddress {
     fn from(value: &[u8]) -> Self {
         #[allow(clippy::unwrap_used)]
-        let bytes: [u8; 8] = value.try_into().unwrap();
+        let bytes: [u8; Self::MSIZE as usize] = value.try_into().unwrap();
         bytes.into()
     }
 }


### PR DESCRIPTION
Right now we assume inside `CompactSpaceHeader` that a `DiskAddress` is 8 bytes. It might not be, though. Namely on 32 bit architecture machines. This PR replaces magic numbers related to this assumption.