### PR TITLE
Don't use smallvec for the value

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -34,11 +34,6 @@ func OpenDatabase(path string) Firewood {
 	return Firewood{Db: ptr}
 }
 
-const (
-	OP_PUT = iota
-	OP_DELETE
-)
-
 type KeyValue struct {
 	Key   []byte
 	Value []byte

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -584,7 +584,6 @@ fn key_from_nibble_iter<Iter: Iterator<Item = u8>>(mut nibbles: Iter) -> Key {
 #[cfg(test)]
 #[allow(clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
-    use smallvec::SmallVec;
     use storage::{MemStore, MutableProposal, NodeStore};
 
     use crate::merkle::Merkle;
@@ -637,7 +636,7 @@ mod tests {
         );
         #[cfg(feature = "branch_factor_256")]
         assert_eq!(node.key_nibbles, vec![0xBE, 0xEF].into_boxed_slice());
-        assert_eq!(node.node.as_leaf().unwrap().value, SmallVec::from([0x42]));
+        assert_eq!(node.node.as_leaf().unwrap().value, Box::from([0x42]));
         assert_eq!(node.next_nibble, None);
 
         assert!(stream.next().is_none());
@@ -699,7 +698,7 @@ mod tests {
         assert_eq!(node.next_nibble, None);
         assert_eq!(
             node.node.as_leaf().unwrap().value,
-            SmallVec::from([0x00, 0x00, 0x00, 0x0FF])
+            Box::from([0x00, 0x00, 0x00, 0x0FF])
         );
 
         assert!(stream.next().is_none());

--- a/storage/benches/serializer.rs
+++ b/storage/benches/serializer.rs
@@ -57,7 +57,7 @@ fn leaf(c: &mut Criterion) {
     let mut group = c.benchmark_group("leaf");
     let input = Node::Leaf(LeafNode {
         partial_path: Path(SmallVec::from_slice(&[0, 1])),
-        value: SmallVec::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        value: Box::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
     });
     let serializer = bincode::DefaultOptions::new().with_varint_encoding();
     group.bench_with_input("serde", &input, |b, input| {

--- a/storage/src/node/leaf.rs
+++ b/storage/src/node/leaf.rs
@@ -2,7 +2,6 @@
 // See the file LICENSE.md for licensing terms.
 
 use serde::{Deserialize, Serialize};
-use smallvec::SmallVec;
 
 use std::fmt::{Debug, Error as FmtError, Formatter};
 
@@ -15,7 +14,7 @@ pub struct LeafNode {
     pub partial_path: Path,
 
     /// The value associated with this leaf
-    pub value: SmallVec<[u8; 16]>,
+    pub value: Box<[u8]>,
 }
 
 impl Debug for LeafNode {

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -5,7 +5,6 @@ use bitfield::bitfield;
 use enum_as_inner::EnumAsInner;
 use integer_encoding::{VarIntReader as _, VarIntWriter as _};
 use serde::{Deserialize, Serialize};
-use smallvec::SmallVec;
 use std::io::{Error, ErrorKind, Read, Write};
 use std::num::NonZero;
 use std::vec;
@@ -37,7 +36,7 @@ impl Default for Node {
     fn default() -> Self {
         Node::Leaf(LeafNode {
             partial_path: Path::new(),
-            value: SmallVec::default(),
+            value: Box::default(),
         })
     }
 }
@@ -174,7 +173,7 @@ impl Node {
     pub fn update_value(&mut self, value: Box<[u8]>) {
         match self {
             Node::Branch(b) => b.value = Some(value),
-            Node::Leaf(l) => l.value = SmallVec::from(&value[..]),
+            Node::Leaf(l) => l.value = value,
         }
     }
 

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1098,7 +1098,6 @@ mod tests {
     use crate::linear::memory::MemStore;
     use crate::{BranchNode, LeafNode};
     use arc_swap::access::DynGuard;
-    use smallvec::SmallVec;
     use test_case::test_case;
 
     use super::*;
@@ -1200,7 +1199,7 @@ mod tests {
     #[test_case(
     Node::Leaf(LeafNode {
         partial_path: Path::from([0, 1, 2]),
-        value: SmallVec::from_slice(&[3, 4, 5]),
+        value: Box::new([3, 4, 5]),
     }); "leaf node")]
 
     fn test_serialized_len<N: Into<Node>>(node: N) {
@@ -1223,7 +1222,7 @@ mod tests {
 
         let giant_leaf = Node::Leaf(LeafNode {
             partial_path: Path::from([0, 1, 2]),
-            value: SmallVec::from_vec(huge_value),
+            value: huge_value.into_boxed_slice(),
         });
 
         node_store.mut_root().replace(giant_leaf);


### PR DESCRIPTION
The caller passes in a box, and we then convert it to a smallvec. Usually this results in the box being converted to a slice, then a new SmallVec is constructed from that, which allocates another Box if the value was larger than 16 bytes.

This code is also suspect in that it might be leaking. The difference between two test cases is only on the size of the value. When the value was larger than 16 bytes, the memory was growing, otherwise not.

So not only is this faster, but it might avoid the leak we see with values over 16 bytes.