### PR TITLE
Remove or downgrade dependencies

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -24,12 +24,10 @@ hex = "0.4.3"
 metrics = "0.24.0"
 serde = { version = "1.0" }
 sha2 = "0.10.8"
+test-case = "3.3.1"
 thiserror = "2.0.3"
-tokio = { version = "1.36.0", features = ["rt", "sync", "macros", "rt-multi-thread"] }
 typed-builder = "0.20.0"
 bincode = "1.3.3"
-log = "0.4.20"
-test-case = "3.3.1"
 integer-encoding = "4.0.0"
 io-uring = {version = "0.7", optional = true }
 smallvec = "1.6.1"
@@ -50,6 +48,8 @@ triehash = "0.8.4"
 clap = { version = "4.5.0", features = ['derive'] }
 pprof = { version = "0.14.0", features = ["flamegraph"] }
 tempfile = "3.12.0"
+tokio = { version = "1.36.0", features = ["rt", "sync", "macros", "rt-multi-thread"] }
+
 
 [[bench]]
 name = "hashops"

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 firewood = { version = "0.0.4", path = "../firewood" }
 clap = { version = "4.5.0", features = ["cargo", "derive"] }
-anyhow = "1.0.79"
 env_logger = "0.11.2"
 log = "0.4.20"
 tokio = { version = "1.36.0", features = ["full"] }
@@ -15,6 +14,7 @@ hex = "0.4.3"
 csv = "1.3.1"
 
 [dev-dependencies]
+anyhow = "1.0.79"
 assert_cmd = "2.0.13"
 predicates = "3.1.0"
 serial_test = "3.0.0"


### PR DESCRIPTION
`cargo +nightly udeps` reported these as unused. Some are still needed in the tests but they shouldn't be needed in the release builds.