### PR TITLE
Add NodeStore free space management

### DIFF
--- a/firewood/src/storage/linear/mod.rs
+++ b/firewood/src/storage/linear/mod.rs
@@ -139,12 +139,6 @@ pub mod tests {
         }
     }
 
-    impl InMemReadWriteLinearStore {
-        pub fn new() -> Self {
-            InMemReadWriteLinearStore { bytes: vec![] }
-        }
-    }
-
     #[test]
     fn test_in_mem_write_linear_store() {
         let mut store = InMemReadWriteLinearStore { bytes: vec![] };

--- a/firewood/src/storage/linear/mod.rs
+++ b/firewood/src/storage/linear/mod.rs
@@ -62,8 +62,8 @@ mod committed;
 ///  - Invalidate any other `LinearStore` that is a child of `LinearStore<FileBacked>`
 ///  - Flush all the `Proposed<FileBacked, ReadOnly>::new` bytes to disk
 ///  - Convert the `LinearStore<Proposed<FileBacked, Readonly>>` to `LinearStore<FileBacked>`
-mod filebacked;
-mod proposed;
+pub(crate) mod filebacked;
+pub(crate) mod proposed;
 
 #[derive(Debug)]
 pub(super) struct LinearStore<S: ReadLinearStore> {
@@ -77,19 +77,21 @@ impl<S: ReadLinearStore> LinearStore<S> {
 }
 
 /// All linearstores support reads
-pub(super) trait ReadLinearStore: Debug {
+pub(crate) trait ReadLinearStore: Debug {
     fn stream_from(&self, addr: u64) -> Result<impl Read, Error>;
     fn size(&self) -> Result<u64, Error>;
 }
 
 /// Some linear stores support updates
-pub(super) trait WriteLinearStore: Debug {
+pub(crate) trait WriteLinearStore: Debug {
     fn write(&mut self, offset: u64, object: &[u8]) -> Result<usize, Error>;
 }
 
-impl<ReadWrite: ReadLinearStore + Debug> WriteLinearStore for LinearStore<ReadWrite> {
-    fn write(&mut self, _offset: u64, _bytes: &[u8]) -> Result<usize, Error> {
-        todo!()
+impl<ReadWrite: ReadLinearStore + WriteLinearStore + Debug> WriteLinearStore
+    for LinearStore<ReadWrite>
+{
+    fn write(&mut self, offset: u64, bytes: &[u8]) -> Result<usize, Error> {
+        self.state.write(offset, bytes)
     }
 }
 
@@ -99,7 +101,7 @@ impl<S: ReadLinearStore> ReadLinearStore for LinearStore<S> {
     }
 
     fn size(&self) -> Result<u64, Error> {
-        todo!()
+        self.state.size()
     }
 }
 

--- a/firewood/src/storage/linear/mod.rs
+++ b/firewood/src/storage/linear/mod.rs
@@ -62,8 +62,8 @@ mod committed;
 ///  - Invalidate any other `LinearStore` that is a child of `LinearStore<FileBacked>`
 ///  - Flush all the `Proposed<FileBacked, ReadOnly>::new` bytes to disk
 ///  - Convert the `LinearStore<Proposed<FileBacked, Readonly>>` to `LinearStore<FileBacked>`
-pub(crate) mod filebacked;
-pub(crate) mod proposed;
+mod filebacked;
+mod proposed;
 
 #[derive(Debug)]
 pub(super) struct LinearStore<S: ReadLinearStore> {
@@ -77,13 +77,13 @@ impl<S: ReadLinearStore> LinearStore<S> {
 }
 
 /// All linearstores support reads
-pub(crate) trait ReadLinearStore: Debug {
+pub(super) trait ReadLinearStore: Debug {
     fn stream_from(&self, addr: u64) -> Result<impl Read, Error>;
     fn size(&self) -> Result<u64, Error>;
 }
 
 /// Some linear stores support updates
-pub(crate) trait WriteLinearStore: Debug {
+pub(super) trait WriteLinearStore: Debug {
     fn write(&mut self, offset: u64, object: &[u8]) -> Result<usize, Error>;
 }
 

--- a/firewood/src/storage/linear/mod.rs
+++ b/firewood/src/storage/linear/mod.rs
@@ -70,6 +70,12 @@ pub(super) struct LinearStore<S: ReadLinearStore> {
     state: S,
 }
 
+impl<S: ReadLinearStore> LinearStore<S> {
+    pub fn new(state: S) -> Self {
+        LinearStore { state }
+    }
+}
+
 /// All linearstores support reads
 pub(super) trait ReadLinearStore: Debug {
     fn stream_from(&self, addr: u64) -> Result<impl Read, Error>;
@@ -97,12 +103,12 @@ impl<S: ReadLinearStore> ReadLinearStore for LinearStore<S> {
     }
 }
 
-mod tests {
+pub mod tests {
     use super::{ReadLinearStore, WriteLinearStore};
     use std::io::Read;
 
     #[derive(Debug)]
-    struct InMemReadWriteLinearStore {
+    pub struct InMemReadWriteLinearStore {
         bytes: Vec<u8>,
     }
 
@@ -124,6 +130,12 @@ mod tests {
 
         fn size(&self) -> Result<u64, std::io::Error> {
             Ok(self.bytes.len() as u64)
+        }
+    }
+
+    impl InMemReadWriteLinearStore {
+        pub fn new() -> Self {
+            InMemReadWriteLinearStore { bytes: vec![] }
         }
     }
 

--- a/firewood/src/storage/linear/proposed.rs
+++ b/firewood/src/storage/linear/proposed.rs
@@ -14,7 +14,7 @@ use super::{LinearStore, ReadLinearStore, WriteLinearStore};
 /// which could be a another [Proposed] or is [FileBacked](super::filebacked::FileBacked)
 /// The M type parameter indicates the mutability of the proposal, either read-write or readonly
 #[derive(Debug)]
-struct Proposed<P: ReadLinearStore, M> {
+pub(crate) struct Proposed<P: ReadLinearStore, M> {
     new: BTreeMap<u64, Box<[u8]>>,
     old: BTreeMap<u64, Box<[u8]>>,
     parent: Arc<LinearStore<P>>,
@@ -22,7 +22,7 @@ struct Proposed<P: ReadLinearStore, M> {
 }
 
 impl<P: ReadLinearStore, M> Proposed<P, M> {
-    fn new(parent: Arc<LinearStore<P>>) -> Self {
+    pub(crate) fn new(parent: Arc<LinearStore<P>>) -> Self {
         Self {
             parent,
             new: Default::default(),
@@ -105,11 +105,11 @@ impl<'a, P: ReadLinearStore, M: Debug> DiffResolver<'a> for Proposed<P, M> {
 
 /// Marker that the Proposal is mutable
 #[derive(Debug)]
-struct Mutable;
+pub(crate) struct Mutable;
 
 /// Marker that the Proposal is immutable
 #[derive(Debug)]
-struct Immutable;
+pub(crate) struct Immutable;
 
 impl<P: ReadLinearStore> WriteLinearStore for Proposed<P, Mutable> {
     fn write(&mut self, offset: u64, object: &[u8]) -> Result<usize, Error> {

--- a/firewood/src/storage/linear/proposed.rs
+++ b/firewood/src/storage/linear/proposed.rs
@@ -22,7 +22,7 @@ pub(crate) struct Proposed<P: ReadLinearStore, M> {
 }
 
 impl<P: ReadLinearStore, M> Proposed<P, M> {
-    pub(crate) fn new(parent: Arc<LinearStore<P>>) -> Self {
+    fn new(parent: Arc<LinearStore<P>>) -> Self {
         Self {
             parent,
             new: Default::default(),

--- a/firewood/src/storage/linear/proposed.rs
+++ b/firewood/src/storage/linear/proposed.rs
@@ -14,7 +14,7 @@ use super::{LinearStore, ReadLinearStore, WriteLinearStore};
 /// which could be a another [Proposed] or is [FileBacked](super::filebacked::FileBacked)
 /// The M type parameter indicates the mutability of the proposal, either read-write or readonly
 #[derive(Debug)]
-pub(crate) struct Proposed<P: ReadLinearStore, M> {
+struct Proposed<P: ReadLinearStore, M> {
     new: BTreeMap<u64, Box<[u8]>>,
     old: BTreeMap<u64, Box<[u8]>>,
     parent: Arc<LinearStore<P>>,
@@ -105,11 +105,11 @@ impl<'a, P: ReadLinearStore, M: Debug> DiffResolver<'a> for Proposed<P, M> {
 
 /// Marker that the Proposal is mutable
 #[derive(Debug)]
-pub(crate) struct Mutable;
+struct Mutable;
 
 /// Marker that the Proposal is immutable
 #[derive(Debug)]
-pub(crate) struct Immutable;
+struct Immutable;
 
 impl<P: ReadLinearStore> WriteLinearStore for Proposed<P, Mutable> {
     fn write(&mut self, offset: u64, object: &[u8]) -> Result<usize, Error> {

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -11,7 +11,6 @@ use std::io::{Error, ErrorKind, Write};
 use std::num::NonZeroU64;
 use std::sync::Arc;
 
-use enum_as_inner::EnumAsInner;
 use serde::{Deserialize, Serialize};
 
 use super::linear::{LinearStore, ReadLinearStore, WriteLinearStore};
@@ -97,11 +96,10 @@ enum Node {
 }
 
 /// Each [StoredArea] contains an [Area] which is either a [Node] or a [FreedArea].
-#[repr(u8)]
-#[derive(PartialEq, Eq, Clone, Debug, EnumAsInner, Deserialize, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Deserialize, Serialize)]
 enum Area<T, U> {
-    Node(T) = 1,
-    Free(U) = 2,
+    Node(T),
+    Free(U),
 }
 
 /// Every item stored in the [NodeStore]'s [LinearStore]  after the

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -113,7 +113,7 @@ struct StoredArea<T> {
 /// Every subsequent write is a [StoredArea] containing a [Node] or a [FreedArea].
 /// The size of each allocation [NodeStore] makes from [LinearStore] is one of [AREA_SIZES].
 #[derive(Debug)]
-pub(crate) struct NodeStore<T: ReadLinearStore> {
+struct NodeStore<T: ReadLinearStore> {
     size: u64, // TODO comment
     header: NodeStoreHeader,
     linear_store: LinearStore<T>,

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -395,5 +395,14 @@ mod tests {
                 );
             }
         }
+
+        for i in 0..MIN_AREA_SIZE {
+            assert_eq!(area_size_to_index(i).unwrap(), 0);
+        }
+
+        assert!(area_size_to_index(MAX_AREA_SIZE + 1).is_err());
     }
+
+    #[test]
+    fn test_area_size_to_index_errors() {}
 }

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -389,23 +389,6 @@ impl FreeLists {
     fn new() -> Self {
         Self([None; NUM_AREA_SIZES])
     }
-
-    fn serialized_size(&self) -> u64 {
-        self.0
-            .iter()
-            .map(|x| {
-                if x.is_some() {
-                    FreeLists::SOME_ELT_SIZE
-                } else {
-                    FreeLists::NONE_ELT_SIZE
-                }
-            })
-            .sum()
-    }
-
-    fn padding_size(&self) -> u64 {
-        NodeStoreHeader::SIZE - Version::SIZE - self.serialized_size()
-    }
 }
 
 /// Persisted metadata for a [NodeStore].
@@ -433,17 +416,6 @@ impl NodeStoreHeader {
             max_size + MIN_AREA_SIZE - remainder
         }
     };
-
-    /// Returns the bincode serialized size of the [NodeStoreHeader] without serializing it.
-    fn serialized_size(&self) -> u64 {
-        std::mem::size_of::<Version>() as u64 + self.free_lists.serialized_size()
-    }
-
-    /// Returns the number of bytes of padding to make the serialized [NodeStoreHeader]
-    /// the same size as [NodeStoreHeader::MAX_SIZE].
-    fn padding_size(&self) -> u64 {
-        Self::SIZE - self.serialized_size()
-    }
 }
 
 /// A [FreedArea] is stored at the start of the area that contained a node that

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -196,6 +196,7 @@ impl<T: WriteLinearStore + ReadLinearStore> NodeStore<T> {
         let area_size = AREA_SIZES[index as usize];
         let addr = DiskAddress::new(self.size).expect("node store size can't be 0");
         self.size += area_size;
+        debug_assert!(addr.get() % 8 == 0);
         Ok((addr, index))
     }
 

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -112,13 +112,13 @@ impl<T: ReadWriteLinearStore + ReadOnlyLinearStore + std::fmt::Debug> NodeStore<
         // discarding the object
         let size = self.node_size(addr)?;
 
-        // place a pointer to the next freed area at old location
-        let freed_area = FreedArea {
+        // place a pointer to the next freed block at old location
+        let freed_block = FreedBlock {
             size,
-            next_free_area: self.header.free_space_head,
+            next_free_block: self.header.free_space_head,
         };
         self.page_store
-            .write(addr.into(), bytemuck::bytes_of(&freed_area))?;
+            .write(addr.into(), bytemuck::bytes_of(&freed_block))?;
 
         // update the free space header
         self.page_store.write(
@@ -210,11 +210,11 @@ struct FreeSpaceManagementHeader {
     free_space_head: Option<DiskAddress>,
 }
 
-/// A [FreedArea] is the object stored where a node used to be when it has been
+/// A [FreedBlock] is the object stored where a node used to be when it has been
 /// freed
 #[repr(C)]
 #[derive(Debug, bytemuck::NoUninit, Clone, Copy)]
-struct FreedArea {
+struct FreedBlock {
     size: usize,
-    next_free_area: Option<DiskAddress>,
+    next_free_block: Option<DiskAddress>,
 }

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -220,8 +220,6 @@ impl<T: WriteLinearStore + ReadLinearStore> NodeStore<T> {
     /// This is complicated by the fact that a node might grow and not be able to fit a the given
     /// address, in which case we return [UpdateError::NodeMoved]
     fn update(&mut self, addr: DiskAddress, node: &Node) -> Result<(), UpdateError> {
-        // figure out how large the object at this address is by deserializing and then
-        // discarding the object
         let (_, old_stored_area_size) = self.area_index_and_size(addr)?;
 
         let new_node_bytes =

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -155,7 +155,7 @@ impl<T: WriteLinearStore + ReadLinearStore> NodeStore<T> {
         // Find the smallest free list that can fit this size.
         let index = area_size_to_index(n)?;
 
-        for index in index as usize..=NUM_AREA_SIZES {
+        for index in index as usize..NUM_AREA_SIZES {
             // Get the first free block of sufficient size.
             let free_head_addr = self.header.free_lists[index];
             if let Some(free_head_addr) = free_head_addr {

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -109,7 +109,7 @@ struct StoredArea<T> {
 /// The first thing written in the [LinearStore] is a [NodeStoreHeader],
 /// which contains the version and the heads of the free lists.
 /// Every subsequent write is a [StoredArea] containing a [Node] or a [FreedArea].
-/// Each allocation [NodeStore] makes from [LinearStore] is one of [AREA_SIZES].
+/// The size of each allocation [NodeStore] makes from [LinearStore] is one of [AREA_SIZES].
 #[derive(Debug)]
 struct NodeStore<T: ReadLinearStore> {
     header: NodeStoreHeader,

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -17,6 +17,29 @@ use serde::{Deserialize, Serialize};
 
 use super::linear::{LinearStore, ReadOnlyLinearStore, ReadWriteLinearStore};
 
+const BLOCK_SIZES: [u64; 18] = [
+    1 << 3, // Min block size is 8
+    1 << 4,
+    1 << 5,
+    1 << 6,
+    1 << 7,
+    1 << 8,
+    1 << 9,
+    1 << 10,
+    1 << 11,
+    1 << 12,
+    1 << 13,
+    1 << 14,
+    1 << 15,
+    1 << 16,
+    1 << 17,
+    1 << 18,
+    1 << 19,
+    1 << 20, // Max block size is 1 MiB
+];
+
+const NUM_BLOCK_SIZES: usize = BLOCK_SIZES.len();
+
 /// Either a branch or leaf node
 #[derive(PartialEq, Eq, Clone, Debug, EnumAsInner, Deserialize, Serialize)]
 enum Node {

--- a/firewood/src/storage/node.rs
+++ b/firewood/src/storage/node.rs
@@ -62,7 +62,7 @@ fn area_size_to_index(n: u64) -> Result<u8, Error> {
         return Ok(0);
     }
 
-    Ok(n.ilog2() as u8 - 2)
+    Ok(n.ilog2() as u8 - 3)
 }
 
 type Path = Box<[u8]>;
@@ -375,4 +375,25 @@ struct NodeStoreHeader {
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 struct FreedArea {
     next_free_block: Option<DiskAddress>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_area_size_to_index() {
+        for i in 0..NUM_AREA_SIZES {
+            // area size is at bottom of range
+            assert_eq!(area_size_to_index(AREA_SIZES[i]).unwrap(), i as u8);
+
+            if i > 0 {
+                // 1 less than bottom of range can go in previous area size
+                assert_eq!(
+                    area_size_to_index(AREA_SIZES[i] - 1).unwrap(),
+                    (i - 1) as u8
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
Implements `NodeStore`, a `LinearStore` backed type which supports CRUD operations on `Node`s