### PR TITLE
use `Option<Child>` instead of having `Child::None`

### DIFF
--- a/firewood/src/hashednode.rs
+++ b/firewood/src/hashednode.rs
@@ -41,7 +41,10 @@ pub fn hash_node(node: &Node, path_prefix: &Path) -> TrieHash {
         Node::Branch(node) => {
             // All child hashes should be filled in.
             // TODO danlaine: Enforce this with the type system.
-            debug_assert!(node.children.iter().all(|c| !matches!(c, Child::Node(..))));
+            debug_assert!(node
+                .children
+                .iter()
+                .all(|c| !matches!(c, Some(Child::Node(_)))));
             NodeAndPrefix {
                 node: node.as_ref(),
                 prefix: path_prefix,

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -797,13 +797,7 @@ impl<T: NodeWriter> MutableProposal<T> {
                         } else {
                             // The branch's only child becomes the root of this subtrie.
                             let mut child = match child {
-                                Child::Node(ref mut child_node) => std::mem::replace(
-                                    child_node,
-                                    Node::Leaf(LeafNode {
-                                        value: Box::from([]),
-                                        partial_path: Path::new(),
-                                    }),
-                                ),
+                                Child::Node(ref mut child_node) => std::mem::take(child_node),
                                 Child::AddressWithHash(addr, _) => {
                                     let node = self.nodestore.read_node(*addr)?;
                                     self.deleted.push(*addr);

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -151,9 +151,9 @@ fn get_helper<T: NodeReader>(
                 Node::Branch(branch) => {
                     #[allow(clippy::indexing_slicing)]
                     let child = match &branch.children[child_index as usize] {
-                        Child::None => return Ok(None),
-                        Child::Node(node) => node,
-                        Child::AddressWithHash(addr, _) => &nodestore.read_node(*addr)?,
+                        None => return Ok(None),
+                        Some(Child::Node(node)) => node,
+                        Some(Child::AddressWithHash(addr, _)) => &nodestore.read_node(*addr)?,
                     };
 
                     get_helper(nodestore, child, key)
@@ -362,9 +362,9 @@ impl<T: NodeReader> Merkle<T> {
                 writeln!(writer, "\"]")?;
                 for (childidx, child) in b.children.iter().enumerate() {
                     let (child_addr, child_hash) = match child {
-                        Child::None => continue,
-                        Child::Node(_) => continue, // TODO
-                        Child::AddressWithHash(addr, hash) => (*addr, Some(hash)),
+                        None => continue,
+                        Some(Child::Node(_)) => continue, // TODO
+                        Some(Child::AddressWithHash(addr, hash)) => (*addr, Some(hash)),
                     };
 
                     let inserted = seen.insert(child_addr);
@@ -498,7 +498,7 @@ impl<T: NodeWriter> MutableProposal<T> {
             Node::Branch(ref mut b) => {
                 for (nibble, child) in b.children.iter_mut().enumerate() {
                     // Take child from b.children
-                    let Child::Node(child_node) = std::mem::take(child) else {
+                    let Some(Child::Node(child_node)) = std::mem::take(child) else {
                         // There is no child or we already know its hash.
                         continue;
                     };
@@ -510,7 +510,7 @@ impl<T: NodeWriter> MutableProposal<T> {
                         .extend(b.partial_path.0.iter().copied().chain(once(nibble as u8)));
 
                     let (child_addr, child_hash) = self.hash_helper(child_node, path_prefix);
-                    *child = Child::AddressWithHash(child_addr, child_hash);
+                    *child = Some(Child::AddressWithHash(child_addr, child_hash));
                     path_prefix.0.truncate(original_length);
                 }
             }
@@ -626,7 +626,7 @@ impl<T: NodeWriter> MutableProposal<T> {
 
                 // Shorten the node's partial path since it has a new parent.
                 node.update_partial_path(partial_path);
-                branch.update_child(child_index, Child::Node(node));
+                branch.update_child(child_index, Some(Child::Node(node)));
 
                 Ok(Node::Branch(Box::new(branch)))
             }
@@ -642,18 +642,18 @@ impl<T: NodeWriter> MutableProposal<T> {
                         #[allow(clippy::indexing_slicing)]
                         let child = match std::mem::take(&mut branch.children[child_index as usize])
                         {
-                            Child::None => {
+                            None => {
                                 // There is no child at this index.
                                 // Create a new leaf and put it here.
                                 let new_leaf = Node::Leaf(LeafNode {
                                     value,
                                     partial_path,
                                 });
-                                branch.update_child(child_index, Child::Node(new_leaf));
+                                branch.update_child(child_index, Some(Child::Node(new_leaf)));
                                 return Ok(node);
                             }
-                            Child::Node(child) => child,
-                            Child::AddressWithHash(addr, _) => {
+                            Some(Child::Node(child)) => child,
+                            Some(Child::AddressWithHash(addr, _)) => {
                                 let node = self.nodestore.read_node(addr)?;
                                 self.deleted.push(addr);
                                 (*node).clone()
@@ -661,7 +661,7 @@ impl<T: NodeWriter> MutableProposal<T> {
                         };
 
                         let child = self.insert_helper(child, partial_path.as_ref(), value)?;
-                        branch.update_child(child_index, Child::Node(child));
+                        branch.update_child(child_index, Some(Child::Node(child)));
                         Ok(node)
                     }
                     Node::Leaf(ref mut leaf) => {
@@ -677,7 +677,7 @@ impl<T: NodeWriter> MutableProposal<T> {
                             partial_path,
                         });
 
-                        branch.update_child(child_index, Child::Node(new_leaf));
+                        branch.update_child(child_index, Some(Child::Node(new_leaf)));
 
                         Ok(Node::Branch(Box::new(branch)))
                     }
@@ -698,13 +698,13 @@ impl<T: NodeWriter> MutableProposal<T> {
                 };
 
                 node.update_partial_path(node_partial_path);
-                branch.update_child(node_index, Child::Node(node));
+                branch.update_child(node_index, Some(Child::Node(node)));
 
                 let new_leaf = Node::Leaf(LeafNode {
                     value,
                     partial_path: key_partial_path,
                 });
-                branch.update_child(key_index, Child::Node(new_leaf));
+                branch.update_child(key_index, Some(Child::Node(new_leaf)));
 
                 Ok(Node::Branch(Box::new(branch)))
             }
@@ -758,7 +758,7 @@ impl<T: NodeWriter> MutableProposal<T> {
             (None, None) => {
                 // 1. The node is at `key`
                 match &mut node {
-                    Node::Branch(branch) => {
+                    Node::Branch(ref mut branch) => {
                         let Some(removed_value) = branch.value.take() else {
                             // The branch has no value. Return the node as is.
                             return Ok((Some(node), None));
@@ -767,11 +767,14 @@ impl<T: NodeWriter> MutableProposal<T> {
                         // This branch node has a value.
                         // If it has multiple children, return the node as is.
                         // Otherwise, its only child becomes the root of this subtrie.
-                        let mut children_iter = branch
-                            .children
-                            .iter_mut()
-                            .enumerate()
-                            .filter(|(_, child)| !matches!(child, Child::None));
+                        let mut children_iter =
+                            branch
+                                .children
+                                .iter_mut()
+                                .enumerate()
+                                .filter_map(|(index, child)| {
+                                    child.as_mut().map(|child| (index, child))
+                                });
 
                         let (child_index, child) = children_iter
                             .next()
@@ -783,8 +786,7 @@ impl<T: NodeWriter> MutableProposal<T> {
                         } else {
                             // The branch's only child becomes the root of this subtrie.
                             let mut child = match child {
-                                Child::None => unreachable!(),
-                                Child::Node(child_node) => std::mem::replace(
+                                Child::Node(ref mut child_node) => std::mem::replace(
                                     child_node,
                                     Node::Leaf(LeafNode {
                                         value: Box::from([]),
@@ -856,11 +858,11 @@ impl<T: NodeWriter> MutableProposal<T> {
                         #[allow(clippy::indexing_slicing)]
                         let child = match std::mem::take(&mut branch.children[child_index as usize])
                         {
-                            Child::None => {
+                            None => {
                                 return Ok((Some(node), None));
                             }
-                            Child::Node(node) => node,
-                            Child::AddressWithHash(addr, _) => {
+                            Some(Child::Node(node)) => node,
+                            Some(Child::AddressWithHash(addr, _)) => {
                                 let node = self.nodestore.read_node(addr)?;
                                 self.deleted.push(addr);
                                 (*node).clone()
@@ -871,16 +873,19 @@ impl<T: NodeWriter> MutableProposal<T> {
                             self.remove_helper(child, child_partial_path.as_ref())?;
 
                         if let Some(child) = child {
-                            branch.update_child(child_index, Child::Node(child));
+                            branch.update_child(child_index, Some(Child::Node(child)));
                         } else {
-                            branch.update_child(child_index, Child::None);
+                            branch.update_child(child_index, None);
                         }
 
-                        let mut children_iter = branch
-                            .children
-                            .iter_mut()
-                            .enumerate()
-                            .filter(|(_, child)| !matches!(child, Child::None));
+                        let mut children_iter =
+                            branch
+                                .children
+                                .iter_mut()
+                                .enumerate()
+                                .filter_map(|(index, child)| {
+                                    child.as_mut().map(|child| (index, child))
+                                });
 
                         let Some((child_index, child)) = children_iter.next() else {
                             // The branch has no children. Turn it into a leaf.
@@ -900,7 +905,6 @@ impl<T: NodeWriter> MutableProposal<T> {
 
                         // The branch has only 1 child. Remove the branch and return the child.
                         let mut child = match child {
-                            Child::None => unreachable!(),
                             Child::Node(child_node) => std::mem::replace(
                                 child_node,
                                 Node::Leaf(LeafNode {

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -6,12 +6,9 @@ use serde::{ser::SerializeStruct as _, Deserialize, Serialize};
 use crate::{LeafNode, LinearAddress, Node, Path, TrieHash};
 use std::fmt::{Debug, Error as FmtError, Formatter};
 
-#[derive(PartialEq, Eq, Clone, Default, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 /// A child of a branch node.
 pub enum Child {
-    #[default]
-    /// There is no child at this index.
-    None,
     /// There is a child at this index, but we haven't hashed it
     /// or written it to storage yet.
     Node(Node),
@@ -32,7 +29,7 @@ pub struct BranchNode {
     /// Element i is the child at index i, or None if there is no child at that index.
     /// Each element is (child_hash, child_address).
     /// child_address is None if we don't know the child's hash.
-    pub children: [Child; Self::MAX_CHILDREN],
+    pub children: [Option<Child>; Self::MAX_CHILDREN],
 }
 
 impl Serialize for BranchNode {
@@ -49,13 +46,15 @@ impl Serialize for BranchNode {
 
         for (i, c) in self.children.iter().enumerate() {
             match c {
-                Child::None => {}
-                Child::Node(_) => {
+                None => {}
+                Some(Child::Node(_)) => {
                     return Err(serde::ser::Error::custom(
                         "node has children in memory. TODO make this impossible.",
                     ))
                 }
-                Child::AddressWithHash(addr, hash) => children[i] = Some((*addr, (*hash).clone())),
+                Some(Child::AddressWithHash(addr, hash)) => {
+                    children[i] = Some((*addr, (*hash).clone()))
+                }
             }
         }
 
@@ -78,10 +77,10 @@ impl<'de> Deserialize<'de> for BranchNode {
 
         let s: SerializedBranchNode = Deserialize::deserialize(deserializer)?;
 
-        let mut children: [Child; BranchNode::MAX_CHILDREN] = Default::default();
+        let mut children: [Option<Child>; BranchNode::MAX_CHILDREN] = Default::default();
         for (i, c) in s.children.iter().enumerate() {
             if let Some((addr, hash)) = c {
-                children[i] = Child::AddressWithHash(*addr, hash.clone());
+                children[i] = Some(Child::AddressWithHash(*addr, hash.clone()));
             }
         }
 
@@ -106,9 +105,9 @@ impl Debug for BranchNode {
 
         for (i, c) in self.children.iter().enumerate() {
             match c {
-                Child::None => {}
-                Child::Node(_) => {} //TODO
-                Child::AddressWithHash(addr, hash) => write!(
+                None => {}
+                Some(Child::Node(_)) => {} //TODO
+                Some(Child::AddressWithHash(addr, hash)) => write!(
                     f,
                     "(index: {i:?}), address={addr:?}, hash={:?})",
                     hex::encode(hash),
@@ -133,7 +132,7 @@ impl BranchNode {
 
     /// Returns the address of the child at the given index.
     /// Panics if `child_index` >= [BranchNode::MAX_CHILDREN].
-    pub fn child(&self, child_index: u8) -> &Child {
+    pub fn child(&self, child_index: u8) -> &Option<Child> {
         self.children
             .get(child_index as usize)
             .expect("child_index is in bounds")
@@ -141,7 +140,7 @@ impl BranchNode {
 
     /// Update the child at `child_index` to be `new_child_addr`.
     /// If `new_child_addr` is None, the child is removed.
-    pub fn update_child(&mut self, child_index: u8, new_child: Child) {
+    pub fn update_child(&mut self, child_index: u8, new_child: Option<Child>) {
         let child = self
             .children
             .get_mut(child_index as usize)
@@ -153,12 +152,11 @@ impl BranchNode {
     /// Returns (index, hash) for each child that has a hash set.
     pub fn children_iter(&self) -> impl Iterator<Item = (usize, &TrieHash)> + Clone {
         self.children.iter().enumerate().filter_map(
-            // TODO danlaine: can we avoid indexing?
             #[allow(clippy::indexing_slicing)]
             |(i, child)| match child {
-                Child::None => None,
-                Child::Node(_) => unreachable!("TODO make unreachable"),
-                Child::AddressWithHash(_, hash) => Some((i, hash)),
+                None => None,
+                Some(Child::Node(_)) => unreachable!("TODO make unreachable"),
+                Some(Child::AddressWithHash(_, hash)) => Some((i, hash)),
             },
         )
     }


### PR DESCRIPTION
I think this is a little bit more Rusty and lets us remove a few `unreachable!` cases