### PR TITLE
Expose graph option for fwdctl

### DIFF
--- a/fwdctl/src/graph.rs
+++ b/fwdctl/src/graph.rs
@@ -1,0 +1,27 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use clap::Args;
+use firewood::db::{Db, DbConfig};
+use firewood::v2::api;
+use std::io::stdout;
+
+#[derive(Debug, Args)]
+pub struct Options {
+    /// The database path (if no path is provided, return an error). Defaults to firewood.
+    #[arg(
+        value_name = "DB_NAME",
+        default_value_t = String::from("firewood"),
+        help = "Name of the database"
+    )]
+    pub db: String,
+}
+
+pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
+    log::debug!("dump database {:?}", opts);
+    let cfg = DbConfig::builder().truncate(false);
+
+    let db = Db::new(opts.db.clone(), cfg.build()).await?;
+    db.dump(&mut stdout())?;
+    Ok(())
+}

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -8,6 +8,7 @@ pub mod create;
 pub mod delete;
 pub mod dump;
 pub mod get;
+pub mod graph;
 pub mod insert;
 pub mod root;
 
@@ -44,6 +45,8 @@ enum Commands {
     Root(root::Options),
     /// Dump contents of key/value store
     Dump(dump::Options),
+    /// Produce a dot file of the database
+    Graph(graph::Options),
 }
 
 #[tokio::main]
@@ -62,5 +65,6 @@ async fn main() -> Result<(), api::Error> {
         Commands::Delete(opts) => delete::run(opts).await,
         Commands::Root(opts) => root::run(opts).await,
         Commands::Dump(opts) => dump::run(opts).await,
+        Commands::Graph(opts) => graph::run(opts).await,
     }
 }

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -424,7 +424,7 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
             return Ok(Some((address, index as AreaIndex)));
         }
 
-        trace!("No free blocks of sufficient size {index} found");
+        trace!("No free blocks of sufficient size {index_wanted} found");
         counter!("firewood.space.notfree").increment(AREA_SIZES[index_wanted as usize]);
         Ok(None)
     }

--- a/storage/src/trie_hash.rs
+++ b/storage/src/trie_hash.rs
@@ -32,7 +32,8 @@ impl AsRef<[u8]> for TrieHash {
 
 impl Debug for TrieHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "{}", hex::encode(self.0))
+        let width = f.precision().unwrap_or_default();
+        write!(f, "{:.*}", width, hex::encode(self.0))
     }
 }
 


### PR DESCRIPTION
Dump was already dumping the keys and values, so we should keep that, but added in the option of calling the dump() method that produces a digraph of the trie.

Additional changes: hashes and binary values are truncated to 6 characters, followed by an ellipsis, and the graphs are rotated so they go left-right. This makes the graphs a lot prettier.

Partial paths can still be long but truncating them seemed like a bad idea, so they are the only long string in the boxes now.