### PR TITLE
refactor hashing

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -86,7 +86,7 @@ fn bench_merkle<const NKEYS: usize, const KEYSIZE: usize>(criterion: &mut Criter
             b.iter_batched(
                 || {
                     let store = MemStore::new(vec![]);
-                    let hns = HashedNodeStore::initialize(store).unwrap();
+                    let hns = HashedNodeStore::new(store).unwrap();
                     let merkle = Merkle::new(hns);
 
                     let keys: Vec<Vec<u8>> = repeat_with(|| {

--- a/firewood/src/hashednode.rs
+++ b/firewood/src/hashednode.rs
@@ -5,9 +5,9 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::io::Error;
 use std::iter::{self, once};
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
-use storage::{Child, TrieHash};
+use storage::{Child, TrieHash, UpdateError};
 use storage::{LinearAddress, NodeStore};
 use storage::{Node, Path, ProposedImmutable};
 use storage::{ReadLinearStore, WriteLinearStore};
@@ -29,80 +29,38 @@ use storage::PathIterItem;
 #[derive(Debug)]
 pub struct HashedNodeStore<T: ReadLinearStore> {
     nodestore: NodeStore<T>,
-    modified: HashMap<LinearAddress, (Arc<Node>, u8)>,
-    root_hash: OnceLock<TrieHash>,
+    added: HashMap<LinearAddress, (Arc<Node>, u8)>,
+    root_hash: Option<TrieHash>,
 }
 
 impl<T: WriteLinearStore> HashedNodeStore<T> {
-    pub fn initialize(linearstore: T) -> Result<Self, Error> {
+    /// Returns a new empty HashedNodeStore that uses `linearstore` as the backing store.
+    pub fn new(linearstore: T) -> Result<Self, Error> {
         let nodestore = NodeStore::initialize(linearstore)?;
         Ok(HashedNodeStore {
             nodestore,
-            modified: Default::default(),
-            root_hash: Default::default(),
+            added: Default::default(),
+            root_hash: None,
         })
-    }
-}
-
-impl<T: ReadLinearStore> From<NodeStore<T>> for HashedNodeStore<T> {
-    fn from(nodestore: NodeStore<T>) -> Self {
-        HashedNodeStore {
-            nodestore,
-            modified: Default::default(),
-            root_hash: Default::default(),
-        }
     }
 }
 
 impl<T: ReadLinearStore> HashedNodeStore<T> {
     pub fn read_node(&self, addr: LinearAddress) -> Result<Arc<Node>, Error> {
-        if let Some((modified_node, _)) = self.modified.get(&addr) {
+        if let Some((modified_node, _)) = self.added.get(&addr) {
             Ok(modified_node.clone())
         } else {
             Ok(self.nodestore.read_node(addr)?)
         }
     }
 
-    // Returns a actual node instead of just an arc to it. This node is then
-    // owned by the caller.
-    // If the node was previously modified, then it will consume the modified Arc
-    // and return the inner value. This assumes no other references to that Arc
-    // exist at this time (that is, no iterators are active on the HashedNodeStore)
-    // If the node was not modified, a clone of the node is returned
-    fn take_node(&mut self, addr: LinearAddress) -> Result<Node, Error> {
-        if let Some((modified_node, _)) = self.modified.remove(&addr) {
-            Ok(Arc::into_inner(modified_node).expect("no other references to this node can exist"))
-        } else {
-            let node = self.nodestore.read_node(addr)?;
-            Ok((*node).clone())
-        }
-    }
-
-    pub fn root_hash(&self) -> Result<TrieHash, Error> {
-        debug_assert!(self.modified.is_empty());
-        let Some(addr) = self.nodestore.root_address() else {
-            return Ok(TrieHash::default());
-        };
-
-        // TODO danlaine: Uncomment this once get_or_try_init is stable
-        // return self
-        //     .root_hash
-        //     .get_or_try_init(|| {
-        //         let node = self.read_node(addr)?;
-        //         Ok(hash_node(&node, &Path(Default::default())))
-        //     })
-        //     .cloned();
-
-        Ok(self
-            .root_hash
-            .get_or_init(|| {
-                let node = self
-                    .nodestore
-                    .read_node(addr)
-                    .expect("TODO: use get_or_try_init once it's available");
-                hash_node(&node, &Path(Default::default()))
-            })
-            .clone())
+    /// Returns the hash of the root of this trie.
+    /// Returns None if the trie is empty.
+    /// Assumes `freeze` has already been called on this store.
+    /// TODO enforce this assumption with the type system.
+    pub fn root_hash(&self) -> Option<&TrieHash> {
+        debug_assert!(self.added.is_empty());
+        self.root_hash.as_ref()
     }
 
     pub const fn root_address(&self) -> Option<LinearAddress> {
@@ -111,69 +69,77 @@ impl<T: ReadLinearStore> HashedNodeStore<T> {
 }
 
 impl<T: WriteLinearStore> HashedNodeStore<T> {
-    // recursively hash this node
+    // Hashes the node at `node_addr` and all of its children recursively.
+    // Returns the hash of the node and the address of the node.
     fn hash(
         &mut self,
         node_addr: LinearAddress,
-        node: &mut Node,
         path_prefix: &mut Path,
-    ) -> Result<TrieHash, Error> {
-        match node {
-            Node::Branch(b) => {
-                // We found a branch, so find all the children that need hashing
-                let mut modified = false;
+    ) -> Result<(TrieHash, LinearAddress), Error> {
+        let modified = self.added.remove(&node_addr);
 
+        let mut node = if let Some((modified_node, _)) = modified {
+            // This node was modified and needs to be rehashed and written to `self.nodestore`.
+            Arc::into_inner(modified_node).expect("no other references to this node can exist")
+        } else {
+            // This node wasn't modified, so we must have all of its child hashes
+            // since we got it from `self.nodestore`. We can hash it and return.
+            let node = self.nodestore.read_node(node_addr)?;
+            return Ok((hash_node(&node, path_prefix), node_addr));
+        };
+
+        match node {
+            Node::Branch(ref mut b) => {
                 for (nibble, child) in b.children.iter_mut().enumerate() {
                     let Child::Address(child_addr) = child else {
                         // There is no child or we already know its hash.
                         continue;
                     };
 
-                    // Hash this child.
+                    // Hash this child and update
                     let child_addr = *child_addr;
-                    let mut child_node = self.take_node(child_addr)?;
                     let original_length = path_prefix.len();
                     path_prefix
                         .0
                         .extend(b.partial_path.0.iter().copied().chain(once(nibble as u8)));
-                    *child = Child::AddressWithHash(
-                        child_addr,
-                        self.hash(child_addr, &mut child_node, path_prefix)?,
-                    );
+
+                    let (child_hash, child_addr) = self.hash(child_addr, path_prefix)?;
+
+                    *child = Child::AddressWithHash(child_addr, child_hash);
                     path_prefix.0.truncate(original_length);
-                    modified = true;
-                    self.nodestore.update_in_place(child_addr, &child_node)?;
                 }
-                if modified {
-                    self.nodestore.update_in_place(node_addr, node)?;
-                    self.modified.remove(&node_addr);
-                }
-                Ok(hash_node(node, path_prefix))
             }
-            Node::Leaf(_) => Ok(hash_node(node, path_prefix)),
+            Node::Leaf(_) => {}
+        }
+
+        let hash = hash_node(&node, path_prefix);
+        match self.nodestore.update_node(node_addr, node) {
+            Ok(()) => Ok((hash, node_addr)),
+            Err(UpdateError::NodeMoved(new_addr)) => Ok((hash, new_addr)),
+            Err(UpdateError::Io(e)) => Err(e),
         }
     }
 
     pub fn freeze(mut self) -> Result<HashedNodeStore<ProposedImmutable>, Error> {
         // fill in all remaining hashes, including the root hash
-        if let Some(root_address) = self.root_address() {
-            let mut root_node = self.take_node(root_address)?;
-            let hash = self.hash(root_address, &mut root_node, &mut Path(Default::default()))?;
-            let _ = self.root_hash.set(hash);
-            self.nodestore.update_in_place(root_address, &root_node)?;
-        }
-        assert!(self.modified.is_empty());
-        let frozen_nodestore = self.nodestore.freeze();
+        let root_hash = if let Some(root_address) = self.root_address() {
+            let (hash, root_address) = self.hash(root_address, &mut Path(Default::default()))?;
+            self.nodestore.set_root(Some(root_address))?;
+            Some(hash)
+        } else {
+            None
+        };
+        assert!(self.added.is_empty());
         Ok(HashedNodeStore {
-            nodestore: frozen_nodestore,
-            modified: Default::default(),
-            root_hash: Default::default(),
+            nodestore: self.nodestore.freeze(),
+            added: Default::default(),
+            root_hash,
         })
     }
 
     pub fn create_node(&mut self, node: Node) -> Result<LinearAddress, Error> {
         let (addr, size) = self.nodestore.allocate_node(&node)?;
-        self.modified.insert(addr, (Arc::new(node), size));
+        self.added.insert(addr, (Arc::new(node), size));
         Ok(addr)
     }
 
@@ -250,7 +216,7 @@ impl<T: WriteLinearStore> HashedNodeStore<T> {
         node: Node,
     ) -> Result<LinearAddress, MerkleError> {
         let old_node_size_index =
-            if let Some((_, old_node_size_index)) = self.modified.get(&old_address) {
+            if let Some((_, old_node_size_index)) = self.added.get(&old_address) {
                 *old_node_size_index
             } else {
                 self.nodestore.node_size(old_address)?
@@ -258,14 +224,14 @@ impl<T: WriteLinearStore> HashedNodeStore<T> {
 
         // If the node was already modified, see if it still fits
         let new_address = if !self.nodestore.still_fits(old_node_size_index, &node)? {
-            self.modified.remove(&old_address);
+            self.added.remove(&old_address);
             self.nodestore.delete_node(old_address)?;
             let (new_address, new_node_size_index) = self.nodestore.allocate_node(&node)?;
-            self.modified
+            self.added
                 .insert(new_address, (Arc::new(node), new_node_size_index));
             new_address
         } else {
-            self.modified
+            self.added
                 .insert(old_address, (Arc::new(node), old_node_size_index));
             old_address
         };
@@ -282,11 +248,19 @@ impl<T: WriteLinearStore> HashedNodeStore<T> {
 
 pub fn hash_node(node: &Node, path_prefix: &Path) -> TrieHash {
     match node {
-        Node::Branch(node) => NodeAndPrefix {
-            node: node.as_ref(),
-            prefix: path_prefix,
+        Node::Branch(node) => {
+            // All child hashes should be filled in.
+            // TODO danlaine: Enforce this with the type system.
+            debug_assert!(node
+                .children
+                .iter()
+                .all(|c| !matches!(c, Child::Address(..))));
+            NodeAndPrefix {
+                node: node.as_ref(),
+                prefix: path_prefix,
+            }
+            .into()
         }
-        .into(),
         Node::Leaf(node) => NodeAndPrefix {
             node,
             prefix: path_prefix,
@@ -518,7 +492,7 @@ mod test {
     #[test]
     fn freeze_test() {
         let memstore = MemStore::new(vec![]);
-        let mut hns = HashedNodeStore::initialize(memstore).unwrap();
+        let mut hns = HashedNodeStore::new(memstore).unwrap();
         let node = Node::Leaf(storage::LeafNode {
             partial_path: Path(Default::default()),
             value: Box::new(*b"abc"),
@@ -527,6 +501,6 @@ mod test {
         hns.set_root(Some(addr)).unwrap();
 
         let frozen = hns.freeze().unwrap();
-        assert_ne!(frozen.root_hash().unwrap(), Default::default());
+        assert_ne!(frozen.root_hash(), None);
     }
 }

--- a/firewood/src/hashednode.rs
+++ b/firewood/src/hashednode.rs
@@ -340,7 +340,7 @@ pub(super) enum ValueDigest<'a> {
     /// A node's value.
     Value(&'a [u8]),
     /// The hash of a a node's value.
-    Hash(Box<[u8]>),
+    _Hash(Box<[u8]>),
 }
 
 trait Hashable {
@@ -434,32 +434,6 @@ impl HashableNode for storage::LeafNode {
     }
 }
 
-impl Hashable for &ProofNode {
-    fn key(&self) -> impl Iterator<Item = u8> + Clone {
-        self.key.as_ref().iter().copied()
-    }
-
-    fn value_digest(&self) -> Option<ValueDigest> {
-        match self.value_digest.as_ref() {
-            None => None,
-            Some(value) if value.len() > 32 => {
-                unreachable!("TODO danlaine: prevent this from happening. The digest should never be more than 32 bytes.")
-            }
-            Some(value) if value.len() == 32 => {
-                Some(ValueDigest::Hash(value.to_vec().into_boxed_slice()))
-            }
-            Some(value) => Some(ValueDigest::Value(value)),
-        }
-    }
-
-    fn children(&self) -> impl Iterator<Item = (usize, &TrieHash)> + Clone {
-        self.child_hashes
-            .iter()
-            .enumerate()
-            .filter_map(|(i, hash)| hash.as_ref().map(|h| (i, h)))
-    }
-}
-
 struct NodeAndPrefix<'a, N: HashableNode> {
     node: &'a N,
     prefix: &'a Path,
@@ -507,7 +481,7 @@ fn add_value_digest_to_buf<H: HasUpdate>(buf: &mut H, value_digest: Option<Value
         ValueDigest::Value(value) => {
             add_len_and_value_to_buf(buf, value);
         }
-        ValueDigest::Hash(hash) => {
+        ValueDigest::_Hash(hash) => {
             add_len_and_value_to_buf(buf, hash.as_ref());
         }
     }

--- a/firewood/src/hashednode.rs
+++ b/firewood/src/hashednode.rs
@@ -340,6 +340,7 @@ pub(super) enum ValueDigest<'a> {
     /// A node's value.
     Value(&'a [u8]),
     /// The hash of a a node's value.
+    /// TODO danlaine: Use this variant when implement ProofNode
     _Hash(Box<[u8]>),
 }
 

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -102,8 +102,7 @@ impl<T: ReadLinearStore> Merkle<T> {
         self.0.root_address()
     }
 
-    // TODO: can we make this &self instead of &mut self?
-    pub fn root_hash(&mut self) -> Result<TrieHash, std::io::Error> {
+    pub fn root_hash(&self) -> Option<&TrieHash> {
         self.0.root_hash()
     }
 
@@ -802,13 +801,37 @@ mod tests {
     use test_case::test_case;
 
     #[test]
+    fn test_get_regression() {
+        let mut merkle = create_in_memory_merkle();
+
+        merkle.insert(&[0], Box::new([0])).unwrap();
+        assert_eq!(merkle.get(&[0]).unwrap(), Some(Box::from([0])));
+
+        merkle.insert(&[1], Box::new([1])).unwrap();
+        assert_eq!(merkle.get(&[1]).unwrap(), Some(Box::from([1])));
+
+        merkle.insert(&[2], Box::new([2])).unwrap();
+        assert_eq!(merkle.get(&[2]).unwrap(), Some(Box::from([2])));
+
+        let merkle = merkle.freeze().unwrap();
+
+        assert_eq!(merkle.get(&[0]).unwrap(), Some(Box::from([0])));
+        assert_eq!(merkle.get(&[1]).unwrap(), Some(Box::from([1])));
+        assert_eq!(merkle.get(&[2]).unwrap(), Some(Box::from([2])));
+
+        for result in merkle.path_iter(&[2]).unwrap() {
+            result.unwrap();
+        }
+    }
+
+    #[test]
     fn insert_one() {
         let mut merkle = create_in_memory_merkle();
         merkle.insert(b"abc", Box::new([])).unwrap()
     }
 
     fn create_in_memory_merkle() -> Merkle<MemStore> {
-        Merkle::new(HashedNodeStore::initialize(MemStore::new(vec![])).unwrap())
+        Merkle::new(HashedNodeStore::new(MemStore::new(vec![])).unwrap())
     }
 
     // use super::*;
@@ -1388,7 +1411,7 @@ mod tests {
     fn merkle_build_test<K: AsRef<[u8]>, V: AsRef<[u8]>>(
         items: Vec<(K, V)>,
     ) -> Result<Merkle<MemStore>, MerkleError> {
-        let mut merkle = Merkle::new(HashedNodeStore::initialize(MemStore::new(vec![])).unwrap());
+        let mut merkle = Merkle::new(HashedNodeStore::new(MemStore::new(vec![])).unwrap());
         for (k, v) in items.iter() {
             merkle.insert(k.as_ref(), Box::from(v.as_ref()))?;
             println!("{}", merkle.dump()?);
@@ -1413,22 +1436,28 @@ mod tests {
         Ok(())
     }
 
-    #[test_case(vec![], "0000000000000000000000000000000000000000000000000000000000000000"; "empty trie")]
-    #[test_case(vec![(&[0],&[0])], "073615413d814b23383fc2c8d8af13abfffcb371b654b98dbf47dd74b1e4d1b9"; "root")]
-    #[test_case(vec![(&[0,1],&[0,1])], "28e67ae4054c8cdf3506567aa43f122224fe65ef1ab3e7b7899f75448a69a6fd"; "root with partial path")]
-    #[test_case(vec![(&[0],&[1;32])], "ba0283637f46fa807280b7d08013710af08dfdc236b9b22f9d66e60592d6c8a3"; "leaf value >= 32 bytes")]
-    #[test_case(vec![(&[0],&[0]),(&[0,1],&[1;32])], "3edbf1fdd345db01e47655bcd0a9a456857c4093188cf35c5c89b8b0fb3de17e"; "branch value >= 32 bytes")]
-    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1])], "c3bdc20aff5cba30f81ffd7689e94e1dbeece4a08e27f0104262431604cf45c6"; "root with leaf child")]
-    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1]),(&[0,1,2],&[0,1,2])], "229011c50ad4d5c2f4efe02b8db54f361ad295c4eee2bf76ea4ad1bb92676f97"; "root with branch child")]
-    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1]),(&[0,8],&[0,8]),(&[0,1,2],&[0,1,2])], "a683b4881cb540b969f885f538ba5904699d480152f350659475a962d6240ef9"; "root with branch child and leaf child")]
-    fn test_root_hash_merkledb_compatible(kvs: Vec<(&[u8], &[u8])>, expected_hash: &str) {
-        let mut merkle = merkle_build_test(kvs).unwrap().freeze().unwrap();
+    #[test_case(vec![], None; "empty trie")]
+    #[test_case(vec![(&[0],&[0])], Some("073615413d814b23383fc2c8d8af13abfffcb371b654b98dbf47dd74b1e4d1b9"); "root")]
+    #[test_case(vec![(&[0,1],&[0,1])], Some("28e67ae4054c8cdf3506567aa43f122224fe65ef1ab3e7b7899f75448a69a6fd"); "root with partial path")]
+    #[test_case(vec![(&[0],&[1;32])], Some("ba0283637f46fa807280b7d08013710af08dfdc236b9b22f9d66e60592d6c8a3"); "leaf value >= 32 bytes")]
+    #[test_case(vec![(&[0],&[0]),(&[0,1],&[1;32])], Some("3edbf1fdd345db01e47655bcd0a9a456857c4093188cf35c5c89b8b0fb3de17e"); "branch value >= 32 bytes")]
+    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1])], Some("c3bdc20aff5cba30f81ffd7689e94e1dbeece4a08e27f0104262431604cf45c6"); "root with leaf child")]
+    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1]),(&[0,1,2],&[0,1,2])], Some("229011c50ad4d5c2f4efe02b8db54f361ad295c4eee2bf76ea4ad1bb92676f97"); "root with branch child")]
+    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1]),(&[0,8],&[0,8]),(&[0,1,2],&[0,1,2])], Some("a683b4881cb540b969f885f538ba5904699d480152f350659475a962d6240ef9"); "root with branch child and leaf child")]
+    fn test_root_hash_merkledb_compatible(kvs: Vec<(&[u8], &[u8])>, expected_hash: Option<&str>) {
+        let merkle = merkle_build_test(kvs).unwrap().freeze().unwrap();
+
+        let Some(got_hash) = merkle.root_hash() else {
+            assert!(expected_hash.is_none());
+            return;
+        };
+
+        let expected_hash = expected_hash.unwrap();
 
         // This hash is from merkledb
         let expected_hash: [u8; 32] = hex::decode(expected_hash).unwrap().try_into().unwrap();
 
-        let actual_hash = merkle.root_hash().unwrap();
-        assert_eq!(actual_hash, TrieHash::from(expected_hash));
+        assert_eq!(*got_hash, TrieHash::from(expected_hash));
     }
 
     #[test]

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -580,7 +580,7 @@ mod tests {
     }
 
     pub(super) fn create_test_merkle() -> Merkle<MemStore> {
-        Merkle::new(HashedNodeStore::initialize(MemStore::new(vec![])).unwrap())
+        Merkle::new(HashedNodeStore::new(MemStore::new(vec![])).unwrap())
     }
 
     #[test_case(&[]; "empty key")]

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -99,6 +99,19 @@ impl BranchNode {
             Some(new_child_addr) => Child::Address(new_child_addr),
         }
     }
+
+    /// Returns (index, hash) for each child that has a hash set.
+    pub fn children_iter(&self) -> impl Iterator<Item = (usize, &TrieHash)> + Clone {
+        self.children.iter().enumerate().filter_map(
+            // TODO danlaine: can we avoid indexing?
+            #[allow(clippy::indexing_slicing)]
+            |(i, child)| match child {
+                Child::None => None,
+                Child::Address(_) => unreachable!("TODO is this reachable?"),
+                Child::AddressWithHash(_, hash) => Some((i, hash)),
+            },
+        )
+    }
 }
 
 impl From<&LeafNode> for BranchNode {

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -107,7 +107,7 @@ impl BranchNode {
             #[allow(clippy::indexing_slicing)]
             |(i, child)| match child {
                 Child::None => None,
-                Child::Address(_) => unreachable!("TODO is this reachable?"),
+                Child::Address(_) => unreachable!("child should have a hash if it has an address"),
                 Child::AddressWithHash(_, hash) => Some((i, hash)),
             },
         )


### PR DESCRIPTION
Generalizes hashing code to more easily accommodate proof node hashing, which will be implemented later.