### PR TITLE
Implement commit

### DIFF
--- a/firewood/examples/insert.rs
+++ b/firewood/examples/insert.rs
@@ -5,13 +5,15 @@
 // insert some random keys using the front-end API.
 
 use clap::Parser;
-use std::{collections::HashMap, error::Error, ops::RangeInclusive};
+use std::{
+    borrow::BorrowMut as _, collections::HashMap, error::Error, ops::RangeInclusive, time::Instant,
+};
 
 use firewood::{
-    db::{Batch, BatchOp},
-    v2::api::DbView,
+    db::{Batch, BatchOp, Db, DbConfig},
+    v2::api::{Db as _, DbView, Proposal as _},
 };
-use rand::Rng;
+use rand::{distributions::Alphanumeric, Rng, SeedableRng as _};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -43,63 +45,60 @@ fn string_to_range(input: &str) -> Result<RangeInclusive<usize>, Box<dyn Error +
 /// cargo run --release --example insert
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<(), Box<dyn Error>> {
+    let cfg = DbConfig::builder().truncate(true).build();
+
+    let args = Args::parse();
+
+    let mut db = Db::new("rev_db", cfg)
+        .await
+        .expect("db initiation should succeed");
+
+    let keys = args.batch_size;
+    let start = Instant::now();
+
+    let mut rng = if let Some(seed) = args.seed {
+        rand::rngs::StdRng::seed_from_u64(seed)
+    } else {
+        rand::rngs::StdRng::from_entropy()
+    };
+
+    for _ in 0..args.number_of_batches {
+        let keylen = rng.gen_range(args.keylen.clone());
+        let valuelen = rng.gen_range(args.valuelen.clone());
+        let batch: Batch<Vec<u8>, Vec<u8>> = (0..keys)
+            .map(|_| {
+                (
+                    rng.borrow_mut()
+                        .sample_iter(&Alphanumeric)
+                        .take(keylen)
+                        .collect::<Vec<u8>>(),
+                    rng.borrow_mut()
+                        .sample_iter(&Alphanumeric)
+                        .take(valuelen)
+                        .collect::<Vec<u8>>(),
+                )
+            })
+            .map(|(key, value)| BatchOp::Put { key, value })
+            .collect();
+
+        let verify = get_keys_to_verify(&batch, args.read_verify_percent);
+
+        #[allow(clippy::unwrap_used)]
+        let proposal = db.propose(batch).await.unwrap();
+        proposal.commit().await?;
+        verify_keys(&db, verify).await?;
+    }
+
+    let duration = start.elapsed();
+    println!(
+        "Generated and inserted {} batches of size {keys} in {duration:?}",
+        args.number_of_batches
+    );
+
     Ok(())
-
-    // TODO replace
-    // let cfg = DbConfig::builder().truncate(true).build();
-
-    // let args = Args::parse();
-
-    // let db = Db::new("rev_db", cfg)
-    //     .await
-    //     .expect("db initiation should succeed");
-
-    // let keys = args.batch_size;
-    // let start = Instant::now();
-
-    // let mut rng = if let Some(seed) = args.seed {
-    //     rand::rngs::StdRng::seed_from_u64(seed)
-    // } else {
-    //     rand::rngs::StdRng::from_entropy()
-    // };
-
-    // for _ in 0..args.number_of_batches {
-    //     let keylen = rng.gen_range(args.keylen.clone());
-    //     let valuelen = rng.gen_range(args.valuelen.clone());
-    //     let batch: Batch<Vec<u8>, Vec<u8>> = (0..keys)
-    //         .map(|_| {
-    //             (
-    //                 rng.borrow_mut()
-    //                     .sample_iter(&Alphanumeric)
-    //                     .take(keylen)
-    //                     .collect::<Vec<u8>>(),
-    //                 rng.borrow_mut()
-    //                     .sample_iter(&Alphanumeric)
-    //                     .take(valuelen)
-    //                     .collect::<Vec<u8>>(),
-    //             )
-    //         })
-    //         .map(|(key, value)| BatchOp::Put { key, value })
-    //         .collect();
-
-    //     let verify = get_keys_to_verify(&batch, args.read_verify_percent);
-
-    //     #[allow(clippy::unwrap_used)]
-    //     let proposal = db.propose(batch).await.unwrap();
-    //     proposal.commit().await?;
-    //     verify_keys(&db, verify).await?;
-    // }
-
-    // let duration = start.elapsed();
-    // println!(
-    //     "Generated and inserted {} batches of size {keys} in {duration:?}",
-    //     args.number_of_batches
-    // );
-
-    // Ok(())
 }
 
