### PR TITLE
For NodeStoreHeader, use bytemuck not bincode

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -63,7 +63,10 @@ impl std::fmt::Debug for DbMetrics {
 
 #[async_trait]
 impl api::DbView for HistoricalRev {
-    type Stream<'a> = MerkleKeyValueStream<'a, Self> where Self: 'a;
+    type Stream<'a>
+        = MerkleKeyValueStream<'a, Self>
+    where
+        Self: 'a;
 
     async fn root_hash(&self) -> Result<Option<api::HashKey>, api::Error> {
         HashedNodeReader::root_hash(self).map_err(api::Error::IO)
@@ -125,7 +128,10 @@ where
 {
     type Historical = NodeStore<Committed, FileBacked>;
 
-    type Proposal<'p> = Proposal<'p> where Self: 'p;
+    type Proposal<'p>
+        = Proposal<'p>
+    where
+        Self: 'p;
 
     async fn revision(&self, root_hash: TrieHash) -> Result<Arc<Self::Historical>, api::Error> {
         let nodestore = self
@@ -230,7 +236,10 @@ pub struct Proposal<'p> {
 
 #[async_trait]
 impl<'a> api::DbView for Proposal<'a> {
-    type Stream<'b> = MerkleKeyValueStream<'b, NodeStore<Arc<ImmutableProposal>, FileBacked>> where Self: 'b;
+    type Stream<'b>
+        = MerkleKeyValueStream<'b, NodeStore<Arc<ImmutableProposal>, FileBacked>>
+    where
+        Self: 'b;
 
     async fn root_hash(&self) -> Result<Option<api::HashKey>, api::Error> {
         self.nodestore.root_hash().map_err(api::Error::from)
@@ -313,15 +322,11 @@ impl<'a> api::Proposal for Proposal<'a> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod test {
-    use std::{
-        ops::{Deref, DerefMut},
-        path::PathBuf,
-    };
+    use std::ops::{Deref, DerefMut};
+    use std::path::PathBuf;
 
-    use crate::{
-        db::Db,
-        v2::api::{Db as _, DbView as _, Error, Proposal as _},
-    };
+    use crate::db::Db;
+    use crate::v2::api::{Db as _, DbView as _, Error, Proposal as _};
 
     use super::{BatchOp, DbConfig};
 

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -3,11 +3,11 @@
 
 #![allow(dead_code)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::io::Error;
 use std::num::NonZero;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::{collections::VecDeque, io::Error};
 
 use storage::logger::warn;
 use typed_builder::TypedBuilder;
@@ -92,7 +92,7 @@ impl RevisionManager {
         }
 
         if truncate {
-            nodestore.flush_header()?;
+            nodestore.flush_header_with_padding()?;
         }
 
         Ok(manager)

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -18,6 +18,8 @@ arc-swap = "1.7.1"
 lru = "0.12.4"
 metrics = "0.23.0"
 log = { version = "0.4.20", optional = true }
+bytemuck = "1.7.0"
+bytemuck_derive = "1.7.0"
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
Bytemuck will just write the bytes directly, not encode it. The header is pretty small and just contains contiguous bytes so we can take this shortcut. Added an endianness check and a version check to ensure that the database isn't opened on a machine with different endianness.

Note that it might have worked before, but probably was not tested. It is possible that you could create a migrator to fix the header and the database could be openable on a machine with different endianness...

Improves performance by about 3% for insert cases, and addresses a bug where the offset of the free list may not be as expected. This bug can only occur on a re-open of the database, as it incorrectly assumed the free lists are at `offset_of!(header.freelists)` when writing it.