### PR TITLE
Enabling changes for `merkle.remove`

### DIFF
--- a/firewood/src/hashednode.rs
+++ b/firewood/src/hashednode.rs
@@ -198,7 +198,7 @@ impl<T: WriteLinearStore> HashedNodeStore<T> {
         Ok(())
     }
 
-    pub fn set_root(&mut self, root_addr: LinearAddress) -> Result<(), Error> {
+    pub fn set_root(&mut self, root_addr: Option<LinearAddress>) -> Result<(), Error> {
         self.nodestore.set_root(root_addr)
     }
 }
@@ -265,7 +265,7 @@ mod test {
             value: Box::new(*b"abc"),
         });
         let addr = hns.create_node(node).unwrap();
-        hns.set_root(addr).unwrap();
+        hns.set_root(Some(addr)).unwrap();
 
         let frozen = hns.freeze().unwrap();
         assert_ne!(frozen.root_hash().unwrap(), Default::default());

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -374,7 +374,7 @@ impl<T: WriteLinearStore> Merkle<T> {
             });
 
             let new_root = self.create_node(leaf)?;
-            self.set_root(new_root)?;
+            self.set_root(Some(new_root))?;
             return Ok(Default::default());
         };
 
@@ -415,7 +415,7 @@ impl<T: WriteLinearStore> Merkle<T> {
 
                 let new_root = Node::Branch(Box::new(new_root));
                 let new_root_addr = self.create_node(new_root)?;
-                self.set_root(new_root_addr)?;
+                self.set_root(Some(new_root_addr))?;
 
                 // Update the old root's partial path to be shorter since now it has a parent.
                 let new_child =
@@ -462,7 +462,7 @@ impl<T: WriteLinearStore> Merkle<T> {
 
                 let new_root = Node::Branch(Box::new(new_root));
                 let new_root_addr = self.create_node(new_root)?;
-                self.set_root(new_root_addr)?;
+                self.set_root(Some(new_root_addr))?;
 
                 return Ok(vec![old_root_addr]);
             }
@@ -511,7 +511,7 @@ impl<T: WriteLinearStore> Merkle<T> {
 
                             let Some(leaf_parent) = last_node_parent else {
                                 // There is no parent of this leaf. It must be the root.
-                                self.set_root(new_addr)?;
+                                self.set_root(Some(new_addr))?;
                                 return Ok(hash_invalidation_addresses);
                             };
 
@@ -585,7 +585,7 @@ impl<T: WriteLinearStore> Merkle<T> {
                                 // Update its parent to point to the new address.
                                 let Some(last_node_parent) = traversal_path.pop() else {
                                     // There is no parent of this branch. It must be the root.
-                                    self.set_root(new_addr)?;
+                                    self.set_root(Some(new_addr))?;
                                     return Ok(hash_invalidation_addresses);
                                 };
 
@@ -842,7 +842,7 @@ impl<T: WriteLinearStore> Merkle<T> {
                             // Update its parent to point to the new address.
                             let Some(last_node_parent) = traversal_path.pop() else {
                                 // There is no parent of this leaf. The new branch is the root.
-                                self.set_root(new_addr)?;
+                                self.set_root(Some(new_addr))?;
                                 return Ok(hash_invalidation_addresses);
                             };
 

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -416,8 +416,8 @@ impl<T: WriteLinearStore> NodeStore<T> {
     }
 
     /// Write the root [LinearAddress] of the [NodeStore]
-    pub fn set_root(&mut self, addr: LinearAddress) -> Result<(), Error> {
-        self.header.root_address = Some(addr);
+    pub fn set_root(&mut self, addr: Option<LinearAddress>) -> Result<(), Error> {
+        self.header.root_address = addr;
         self.write_header()
     }
 }


### PR DESCRIPTION
Broken out of #644 to make reviewing easier.

* Changes the value type of `modified` to `Option`, where `None` indicates the node was deleted.
* Allows setting the root of a node store to `None`.