### PR TITLE
Reformat all imports

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -3,15 +3,20 @@
 
 // hash benchmarks; run with 'cargo bench'
 
-use criterion::{criterion_group, criterion_main, profiler::Profiler, BatchSize, Criterion};
+use criterion::profiler::Profiler;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use firewood::db::{BatchOp, DbConfig};
 use firewood::merkle::Merkle;
 use firewood::v2::api::{Db as _, Proposal as _};
 use pprof::ProfilerGuard;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use rand_distr::Alphanumeric;
+use std::fs::File;
+use std::iter::repeat_with;
+use std::os::raw::c_int;
+use std::path::Path;
 use std::sync::Arc;
-use std::{fs::File, iter::repeat_with, os::raw::c_int, path::Path};
 use storage::{MemStore, NodeStore};
 
 // To enable flamegraph output

--- a/firewood/examples/insert.rs
+++ b/firewood/examples/insert.rs
@@ -5,16 +5,16 @@
 // insert some random keys using the front-end API.
 
 use clap::Parser;
-use std::{
-    borrow::BorrowMut as _, collections::HashMap, error::Error, num::NonZeroUsize,
-    ops::RangeInclusive, time::Instant,
-};
+use std::borrow::BorrowMut as _;
+use std::collections::HashMap;
+use std::error::Error;
+use std::num::NonZeroUsize;
+use std::ops::RangeInclusive;
+use std::time::Instant;
 
-use firewood::{
-    db::{Batch, BatchOp, Db, DbConfig},
-    manager::RevisionManagerConfig,
-    v2::api::{Db as _, DbView, Proposal as _},
-};
+use firewood::db::{Batch, BatchOp, Db, DbConfig};
+use firewood::manager::RevisionManagerConfig;
+use firewood::v2::api::{Db as _, DbView, Proposal as _};
 use rand::{Rng, SeedableRng as _};
 use rand_distr::Alphanumeric;
 

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -2,12 +2,13 @@
 // See the file LICENSE.md for licensing terms.
 
 use crate::manager::RevisionManagerError;
-use crate::proof::ProofNode;
+use crate::merkle::MerkleError;
+use crate::proof::{Proof, ProofNode};
 pub use crate::range_proof::RangeProof;
-use crate::{merkle::MerkleError, proof::Proof};
 use async_trait::async_trait;
 use futures::Stream;
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
+use std::sync::Arc;
 use storage::TrieHash;
 
 /// A `KeyType` is something that can be xcast to a u8 reference,

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -1,15 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::{
-    proof::{Proof, ProofNode},
-    range_proof::RangeProof,
-};
+use crate::proof::{Proof, ProofNode};
+use crate::range_proof::RangeProof;
 
-use super::{
-    api::{Batch, Db, DbView, Error, HashKey, KeyType, ValueType},
-    propose::{Proposal, ProposalBase},
-};
+use super::api::{Batch, Db, DbView, Error, HashKey, KeyType, ValueType};
+use super::propose::{Proposal, ProposalBase};
 use async_trait::async_trait;
 use futures::Stream;
 use std::sync::Arc;

--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -1,7 +1,9 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::stream::Empty;

--- a/firewood/tests/common/mod.rs
+++ b/firewood/tests/common/mod.rs
@@ -1,7 +1,10 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use std::{env::temp_dir, fs::remove_file, ops::Deref, path::PathBuf};
+use std::env::temp_dir;
+use std::fs::remove_file;
+use std::ops::Deref;
+use std::path::PathBuf;
 
 use firewood::db::{Db, DbConfig};
 use typed_builder::TypedBuilder;

--- a/grpc-testtool/benches/insert.rs
+++ b/grpc-testtool/benches/insert.rs
@@ -2,11 +2,17 @@
 // See the file LICENSE.md for licensing terms.
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
-use rand::{distributions::Alphanumeric, Rng, SeedableRng};
-use std::{
-    borrow::BorrowMut as _, cell::RefCell, env, fs::remove_dir_all, net::TcpStream,
-    os::unix::process::CommandExt, path::PathBuf, thread::sleep, time::Duration,
-};
+use rand::distributions::Alphanumeric;
+use rand::{Rng, SeedableRng};
+use std::borrow::BorrowMut as _;
+use std::cell::RefCell;
+use std::env;
+use std::fs::remove_dir_all;
+use std::net::TcpStream;
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::thread::sleep;
+use std::time::Duration;
 
 use rpc::rpcdb::{self, PutRequest, WriteBatchRequest};
 pub use rpc::service::Database as DatabaseService;

