### PR TITLE
remove Nibbles type

### DIFF
--- a/firewood/src/nibbles.rs
+++ b/firewood/src/nibbles.rs
@@ -1,86 +1,15 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use std::{iter::FusedIterator, ops::Index};
+use std::iter::FusedIterator;
 
 static NIBBLES: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
 
-/// Nibbles is a newtype that contains only a reference to a [u8], and produces
-/// nibbles. Nibbles can be indexed using nib\[x\] or you can get an iterator
-/// with `into_iter()`
-///
-/// # Examples
-///
-/// ```
-/// # use firewood::nibbles;
-/// # fn main() {
-/// let nib = nibbles::Nibbles::new(&[0x56, 0x78]);
-/// assert_eq!(nib.into_iter().collect::<Vec<_>>(), [0x5, 0x6, 0x7, 0x8]);
-///
-/// // nibbles can be efficiently advanced without rendering the
-/// // intermediate values
-/// assert_eq!(nib.into_iter().skip(3).collect::<Vec<_>>(), [0x8]);
-///
-/// // nibbles can also be indexed
-///
-/// assert_eq!(nib[1], 0x6);
-///
-/// // or reversed
-/// assert_eq!(nib.into_iter().rev().next(), Some(0x8));
-/// # }
-/// ```
-#[derive(Debug, Copy, Clone)]
-pub struct Nibbles<'a>(&'a [u8]);
-
-impl<'a> Index<usize> for Nibbles<'a> {
-    type Output = u8;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        if index % 2 == 0 {
-            #[allow(clippy::indexing_slicing)]
-            &NIBBLES[(self.0[(index) / 2] >> 4) as usize]
-        } else {
-            #[allow(clippy::indexing_slicing)]
-            &NIBBLES[(self.0[(index) / 2] & 0xf) as usize]
-        }
-    }
-}
-
-impl<'a> IntoIterator for Nibbles<'a> {
-    type Item = u8;
-    type IntoIter = NibblesIterator<'a>;
-
-    #[must_use]
-    fn into_iter(self) -> Self::IntoIter {
-        NibblesIterator {
-            data: self,
-            head: 0,
-            tail: self.len(),
-        }
-    }
-}
-
-impl<'a> Nibbles<'a> {
-    #[must_use]
-    pub const fn len(&self) -> usize {
-        2 * self.0.len()
-    }
-
-    #[must_use]
-    pub const fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    pub const fn new(inner: &'a [u8]) -> Self {
-        Nibbles(inner)
-    }
-}
-
-/// An iterator returned by [Nibbles::into_iter]
-/// See their documentation for details.
+/// Iterates over the nibbles in `data`. That is, each byte in `data` is
+/// converted to two nibbles.
 #[derive(Clone, Debug)]
 pub struct NibblesIterator<'a> {
-    data: Nibbles<'a>,
+    data: &'a [u8],
     head: usize,
     tail: usize,
 }
