### PR TITLE
cache node reads + use cache with lfu admit, lru evict

### DIFF
--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -22,6 +22,7 @@ bytemuck = "1.7.0"
 bytemuck_derive = "1.7.0"
 bitfield = "0.18.1"
 fastrace = { version = "0.7.4" }
+moka = { version = "0.12.10", features = ["sync"] }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -22,7 +22,7 @@ bytemuck = "1.7.0"
 bytemuck_derive = "1.7.0"
 bitfield = "0.18.1"
 fastrace = { version = "0.7.4" }
-moka = { version = "0.12.10", features = ["sync"] }
+mini-moka = "0.10.3"
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use lru::LruCache;
-use moka::sync::Cache;
+use mini_moka::sync::Cache;
 use metrics::counter;
 
 use crate::{LinearAddress, Node};
@@ -93,7 +93,7 @@ impl WritableStorage for FileBacked {
 
     fn invalidate_cached_nodes<'a>(&self, addresses: impl Iterator<Item = &'a LinearAddress>) {
         for addr in addresses {
-            self.cache.remove(addr);
+            self.cache.invalidate(addr);
         }
     }
 

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -51,6 +51,14 @@ pub trait ReadableStorage: Debug + Sync + Send {
     fn free_list_cache(&self, _addr: LinearAddress) -> Option<Option<LinearAddress>> {
         None
     }
+
+    /// Write all nodes to the cache (if any)
+    fn write_cached_nodes<'a>(
+        &self,
+        _nodes: impl Iterator<Item = (&'a NonZero<u64>, &'a Arc<Node>)>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 /// Trait for writable storage.
@@ -66,14 +74,6 @@ pub trait WritableStorage: ReadableStorage {
     ///
     /// The number of bytes written, or an error if the write operation fails.
     fn write(&self, offset: u64, object: &[u8]) -> Result<usize, Error>;
-
-    /// Write all nodes to the cache (if any)
-    fn write_cached_nodes<'a>(
-        &self,
-        _nodes: impl Iterator<Item = (&'a NonZero<u64>, &'a Arc<Node>)>,
-    ) -> Result<(), Error> {
-        Ok(())
-    }
 
     /// Invalidate all nodes that are part of a specific revision, as these will never be referenced again
     fn invalidate_cached_nodes<'a>(&self, _addresses: impl Iterator<Item = &'a LinearAddress>) {}

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -229,8 +229,7 @@ impl<T: ReadInMemoryNode, S: ReadableStorage> NodeStore<T, S> {
     /// Put a [Node] into the cache at the given address.
     fn cache_node(&self, addr: LinearAddress, node: Arc<Node>) -> Result<Arc<Node>, Error> {
         self.storage
-            .write_cached_nodes(once((&addr, &node)))
-            .expect("failed to write cached nodes");
+            .write_cached_nodes(once((&addr, &node)))?;
         Ok(node)
     }
 }


### PR DESCRIPTION
related to: https://github.com/ava-labs/firewood/issues/358

Uses mini_moka cache crate:
- allows concurrent access (explicit locks not needed)
- has lfu admission + lru eviction, should work for range proof reads and normal reads as range reads would not be admitted
- adding caching for node reads

(originally tried moka but mini_moka seems fine and has fewer dependencies)