--- a/grpc-testtool/src/bin/process-server.rs
+++ b/grpc-testtool/src/bin/process-server.rs
@@ -5,20 +5,18 @@ use chrono::Local;
 use clap::Parser;
 use env_logger::Builder;
 use log::{info, LevelFilter};
-use rpc::{
-    process_server::process_server_service_server::ProcessServerServiceServer,
-    rpcdb::database_server::DatabaseServer as RpcServer, sync::db_server::DbServer as SyncServer,
-    DatabaseService,
-};
+use rpc::process_server::process_server_service_server::ProcessServerServiceServer;
+use rpc::rpcdb::database_server::DatabaseServer as RpcServer;
+use rpc::sync::db_server::DbServer as SyncServer;
+use rpc::DatabaseService;
 use serde::Deserialize;
-use std::{
-    error::Error,
-    io::Write,
-    net::{IpAddr::V4, Ipv4Addr},
-    path::PathBuf,
-    str::FromStr,
-    sync::Arc,
-};
+use std::error::Error;
+use std::io::Write;
+use std::net::IpAddr::V4;
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
 use tonic::transport::Server;
 
 #[derive(Clone, Debug, Deserialize)]

--- a/grpc-testtool/src/service.rs
+++ b/grpc-testtool/src/service.rs
@@ -2,18 +2,13 @@
 // See the file LICENSE.md for licensing terms.
 
 use firewood::db::{Db, DbConfig};
-use firewood::v2::api::Db as _;
-use firewood::v2::api::Error;
+use firewood::v2::api::{Db as _, Error};
 
+use std::collections::HashMap;
+use std::ops::Deref;
 use std::path::Path;
-use std::{
-    collections::HashMap,
-    ops::Deref,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
-};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use tonic::Status;
 

--- a/grpc-testtool/src/service/database.rs
+++ b/grpc-testtool/src/service/database.rs
@@ -2,13 +2,14 @@
 // See the file LICENSE.md for licensing terms.
 
 use super::{Database as DatabaseService, IntoStatusResultExt as _, Iter};
+use crate::rpcdb::database_server::Database;
 use crate::rpcdb::{
-    database_server::Database, CloseRequest, CloseResponse, CompactRequest, CompactResponse,
-    DeleteRequest, DeleteResponse, GetRequest, GetResponse, HasRequest, HasResponse,
-    HealthCheckResponse, IteratorErrorRequest, IteratorErrorResponse, IteratorNextRequest,
-    IteratorNextResponse, IteratorReleaseRequest, IteratorReleaseResponse,
-    NewIteratorWithStartAndPrefixRequest, NewIteratorWithStartAndPrefixResponse, PutRequest,
-    PutResponse, WriteBatchRequest, WriteBatchResponse,
+    CloseRequest, CloseResponse, CompactRequest, CompactResponse, DeleteRequest, DeleteResponse,
+    GetRequest, GetResponse, HasRequest, HasResponse, HealthCheckResponse, IteratorErrorRequest,
+    IteratorErrorResponse, IteratorNextRequest, IteratorNextResponse, IteratorReleaseRequest,
+    IteratorReleaseResponse, NewIteratorWithStartAndPrefixRequest,
+    NewIteratorWithStartAndPrefixResponse, PutRequest, PutResponse, WriteBatchRequest,
+    WriteBatchResponse,
 };
 use firewood::v2::api::{BatchOp, Db as _, DbView as _, Proposal as _};
 

--- a/grpc-testtool/src/service/db.rs
+++ b/grpc-testtool/src/service/db.rs
@@ -2,10 +2,11 @@
 // See the file LICENSE.md for licensing terms.
 
 use super::Database;
+use crate::sync::db_server::Db as DbServerTrait;
 use crate::sync::{
-    db_server::Db as DbServerTrait, CommitChangeProofRequest, CommitRangeProofRequest,
-    GetChangeProofRequest, GetChangeProofResponse, GetMerkleRootResponse, GetProofRequest,
-    GetProofResponse, GetRangeProofRequest, GetRangeProofResponse, VerifyChangeProofRequest,
+    CommitChangeProofRequest, CommitRangeProofRequest, GetChangeProofRequest,
+    GetChangeProofResponse, GetMerkleRootResponse, GetProofRequest, GetProofResponse,
+    GetRangeProofRequest, GetRangeProofResponse, VerifyChangeProofRequest,
     VerifyChangeProofResponse,
 };
 use tonic::{async_trait, Request, Response, Status};

