### PR TITLE
Must delete from context of latest revision

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -143,7 +143,7 @@ impl RevisionManager {
             return Err(RevisionManagerError::NotLatest);
         }
 
-        let committed = proposal.as_committed();
+        let mut committed = proposal.as_committed();
 
         // 2. Persist delete list for this committed revision to disk for recovery
 
@@ -162,7 +162,7 @@ impl RevisionManager {
             // This guarantee is there because we have a `&mut self` reference to the manager, so
             // the compiler guarantees we are the only one using this manager.
             match Arc::try_unwrap(oldest) {
-                Ok(oldest) => oldest.reap_deleted()?,
+                Ok(oldest) => oldest.reap_deleted(&mut committed)?,
                 Err(original) => {
                     warn!("Oldest revision could not be reaped; still referenced");
                     self.historical.push_front(original);

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1130,12 +1130,12 @@ where
 
 impl<S: WritableStorage> NodeStore<Committed, S> {
     /// adjust the freelist of this proposal to reflect the freed nodes in the oldest proposal
-    pub fn reap_deleted(mut self) -> Result<(), Error> {
+    pub fn reap_deleted(mut self, proposal: &mut NodeStore<Committed, S>) -> Result<(), Error> {
         self.storage
             .invalidate_cached_nodes(self.kind.deleted.iter());
         trace!("There are {} nodes to reap", self.kind.deleted.len());
         for addr in take(&mut self.kind.deleted) {
-            self.delete_node(addr)?;
+            proposal.delete_node(addr)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Deleting from the oldest revision doesn't update the freelist from the newly committed revision, and it has to. If not, the freelist remains empty.