### PR TITLE
Code cleanups

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -43,6 +43,7 @@ rand = "0.8.5"
 triehash = "0.8.4"
 clap = { version = "4.5.0", features = ['derive'] }
 pprof = { version = "0.13.0", features = ["flamegraph"] }
+tempfile = "3.12.0"
 
 [[bench]]
 name = "hashops"


### PR DESCRIPTION
- Added a type alias for `Arc<NodeStore<Committed, FileBacked>>>1` which represents a committed version on disk and is used a lot in the revision manager
- Added a type alias for `Arc<NodeStore<ImmutableProposed, FileBacked>>` which represents a proposed revision, mostly on disk, but new nodes are in memory
- Added a unit test for attempting to commit a cloned proposal