### PR TITLE
More HashedNodeStore refactoring

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -86,7 +86,7 @@ fn bench_merkle<const NKEYS: usize, const KEYSIZE: usize>(criterion: &mut Criter
             b.iter_batched(
                 || {
                     let store = MemStore::new(vec![]);
-                    let hns = HashedNodeStore::initialize(store).unwrap();
+                    let hns = HashedNodeStore::new(store).unwrap();
                     let merkle = Merkle::new(hns);
 
                     let keys: Vec<Vec<u8>> = repeat_with(|| {

--- a/firewood/src/hashednode.rs
+++ b/firewood/src/hashednode.rs
@@ -44,16 +44,6 @@ impl<T: WriteLinearStore> HashedNodeStore<T> {
     }
 }
 
-impl<T: ReadLinearStore> From<NodeStore<T>> for HashedNodeStore<T> {
-    fn from(nodestore: NodeStore<T>) -> Self {
-        HashedNodeStore {
-            nodestore,
-            added: Default::default(),
-            root_hash: Default::default(),
-        }
-    }
-}
-
 impl<T: ReadLinearStore> HashedNodeStore<T> {
     pub fn read_node(&self, addr: LinearAddress) -> Result<Arc<Node>, Error> {
         if let Some((modified_node, _)) = self.added.get(&addr) {

--- a/firewood/src/hashednode.rs
+++ b/firewood/src/hashednode.rs
@@ -5,7 +5,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::io::Error;
 use std::iter::{self, once};
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use storage::{Child, TrieHash, UpdateError};
 use storage::{LinearAddress, NodeStore};
@@ -30,7 +30,7 @@ use storage::PathIterItem;
 pub struct HashedNodeStore<T: ReadLinearStore> {
     nodestore: NodeStore<T>,
     added: HashMap<LinearAddress, (Arc<Node>, u8)>,
-    root_hash: OnceLock<TrieHash>,
+    root_hash: Option<TrieHash>,
 }
 
 impl<T: WriteLinearStore> HashedNodeStore<T> {
@@ -63,31 +63,13 @@ impl<T: ReadLinearStore> HashedNodeStore<T> {
         }
     }
 
-    pub fn root_hash(&self) -> Result<TrieHash, Error> {
+    /// Returns the hash of the root of this trie.
+    /// Returns None if the trie is empty.
+    /// Assumes `freeze` has already been called on this store.
+    /// TODO enforce this assumption with the type system.
+    pub fn root_hash(&self) -> Option<&TrieHash> {
         debug_assert!(self.added.is_empty());
-        let Some(addr) = self.nodestore.root_address() else {
-            return Ok(TrieHash::default());
-        };
-
-        // TODO danlaine: Uncomment this once get_or_try_init is stable
-        // return self
-        //     .root_hash
-        //     .get_or_try_init(|| {
-        //         let node = self.read_node(addr)?;
-        //         Ok(hash_node(&node, &Path(Default::default())))
-        //     })
-        //     .cloned();
-
-        Ok(self
-            .root_hash
-            .get_or_init(|| {
-                let node = self
-                    .nodestore
-                    .read_node(addr)
-                    .expect("TODO: use get_or_try_init once it's available");
-                hash_node(&node, &Path(Default::default()))
-            })
-            .clone())
+        self.root_hash.as_ref()
     }
 
     pub const fn root_address(&self) -> Option<LinearAddress> {
@@ -152,12 +134,9 @@ impl<T: WriteLinearStore> HashedNodeStore<T> {
         let root_hash = if let Some(root_address) = self.root_address() {
             let (hash, root_address) = self.hash(root_address, &mut Path(Default::default()))?;
             self.nodestore.set_root(Some(root_address))?;
-
-            let root_hash = OnceLock::new();
-            let _ = root_hash.set(hash);
-            root_hash
+            Some(hash)
         } else {
-            Default::default()
+            None
         };
         assert!(self.added.is_empty());
         let frozen_nodestore = self.nodestore.freeze();
@@ -524,6 +503,6 @@ mod test {
         hns.set_root(Some(addr)).unwrap();
 
         let frozen = hns.freeze().unwrap();
-        assert_ne!(frozen.root_hash().unwrap(), Default::default());
+        assert_ne!(frozen.root_hash(), None);
     }
 }

--- a/firewood/src/hashednode.rs
+++ b/firewood/src/hashednode.rs
@@ -34,12 +34,13 @@ pub struct HashedNodeStore<T: ReadLinearStore> {
 }
 
 impl<T: WriteLinearStore> HashedNodeStore<T> {
-    pub fn initialize(linearstore: T) -> Result<Self, Error> {
+    /// Returns a new empty HashedNodeStore that uses `linearstore` as the backing store.
+    pub fn new(linearstore: T) -> Result<Self, Error> {
         let nodestore = NodeStore::initialize(linearstore)?;
         Ok(HashedNodeStore {
             nodestore,
             added: Default::default(),
-            root_hash: Default::default(),
+            root_hash: None,
         })
     }
 }
@@ -129,9 +130,8 @@ impl<T: WriteLinearStore> HashedNodeStore<T> {
             None
         };
         assert!(self.added.is_empty());
-        let frozen_nodestore = self.nodestore.freeze();
         Ok(HashedNodeStore {
-            nodestore: frozen_nodestore,
+            nodestore: self.nodestore.freeze(),
             added: Default::default(),
             root_hash,
         })
@@ -484,7 +484,7 @@ mod test {
     #[test]
     fn freeze_test() {
         let memstore = MemStore::new(vec![]);
-        let mut hns = HashedNodeStore::initialize(memstore).unwrap();
+        let mut hns = HashedNodeStore::new(memstore).unwrap();
         let node = Node::Leaf(storage::LeafNode {
             partial_path: Path(Default::default()),
             value: Box::new(*b"abc"),

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -831,7 +831,7 @@ mod tests {
     }
 
     fn create_in_memory_merkle() -> Merkle<MemStore> {
-        Merkle::new(HashedNodeStore::initialize(MemStore::new(vec![])).unwrap())
+        Merkle::new(HashedNodeStore::new(MemStore::new(vec![])).unwrap())
     }
 
     // use super::*;
@@ -1411,7 +1411,7 @@ mod tests {
     fn merkle_build_test<K: AsRef<[u8]>, V: AsRef<[u8]>>(
         items: Vec<(K, V)>,
     ) -> Result<Merkle<MemStore>, MerkleError> {
-        let mut merkle = Merkle::new(HashedNodeStore::initialize(MemStore::new(vec![])).unwrap());
+        let mut merkle = Merkle::new(HashedNodeStore::new(MemStore::new(vec![])).unwrap());
         for (k, v) in items.iter() {
             merkle.insert(k.as_ref(), Box::from(v.as_ref()))?;
             println!("{}", merkle.dump()?);

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -102,8 +102,7 @@ impl<T: ReadLinearStore> Merkle<T> {
         self.0.root_address()
     }
 
-    // TODO: can we make this &self instead of &mut self?
-    pub fn root_hash(&mut self) -> Result<TrieHash, std::io::Error> {
+    pub fn root_hash(&self) -> Option<&TrieHash> {
         self.0.root_hash()
     }
 
@@ -1437,22 +1436,28 @@ mod tests {
         Ok(())
     }
 
-    #[test_case(vec![], "0000000000000000000000000000000000000000000000000000000000000000"; "empty trie")]
-    #[test_case(vec![(&[0],&[0])], "073615413d814b23383fc2c8d8af13abfffcb371b654b98dbf47dd74b1e4d1b9"; "root")]
-    #[test_case(vec![(&[0,1],&[0,1])], "28e67ae4054c8cdf3506567aa43f122224fe65ef1ab3e7b7899f75448a69a6fd"; "root with partial path")]
-    #[test_case(vec![(&[0],&[1;32])], "ba0283637f46fa807280b7d08013710af08dfdc236b9b22f9d66e60592d6c8a3"; "leaf value >= 32 bytes")]
-    #[test_case(vec![(&[0],&[0]),(&[0,1],&[1;32])], "3edbf1fdd345db01e47655bcd0a9a456857c4093188cf35c5c89b8b0fb3de17e"; "branch value >= 32 bytes")]
-    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1])], "c3bdc20aff5cba30f81ffd7689e94e1dbeece4a08e27f0104262431604cf45c6"; "root with leaf child")]
-    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1]),(&[0,1,2],&[0,1,2])], "229011c50ad4d5c2f4efe02b8db54f361ad295c4eee2bf76ea4ad1bb92676f97"; "root with branch child")]
-    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1]),(&[0,8],&[0,8]),(&[0,1,2],&[0,1,2])], "a683b4881cb540b969f885f538ba5904699d480152f350659475a962d6240ef9"; "root with branch child and leaf child")]
-    fn test_root_hash_merkledb_compatible(kvs: Vec<(&[u8], &[u8])>, expected_hash: &str) {
-        let mut merkle = merkle_build_test(kvs).unwrap().freeze().unwrap();
+    #[test_case(vec![], None; "empty trie")]
+    #[test_case(vec![(&[0],&[0])], Some("073615413d814b23383fc2c8d8af13abfffcb371b654b98dbf47dd74b1e4d1b9"); "root")]
+    #[test_case(vec![(&[0,1],&[0,1])], Some("28e67ae4054c8cdf3506567aa43f122224fe65ef1ab3e7b7899f75448a69a6fd"); "root with partial path")]
+    #[test_case(vec![(&[0],&[1;32])], Some("ba0283637f46fa807280b7d08013710af08dfdc236b9b22f9d66e60592d6c8a3"); "leaf value >= 32 bytes")]
+    #[test_case(vec![(&[0],&[0]),(&[0,1],&[1;32])], Some("3edbf1fdd345db01e47655bcd0a9a456857c4093188cf35c5c89b8b0fb3de17e"); "branch value >= 32 bytes")]
+    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1])], Some("c3bdc20aff5cba30f81ffd7689e94e1dbeece4a08e27f0104262431604cf45c6"); "root with leaf child")]
+    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1]),(&[0,1,2],&[0,1,2])], Some("229011c50ad4d5c2f4efe02b8db54f361ad295c4eee2bf76ea4ad1bb92676f97"); "root with branch child")]
+    #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1]),(&[0,8],&[0,8]),(&[0,1,2],&[0,1,2])], Some("a683b4881cb540b969f885f538ba5904699d480152f350659475a962d6240ef9"); "root with branch child and leaf child")]
+    fn test_root_hash_merkledb_compatible(kvs: Vec<(&[u8], &[u8])>, expected_hash: Option<&str>) {
+        let merkle = merkle_build_test(kvs).unwrap().freeze().unwrap();
+
+        let Some(got_hash) = merkle.root_hash() else {
+            assert!(expected_hash.is_none());
+            return;
+        };
+
+        let expected_hash = expected_hash.unwrap();
 
         // This hash is from merkledb
         let expected_hash: [u8; 32] = hex::decode(expected_hash).unwrap().try_into().unwrap();
 
-        let actual_hash = merkle.root_hash().unwrap();
-        assert_eq!(actual_hash, TrieHash::from(expected_hash));
+        assert_eq!(*got_hash, TrieHash::from(expected_hash));
     }
 
     #[test]

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -580,7 +580,7 @@ mod tests {
     }
 
     pub(super) fn create_test_merkle() -> Merkle<MemStore> {
-        Merkle::new(HashedNodeStore::initialize(MemStore::new(vec![])).unwrap())
+        Merkle::new(HashedNodeStore::new(MemStore::new(vec![])).unwrap())
     }
 
     #[test_case(&[]; "empty key")]


### PR DESCRIPTION
* Renames `HashedNodeStore::initialize` to `HashedNodeStore::new`. I think this more clearly communicates the fact that it is an _empty_ store.
* Changes `HashedNodeStore.root_hash` to a `Option<TrieHash>`. If the root hash is defined, it's returned. Otherwise None.  No more OnceLock -- a `HashedNodeStore`'s hash doesn't change after creation.