### PR TITLE
Improve `alloc_from_freed` readability

### DIFF
--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -299,10 +299,6 @@ impl From<CompactSpaceInner<StoreRevMut>> for CompactSpaceInner<StoreRevShared> 
 }
 
 impl<M: LinearStore> CompactSpaceInner<M> {
-    fn get_descriptor(&self, ptr: DiskAddress) -> Result<Obj<CompactDescriptor>, ShaleError> {
-        StoredView::ptr_to_obj(&self.meta_space, ptr, CompactDescriptor::SERIALIZED_LEN)
-    }
-
     fn get_data_ref<U: Storable + 'static>(
         &self,
         ptr: DiskAddress,
@@ -319,7 +315,11 @@ impl<M: LinearStore> CompactSpaceInner<M> {
         self.get_data_ref::<CompactFooter>(ptr, CompactFooter::SERIALIZED_LEN)
     }
 
-    fn del_desc(&mut self, desc_addr: DiskAddress) -> Result<(), ShaleError> {
+    fn get_descriptor(&self, ptr: DiskAddress) -> Result<Obj<CompactDescriptor>, ShaleError> {
+        StoredView::ptr_to_obj(&self.meta_space, ptr, CompactDescriptor::SERIALIZED_LEN)
+    }
+
+    fn delete_descriptor(&mut self, desc_addr: DiskAddress) -> Result<(), ShaleError> {
         let desc_size = CompactDescriptor::SERIALIZED_LEN;
         // TODO: subtracting two disk addresses is only used here, probably can rewrite this
         // debug_assert!((desc_addr.0 - self.header.base_addr.value.into()) % desc_size == 0);
@@ -342,7 +342,7 @@ impl<M: LinearStore> CompactSpaceInner<M> {
         Ok(())
     }
 
-    fn new_desc(&mut self) -> Result<DiskAddress, ShaleError> {
+    fn new_descriptor_address(&mut self) -> Result<DiskAddress, ShaleError> {
         let addr = **self.header.meta_space_tail;
         #[allow(clippy::unwrap_used)]
         self.header
@@ -379,7 +379,7 @@ impl<M: LinearStore> CompactSpaceInner<M> {
             if pheader_is_freed {
                 h = offset;
                 payload_size += hsize + fsize + pheader_payload_size;
-                self.del_desc(pheader_desc_addr)?;
+                self.delete_descriptor(pheader_desc_addr)?;
             }
         }
 
@@ -404,11 +404,11 @@ impl<M: LinearStore> CompactSpaceInner<M> {
                     assert!(nheader_payload_size == nfooter.payload_size);
                 }
                 payload_size += hsize + fsize + nheader_payload_size;
-                self.del_desc(nheader_desc_addr)?;
+                self.delete_descriptor(nheader_desc_addr)?;
             }
         }
 
-        let desc_addr = self.new_desc()?;
+        let desc_addr = self.new_descriptor_address()?;
         {
             let mut desc = self.get_descriptor(desc_addr)?;
             #[allow(clippy::unwrap_used)]
@@ -466,7 +466,7 @@ impl<M: LinearStore> CompactSpaceInner<M> {
                     #[allow(clippy::unwrap_used)]
                     header.modify(|h| h.is_freed = false).unwrap();
                 }
-                self.del_desc(ptr)?;
+                self.delete_descriptor(ptr)?;
                 true
             } else if desc_payload_size > length as usize + hsize + fsize {
                 // able to split
@@ -492,7 +492,7 @@ impl<M: LinearStore> CompactSpaceInner<M> {
 
                 let offset = desc_haddr + hsize + length as usize + fsize;
                 let rpayload_size = desc_payload_size - length as usize - fsize - hsize;
-                let rdesc_addr = self.new_desc()?;
+                let rdesc_addr = self.new_descriptor_address()?;
                 {
                     let mut rdesc = self.get_descriptor(rdesc_addr)?;
                     #[allow(clippy::unwrap_used)]
@@ -522,7 +522,7 @@ impl<M: LinearStore> CompactSpaceInner<M> {
                         .modify(|f| f.payload_size = rpayload_size as u64)
                         .unwrap();
                 }
-                self.del_desc(ptr)?;
+                self.delete_descriptor(ptr)?;
                 true
             } else {
                 false

--- a/firewood/src/shale/compact.rs
+++ b/firewood/src/shale/compact.rs
@@ -440,21 +440,21 @@ impl<M: LinearStore> StoreInner<M> {
         const FOOTER_SIZE: usize = ChunkFooter::SERIALIZED_LEN as usize;
         const DESCRIPTOR_SIZE: usize = ChunkDescriptor::SERIALIZED_LEN as usize;
 
-        let meta_store_tail = *self.header.meta_store_tail;
-        if meta_store_tail == *self.header.base_addr {
+        let tail = *self.header.meta_store_tail;
+        if tail == *self.header.base_addr {
             return Ok(None);
         }
 
         let mut old_alloc_addr = *self.header.alloc_addr;
 
-        if old_alloc_addr >= meta_store_tail {
+        if old_alloc_addr >= tail {
             old_alloc_addr = *self.header.base_addr;
         }
 
         let mut ptr = old_alloc_addr;
         let mut res: Option<u64> = None;
         for _ in 0..self.alloc_max_walk {
-            assert!(ptr < meta_store_tail);
+            assert!(ptr < tail);
             let (chunk_size, desc_haddr) = {
                 let desc = self.get_descriptor(ptr)?;
                 (desc.chunk_size as usize, desc.haddr)
@@ -537,7 +537,7 @@ impl<M: LinearStore> StoreInner<M> {
                 break;
             }
             ptr += DESCRIPTOR_SIZE;
-            if ptr >= meta_store_tail {
+            if ptr >= tail {
                 ptr = *self.header.base_addr;
             }
             if ptr == old_alloc_addr {


### PR DESCRIPTION
Updates variable names to be more descriptive, adds comments, swaps some code ordering. No semantic changes.