### PR TITLE
Remove `Merkle` dependency from stream code

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -235,7 +235,7 @@ impl<T: NodeReader> Merkle<T> {
 
     // TODO danlaine: can we use the LinearAddress of the `root` instead?
     pub fn path_iter<'a>(&self, key: &'a [u8]) -> Result<PathIterator<'_, 'a, T>, MerkleError> {
-        PathIterator::new(self, key)
+        PathIterator::new(&self.nodestore, key)
     }
 
     pub(crate) fn _key_value_iter(&self) -> MerkleKeyValueStream<'_, T> {

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -252,7 +252,7 @@ impl<T: NodeReader> Merkle<T> {
         PathIterator::new(&self.nodestore, key)
     }
 
-    pub(crate) fn _key_value_iter<'a>(&'a self) -> MerkleKeyValueStream<'a, T> {
+    pub(crate) fn _key_value_iter(&self) -> MerkleKeyValueStream<'_, T> {
         MerkleKeyValueStream::from(&self.nodestore)
     }
 

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -179,6 +179,10 @@ impl<T: NodeReader> Merkle<T> {
         Some((root_addr, root_hash))
     }
 
+    pub fn nodestore(&self) -> &T {
+        &self.nodestore
+    }
+
     pub(crate) fn read_node(&self, addr: LinearAddress) -> Result<Arc<Node>, MerkleError> {
         self.nodestore.read_node(addr)
     }
@@ -239,12 +243,12 @@ impl<T: NodeReader> Merkle<T> {
     }
 
     pub(crate) fn _key_value_iter(&self) -> MerkleKeyValueStream<'_, T> {
-        MerkleKeyValueStream::_new(self)
+        MerkleKeyValueStream::_new(&self.nodestore)
     }
 
     pub(crate) fn _key_value_iter_from_key(&self, key: Key) -> MerkleKeyValueStream<'_, T> {
         // TODO danlaine: change key to &[u8]
-        MerkleKeyValueStream::_from_key(self, key)
+        MerkleKeyValueStream::_from_key(&self.nodestore, key)
     }
 
     pub(super) async fn _range_proof(

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -248,13 +248,12 @@ impl<T: NodeReader> Merkle<T> {
         todo!()
     }
 
-    // TODO danlaine: can we use the LinearAddress of the `root` instead?
     pub fn path_iter<'a>(&self, key: &'a [u8]) -> Result<PathIterator<'_, 'a, T>, MerkleError> {
         PathIterator::new(&self.nodestore, key)
     }
 
-    pub(crate) fn _key_value_iter(&self) -> MerkleKeyValueStream<'_, T> {
-        MerkleKeyValueStream::_new(&self.nodestore)
+    pub(crate) fn _key_value_iter<'a>(&'a self) -> MerkleKeyValueStream<'a, T> {
+        MerkleKeyValueStream::from(&self.nodestore)
     }
 
     pub(crate) fn _key_value_iter_from_key(&self, key: Key) -> MerkleKeyValueStream<'_, T> {

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -179,7 +179,7 @@ impl<T: NodeReader> Merkle<T> {
         Some((root_addr, root_hash))
     }
 
