### PR TITLE
Allow configurable dbname in benchmark

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 firewood = { path = "../firewood" }
 hex = "0.4.3"
-clap = { version = "4.5.0", features = ['derive'] }
+clap = { version = "4.5.0", features = ['derive', 'string'] }
 sha2 = "0.10.8"
 metrics = "0.23.0"
 metrics-util = "0.17.0"

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -20,6 +20,7 @@ use sha2::{Digest, Sha256};
 use std::error::Error;
 use std::net::{Ipv6Addr, SocketAddr};
 use std::num::NonZeroUsize;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use firewood::db::{BatchOp, Db, DbConfig};
@@ -60,6 +61,15 @@ struct GlobalOpts {
         default_value_t = String::from("info"),
     )]
     log_level: String,
+    #[arg(
+        long,
+        short = 'd',
+        required = false,
+        help = "Use this database name instead of the default",
+        value_name = "TRUNCATE",
+        default_value = PathBuf::from("benchmark_db").into_os_string(),
+    )]
+    dbname: PathBuf,
 }
 
 mod create;
@@ -146,7 +156,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .manager(mgrcfg)
         .build();
 
-    let db = Db::new("rev_db", cfg)
+    let db = Db::new(args.global_opts.dbname.clone(), cfg)
         .await
         .expect("db initiation should succeed");
 


### PR DESCRIPTION
This lets me run multiple instances simultaneously.