### PR TITLE
Invert and rename telemetry argument

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -19,10 +19,10 @@ tikv-jemallocator = "0.6.0"
 env_logger = "0.11.5"
 log = "0.4.20"
 fastrace = { version = "0.7.4", features = ["enable"] }
-fastrace-opentelemetry = { version = "0.8.0" }
-opentelemetry-otlp = "0.27.0"
-opentelemetry = "0.27.0"
-opentelemetry_sdk = "0.27.1"
+fastrace-opentelemetry = { version = "0.9.0" }
+opentelemetry-otlp = { version = "0.28.0", features = ["grpc-tonic"] }
+opentelemetry = "0.28.0"
+opentelemetry_sdk = "0.28.0"
 
 [features]
 logger = ["firewood/logger"]

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -168,3 +168,16 @@ If you're looking for detailed logging, there are some command line options to e
 ```sh
     cargo run --profile release --bin benchmark -- -l debug -n 10000 single
 ```
+
+# Using opentelemetry
+
+To use the opentelemetry server and record timings, just run a docker image that collects the data using:
+
+```sh
+docker run   -p 127.0.0.1:4318:4318   -p 127.0.0.1:55679:55679   otel/opentelemetry-collector-contrib:0.97.0   2>&1
+```
+
+Then, pass the `-e` option to the benchmark.
+```
+
+Then, pass the `-e` option to the benchmark.

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -32,7 +32,6 @@ use fastrace::collector::Config;
 
 use opentelemetry::trace::SpanKind;
 use opentelemetry::InstrumentationScope;
-use opentelemetry::KeyValue;
 use opentelemetry_otlp::SpanExporter;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::Resource;
@@ -162,10 +161,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .build()
                 .expect("initialize oltp exporter"),
             SpanKind::Server,
-            Cow::Owned(Resource::new([KeyValue::new(
-                "service.name",
-                "avalabs.firewood.benchmark",
-            )])),
+            Cow::Owned(
+                Resource::builder()
+                    .with_service_name("avalabs.firewood.benchmark")
+                    .build(),
+            ),
             InstrumentationScope::builder("firewood")
                 .with_version(env!("CARGO_PKG_VERSION"))
                 .build(),

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -32,8 +32,7 @@ use fastrace::collector::Config;
 
 use opentelemetry::trace::SpanKind;
 use opentelemetry::InstrumentationScope;
-use opentelemetry_otlp::SpanExporter;
-use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::Resource;
 
 #[derive(Parser, Debug)]

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -39,8 +39,8 @@ use opentelemetry_sdk::Resource;
 
 #[derive(Parser, Debug)]
 struct Args {
-    #[arg(short = 't', long, default_value_t = false)]
-    no_telemetry_server: bool,
+    #[arg(short = 'e', long, default_value_t = false, help = "Enable telemetry server reporting")]
+    telemetry_server: bool,
     #[arg(short, long, default_value_t = 10000)]
     batch_size: u64,
     #[arg(short, long, default_value_t = 1000)]
@@ -145,7 +145,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
 
-    if !args.no_telemetry_server {
+    if args.telemetry_server {
         let reporter = OpenTelemetryReporter::new(
             SpanExporter::builder()
                 .with_tonic()

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -39,7 +39,12 @@ use opentelemetry_sdk::Resource;
 
 #[derive(Parser, Debug)]
 struct Args {
-    #[arg(short = 'e', long, default_value_t = false, help = "Enable telemetry server reporting")]
+    #[arg(
+        short = 'e',
+        long,
+        default_value_t = false,
+        help = "Enable telemetry server reporting"
+    )]
     telemetry_server: bool,
     #[arg(short, long, default_value_t = 10000)]
     batch_size: u64,


### PR DESCRIPTION
The 't' option was used for both timeout and disabling the telemetry server. Seems like we want the reporting off by default, otherwise there are more dependencies when starting up the benchmark by default.