### PR TITLE
tweak descriptor method names

### DIFF
--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -299,10 +299,6 @@ impl From<CompactSpaceInner<StoreRevMut>> for CompactSpaceInner<StoreRevShared> 
 }
 
 impl<M: LinearStore> CompactSpaceInner<M> {
-    fn get_descriptor(&self, ptr: DiskAddress) -> Result<Obj<CompactDescriptor>, ShaleError> {
-        StoredView::ptr_to_obj(&self.meta_space, ptr, CompactDescriptor::SERIALIZED_LEN)
-    }
-
     fn get_data_ref<U: Storable + 'static>(
         &self,
         ptr: DiskAddress,
@@ -319,7 +315,11 @@ impl<M: LinearStore> CompactSpaceInner<M> {
         self.get_data_ref::<CompactFooter>(ptr, CompactFooter::SERIALIZED_LEN)
     }
 
-    fn del_desc(&mut self, desc_addr: DiskAddress) -> Result<(), ShaleError> {
+    fn get_descriptor(&self, ptr: DiskAddress) -> Result<Obj<CompactDescriptor>, ShaleError> {
+        StoredView::ptr_to_obj(&self.meta_space, ptr, CompactDescriptor::SERIALIZED_LEN)
+    }
+
+    fn delete_descriptor(&mut self, desc_addr: DiskAddress) -> Result<(), ShaleError> {
         let desc_size = CompactDescriptor::SERIALIZED_LEN;
         // TODO: subtracting two disk addresses is only used here, probably can rewrite this
         // debug_assert!((desc_addr.0 - self.header.base_addr.value.into()) % desc_size == 0);
@@ -342,7 +342,7 @@ impl<M: LinearStore> CompactSpaceInner<M> {
         Ok(())
     }
 
-    fn new_desc(&mut self) -> Result<DiskAddress, ShaleError> {
+    fn new_descriptor_address(&mut self) -> Result<DiskAddress, ShaleError> {
         let addr = **self.header.meta_space_tail;
         #[allow(clippy::unwrap_used)]
         self.header
@@ -379,7 +379,7 @@ impl<M: LinearStore> CompactSpaceInner<M> {
             if pheader_is_freed {
                 h = offset;
                 payload_size += hsize + fsize + pheader_payload_size;
-                self.del_desc(pheader_desc_addr)?;
+                self.delete_descriptor(pheader_desc_addr)?;
             }
         }
 
@@ -404,11 +404,11 @@ impl<M: LinearStore> CompactSpaceInner<M> {
                     assert!(nheader_payload_size == nfooter.payload_size);
                 }
                 payload_size += hsize + fsize + nheader_payload_size;
-                self.del_desc(nheader_desc_addr)?;
+                self.delete_descriptor(nheader_desc_addr)?;
             }
         }
 
-        let desc_addr = self.new_desc()?;
+        let desc_addr = self.new_descriptor_address()?;
         {
             let mut desc = self.get_descriptor(desc_addr)?;
             #[allow(clippy::unwrap_used)]
@@ -466,7 +466,7 @@ impl<M: LinearStore> CompactSpaceInner<M> {
                     #[allow(clippy::unwrap_used)]
                     header.modify(|h| h.is_freed = false).unwrap();
                 }
-                self.del_desc(ptr)?;
+                self.delete_descriptor(ptr)?;
                 true
             } else if desc_payload_size > length as usize + hsize + fsize {
                 // able to split
@@ -492,7 +492,7 @@ impl<M: LinearStore> CompactSpaceInner<M> {
 
                 let offset = desc_haddr + hsize + length as usize + fsize;
                 let rpayload_size = desc_payload_size - length as usize - fsize - hsize;
-                let rdesc_addr = self.new_desc()?;
+                let rdesc_addr = self.new_descriptor_address()?;
                 {
                     let mut rdesc = self.get_descriptor(rdesc_addr)?;
                     #[allow(clippy::unwrap_used)]
@@ -522,7 +522,7 @@ impl<M: LinearStore> CompactSpaceInner<M> {
                         .modify(|f| f.payload_size = rpayload_size as u64)
                         .unwrap();
                 }
-                self.del_desc(ptr)?;
+                self.delete_descriptor(ptr)?;
                 true
             } else {
                 false


### PR DESCRIPTION
* Moves `get_descriptor` next to other `*_descriptor` methods
* Renames `del_desc` to `delete_descriptor` to align with `get_descriptor`
* Renames `new_desc` to `new_descriptor_address` to align with `get_descriptor` and `delete_descriptor` and clarify that it returns an address, not a descriptor