### PR TITLE
refactor `HashedNodeStore.hash`

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -86,7 +86,7 @@ fn bench_merkle<const NKEYS: usize, const KEYSIZE: usize>(criterion: &mut Criter
             b.iter_batched(
                 || {
                     let store = MemStore::new(vec![]);
-                    let hns = HashedNodeStore::initialize(store).unwrap();
+                    let hns = HashedNodeStore::new(store).unwrap();
                     let merkle = Merkle::new(hns);
 
                     let keys: Vec<Vec<u8>> = repeat_with(|| {

--- a/firewood/src/hashednode.rs
+++ b/firewood/src/hashednode.rs
@@ -248,11 +248,19 @@ impl<T: WriteLinearStore> HashedNodeStore<T> {
 
 pub fn hash_node(node: &Node, path_prefix: &Path) -> TrieHash {
     match node {
-        Node::Branch(node) => NodeAndPrefix {
-            node: node.as_ref(),
-            prefix: path_prefix,
+        Node::Branch(node) => {
+            // All child hashes should be filled in.
+            // TODO danlaine: Enforce this with the type system.
+            debug_assert!(node
+                .children
+                .iter()
+                .all(|c| !matches!(c, Child::Address(..))));
+            NodeAndPrefix {
+                node: node.as_ref(),
+                prefix: path_prefix,
+            }
+            .into()
         }
-        .into(),
         Node::Leaf(node) => NodeAndPrefix {
             node,
             prefix: path_prefix,

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -802,6 +802,30 @@ mod tests {
     use test_case::test_case;
 
     #[test]
+    fn test_get_regression() {
+        let mut merkle = create_in_memory_merkle();
+
+        merkle.insert(&[0], Box::new([0])).unwrap();
+        assert_eq!(merkle.get(&[0]).unwrap(), Some(Box::from([0])));
+
+        merkle.insert(&[1], Box::new([1])).unwrap();
+        assert_eq!(merkle.get(&[1]).unwrap(), Some(Box::from([1])));
+
+        merkle.insert(&[2], Box::new([2])).unwrap();
+        assert_eq!(merkle.get(&[2]).unwrap(), Some(Box::from([2])));
+
+        let merkle = merkle.freeze().unwrap();
+
+        assert_eq!(merkle.get(&[0]).unwrap(), Some(Box::from([0])));
+        assert_eq!(merkle.get(&[1]).unwrap(), Some(Box::from([1])));
+        assert_eq!(merkle.get(&[2]).unwrap(), Some(Box::from([2])));
+
+        for result in merkle.path_iter(&[2]).unwrap() {
+            result.unwrap();
+        }
+    }
+
+    #[test]
     fn insert_one() {
         let mut merkle = create_in_memory_merkle();
         merkle.insert(b"abc", Box::new([])).unwrap()

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -580,7 +580,7 @@ mod tests {
     }
 
     pub(super) fn create_test_merkle() -> Merkle<MemStore> {
-        Merkle::new(HashedNodeStore::initialize(MemStore::new(vec![])).unwrap())
+        Merkle::new(HashedNodeStore::new(MemStore::new(vec![])).unwrap())
     }
 
     #[test_case(&[]; "empty key")]

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -107,7 +107,7 @@ impl BranchNode {
             #[allow(clippy::indexing_slicing)]
             |(i, child)| match child {
                 Child::None => None,
-                Child::Address(_) => unreachable!("TODO is this reachable?"),
+                Child::Address(_) => unreachable!("child should have a hash if it has an address"),
                 Child::AddressWithHash(_, hash) => Some((i, hash)),
             },
         )


### PR DESCRIPTION
This fixes a regression. I also think this simplifies the code. 

`added` is a better name than `modified`.

The updated `hash` implementation now handles changed node sizes, which it couldn't before. This is sort of a hack because we shouldn't ever _need_ to increase the size allocated to a branch node _once we know the number of children_. That is, a branch node with more `AddressWithHash` children has a larger serialized representation than the same node with only `Address` children. This can be addressed in a follow up PR.