### PR TITLE
Rkuris/cache read strategy in benchmark cmd

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -23,6 +23,7 @@ fastrace-opentelemetry = { version = "0.9.0" }
 opentelemetry-otlp = { version = "0.28.0", features = ["grpc-tonic"] }
 opentelemetry = "0.28.0"
 opentelemetry_sdk = "0.28.0"
+strum = "0.27.0"
 
 [features]
 logger = ["firewood/logger"]

--- a/benchmark/src/create.rs
+++ b/benchmark/src/create.rs
@@ -19,14 +19,14 @@ pub struct Create;
 
 impl TestRunner for Create {
     async fn run(&self, db: &Db, args: &Args) -> Result<(), Box<dyn Error>> {
-        let keys = args.batch_size;
+        let keys = args.global_opts.batch_size;
         let start = Instant::now();
 
-        for key in 0..args.number_of_batches {
+        for key in 0..args.global_opts.number_of_batches {
             let root = Span::root(func_path!(), SpanContext::random());
             let _guard = root.set_local_parent();
 
-            let batch = Self::generate_inserts(key * keys, args.batch_size).collect();
+            let batch = Self::generate_inserts(key * keys, args.global_opts.batch_size).collect();
 
             let proposal = db.propose(batch).await.expect("proposal should succeed");
             proposal.commit().await?;
@@ -34,7 +34,7 @@ impl TestRunner for Create {
         let duration = start.elapsed();
         info!(
             "Generated and inserted {} batches of size {keys} in {}",
-            args.number_of_batches,
+            args.global_opts.number_of_batches,
             pretty_duration(&duration, None)
         );
 

--- a/benchmark/src/single.rs
+++ b/benchmark/src/single.rs
@@ -16,7 +16,7 @@ pub struct Single;
 impl TestRunner for Single {
     async fn run(&self, db: &Db, args: &crate::Args) -> Result<(), Box<dyn Error>> {
         let start = Instant::now();
-        let inner_keys: Vec<_> = (0..args.batch_size)
+        let inner_keys: Vec<_> = (0..args.global_opts.batch_size)
             .map(|i| Sha256::digest(i.to_ne_bytes()))
             .collect();
         let mut batch_id = 0;

--- a/benchmark/src/tenkrandom.rs
+++ b/benchmark/src/tenkrandom.rs
@@ -17,8 +17,8 @@ pub struct TenKRandom;
 impl TestRunner for TenKRandom {
     async fn run(&self, db: &Db, args: &Args) -> Result<(), Box<dyn Error>> {
         let mut low = 0;
-        let mut high = args.number_of_batches * args.batch_size;
-        let twenty_five_pct = args.batch_size / 4;
+        let mut high = args.global_opts.number_of_batches * args.global_opts.batch_size;
+        let twenty_five_pct = args.global_opts.batch_size / 4;
 
         let start = Instant::now();
 

--- a/benchmark/src/zipf.rs
+++ b/benchmark/src/zipf.rs
@@ -28,14 +28,14 @@ impl TestRunner for Zipf {
         } else {
             unreachable!()
         };
-        let rows = (args.number_of_batches * args.batch_size) as f64;
+        let rows = (args.global_opts.number_of_batches * args.global_opts.batch_size) as f64;
         let zipf = rand_distr::Zipf::new(rows, exponent).unwrap();
         let start = Instant::now();
         let mut batch_id = 0;
 
         while start.elapsed().as_secs() / 60 < args.global_opts.duration_minutes {
             let batch: Vec<BatchOp<_, _>> =
-                generate_updates(batch_id, args.batch_size as usize, zipf).collect();
+                generate_updates(batch_id, args.global_opts.batch_size as usize, zipf).collect();
             if log::log_enabled!(log::Level::Debug) {
                 let mut distinct = HashSet::new();
                 for op in &batch {

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -14,9 +14,8 @@ use typed_builder::TypedBuilder;
 
 use crate::v2::api::HashKey;
 
-use storage::{
-    CacheReadStrategy, Committed, FileBacked, ImmutableProposal, NodeStore, Parentable, TrieHash,
-};
+pub use storage::CacheReadStrategy;
+use storage::{Committed, FileBacked, ImmutableProposal, NodeStore, Parentable, TrieHash};
 
 #[derive(Clone, Debug, TypedBuilder)]
 /// Revision manager configuratoin

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -22,6 +22,8 @@ bytemuck = "1.7.0"
 bytemuck_derive = "1.7.0"
 bitfield = "0.18.1"
 fastrace = { version = "0.7.4" }
+strum = "0.27.0"
+strum_macros = "0.27.0"
 
 [dev-dependencies]
 rand = "0.9.0"

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -33,13 +33,14 @@ pub use nodestore::{
 pub use linear::filebacked::FileBacked;
 pub use linear::memory::MemStore;
 
+use strum_macros::VariantArray;
 pub use trie_hash::TrieHash;
 
 /// The strategy for caching nodes that are read
 /// from the storage layer. Generally, we only want to
 /// cache write operations, but for some read-heavy workloads
 /// you can enable caching of branch reads or all reads.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, VariantArray)]
 pub enum CacheReadStrategy {
     /// Only cache writes (no reads will be cached)
     WritesOnly,
@@ -49,4 +50,10 @@ pub enum CacheReadStrategy {
 
     /// Cache all reads (leaves and branches)
     All,
+}
+
+impl std::fmt::Display for CacheReadStrategy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
 }


### PR DESCRIPTION
Expose cache read strategy to benchmark command
    
Has a decent impact to the load times on my mac:
    
      $ cargo run --profile maxperf --bin benchmark -- -n 100 create
        Finished `maxperf` profile [optimized] target(s) in 0.33s
         Running `target/maxperf/benchmark -n 100 create`
      [2025-02-12T20:27:46Z INFO  benchmark::create] Generated and inserted 100 batches of size 10000 in 9s 981ms
    
      $ cargo run --profile maxperf --bin benchmark -- -n 100 -C branch-reads create
        Finished `maxperf` profile [optimized] target(s) in 0.14s
         Running `target/maxperf/benchmark -n 100 -C branch-reads create`
      [2025-02-12T20:29:58Z INFO  benchmark::create] Generated and inserted 100 batches of size 10000 in 10s 179ms
    
      $ cargo run --profile maxperf --bin benchmark -- -n 100 -C all create
        Finished `maxperf` profile [optimized] target(s) in 0.33s
         Running `target/maxperf/benchmark -n 100 -C all create`
      [2025-02-12T20:27:29Z INFO  benchmark::create] Generated and inserted 100 batches of size 10000 in 12s 596ms