### PR TITLE
Break after determining we can't reap the latest

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -166,6 +166,7 @@ impl RevisionManager {
                 Err(original) => {
                     warn!("Oldest revision could not be reaped; still referenced");
                     self.historical.push_front(original);
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Otherwise we hang waiting for the latest revision to be reaped. Discovered when setting the revision max to 1.