### PR TITLE
Remove Undo/Redo Persistence

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -207,14 +207,6 @@ struct Universe<T> {
     merkle: SubUniverse<T>,
 }
 
-impl Universe<StoreRevShared> {
-    // fn to_mem_store_r(&self) -> Universe<Arc<impl MemStoreR>> {
-    //     Universe {
-    //         merkle: self.merkle.to_mem_store_r(),
-    //     }
-    // }
-}
-
 impl Universe<StoreRevMut> {
     fn new_from_other(&self) -> Universe<StoreRevMut> {
         Universe {
@@ -830,8 +822,7 @@ impl Db {
         let inner_lock = self.inner.read();
 
         // Find the revision index with the given root hash.
-        let nback = revisions.root_hashes.iter().position(|r| r == root_hash);
-        let nback = nback?;
+        let nback = revisions.root_hashes.iter().position(|r| r == root_hash)?;
         let store = if nback == 0 {
             &revisions.base
         } else {

--- a/firewood/src/db/proposal.rs
+++ b/firewood/src/db/proposal.rs
@@ -172,8 +172,8 @@ impl Proposal {
         };
 
         // clear the staging layer and apply changes to the CachedStore
-        let (merkle_payload_redo, _) = store.merkle.payload.delta();
-        let (merkle_meta_redo, _) = store.merkle.meta.delta();
+        let merkle_payload_redo = store.merkle.payload.delta();
+        let merkle_meta_redo = store.merkle.meta.delta();
 
         let mut rev_inner = m.write();
         #[allow(clippy::unwrap_used)]
@@ -225,7 +225,7 @@ impl Proposal {
         }
 
         rev_inner.root_hash_staging.write(0, &hash.0)?;
-        let (root_hash_redo, _) = rev_inner.root_hash_staging.delta();
+        let root_hash_redo = rev_inner.root_hash_staging.delta();
 
         // schedule writes to the disk
         rev_inner.disk_requester.write(Box::new([

--- a/firewood/src/storage/buffer.rs
+++ b/firewood/src/storage/buffer.rs
@@ -732,7 +732,7 @@ mod tests {
 
         // Commit the change. Take the delta from cached store,
         // then apply changes to the CachedStore.
-        let (redo_delta, _) = mut_store.delta();
+        let redo_delta = mut_store.delta();
         state_cache.update(&redo_delta).unwrap();
 
         // page is not yet persisted to disk.
@@ -817,13 +817,11 @@ mod tests {
         assert_eq!(view.as_deref(), hash);
 
         // Commit the change. Take the delta from both stores.
-        let (redo_delta, wal) = store.delta();
+        let redo_delta = store.delta();
         assert_eq!(1, redo_delta.0.len());
-        assert_eq!(1, wal.undo.len());
 
-        let (another_redo_delta, another_wal) = another_store.delta();
+        let another_redo_delta = another_store.delta();
         assert_eq!(1, another_redo_delta.0.len());
-        assert_eq!(2, another_wal.undo.len());
 
         // Verify after the changes been applied to underlying CachedStore,
         // the newly created stores should see the previous changes.

--- a/firewood/src/storage/mod.rs
+++ b/firewood/src/storage/mod.rs
@@ -488,7 +488,7 @@ impl StoreRevMut {
     }
 
     #[must_use]
-    pub fn delta(&self) -> (StoreDelta, Ash) {
+    pub fn delta(&self) -> StoreDelta {
         let guard = self.deltas.read();
         let mut pages: Vec<DeltaPage> = guard
             .pages
@@ -496,7 +496,7 @@ impl StoreRevMut {
             .map(|page| DeltaPage(*page.0, page.1.clone()))
             .collect();
         pages.sort_by_key(|p| p.0);
-        (StoreDelta(pages), guard.plain.clone())
+        StoreDelta(pages)
     }
     pub fn reset_deltas(&self) {
         let mut guard = self.deltas.write();

--- a/firewood/tests/common/mod.rs
+++ b/firewood/tests/common/mod.rs
@@ -53,17 +53,6 @@ impl Deref for TestDb {
     }
 }
 
-impl TestDb {
-    /// reopen the database, consuming the old TestDb and giving you a new one
-    pub async fn reopen(mut self) -> Self {
-        let mut creator = self.creator.clone();
-        self.preserve_on_drop = true;
-        drop(self);
-        creator.cfg.truncate = false;
-        creator.create().await
-    }
-}
-
 impl Drop for TestDb {
     fn drop(&mut self) {
         if !self.preserve_on_drop {

--- a/firewood/tests/db.rs
+++ b/firewood/tests/db.rs
@@ -144,17 +144,6 @@ async fn test_revisions() {
                 assert_eq!(kv_dump!(rev), *dump, "not the same: Pass {i}");
             }
         }
-
-        // let db = db.reopen().await;
-        // for (dump, hash) in dumped.iter().zip(hashes.iter().cloned()) {
-        //     let rev = db.revision(hash).await.unwrap();
-        //     rev.root_hash().await.unwrap();
-        //     assert_eq!(
-        //         *dump,
-        //         block_in_place(|| kv_dump!(rev)),
-        //         "not the same: pass {i}"
-        //     );
-        // }
     }
 }
 

--- a/firewood/tests/db.rs
+++ b/firewood/tests/db.rs
@@ -5,7 +5,6 @@ use firewood::{
     db::{DbConfig, WalConfig},
     v2::api::{self, BatchOp, Db as _, DbView, Proposal},
 };
-use tokio::task::block_in_place;
 
 use std::{collections::VecDeque, env::temp_dir, path::PathBuf, sync::Arc};
 
@@ -146,16 +145,16 @@ async fn test_revisions() {
             }
         }
 
-        let db = db.reopen().await;
-        for (dump, hash) in dumped.iter().zip(hashes.iter().cloned()) {
-            let rev = db.revision(hash).await.unwrap();
-            rev.root_hash().await.unwrap();
-            assert_eq!(
-                *dump,
-                block_in_place(|| kv_dump!(rev)),
-                "not the same: pass {i}"
-            );
-        }
+        // let db = db.reopen().await;
+        // for (dump, hash) in dumped.iter().zip(hashes.iter().cloned()) {
+        //     let rev = db.revision(hash).await.unwrap();
+        //     rev.root_hash().await.unwrap();
+        //     assert_eq!(
+        //         *dump,
+        //         block_in_place(|| kv_dump!(rev)),
+        //         "not the same: pass {i}"
+        //     );
+        // }
     }
 }
 


### PR DESCRIPTION
As we identified the syncer layer doesn't require the database (firewood) to replay older revisions from disk if they are not already in memory. This PR removes the logic to no longer persist the redo/undo from previous revisions for replay. Note that currently these redo/undo are not used for crash recovery and only used for replay older revisions.

As persisting redo/undo is one of the major bottleneck for fast writes, with this removal,  it provides at least 1x performance improvements. 

Before,
```
~/src/firewood-cp/firewood$ cargo run --release  --example insert --  -n 10000 -b 10 -s 0
     Running `target/release/examples/insert -n 10000 -b 10 -s 0`
Generated and inserted 10000 batches of size 10 in 48.60570351s
```

After,
```
~/src/firewood-cp/firewood$ cargo run --release  --example insert --  -n 10000 -b 10 -s 0
     Running `target/release/examples/insert -n 10000 -b 10 -s 0`
Generated and inserted 10000 batches of size 10 in 21.398385009s
```
