### PR TITLE
remove verify_proof

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -225,14 +225,6 @@ impl<T: NodeReader> Merkle<T> {
         Ok(Proof(proof.into_boxed_slice()))
     }
 
-    pub fn verify_proof(
-        &self,
-        _key: &[u8],
-        _proof: &Proof,
-    ) -> Result<Option<Vec<u8>>, MerkleError> {
-        todo!()
-    }
-
     pub fn verify_range_proof<V: AsRef<[u8]>>(
         &self,
         _proof: &Proof,


### PR DESCRIPTION
A proof doesn't need a merkle to be verified. It can be verified without any context.