-    pub fn nodestore(&self) -> &T {
+    pub const fn nodestore(&self) -> &T {
         &self.nodestore
     }
 

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -270,16 +270,16 @@ enum MerkleKeyValueStreamState<'a, T: NodeReader> {
     Initialized { node_iter: MerkleNodeStream<'a, T> },
 }
 
+impl<'a, T: NodeReader> From<Key> for MerkleKeyValueStreamState<'a, T> {
+    fn from(key: Key) -> Self {
+        Self::_Uninitialized(key)
+    }
+}
+
 impl<'a, T: NodeReader> MerkleKeyValueStreamState<'a, T> {
     /// Returns a new iterator that will iterate over all the key-value pairs in `merkle`.
     fn _new() -> Self {
         Self::_Uninitialized(Box::new([]))
-    }
-
-    /// Returns a new iterator that will iterate over all the key-value pairs in `merkle`
-    /// with keys greater than or equal to `key`.
-    fn _with_key(key: Key) -> Self {
-        Self::_Uninitialized(key)
     }
 }
 
@@ -307,7 +307,7 @@ impl<'a, T: NodeReader> FusedStream for MerkleKeyValueStream<'a, T> {
 impl<'a, T: NodeReader> MerkleKeyValueStream<'a, T> {
     pub(super) fn _from_key(merkle: &'a T, key: Key) -> Self {
         Self {
-            state: MerkleKeyValueStreamState::_with_key(key),
+            state: MerkleKeyValueStreamState::from(key),
             merkle,
         }
     }

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -283,6 +283,15 @@ impl<'a, T: NodeReader> MerkleKeyValueStreamState<'a, T> {
     }
 }
 
+impl<'a, T: NodeReader> From<&'a T> for MerkleKeyValueStream<'a, T> {
+    fn from(merkle: &'a T) -> Self {
+        Self {
+            state: MerkleKeyValueStreamState::_new(),
+            merkle,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct MerkleKeyValueStream<'a, T: NodeReader> {
     state: MerkleKeyValueStreamState<'a, T>,
@@ -296,13 +305,6 @@ impl<'a, T: NodeReader> FusedStream for MerkleKeyValueStream<'a, T> {
 }
 
 impl<'a, T: NodeReader> MerkleKeyValueStream<'a, T> {
-    pub(super) fn _new(merkle: &'a T) -> Self {
-        Self {
-            state: MerkleKeyValueStreamState::_new(),
-            merkle,
-        }
-    }
-
     pub(super) fn _from_key(merkle: &'a T, key: Key) -> Self {
         Self {
             state: MerkleKeyValueStreamState::_with_key(key),

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -592,14 +592,6 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
-    pub(crate) fn node_iter<T: NodeReader>(node_reader: &T) -> MerkleNodeStream<T> {
-        MerkleNodeStream::new(node_reader, Box::new([]))
-    }
-
-    pub(crate) fn node_iter_from<T: NodeReader>(node_reader: &T, key: Key) -> MerkleNodeStream<T> {
-        MerkleNodeStream::new(node_reader, key)
-    }
-
     pub(super) fn create_test_merkle() -> MutableProposal<NodeStore<MemStore>> {
         let nodestore = NodeStore::initialize(MemStore::new(vec![])).unwrap();
         merkle::new(nodestore).unwrap()
@@ -743,7 +735,7 @@ mod tests {
     #[tokio::test]
     async fn node_iterate_empty() {
         let merkle = create_test_merkle().hash().unwrap();
-        let stream = node_iter(merkle.nodestore());
+        let stream = MerkleNodeStream::new(merkle.nodestore(), Box::new([]));
         check_stream_is_done(stream).await;
     }
 
@@ -755,7 +747,7 @@ mod tests {
 
         let merkle = merkle.hash().unwrap();
 
-        let mut stream = node_iter(merkle.nodestore());
+        let mut stream = MerkleNodeStream::new(merkle.nodestore(), Box::new([]));
 
         let (key, node) = stream.next().await.unwrap().unwrap();
 
@@ -812,7 +804,7 @@ mod tests {
     async fn node_iterator_no_start_key() {
         let merkle = created_populated_merkle().hash().unwrap();
 
-        let mut stream = node_iter(merkle.nodestore());
+        let mut stream = MerkleNodeStream::new(merkle.nodestore(), Box::new([]));
 
         // Covers case of branch with no value
         let (key, node) = stream.next().await.unwrap().unwrap();
@@ -861,7 +853,7 @@ mod tests {
     async fn node_iterator_start_key_between_nodes() {
         let merkle = created_populated_merkle().hash().unwrap();
 
-        let mut stream = node_iter_from(
+        let mut stream = MerkleNodeStream::new(
             merkle.nodestore(),
             vec![0x00, 0x00, 0x01].into_boxed_slice(),
         );
@@ -888,7 +880,7 @@ mod tests {
     async fn node_iterator_start_key_on_node() {
         let merkle = created_populated_merkle().hash().unwrap();
 
-        let mut stream = node_iter_from(
+        let mut stream = MerkleNodeStream::new(
             merkle.nodestore(),
             vec![0x00, 0xD0, 0xD0].into_boxed_slice(),
         );
@@ -915,7 +907,7 @@ mod tests {
     async fn node_iterator_start_key_after_last_key() {
         let merkle = created_populated_merkle().hash().unwrap();
 
-        let stream = node_iter_from(merkle.nodestore(), vec![0xFF].into_boxed_slice());
+        let stream = MerkleNodeStream::new(merkle.nodestore(), vec![0xFF].into_boxed_slice());
 
         check_stream_is_done(stream).await;
     }

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -60,8 +60,8 @@ enum NodeStreamState {
     },
 }
 
-impl NodeStreamState {
-    fn new(key: Key) -> Self {
+impl From<Key> for NodeStreamState {
+    fn from(key: Key) -> Self {
         Self::StartFromKey(key)
     }
 }
@@ -85,7 +85,7 @@ impl<'a, T: NodeReader> MerkleNodeStream<'a, T> {
     /// with keys greater than or equal to `key`.
     pub(super) fn new(merkle: &'a T, key: Key) -> Self {
         Self {
-            state: NodeStreamState::new(key),
+            state: NodeStreamState::from(key),
             merkle,
         }
     }


### PR DESCRIPTION
The streams actually just need a `NodeReader`, not a `Merkle`. Also removes some unneeded Arc cloning.