--- a/storage/benches/serializer.rs
+++ b/storage/benches/serializer.rs
@@ -1,10 +1,14 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use std::{array::from_fn, fs::File, num::NonZeroU64, os::raw::c_int};
+use std::array::from_fn;
+use std::fs::File;
+use std::num::NonZeroU64;
+use std::os::raw::c_int;
 
 use bincode::Options;
-use criterion::{criterion_group, criterion_main, profiler::Profiler, Criterion};
+use criterion::profiler::Profiler;
+use criterion::{criterion_group, criterion_main, Criterion};
 use pprof::ProfilerGuard;
 use smallvec::SmallVec;
 use storage::{LeafNode, Node, Path};

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -4,8 +4,7 @@
 use sha2::{Digest, Sha256};
 use std::iter::{self};
 
-use crate::{BranchNode, Child, LeafNode, TrieHash};
-use crate::{Node, Path};
+use crate::{BranchNode, Child, LeafNode, Node, Path, TrieHash};
 
 use integer_encoding::VarInt;
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -23,14 +23,14 @@ pub mod logger;
 // re-export these so callers don't need to know where they are
 pub use hashednode::{hash_node, hash_preimage, Hashable, Preimage, ValueDigest};
 pub use linear::{ReadableStorage, WritableStorage};
-pub use node::{
-    path::NibblesIterator, path::Path, BranchNode, Child, LeafNode, Node, PathIterItem,
-};
+pub use node::path::{NibblesIterator, Path};
+pub use node::{BranchNode, Child, LeafNode, Node, PathIterItem};
 pub use nodestore::{
     Committed, HashedNodeReader, ImmutableProposal, LinearAddress, MutableProposal, NodeReader,
     NodeStore, Parentable, ReadInMemoryNode, RootReader, TrieReader, UpdateError,
 };
 
-pub use linear::{filebacked::FileBacked, memory::MemStore};
+pub use linear::filebacked::FileBacked;
+pub use linear::memory::MemStore;
 
 pub use trie_hash::TrieHash;

--- a/storage/src/linear/memory.rs
+++ b/storage/src/linear/memory.rs
@@ -2,10 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 use super::{ReadableStorage, WritableStorage};
-use std::{
-    io::{Cursor, Read},
-    sync::Mutex,
-};
+use std::io::{Cursor, Read};
+use std::sync::Mutex;
 
 #[derive(Debug, Default)]
 /// An in-memory impelementation of [WritableStorage] and [ReadableStorage]

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -1,7 +1,8 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use serde::{ser::SerializeStruct as _, Deserialize, Serialize};
+use serde::ser::SerializeStruct as _;
+use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::{LeafNode, LinearAddress, Node, Path, TrieHash};

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -5,17 +5,17 @@ use bitfield::bitfield;
 use enum_as_inner::EnumAsInner;
 use integer_encoding::{VarIntReader as _, VarIntWriter as _};
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 use std::io::{Error, ErrorKind, Read, Write};
 use std::num::NonZero;
+use std::sync::Arc;
 use std::vec;
-use std::{fmt::Debug, sync::Arc};
 
 mod branch;
 mod leaf;
 pub mod path;
 
-pub use branch::BranchNode;
-pub use branch::Child;
+pub use branch::{BranchNode, Child};
 pub use leaf::LeafNode;
 
 use crate::Path;
@@ -464,10 +464,8 @@ pub struct PathIterItem {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        node::{BranchNode, LeafNode, Node},
-        Child, LinearAddress, Path,
-    };
+    use crate::node::{BranchNode, LeafNode, Node};
+    use crate::{Child, LinearAddress, Path};
     use test_case::test_case;
 
     #[test_case(

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -5,11 +5,8 @@
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-use std::iter::FusedIterator;
-use std::{
-    fmt::{self, Debug},
-    iter::once,
-};
+use std::fmt::{self, Debug};
+use std::iter::{once, FusedIterator};
 
 static NIBBLES: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
 

--- a/storage/src/trie_hash.rs
+++ b/storage/src/trie_hash.rs
@@ -3,8 +3,10 @@
 
 use std::fmt::{self, Debug};
 
-use serde::{de::Visitor, Deserialize, Serialize};
-use sha2::digest::{generic_array::GenericArray, typenum};
+use serde::de::Visitor;
+use serde::{Deserialize, Serialize};
+use sha2::digest::generic_array::GenericArray;
+use sha2::digest::typenum;
 
 /// A hash value inside a merkle trie
 /// We use the same type as returned by sha2 here to avoid copies


### PR DESCRIPTION
Starting to get messy, reformatted using `cargo +nightly fmt` with a rustfmt.toml containing:

    imports_granularity = "module"