-fn _get_keys_to_verify(batch: &Batch<Vec<u8>, Vec<u8>>, pct: u16) -> HashMap<Vec<u8>, Vec<u8>> {
+fn get_keys_to_verify(batch: &Batch<Vec<u8>, Vec<u8>>, pct: u16) -> HashMap<Vec<u8>, Vec<u8>> {
     if pct == 0 {
         HashMap::new()
     } else {
@@ -117,7 +116,7 @@ fn _get_keys_to_verify(batch: &Batch<Vec<u8>, Vec<u8>>, pct: u16) -> HashMap<Vec
     }
 }
 
-async fn _verify_keys(
+async fn verify_keys(
     db: &impl firewood::v2::api::Db,
     verify: HashMap<Vec<u8>, Vec<u8>>,
 ) -> Result<(), firewood::v2::api::Error> {

--- a/firewood/examples/insert.rs
+++ b/firewood/examples/insert.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn get_keys_to_verify(batch: &Batch<Vec<u8>, Vec<u8>>, pct: u16) -> HashMap<Vec<u8>, Vec<u8>> {
+fn get_keys_to_verify(batch: &Batch<Vec<u8>, Vec<u8>>, pct: u16) -> HashMap<Vec<u8>, Box<[u8]>> {
     if pct == 0 {
         HashMap::new()
     } else {
@@ -107,7 +107,7 @@ fn get_keys_to_verify(batch: &Batch<Vec<u8>, Vec<u8>>, pct: u16) -> HashMap<Vec<
             .filter(|_last_key| rand::thread_rng().gen_range(0..=(100 - pct)) == 0)
             .map(|op| {
                 if let BatchOp::Put { key, value } = op {
-                    (key.clone(), value.clone())
+                    (key.clone(), value.clone().into_boxed_slice())
                 } else {
                     unreachable!()
                 }
@@ -118,7 +118,7 @@ fn get_keys_to_verify(batch: &Batch<Vec<u8>, Vec<u8>>, pct: u16) -> HashMap<Vec<
 
 async fn verify_keys(
     db: &impl firewood::v2::api::Db,
-    verify: HashMap<Vec<u8>, Vec<u8>>,
+    verify: HashMap<Vec<u8>, Box<[u8]>>,
 ) -> Result<(), firewood::v2::api::Error> {
     if !verify.is_empty() {
         let hash = db.root_hash().await?.expect("root hash should exist");

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -226,12 +226,12 @@ where
 
     type Proposal<'p> = Proposal<'p> where Self: 'p;
 
-    async fn revision(&self, _root_hash: TrieHash) -> Result<Arc<Self::Historical>, api::Error> {
+    async fn revision(&self, root_hash: TrieHash) -> Result<Arc<Self::Historical>, api::Error> {
         let nodestore = self
             .manager
             .read()
             .expect("poisoned lock")
-            .revision(_root_hash)?;
+            .revision(root_hash)?;
         Ok(nodestore)
     }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -64,8 +64,9 @@ impl api::DbView for HistoricalRev {
         HashedNodeReader::root_hash(self).map_err(api::Error::IO)
     }
 
-    async fn val<K: api::KeyType>(&self, _key: K) -> Result<Option<Vec<u8>>, api::Error> {
-        todo!()
+    async fn val<K: api::KeyType>(&self, key: K) -> Result<Option<Box<[u8]>>, api::Error> {
+        let merkle = Merkle::from(self);
+        Ok(merkle.get(key.as_ref())?)
     }
 
     async fn single_key_proof<K: api::KeyType>(
@@ -326,7 +327,7 @@ impl<'a> api::DbView for Proposal<'a> {
         todo!()
     }
 
-    async fn val<K: KeyType>(&self, _key: K) -> Result<Option<Vec<u8>>, api::Error> {
+    async fn val<K: KeyType>(&self, _key: K) -> Result<Option<Box<[u8]>>, api::Error> {
         todo!()
     }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -1,11 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::merkle::MerkleError;
+use crate::merkle::{Merkle, MerkleError};
 use crate::proof::{Proof, ProofNode};
 use crate::range_proof::RangeProof;
 use crate::stream::MerkleKeyValueStream;
-use crate::v2::api::{self, KeyType};
+use crate::v2::api::{self, KeyType, ValueType};
 pub use crate::v2::api::{Batch, BatchOp};
 
 use crate::manager::{RevisionManager, RevisionManagerConfig};
@@ -16,7 +16,7 @@ use std::fmt;
 use std::io::Write;
 use std::path::Path;
 use std::sync::Arc;
-use storage::{Committed, FileBacked, HashedNodeReader, NodeStore};
+use storage::{Committed, FileBacked, HashedNodeReader, ImmutableProposal, NodeStore, TrieHash};
 use typed_builder::TypedBuilder;
 
 // TODO use or remove
@@ -211,36 +211,48 @@ pub struct DbConfig {
 #[derive(Debug)]
 pub struct Db {
     metrics: Arc<DbMetrics>,
-    _manager: RevisionManager,
+    manager: RevisionManager,
 }
 
-// #[async_trait]
-// impl api::Db for Db {
-//     type Historical = HistoricalRev<HistoricalStore>;
+#[async_trait]
+impl api::Db for Db {
+    type Historical = NodeStore<Committed, FileBacked>;
 
-//     type Proposal = Proposal<ProposedMutable>;
+    type Proposal = NodeStore<ImmutableProposal, FileBacked>;
 
-//     async fn revision(
-//         &self,
-//         _root_hash: HashKey,
-//     ) -> Result<Arc<HistoricalRev<HistoricalStore>>, api::Error> {
-//         let store = self.manager.revision(_root_hash)?;
-//         Ok(Arc::new(HistoricalRev::<HistoricalStore> {
-//             _historical: store,
-//         }))
-//     }
+    async fn revision(&self, _root_hash: TrieHash) -> Result<Arc<Self::Historical>, api::Error> {
+        let nodestore = self.manager.revision(_root_hash)?;
+        Ok(nodestore)
+    }
 
-//     async fn root_hash(&self) -> Result<HashKey, api::Error> {
-//         Ok(self.manager.root_hash()?)
-//     }
+    async fn root_hash(&self) -> Result<Option<TrieHash>, api::Error> {
+        Ok(self.manager.root_hash()?)
+    }
 
-//     async fn propose<K: KeyType, V: ValueType>(
-//         &self,
-//         _batch: api::Batch<K, V>,
-//     ) -> Result<Arc<Self::Proposal>, api::Error> {
-//         todo!()
-//     }
-// }
+    async fn propose<K: KeyType, V: ValueType>(
+        &mut self,
+        batch: api::Batch<K, V>,
+    ) -> Result<Arc<Self::Proposal>, api::Error> {
+        let parent = self.manager.latest_revision().expect("no latest revision");
+        let proposal = NodeStore::new(parent)?;
+        let mut merkle = Merkle::from(proposal);
+        for op in batch {
+            match op {
+                BatchOp::Put { key, value } => {
+                    merkle.insert(key.as_ref(), value.as_ref().into())?;
+                }
+                BatchOp::Delete { key } => {
+                    merkle.remove(key.as_ref())?;
+                }
+            }
+        }
+        let nodestore = merkle.into_inner();
+        let immutable: Arc<NodeStore<ImmutableProposal, FileBacked>> = Arc::new(nodestore.into());
+        self.manager.add_proposal(immutable.clone());
+
+        Ok(immutable)
+    }
+}
 
 #[metered(registry = DbMetrics, visibility = pub)]
 impl Db {
@@ -251,10 +263,7 @@ impl Db {
             cfg.truncate,
             cfg.manager.clone(),
         )?;
-        let db = Self {
-            metrics,
-            _manager: manager,
-        };
+        let db = Self { metrics, manager };
         Ok(db)
     }
 
@@ -273,5 +282,57 @@ impl Db {
 
     pub fn metrics(&self) -> Arc<DbMetrics> {
         self.metrics.clone()
+    }
+}
+
+#[async_trait]
+impl api::DbView for NodeStore<ImmutableProposal, FileBacked> {
+    type Stream<'a> = MerkleKeyValueStream<'a, Self>;
+
+    async fn root_hash(&self) -> Result<Option<api::HashKey>, api::Error> {
+        todo!()
+    }
+
+    async fn val<K: KeyType>(&self, _key: K) -> Result<Option<Vec<u8>>, api::Error> {
+        todo!()
+    }
+
+    async fn single_key_proof<K: KeyType>(
+        &self,
+        _key: K,
+    ) -> Result<Option<Proof<ProofNode>>, api::Error> {
+        todo!()
+    }
+
+    async fn range_proof<K: KeyType, V>(
+        &self,
+        _first_key: Option<K>,
+        _last_key: Option<K>,
+        _limit: Option<usize>,
+    ) -> Result<Option<api::RangeProof<Vec<u8>, Vec<u8>, ProofNode>>, api::Error> {
+        todo!()
+    }
+
+    fn iter_option<K: KeyType>(
+        &self,
+        _first_key: Option<K>,
+    ) -> Result<Self::Stream<'_>, api::Error> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl api::Proposal for NodeStore<ImmutableProposal, FileBacked> {
+    type Proposal = NodeStore<ImmutableProposal, FileBacked>;
+
+    async fn propose<K: KeyType, V: ValueType>(
+        self: Arc<Self>,
+        _data: api::Batch<K, V>,
+    ) -> Result<Arc<Self::Proposal>, api::Error> {
+        todo!()
+    }
+
+    async fn commit(self: Arc<Self>) -> Result<(), api::Error> {
+        todo!()
     }
 }

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -364,13 +364,14 @@ impl<'a> api::Proposal for Proposal<'a> {
         todo!()
     }
 
+    // When committing a proposal, refuse to commit if there are any cloned proposals.
     async fn commit(self: Arc<Self>) -> Result<(), api::Error> {
         match Arc::into_inner(self) {
             Some(proposal) => {
                 let mut manager = proposal.db.manager.write().expect("poisoned lock");
                 Ok(manager.commit(proposal.nodestore.clone())?)
             }
-            None => Err(api::Error::InvalidProposal),
+            None => Err(api::Error::CannotCommitClonedProposal),
         }
     }
 }

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -15,7 +15,7 @@ use std::error::Error;
 use std::fmt;
 use std::io::Write;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use storage::{Committed, FileBacked, HashedNodeReader, ImmutableProposal, NodeStore, TrieHash};
 use typed_builder::TypedBuilder;
 
@@ -211,29 +211,46 @@ pub struct DbConfig {
 #[derive(Debug)]
 pub struct Db {
     metrics: Arc<DbMetrics>,
-    manager: RevisionManager,
+    // TODO: consider using https://docs.rs/lock_api/latest/lock_api/struct.RwLock.html#method.upgradable_read
+    // TODO: This should probably use an async RwLock
+    manager: RwLock<RevisionManager>,
 }
 
 #[async_trait]
-impl api::Db for Db {
+impl api::Db for Db
+where
+    for<'p> Proposal<'p>: api::Proposal,
+{
     type Historical = NodeStore<Committed, FileBacked>;
 
-    type Proposal = NodeStore<ImmutableProposal, FileBacked>;
+    type Proposal<'p> = Proposal<'p> where Self: 'p;
 
     async fn revision(&self, _root_hash: TrieHash) -> Result<Arc<Self::Historical>, api::Error> {
-        let nodestore = self.manager.revision(_root_hash)?;
+        let nodestore = self
+            .manager
+            .read()
+            .expect("poisoned lock")
+            .revision(_root_hash)?;
         Ok(nodestore)
     }
 
     async fn root_hash(&self) -> Result<Option<TrieHash>, api::Error> {
-        Ok(self.manager.root_hash()?)
+        Ok(self.manager.read().expect("poisoned lock").root_hash()?)
     }
 
-    async fn propose<K: KeyType, V: ValueType>(
-        &mut self,
+    async fn propose<'p, K: KeyType, V: ValueType>(
+        &'p mut self,
         batch: api::Batch<K, V>,
-    ) -> Result<Arc<Self::Proposal>, api::Error> {
-        let parent = self.manager.latest_revision().expect("no latest revision");
+    ) -> Result<Arc<Self::Proposal<'p>>, api::Error>
+    where
+        Self: 'p,
+    {
+        let parent = self
+            .manager
+            .read()
+            .expect("poisoned lock")
+            .latest_revision()
+            .expect("no latest revision");
         let proposal = NodeStore::new(parent)?;
         let mut merkle = Merkle::from(proposal);
         for op in batch {
@@ -248,9 +265,16 @@ impl api::Db for Db {
         }
         let nodestore = merkle.into_inner();
         let immutable: Arc<NodeStore<ImmutableProposal, FileBacked>> = Arc::new(nodestore.into());
-        self.manager.add_proposal(immutable.clone());
+        self.manager
+            .write()
+            .expect("poisoned lock")
+            .add_proposal(immutable.clone());
 
-        Ok(immutable)
+        Ok(Self::Proposal {
+            nodestore: immutable,
+            db: self,
+        }
+        .into())
     }
 }
 
@@ -263,7 +287,10 @@ impl Db {
             cfg.truncate,
             cfg.manager.clone(),
         )?;
-        let db = Self { metrics, manager };
+        let db = Self {
+            metrics,
+            manager: manager.into(),
+        };
         Ok(db)
     }
 
@@ -285,9 +312,15 @@ impl Db {
     }
 }
 
+#[derive(Debug)]
+pub struct Proposal<'p> {
+    nodestore: Arc<NodeStore<ImmutableProposal, FileBacked>>,
+    db: &'p Db,
+}
+
 #[async_trait]
-impl api::DbView for NodeStore<ImmutableProposal, FileBacked> {
-    type Stream<'a> = MerkleKeyValueStream<'a, Self>;
+impl<'a> api::DbView for Proposal<'a> {
+    type Stream<'b> = MerkleKeyValueStream<'b, NodeStore<ImmutableProposal, FileBacked>> where Self: 'b;
 
     async fn root_hash(&self) -> Result<Option<api::HashKey>, api::Error> {
         todo!()
@@ -322,8 +355,8 @@ impl api::DbView for NodeStore<ImmutableProposal, FileBacked> {
 }
 
 #[async_trait]
-impl api::Proposal for NodeStore<ImmutableProposal, FileBacked> {
-    type Proposal = NodeStore<ImmutableProposal, FileBacked>;
+impl<'a> api::Proposal for Proposal<'a> {
+    type Proposal = Proposal<'a>;
 
     async fn propose<K: KeyType, V: ValueType>(
         self: Arc<Self>,
@@ -333,6 +366,12 @@ impl api::Proposal for NodeStore<ImmutableProposal, FileBacked> {
     }
 
     async fn commit(self: Arc<Self>) -> Result<(), api::Error> {
-        todo!()
+        match Arc::into_inner(self) {
+            Some(proposal) => {
+                let mut manager = proposal.db.manager.write().expect("poisoned lock");
+                Ok(manager.commit(proposal.nodestore.clone())?)
+            }
+            None => Err(api::Error::InvalidProposal),
+        }
     }
 }

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -66,7 +66,7 @@ impl api::DbView for HistoricalRev {
 
     async fn val<K: api::KeyType>(&self, key: K) -> Result<Option<Box<[u8]>>, api::Error> {
         let merkle = Merkle::from(self);
-        Ok(merkle.get(key.as_ref())?)
+        Ok(merkle.get_value(key.as_ref())?)
     }
 
     async fn single_key_proof<K: api::KeyType>(
@@ -343,7 +343,7 @@ impl<'a> api::DbView for Proposal<'a> {
         _first_key: Option<K>,
         _last_key: Option<K>,
         _limit: Option<usize>,
-    ) -> Result<Option<api::RangeProof<Vec<u8>, Vec<u8>, ProofNode>>, api::Error> {
+    ) -> Result<Option<api::RangeProof<Box<[u8]>, Box<[u8]>, ProofNode>>, api::Error> {
         todo!()
     }
 

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -12,7 +12,7 @@ use typed_builder::TypedBuilder;
 
 use crate::v2::api::HashKey;
 
-use storage::{Committed, FileBacked, ImmutableProposal, NodeStore, TrieHash};
+use storage::{Committed, FileBacked, ImmutableProposal, NodeStore, Parentable, TrieHash};
 
 #[derive(Clone, Debug, TypedBuilder)]
 pub struct RevisionManagerConfig {
@@ -69,31 +69,117 @@ pub(crate) enum RevisionManagerError {
 }
 
 impl RevisionManager {
+    /// Commit a proposal
+    /// To commit a proposal involves a few steps:
+    /// 1. Commit check.
+    ///    The proposal’s parent must be the last committed revision, otherwise the commit fails.
+    /// 2. Persist delete list.
+    ///    The list of all nodes that were to be deleted for this proposal must be fully flushed to disk.
+    ///    The address of the root node and the root hash is also persisted.
+    ///    Note that this is *not* a write ahead log.
+    ///    It only contains the address of the nodes that are deleted, which should be very small.
+    /// 3. Set last committed revision.
+    ///    Set last committed revision in memory.
+    ///    Another commit can start after this but before the node flush is completed.
+    /// 4. Free list flush.
+    ///    Persist/write the free list header.
+    ///    The free list is flushed first to prevent future allocations from using the space allocated to this proposal.
+    ///    This should be done in a single write since the free list headers are small, and must be persisted to disk before starting the next step.
+    /// 5. Node flush.
+    ///    Persist/write all the nodes to disk.
+    ///    Note that since these are all freshly allocated nodes, they will never be referred to by any prior commit.
+    ///    After flushing all nodes, the file should be flushed to disk (fsync) before performing the next step.
+    /// 6. Root move.
+    ///    The root address on disk must be updated.
+    ///    This write can be delayed, but would mean that recovery will not roll forward to this revision.
+    /// 7. Proposal Cleanup.
+    ///    Any other proposals that have this proposal as a parent should be reparented to the committed version.
+    /// 8. Revision reaping.
+    ///    If more than the configurable number of revisions is available, the oldest revision can be forgotten.
     pub fn commit(
         &mut self,
-        _proposal: Arc<NodeStore<ImmutableProposal, FileBacked>>,
+        proposal: Arc<NodeStore<ImmutableProposal, FileBacked>>,
     ) -> Result<(), RevisionManagerError> {
-        todo!()
+        // 1. Commit check
+        let current_revision = self.current_revision();
+        if !proposal
+            .kind
+            .parent_is(&current_revision.kind.as_nodestore_parent())
+        {
+            return Err(RevisionManagerError::NotLatest);
+        }
+        // 2. Persist delete list
+        // TODO
+
+        // 3. Set last committed revision
+        let committed: Arc<NodeStore<Committed, FileBacked>> = proposal.as_committed().into();
+        self.historical.push_back(committed.clone());
+        if let Some(hash) = committed.kind.root_hash() {
+            self.by_hash.insert(hash, committed.clone());
+        }
+        // TODO: We could allow other commits to start here using the pending list
+
+        // 4. Free list flush
+        proposal.flush_freelist()?;
+
+        // 5. Node flush
+        proposal.flush_nodes()?;
+
+        // 6. Root move
+        proposal.flush_header()?;
+
+        // 7. Proposal Cleanup
+        self.proposals.retain(|p| {
+            // TODO: reparent proposals; this needs a lock on the parent element of immutable proposals
+            // if p
+            //     .kind
+            //     .parent_is(&proposal.kind.as_nodestore_parent())
+            // {
+            //     p.kind.reparent_to(&committed.kind.as_nodestore_parent());
+            // }
+            !Arc::ptr_eq(&proposal, p)
+        });
+
+        Ok(())
     }
 }
 
 pub type NewProposalError = (); // TODO implement
 
 impl RevisionManager {
-    // TODO fix this or remove it. It should take in a proposal.
     pub fn add_proposal(&mut self, proposal: Arc<NodeStore<ImmutableProposal, FileBacked>>) {
         self.proposals.push(proposal);
     }
 
     pub fn revision(
         &self,
-        _root_hash: HashKey,
+        root_hash: HashKey,
     ) -> Result<Arc<NodeStore<Committed, FileBacked>>, RevisionManagerError> {
-        todo!()
+        self.by_hash
+            .get(&root_hash)
+            .cloned()
+            .ok_or(RevisionManagerError::IO(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Revision not found",
+            )))
     }
 
     pub fn root_hash(&self) -> Result<Option<HashKey>, RevisionManagerError> {
-        todo!()
+        self.current_revision()
+            .kind
+            .root_hash()
+            .map(Option::Some)
+            .ok_or(RevisionManagerError::IO(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Root hash not found",
+            )))
+    }
+
+    fn current_revision(&self) -> Arc<NodeStore<Committed, FileBacked>> {
+        self.historical
+            .back()
+            .expect("there is always one revision")
+            .clone()
     }
 }
 

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -4,6 +4,7 @@
 #![allow(dead_code)]
 
 use std::collections::HashMap;
+use std::num::NonZero;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::{collections::VecDeque, io::Error};
@@ -19,6 +20,9 @@ pub struct RevisionManagerConfig {
     /// The number of historical revisions to keep in memory.
     #[builder(default = 64)]
     max_revisions: usize,
+
+    #[builder(default_code = "NonZero::new(1024).expect(\"non-zero\")")]
+    node_cache_size: NonZero<usize>,
 }
 
 #[derive(Debug)]
@@ -38,7 +42,7 @@ impl RevisionManager {
         truncate: bool,
         config: RevisionManagerConfig,
     ) -> Result<Self, Error> {
-        let storage = Arc::new(FileBacked::new(filename, truncate)?);
+        let storage = Arc::new(FileBacked::new(filename, config.node_cache_size, truncate)?);
         let nodestore = Arc::new(NodeStore::new_empty_committed(storage.clone())?);
         let manager = Self {
             max_revisions: config.max_revisions,

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -27,8 +27,14 @@ pub struct RevisionManagerConfig {
 
 #[derive(Debug)]
 pub(crate) struct RevisionManager {
+    /// Maximum number of revisions to keep on disk
     max_revisions: usize,
+
+    /// The underlying file storage
     filebacked: Arc<FileBacked>,
+
+    /// The list of revisions that are on disk; these point to the different roots
+    /// stored in the filebacked storage.
     historical: VecDeque<Arc<NodeStore<Committed, FileBacked>>>,
     proposals: Vec<Arc<NodeStore<ImmutableProposal, FileBacked>>>,
     // committing_proposals: VecDeque<Arc<ProposedImmutable>>,

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -27,25 +27,11 @@ pub struct RevisionManagerConfig {
 
 #[derive(Debug)]
 pub(crate) struct RevisionManager {
-    /// Maximum number of revisions to keep on disk
     max_revisions: usize,
-
-    /// The underlying file storage
     filebacked: Arc<FileBacked>,
-
-    /// The list of revisions that are on disk; these point to the different roots
-    /// stored in the filebacked storage.
     historical: VecDeque<Arc<NodeStore<Committed, FileBacked>>>,
-<<<<<<< Updated upstream
     proposals: Vec<Arc<NodeStore<ImmutableProposal, FileBacked>>>,
     // committing_proposals: VecDeque<Arc<ProposedImmutable>>,
-=======
-
-    /// List of oustanding proposals
-    proposals: Vec<Arc<NodeStore<Arc<ImmutableProposal>, FileBacked>>>,
-
-    /// A map of root hashes to the corresponding revision
->>>>>>> Stashed changes
     by_hash: HashMap<TrieHash, Arc<NodeStore<Committed, FileBacked>>>,
     // TODO: maintain root hash of the most recent commit
 }

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -27,11 +27,25 @@ pub struct RevisionManagerConfig {
 
 #[derive(Debug)]
 pub(crate) struct RevisionManager {
+    /// Maximum number of revisions to keep on disk
     max_revisions: usize,
+
+    /// The underlying file storage
     filebacked: Arc<FileBacked>,
+
+    /// The list of revisions that are on disk; these point to the different roots
+    /// stored in the filebacked storage.
     historical: VecDeque<Arc<NodeStore<Committed, FileBacked>>>,
+<<<<<<< Updated upstream
     proposals: Vec<Arc<NodeStore<ImmutableProposal, FileBacked>>>,
     // committing_proposals: VecDeque<Arc<ProposedImmutable>>,
+=======
+
+    /// List of oustanding proposals
+    proposals: Vec<Arc<NodeStore<Arc<ImmutableProposal>, FileBacked>>>,
+
+    /// A map of root hashes to the corresponding revision
+>>>>>>> Stashed changes
     by_hash: HashMap<TrieHash, Arc<NodeStore<Committed, FileBacked>>>,
     // TODO: maintain root hash of the most recent commit
 }

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -24,7 +24,7 @@ pub struct RevisionManagerConfig {
 #[derive(Debug)]
 pub(crate) struct RevisionManager {
     max_revisions: usize,
-    filebacked: FileBacked,
+    filebacked: Arc<FileBacked>,
     historical: VecDeque<Arc<NodeStore<Committed, FileBacked>>>,
     proposals: Vec<Arc<NodeStore<ImmutableProposal, FileBacked>>>,
     // committing_proposals: VecDeque<Arc<ProposedImmutable>>,
@@ -38,14 +38,17 @@ impl RevisionManager {
         truncate: bool,
         config: RevisionManagerConfig,
     ) -> Result<Self, Error> {
-        Ok(Self {
+        let storage = Arc::new(FileBacked::new(filename, truncate)?);
+        let nodestore = Arc::new(NodeStore::new_empty_committed(storage.clone())?);
+        let manager = Self {
             max_revisions: config.max_revisions,
-            filebacked: FileBacked::new(filename, truncate)?,
-            historical: Default::default(),
+            filebacked: storage,
+            historical: VecDeque::from([nodestore]),
             by_hash: Default::default(),
             proposals: Default::default(),
             // committing_proposals: Default::default(),
-        })
+        };
+        Ok(manager)
     }
 
     pub fn latest_revision(&self) -> Option<Arc<NodeStore<Committed, FileBacked>>> {
@@ -66,111 +69,11 @@ pub(crate) enum RevisionManagerError {
 }
 
 impl RevisionManager {
-    // TODO fix this or remove it. It should take in a proposal.
-    fn commit(&mut self, _proposal: ()) -> Result<(), RevisionManagerError> {
+    pub fn commit(
+        &mut self,
+        _proposal: Arc<NodeStore<ImmutableProposal, FileBacked>>,
+    ) -> Result<(), RevisionManagerError> {
         todo!()
-        // // detach FileBacked from all revisions to make writes safe
-        // let new_historical = self.prepare_for_writes(&proposal)?;
-
-        // // append this historical to the list of known historicals
-        // self.historical.push_back(new_historical);
-
-        // // forget about older revisions
-        // while self.historical.len() > self.max_revisions {
-        //     self.historical.pop_front();
-        // }
-
-        // // If we do copy on writes for underneath files, since we keep all changes
-        // // after bootstrapping, we should be able to read from the changes and the
-        // // read only file map to the state at bootstrapping.
-        // // We actually doesn't care whether the writes are successful or not
-        // // (crash recovery may need to be handled above)
-        // for write in proposal.new.iter() {
-        //     self.filebacked.write(*write.0, write.1)?;
-        // }
-
-        // self.writes_completed(proposal)
-    }
-
-    // TODO fix or remove this. It should take in a proposal.
-    fn prepare_for_writes(&mut self, _proposal: ()) -> Result<(), RevisionManagerError> {
-        todo!()
-        // // check to see if we can commit this proposal
-        // let parent = proposal.parent();
-        // match parent {
-        //     LinearStoreParent::FileBacked(_) => {
-        //         if !self.committing_proposals.is_empty() {
-        //             return Err(RevisionManagerError::NotLatest);
-        //         }
-        //     }
-        //     LinearStoreParent::Proposed(ref parent_proposal) => {
-        //         let Some(last_commiting_proposal) = self.committing_proposals.back() else {
-        //             return Err(RevisionManagerError::NotLatest);
-        //         };
-        //         if !Arc::ptr_eq(parent_proposal, last_commiting_proposal) {
-        //             return Err(RevisionManagerError::NotLatest);
-        //         }
-        //     }
-        //     _ => return Err(RevisionManagerError::SiblingCommitted),
-        // }
-        // // checks complete: safe to commit
-
-        // let new_historical = Arc::new(Historical::new(
-        //     std::mem::take(&mut proposal.old.clone()), // TODO: remove clone
-        //     parent.clone(),
-        //     proposal.size()?,
-        // ));
-
-        // // reparent the oldest historical to point to the new proposal
-        // if let Some(historical) = self.historical.back() {
-        //     historical.reparent(new_historical.clone().into());
-        // }
-
-        // // for each outstanding proposal, see if their parent is the last committed linear store
-        // for candidate in self
-        //     .proposals
-        //     .iter()
-        //     .filter(|&candidate| candidate.has_parent(&parent) && !Arc::ptr_eq(candidate, proposal))
-        // {
-        //     candidate.reparent(LinearStoreParent::Historical(new_historical.clone()));
-        // }
-
-        // // mark this proposal as committing
-        // self.committing_proposals.push_back(proposal.clone());
-
-        // Ok(new_historical)
-    }
-
-    // TODO fix or remove this. It should take in a proposal.
-    fn writes_completed(&mut self, _proposal: ()) -> Result<(), RevisionManagerError> {
-        todo!()
-        // // now that the committed proposal is on disk, reparent anything that pointed to our proposal,
-        // // which is now fully flushed to our parent, as our parent
-        // // TODO: This needs work when we support multiple simultaneous commit writes; we should
-        // // only do this work when the entire stack below us has been flushed
-        // let parent = proposal.parent();
-        // let proposal = LinearStoreParent::Proposed(proposal);
-        // for candidate in self
-        //     .proposals
-        //     .iter()
-        //     .filter(|&candidate| candidate.has_parent(&proposal))
-        // {
-        //     candidate.reparent(parent.clone());
-        // }
-
-        // // TODO: As of now, this is always what we just pushed, no support for multiple simultaneous
-        // // commits yet; the assert verifies this and should be removed when we add support for this
-        // let should_be_us = self
-        //     .committing_proposals
-        //     .pop_front()
-        //     .expect("can't be empty");
-        // assert!(
-        //     matches!(proposal, LinearStoreParent::Proposed(us) if Arc::ptr_eq(&us, &should_be_us))
-        // );
-
-        // // TODO: we should reparent fileback as the parent of this committed proposal??
-
-        // Ok(())
     }
 }
 

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -127,11 +127,17 @@ fn get_helper<T: TrieReader>(
 }
 
 #[derive(Debug)]
-pub struct Merkle<T: TrieReader> {
+pub struct Merkle<T> {
     nodestore: T,
 }
 
-impl<T: TrieReader> From<T> for Merkle<T> {
+impl<T> Merkle<T> {
+    pub fn into_inner(self) -> T {
+        self.nodestore
+    }
+}
+
+impl<T> From<T> for Merkle<T> {
     fn from(nodestore: T) -> Self {
         Merkle { nodestore }
     }

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -82,6 +82,12 @@ pub enum Error {
     #[error("Invalid proposal")]
     InvalidProposal,
 
+    // Cloned proposals are problematic because if they are committed, then you could
+    // create another proposal from this committed proposal, so we error at commit time
+    // if there are outstanding clones
+    #[error("Cannot commit a cloned proposal")]
+    CannotCommitClonedProposal,
+
     #[error("Internal error")]
     InternalError(Box<dyn std::error::Error + Send>),
 

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -113,7 +113,9 @@ impl From<RevisionManagerError> for Error {
 pub trait Db {
     type Historical: DbView;
 
-    type Proposal: DbView + Proposal;
+    type Proposal<'p>: DbView + Proposal
+    where
+        Self: 'p;
 
     /// Get a reference to a specific view based on a hash
     ///
@@ -135,10 +137,12 @@ pub trait Db {
     /// * `data` - A batch consisting of [BatchOp::Put] and
     ///            [BatchOp::Delete] operations to apply
     ///
-    async fn propose<K: KeyType, V: ValueType>(
-        &mut self,
+    async fn propose<'p, K: KeyType, V: ValueType>(
+        &'p mut self,
         data: Batch<K, V>,
-    ) -> Result<Arc<Self::Proposal>, Error>;
+    ) -> Result<Arc<Self::Proposal<'p>>, Error>
+    where
+        Self: 'p;
 }
 
 /// A view of the database at a specific time. These are wrapped with

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -8,6 +8,7 @@ use crate::{merkle::MerkleError, proof::Proof};
 use async_trait::async_trait;
 use futures::Stream;
 use std::{fmt::Debug, sync::Arc};
+use storage::{Hashable, TrieHash};
 
 /// A `KeyType` is something that can be xcast to a u8 reference,
 /// and can be sent and shared across threads. References with
@@ -119,10 +120,10 @@ pub trait Db {
     /// # Arguments
     ///
     /// - `hash` - Identifies the revision for the view
-    async fn revision(&self, hash: HashKey) -> Result<Arc<Self::Historical>, Error>;
+    async fn revision(&self, hash: TrieHash) -> Result<Arc<Self::Historical>, Error>;
 
     /// Get the hash of the most recently committed version
-    async fn root_hash(&self) -> Result<Option<HashKey>, Error>;
+    async fn root_hash(&self) -> Result<Option<TrieHash>, Error>;
 
     /// Propose a change to the database via a batch
     ///
@@ -135,7 +136,7 @@ pub trait Db {
     ///            [BatchOp::Delete] operations to apply
     ///
     async fn propose<K: KeyType, V: ValueType>(
-        &self,
+        &mut self,
         data: Batch<K, V>,
     ) -> Result<Arc<Self::Proposal>, Error>;
 }

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -164,7 +164,7 @@ pub trait DbView {
     async fn root_hash(&self) -> Result<Option<HashKey>, Error>;
 
     /// Get the value of a specific key
-    async fn val<K: KeyType>(&self, key: K) -> Result<Option<Vec<u8>>, Error>;
+    async fn val<K: KeyType>(&self, key: K) -> Result<Option<Box<[u8]>>, Error>;
 
     /// Obtain a proof for a single key
     async fn single_key_proof<K: KeyType>(&self, key: K)

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -3,12 +3,12 @@
 
 use crate::manager::RevisionManagerError;
 use crate::proof::ProofNode;
-use crate::range_proof::RangeProof;
+pub use crate::range_proof::RangeProof;
 use crate::{merkle::MerkleError, proof::Proof};
 use async_trait::async_trait;
 use futures::Stream;
 use std::{fmt::Debug, sync::Arc};
-use storage::{Hashable, TrieHash};
+use storage::TrieHash;
 
 /// A `KeyType` is something that can be xcast to a u8 reference,
 /// and can be sent and shared across threads. References with

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -39,7 +39,7 @@ impl Db for EmptyDb {
         Ok(None)
     }
 
-    async fn propose<K, V>(&self, data: Batch<K, V>) -> Result<Arc<Self::Proposal>, Error>
+    async fn propose<K, V>(&mut self, data: Batch<K, V>) -> Result<Arc<Self::Proposal>, Error>
     where
         K: KeyType,
         V: ValueType,
@@ -105,7 +105,7 @@ mod tests {
 
     #[tokio::test]
     async fn basic_proposal() -> Result<(), Error> {
-        let db = Arc::new(EmptyDb);
+        let mut db = EmptyDb;
 
         let batch = vec![
             BatchOp::Put {
@@ -126,8 +126,7 @@ mod tests {
 
     #[tokio::test]
     async fn nested_proposal() -> Result<(), Error> {
-        let db = Arc::new(EmptyDb);
-
+        let mut db = EmptyDb;
         // create proposal1 which adds key "k" with value "v" and deletes "z"
         let batch = vec![
             BatchOp::Put {

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -29,7 +29,7 @@ pub struct HistoricalImpl;
 impl Db for EmptyDb {
     type Historical = HistoricalImpl;
 
-    type Proposal = Proposal<HistoricalImpl>;
+    type Proposal<'p> = Proposal<HistoricalImpl>;
 
     async fn revision(&self, hash_key: HashKey) -> Result<Arc<Self::Historical>, Error> {
         Err(Error::HashNotFound { provided: hash_key })
@@ -39,7 +39,10 @@ impl Db for EmptyDb {
         Ok(None)
     }
 
-    async fn propose<K, V>(&mut self, data: Batch<K, V>) -> Result<Arc<Self::Proposal>, Error>
+    async fn propose<'p, K, V>(
+        &'p mut self,
+        data: Batch<K, V>,
+    ) -> Result<Arc<Self::Proposal<'p>>, Error>
     where
         K: KeyType,
         V: ValueType,

--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -110,12 +110,12 @@ impl<T: api::DbView + Send + Sync> api::DbView for Proposal<T> {
         todo!();
     }
 
-    async fn val<K: KeyType>(&self, key: K) -> Result<Option<Vec<u8>>, api::Error> {
+    async fn val<K: KeyType>(&self, key: K) -> Result<Option<Box<[u8]>>, api::Error> {
         // see if this key is in this proposal
         match self.delta.get(key.as_ref()) {
             Some(change) => match change {
                 // key in proposal, check for Put or Delete
-                KeyOp::Put(val) => Ok(Some(val.to_owned())),
+                KeyOp::Put(val) => Ok(Some(val.clone().into_boxed_slice())),
                 KeyOp::Delete => Ok(None), // key was deleted in this proposal
             },
             None => match &self.base {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0.199", features = ["derive"] }
 smallvec = { version = "1.13.2", features = ["serde", "write", "union"] }
 sha2 = "0.10.8"
 integer-encoding = "4.0.0"
+lru = "0.8.0"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -25,7 +25,7 @@ pub use node::{
 };
 pub use nodestore::{
     Committed, HashedNodeReader, ImmutableProposal, LinearAddress, MutableProposal, NodeReader,
-    NodeStore, ReadInMemoryNode, RootReader, TrieReader, UpdateError,
+    NodeStore, Parentable, ReadInMemoryNode, RootReader, TrieReader, UpdateError,
 };
 
 pub use linear::{filebacked::FileBacked, memory::MemStore};

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -15,7 +15,7 @@ use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-use super::ReadableStorage;
+use super::{ReadableStorage, WritableStorage};
 
 #[derive(Debug)]
 /// A [ReadableStorage] backed by a file
@@ -52,10 +52,10 @@ impl ReadableStorage for FileBacked {
     }
 }
 
-impl FileBacked {
+impl WritableStorage for FileBacked {
     /// Write to the backend filestore. This does not implement [crate::WritableStorage]
     /// because we don't want someone accidentally writing nodes directly to disk
-    pub fn write(&mut self, offset: u64, object: &[u8]) -> Result<usize, Error> {
+    fn write(&self, offset: u64, object: &[u8]) -> Result<usize, Error> {
         self.fd
             .lock()
             .expect("poisoned lock")

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -11,9 +11,14 @@
 
 use std::fs::{File, OpenOptions};
 use std::io::{Error, Read, Seek};
+use std::num::NonZero;
 use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
+
+use lru::LruCache;
+
+use crate::{LinearAddress, Node};
 
 use super::{ReadableStorage, WritableStorage};
 
@@ -21,11 +26,16 @@ use super::{ReadableStorage, WritableStorage};
 /// A [ReadableStorage] backed by a file
 pub struct FileBacked {
     fd: Mutex<File>,
+    cache: Mutex<LruCache<LinearAddress, Arc<Node>>>,
 }
 
 impl FileBacked {
     /// Create or open a file at a given path
-    pub fn new(path: PathBuf, truncate: bool) -> Result<Self, Error> {
+    pub fn new(
+        path: PathBuf,
+        node_cache_size: NonZero<usize>,
+        truncate: bool,
+    ) -> Result<Self, Error> {
         let fd = OpenOptions::new()
             .read(true)
             .write(true)
@@ -33,7 +43,10 @@ impl FileBacked {
             .truncate(truncate)
             .open(path)?;
 
-        Ok(Self { fd: Mutex::new(fd) })
+        Ok(Self {
+            fd: Mutex::new(fd),
+            cache: Mutex::new(LruCache::new(node_cache_size)),
+        })
     }
 }
 
@@ -50,6 +63,11 @@ impl ReadableStorage for FileBacked {
             .expect("poisoned lock")
             .seek(std::io::SeekFrom::End(0))
     }
+
+    fn read_cached_node(&self, addr: LinearAddress) -> Option<Arc<Node>> {
+        let mut guard = self.cache.lock().expect("poisoned lock");
+        guard.get(&addr).cloned()
+    }
 }
 
 impl WritableStorage for FileBacked {
@@ -60,5 +78,16 @@ impl WritableStorage for FileBacked {
             .lock()
             .expect("poisoned lock")
             .write_at(object, offset)
+    }
+
+    fn write_cached_nodes<'a>(
+        &self,
+        nodes: impl Iterator<Item = (&'a std::num::NonZero<u64>, &'a std::sync::Arc<crate::Node>)>,
+    ) -> Result<(), Error> {
+        let mut guard = self.cache.lock().expect("poisoned lock");
+        for (addr, node) in nodes {
+            guard.put(*addr, node.clone());
+        }
+        Ok(())
     }
 }

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -19,6 +19,10 @@
 
 use std::fmt::Debug;
 use std::io::{Error, Read};
+use std::num::NonZero;
+use std::sync::Arc;
+
+use crate::{LinearAddress, Node};
 pub(super) mod filebacked;
 pub mod memory;
 
@@ -38,6 +42,11 @@ pub trait ReadableStorage: Debug + Sync + Send {
 
     /// Return the size of the underlying storage, in bytes
     fn size(&self) -> Result<u64, Error>;
+
+    /// Read a node from the cache (if any)
+    fn read_cached_node(&self, _addr: LinearAddress) -> Option<Arc<Node>> {
+        None
+    }
 }
 
 /// Trait for writable storage.
@@ -53,4 +62,12 @@ pub trait WritableStorage: ReadableStorage {
     ///
     /// The number of bytes written, or an error if the write operation fails.
     fn write(&self, offset: u64, object: &[u8]) -> Result<usize, Error>;
+
+    /// Write all nodes to the cache (if any)
+    fn write_cached_nodes<'a>(
+        &self,
+        _nodes: impl Iterator<Item = (&'a NonZero<u64>, &'a Arc<Node>)>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -231,30 +231,6 @@ impl Parentable for ImmutableProposal {
     }
 }
 
-<<<<<<< Updated upstream
-=======
-impl<S> NodeStore<Arc<ImmutableProposal>, S> {
-    /// When an immutable proposal commits, we need to reparent any proposal that
-    /// has the committed proposal as it's parent
-    pub fn commit_reparent(&self, other: &Arc<NodeStore<Arc<ImmutableProposal>, S>>) -> bool {
-        match *other.kind.parent.load() {
-            NodeStoreParent::Proposed(ref parent) => {
-                if Arc::ptr_eq(&self.kind, parent) {
-                    other
-                        .kind
-                        .parent
-                        .store(NodeStoreParent::Committed(self.kind.root_hash()).into());
-                    true
-                } else {
-                    false
-                }
-            }
-            NodeStoreParent::Committed(_) => false,
-        }
-    }
-}
-
->>>>>>> Stashed changes
 impl Parentable for Committed {
     fn as_nodestore_parent(&self) -> NodeStoreParent {
         NodeStoreParent::Committed(self.root_hash.clone())
@@ -985,42 +961,6 @@ mod tests {
         assert!(area_size_to_index(MAX_AREA_SIZE + 1).is_err());
     }
 
-<<<<<<< Updated upstream
-=======
-    #[test]
-    fn test_reparent() {
-        // create an empty base revision
-        let memstore = MemStore::new(vec![]);
-        let base = NodeStore::new_empty_committed(memstore.into())
-            .unwrap()
-            .into();
-
-        // create an empty r1, check that it's parent is the empty committed version
-        let r1 = NodeStore::new(base).unwrap();
-        let r1: Arc<NodeStore<Arc<ImmutableProposal>, _>> = Arc::new(r1.into());
-        let parent: DynGuard<Arc<NodeStoreParent>> = r1.kind.parent.load();
-        assert!(matches!(**parent, NodeStoreParent::Committed(None)));
-
-        // create an empty r2, check that it's parent is the proposed version r1
-        let r2: NodeStore<MutableProposal, _> = NodeStore::new(r1.clone()).unwrap();
-        let r2: Arc<NodeStore<Arc<ImmutableProposal>, _>> = Arc::new(r2.into());
-        let parent: DynGuard<Arc<NodeStoreParent>> = r2.kind.parent.load();
-        assert!(matches!(**parent, NodeStoreParent::Proposed(_)));
-
-        // reparent r2
-        r1.commit_reparent(&r2);
-
-        // now check r2's parent, should match the hash of r1 (which is still None)
-        let parent: DynGuard<Arc<NodeStoreParent>> = r2.kind.parent.load();
-        if let NodeStoreParent::Committed(hash) = &**parent {
-            assert_eq!(*hash, r1.root_hash().unwrap());
-            assert_eq!(*hash, None);
-        } else {
-            panic!("expected committed parent");
-        }
-    }
-
->>>>>>> Stashed changes
     // TODO add new tests
     // #[test]
     // fn test_create() {

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -606,6 +606,8 @@ impl PartialEq for NodeStoreParent {
     }
 }
 
+impl Eq for NodeStoreParent {}
+
 #[derive(Clone, Debug)]
 /// Contains state for a proposed revision of the trie.
 pub struct ImmutableProposal {

--- a/storage/src/trie_hash.rs
+++ b/storage/src/trie_hash.rs
@@ -8,7 +8,7 @@ use sha2::digest::{generic_array::GenericArray, typenum};
 
 /// A hash value inside a merkle trie
 /// We use the same type as returned by sha2 here to avoid copies
-#[derive(PartialEq, Eq, Clone, Default)]
+#[derive(PartialEq, Eq, Clone, Default, Hash)]
 pub struct TrieHash(GenericArray<u8, typenum::U32>);
 
 impl std::ops::Deref for TrieHash {


### PR DESCRIPTION
Changes in this revision:
 - DB trait now requires the DB to outlive any proposal at compile time
 - API `HashKey` type is now `storage::TrieHash`
 - API's values are now `Box<[u8]>` instead of `Vec<u8>`
 - Implements `val` for `HistoricalRev`
 - Adds an `RwLock` around the `RevisionManager`
 - Implements `propose` and `commit`
 - Adds stubs/todo for `DbView` of a `Proposal`
 - Adds a node cache and node_cache_size
 - Adds convenience method `latest_revision` for `RevisionManager`

Tested using the `insert` test only. Additional unit tests will happen once we have the other methods implemented.