### PR TITLE
Terminate the benchmark after 65 mintues

### DIFF
--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -70,6 +70,15 @@ struct GlobalOpts {
         default_value = PathBuf::from("benchmark_db").into_os_string(),
     )]
     dbname: PathBuf,
+    #[arg(
+        long,
+        short = 't',
+        required = false,
+        help = "Terminate the test after this many minutes",
+        value_name = "TRUNCATE",
+        default_value_t = 65
+    )]
+    duration_minutes: u64,
 }
 
 mod create;

--- a/benchmark/src/single.rs
+++ b/benchmark/src/single.rs
@@ -14,11 +14,12 @@ use std::time::Instant;
 pub struct Single;
 
 impl TestRunner for Single {
-    async fn run(&self, db: &Db, _args: &crate::Args) -> Result<(), Box<dyn Error>> {
+    async fn run(&self, db: &Db, args: &crate::Args) -> Result<(), Box<dyn Error>> {
         let start = Instant::now();
         let inner_key = Sha256::digest(0u64.to_ne_bytes()).to_vec();
+        let mut batch_id = 0;
 
-        for batch_id in 0.. {
+        while start.elapsed().as_secs() / 60 < args.global_opts.duration_minutes {
             let batch = vec![BatchOp::Put {
                 key: inner_key.clone(),
                 value: vec![batch_id as u8],
@@ -33,7 +34,8 @@ impl TestRunner for Single {
                     pretty_duration(&start.elapsed(), None)
                 );
             }
+            batch_id += 1;
         }
-        unreachable!()
+        Ok(())
     }
 }

--- a/benchmark/src/tenkrandom.rs
+++ b/benchmark/src/tenkrandom.rs
@@ -2,6 +2,7 @@
 // See the file LICENSE.md for licensing terms.
 
 use std::error::Error;
+use std::time::Instant;
 
 use firewood::db::{BatchOp, Db};
 use firewood::logger::debug;
@@ -19,7 +20,9 @@ impl TestRunner for TenKRandom {
         let mut high = args.number_of_batches * args.batch_size;
         let twenty_five_pct = args.batch_size / 4;
 
-        loop {
+        let start = Instant::now();
+
+        while start.elapsed().as_secs() / 60 < args.global_opts.duration_minutes {
             let batch: Vec<BatchOp<_, _>> = Self::generate_inserts(high, twenty_five_pct)
                 .chain(generate_deletes(low, twenty_five_pct))
                 .chain(generate_updates(low + high / 2, twenty_five_pct * 2, low))
@@ -29,6 +32,7 @@ impl TestRunner for TenKRandom {
             low += twenty_five_pct;
             high += twenty_five_pct;
         }
+        Ok(())
     }
 }
 fn generate_updates(

--- a/benchmark/src/zipf.rs
+++ b/benchmark/src/zipf.rs
@@ -32,8 +32,9 @@ impl TestRunner for Zipf {
         let rows = (args.number_of_batches * args.batch_size) as usize;
         let zipf = zipf::ZipfDistribution::new(rows, exponent).unwrap();
         let start = Instant::now();
+        let mut batch_id = 0;
 
-        for batch_id in 0.. {
+        while start.elapsed().as_secs() / 60 < args.global_opts.duration_minutes {
             let batch: Vec<BatchOp<_, _>> =
                 generate_updates(batch_id, args.batch_size as usize, &zipf).collect();
             if log::log_enabled!(log::Level::Debug) {
@@ -62,8 +63,9 @@ impl TestRunner for Zipf {
                     pretty_duration(&start.elapsed(), None)
                 );
             }
+            batch_id += 1;
         }
-        unreachable!()
+        Ok(())
     }
 }
 fn generate_updates(


### PR DESCRIPTION
Why 65? 60 minutes to run the benchmark plus 5 minutes warmup.