### PR TITLE
Increase free list cache sizes

### DIFF
--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -66,7 +66,6 @@ struct GlobalOpts {
         short = 'd',
         required = false,
         help = "Use this database name instead of the default",
-        value_name = "TRUNCATE",
         default_value = PathBuf::from("benchmark_db").into_os_string(),
     )]
     dbname: PathBuf,
@@ -75,7 +74,6 @@ struct GlobalOpts {
         short = 't',
         required = false,
         help = "Terminate the test after this many minutes",
-        value_name = "TRUNCATE",
         default_value_t = 65
     )]
     duration_minutes: u64,
@@ -156,7 +154,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mgrcfg = RevisionManagerConfig::builder()
         .node_cache_size(args.cache_size)
         .free_list_cache_size(
-            NonZeroUsize::new(2 * args.batch_size as usize).expect("batch size > 0"),
+            NonZeroUsize::new(4 * args.batch_size as usize).expect("batch size > 0"),
         )
         .max_revisions(args.revisions)
         .build();

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -25,7 +25,7 @@ pub struct RevisionManagerConfig {
     #[builder(default_code = "NonZero::new(1500000).expect(\"non-zero\")")]
     node_cache_size: NonZero<usize>,
 
-    #[builder(default_code = "NonZero::new(20000).expect(\"non-zero\")")]
+    #[builder(default_code = "NonZero::new(40000).expect(\"non-zero\")")]
     free_list_cache_size: NonZero<usize>,
 }
 


### PR DESCRIPTION
The maximum size needed depends on the trie depth, so more misses happen as we create a deeper trie. Should improve performance for bigger tries.