### PR TITLE
Add feature branch_factor_256

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -39,6 +39,7 @@ default = []
 nightly = []
 iouring = ["io-uring"]
 logger = ["storage/logger"]
+branch_factor_256 = [ "storage/branch_factor_256" ]
 
 [dev-dependencies]
 criterion = {version = "0.5.1", features = ["async_tokio"]}

--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -71,7 +71,8 @@ impl Hashable for ProofNode {
 
 impl From<PathIterItem> for ProofNode {
     fn from(item: PathIterItem) -> Self {
-        let mut child_hashes: [Option<TrieHash>; BranchNode::MAX_CHILDREN] = Default::default();
+        let mut child_hashes: [Option<TrieHash>; BranchNode::MAX_CHILDREN] =
+            [const { None }; BranchNode::MAX_CHILDREN];
 
         if let Some(branch) = item.node.as_branch() {
             // TODO danlaine: can we avoid indexing?
@@ -170,6 +171,7 @@ impl<T: Hashable> Proof<T> {
 
             // Assert that only nodes whose keys are an even number of nibbles
             // have a `value_digest`.
+            #[cfg(not(feature = "branch_factor_256"))]
             if node.key().count() % 2 != 0 && node.value_digest().is_some() {
                 return Err(ProofError::ValueAtOddNibbleLength);
             }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -28,6 +28,7 @@ criterion = { version = "0.5.1", features = ["async_tokio", "html_reports"] }
 
 [features]
 logger = ["log"]
+branch_factor_256 = []
 
 [[bench]]
 name = "serializer"

--- a/storage/benches/serializer.rs
+++ b/storage/benches/serializer.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use std::num::NonZeroU64;
+use std::{array::from_fn, num::NonZeroU64};
 
 use bincode::Options;
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -27,27 +27,16 @@ fn branch(c: &mut Criterion) {
     let mut input = Node::Branch(Box::new(storage::BranchNode {
         partial_path: Path(SmallVec::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9])),
         value: Some(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_boxed_slice()),
-        children: [
-            Some(storage::Child::AddressWithHash(
-                NonZeroU64::new(1).unwrap(),
-                storage::TrieHash::from([0; 32]),
-            )),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        ],
+        children: from_fn(|i| {
+            if i == 0 {
+                Some(storage::Child::AddressWithHash(
+                    NonZeroU64::new(1).unwrap(),
+                    storage::TrieHash::from([0; 32]),
+                ))
+            } else {
+                None
+            }
+        }),
     }));
     let serializer = bincode::DefaultOptions::new().with_varint_encoding();
     let benchfn = |b: &mut criterion::Bencher, input: &storage::Node| {

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -122,7 +122,7 @@ impl BranchNode {
     /// The maximum number of children in a [BranchNode]
     #[cfg(feature = "branch_factor_256")]
     pub const MAX_CHILDREN: usize = 256;
-    
+
     /// The maximum number of children in a [BranchNode]
     #[cfg(not(feature = "branch_factor_256"))]
     pub const MAX_CHILDREN: usize = 16;

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -42,7 +42,7 @@ impl Serialize for BranchNode {
         state.serialize_field("partial_path", &self.partial_path)?;
         state.serialize_field("value", &self.value)?;
 
-        let children: SmallVec<[(u8, LinearAddress, TrieHash); 16]> = self
+        let children: SmallVec<[(u8, LinearAddress, TrieHash); Self::MAX_CHILDREN]> = self
             .children
             .iter()
             .enumerate()
@@ -71,12 +71,13 @@ impl<'de> Deserialize<'de> for BranchNode {
         struct SerializedBranchNode {
             partial_path: Path,
             value: Option<Box<[u8]>>,
-            children: SmallVec<[(u8, LinearAddress, TrieHash); 16]>,
+            children: SmallVec<[(u8, LinearAddress, TrieHash); BranchNode::MAX_CHILDREN]>,
         }
 
         let s: SerializedBranchNode = Deserialize::deserialize(deserializer)?;
 
-        let mut children: [Option<Child>; BranchNode::MAX_CHILDREN] = Default::default();
+        let mut children: [Option<Child>; BranchNode::MAX_CHILDREN] =
+            [const { None }; BranchNode::MAX_CHILDREN];
         for (offset, addr, hash) in s.children.iter() {
             children[*offset as usize] = Some(Child::AddressWithHash(*addr, hash.clone()));
         }
@@ -119,6 +120,9 @@ impl Debug for BranchNode {
 
 impl BranchNode {
     /// The maximum number of children in a [BranchNode]
+    #[cfg(feature = "branch_factor_256")]
+    pub const MAX_CHILDREN: usize = 256;
+    #[cfg(not(feature = "branch_factor_256"))]
     pub const MAX_CHILDREN: usize = 16;
 
     /// Returns the address of the child at the given index.
@@ -158,7 +162,7 @@ impl From<&LeafNode> for BranchNode {
         BranchNode {
             partial_path: leaf.partial_path.clone(),
             value: Some(Box::from(&leaf.value[..])),
-            children: Default::default(),
+            children: [const { None }; BranchNode::MAX_CHILDREN],
         }
     }
 }

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -122,6 +122,8 @@ impl BranchNode {
     /// The maximum number of children in a [BranchNode]
     #[cfg(feature = "branch_factor_256")]
     pub const MAX_CHILDREN: usize = 256;
+    
+    /// The maximum number of children in a [BranchNode]
     #[cfg(not(feature = "branch_factor_256"))]
     pub const MAX_CHILDREN: usize = 16;
 

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1145,6 +1145,8 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use std::array::from_fn;
+
     use crate::linear::memory::MemStore;
     use crate::{BranchNode, LeafNode};
     use arc_swap::access::DynGuard;
@@ -1232,7 +1234,13 @@ mod tests {
     #[test_case(BranchNode {
         partial_path: Path::from([6, 7, 8]),
         value: Some(vec![9, 10, 11].into_boxed_slice()),
-        children: [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, Some(Child::AddressWithHash(LinearAddress::new(1).unwrap(), std::array::from_fn::<u8, 32, _>(|i| i as u8).into()))],
+        children: from_fn(|i| {
+            if i == 15 {
+                Some(Child::AddressWithHash(LinearAddress::new(1).unwrap(), std::array::from_fn::<u8, 32, _>(|i| i as u8).into()))
+            } else {
+                None
+            }
+        }),
     }; "branch node with 1 child")]
     #[test_case(
     Node::Leaf(LeafNode {


### PR DESCRIPTION
Support branch factor of 256. Removes all assumptions that branches contain 16 children, reimplements NibblesIterator for the larger branch factor to just return the bytes.

Removes some tests that don't make sense with 256 brandchs