@@ -94,10 +23,15 @@ impl<'a> Iterator for NibblesIterator<'a> {
         if self.is_empty() {
             return None;
         }
-        #[allow(clippy::indexing_slicing)]
-        let result = Some(self.data[self.head]);
+        let result = if self.head % 2 == 0 {
+            #[allow(clippy::indexing_slicing)]
+            NIBBLES[(self.data[self.head / 2] >> 4) as usize]
+        } else {
+            #[allow(clippy::indexing_slicing)]
+            NIBBLES[(self.data[self.head / 2] & 0xf) as usize]
+        };
         self.head += 1;
-        result
+        Some(result)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -116,6 +50,14 @@ impl<'a> NibblesIterator<'a> {
     pub const fn is_empty(&self) -> bool {
         self.head == self.tail
     }
+
+    pub fn new(data: &'a [u8]) -> Self {
+        NibblesIterator {
+            data,
+            head: 0,
+            tail: 2 * data.len(),
+        }
+    }
 }
 
 impl<'a> DoubleEndedIterator for NibblesIterator<'a> {
@@ -123,9 +65,17 @@ impl<'a> DoubleEndedIterator for NibblesIterator<'a> {
         if self.is_empty() {
             return None;
         }
+
+        let result = if self.tail % 2 == 0 {
+            #[allow(clippy::indexing_slicing)]
+            NIBBLES[(self.data[self.tail / 2 - 1] & 0xf) as usize]
+        } else {
+            #[allow(clippy::indexing_slicing)]
+            NIBBLES[(self.data[self.tail / 2] >> 4) as usize]
+        };
         self.tail -= 1;
-        #[allow(clippy::indexing_slicing)]
-        Some(self.data[self.tail])
+
+        Some(result)
     }
 
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
@@ -137,52 +87,45 @@ impl<'a> DoubleEndedIterator for NibblesIterator<'a> {
 #[cfg(test)]
 #[allow(clippy::indexing_slicing)]
 mod test {
-    use super::Nibbles;
+    use super::NibblesIterator;
+
     static TEST_BYTES: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
 
     #[test]
     fn happy_regular_nibbles() {
-        let nib = Nibbles(&TEST_BYTES);
+        let iter = NibblesIterator::new(&TEST_BYTES);
         let expected = [0xd, 0xe, 0xa, 0xd, 0xb, 0xe, 0xe, 0xf];
-        for v in expected.into_iter().enumerate() {
-            assert_eq!(nib[v.0], v.1, "{v:?}");
-        }
-    }
 
-    #[test]
-    #[should_panic]
-    fn out_of_bounds_panics() {
-        let nib = Nibbles(&TEST_BYTES);
-        let _ = nib[8];
-    }
-
-    #[test]
-    fn last_nibble() {
-        let nib = Nibbles(&TEST_BYTES);
-        assert_eq!(nib[7], 0xf);
+        assert!(iter.eq(expected));
     }
 
     #[test]
     fn size_hint() {
-        let nib = Nibbles(&TEST_BYTES);
-        let mut nib_iter = nib.into_iter();
-        assert_eq!((8, Some(8)), nib_iter.size_hint());
-        let _ = nib_iter.next();
-        assert_eq!((7, Some(7)), nib_iter.size_hint());
+        let mut iter = NibblesIterator::new(&TEST_BYTES);
+        assert_eq!((8, Some(8)), iter.size_hint());
+        let _ = iter.next();
+        assert_eq!((7, Some(7)), iter.size_hint());
     }
 
     #[test]
     fn backwards() {
-        let nib = Nibbles(&TEST_BYTES);
-        let nib_iter = nib.into_iter().rev();
+        let iter = NibblesIterator::new(&TEST_BYTES).rev();
         let expected = [0xf, 0xe, 0xe, 0xb, 0xd, 0xa, 0xe, 0xd];
+        assert!(iter.eq(expected));
+    }
 
-        assert!(nib_iter.eq(expected));
+    #[test]
+    fn neth_back() {
+        let mut iter = NibblesIterator::new(&TEST_BYTES);
+        assert_eq!(iter.nth_back(0), Some(0xf));
+        assert_eq!(iter.nth_back(0), Some(0xe));
+        assert_eq!(iter.nth_back(1), Some(0xb));
+        assert_eq!(iter.nth_back(2), Some(0xe));
     }
 
     #[test]
     fn empty() {
-        let nib = Nibbles(&[]);
+        let nib = NibblesIterator::new(&[]);
         assert!(nib.is_empty());
         let it = nib.into_iter();
         assert!(it.is_empty());
@@ -191,16 +134,15 @@ mod test {
 
     #[test]
     fn not_empty_because_of_data() {
-        let nib = Nibbles(&[1]);
-        assert!(!nib.is_empty());
-        let mut it = nib.into_iter();
-        assert!(!it.is_empty());
-        assert_eq!(it.size_hint(), (2, Some(2)));
-        assert_eq!(it.next(), Some(0));
-        assert!(!it.is_empty());
-        assert_eq!(it.size_hint(), (1, Some(1)));
-        assert_eq!(it.next(), Some(1));
-        assert!(it.is_empty());
-        assert_eq!(it.size_hint(), (0, Some(0)));
+        let mut iter = NibblesIterator::new(&[1]);
+        assert!(!iter.is_empty());
+        assert!(!iter.is_empty());
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+        assert_eq!(iter.next(), Some(0));
+        assert!(!iter.is_empty());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+        assert_eq!(iter.next(), Some(1));
+        assert!(iter.is_empty());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
     }
 }

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     merkle::{Key, Merkle, MerkleError, Value},
-    nibbles::{Nibbles, NibblesIterator},
+    nibbles::NibblesIterator,
     v2::api,
 };
 
@@ -185,7 +185,7 @@ fn get_iterator_intial_state<T: ReadLinearStore>(
     // partial path at the start of each loop iteration.
     let mut matched_key_nibbles = vec![];
 
-    let mut unmatched_key_nibbles = Nibbles::new(key).into_iter();
+    let mut unmatched_key_nibbles = NibblesIterator::new(key);
 
     let mut iter_stack: Vec<IterationNode> = vec![];
 
@@ -406,7 +406,7 @@ impl<'a, 'b, T: ReadLinearStore> PathIterator<'a, 'b, T> {
             merkle,
             state: PathIteratorState::Iterating {
                 matched_key: vec![],
-                unmatched_key: Nibbles::new(key).into_iter(),
+                unmatched_key: NibblesIterator::new(key),
                 address: root_addr,
             },
         })


### PR DESCRIPTION
We only used this type to make an iterator. So we can remove this type and just use `NibblesIterator`.