### PR TITLE
Cache size adjustments

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -22,10 +22,10 @@ pub struct RevisionManagerConfig {
     #[builder(default = 128)]
     max_revisions: usize,
 
-    #[builder(default_code = "NonZero::new(20480).expect(\"non-zero\")")]
+    #[builder(default_code = "NonZero::new(1500000).expect(\"non-zero\")")]
     node_cache_size: NonZero<usize>,
 
-    #[builder(default_code = "NonZero::new(10000).expect(\"non-zero\")")]
+    #[builder(default_code = "NonZero::new(20000).expect(\"non-zero\")")]
     free_list_cache_size: NonZero<usize>,
 }
 


### PR DESCRIPTION
The cache freelist needs to hold all the nodes plus all the intermediate nodes. Also adjusted the default cache size to 1.5M nodes, probably good enough for all of the benchmarks.