### PR TITLE
Migrate to rand_distr for zipf

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -12,11 +12,11 @@ metrics = "0.24.1"
 metrics-util = "0.19.0"
 metrics-exporter-prometheus = "0.16.1"
 tokio = { version = "1.36.0", features = ["rt", "sync", "macros", "rt-multi-thread"] }
-rand = "0.8.5"
+rand = "0.9.0"
+rand_distr = "0.5.0"
 pretty-duration = "0.1.1"
 tikv-jemallocator = "0.6.0"
 env_logger = "0.11.5"
-zipf = "7.0.1"
 log = "0.4.20"
 fastrace = { version = "0.7.4", features = ["enable"] }
 fastrace-opentelemetry = { version = "0.8.0" }


### PR DESCRIPTION
The zipf crate appears to be unmaintained, but there is an implementation in rand_distr which works with the new version of rand.