### PR TITLE
Use read_at and write_at to avoid mutating File

### DIFF
--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -37,7 +37,7 @@ pub trait ReadableStorage: Debug + Sync + Send {
     /// # Returns
     ///
     /// A `Result` containing a boxed `Read` trait object, or an `Error` if the operation fails.
-    fn stream_from(&self, addr: u64) -> Result<Box<dyn Read>, Error>;
+    fn stream_from(&self, addr: u64) -> Result<Box<dyn Read + '_>, Error>;
 
     /// Return the size of the underlying storage, in bytes
     fn size(&self) -> Result<u64, Error>;


### PR DESCRIPTION
This reduces the number of system calls when reading

was dup(), seek(), read(), close()

now just pread()

Also eliminates a mutex around the file since nobody modifies the file offset.