### PR TITLE
Add periodic metric reporting to the ffi

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -12,6 +12,7 @@ firewood = { path = "../firewood" }
 metrics = "0.24.1"
 metrics-util = "0.19.0"
 chrono = "0.4.39"
+oxhttp = "0.3.0"
 
 [build-dependencies]
 cbindgen = "0.28.0"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -9,6 +9,9 @@ crate-type = ["staticlib"]
 [dependencies]
 libc = "0.2.2"
 firewood = { path = "../firewood" }
+metrics = "0.24.1"
+metrics-util = "0.19.0"
+chrono = "0.4.39"
 
 [build-dependencies]
 cbindgen = "0.28.0"

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -17,12 +17,12 @@ type Firewood struct {
 
 // openConfig is used to configure the database at open time
 type openConfig struct {
-	path                  string
-	nodeCacheEntries      uintptr
-	revisions             uintptr
-	readCacheStrategy     uint8
-	create                bool
-	metrics_interval_secs uint32
+	path              string
+	nodeCacheEntries  uintptr
+	revisions         uintptr
+	readCacheStrategy uint8
+	create            bool
+	metricsPort       uint16
 }
 
 // OpenOption is a function that configures the database at open time
@@ -57,9 +57,9 @@ func WithRevisions(revisions uintptr) OpenOption {
 
 // WithMetricIntervalSeconds sets the interval in seconds for metrics
 // set to 0 for no metrics
-func WithMetricIntervalSeconds(interval_seconds uint32) OpenOption {
+func WithMetricsPort(metrics_port uint16) OpenOption {
 	return func(o *openConfig) {
-		o.metrics_interval_secs = interval_seconds
+		o.metricsPort = metrics_port
 	}
 }
 
@@ -89,11 +89,11 @@ func WithCreate(create bool) OpenOption {
 // Returns a handle that can be used for subsequent database operations.
 func NewDatabase(options ...OpenOption) Firewood {
 	opts := &openConfig{
-		nodeCacheEntries:      1_000_000,
-		revisions:             100,
-		readCacheStrategy:     0,
-		path:                  "firewood.db",
-		metrics_interval_secs: 60,
+		nodeCacheEntries:  1_000_000,
+		revisions:         100,
+		readCacheStrategy: 0,
+		path:              "firewood.db",
+		metricsPort:       3000,
 	}
 
 	for _, opt := range options {
@@ -101,9 +101,9 @@ func NewDatabase(options ...OpenOption) Firewood {
 	}
 	var db unsafe.Pointer
 	if opts.create {
-		db = C.fwd_create_db(C.CString(opts.path), C.size_t(opts.nodeCacheEntries), C.size_t(opts.revisions), C.uint8_t(opts.readCacheStrategy), C.uint32_t(opts.metrics_interval_secs))
+		db = C.fwd_create_db(C.CString(opts.path), C.size_t(opts.nodeCacheEntries), C.size_t(opts.revisions), C.uint8_t(opts.readCacheStrategy), C.uint16_t(opts.metricsPort))
 	} else {
-		db = C.fwd_open_db(C.CString(opts.path), C.size_t(opts.nodeCacheEntries), C.size_t(opts.revisions), C.uint8_t(opts.readCacheStrategy), C.uint32_t(opts.metrics_interval_secs))
+		db = C.fwd_open_db(C.CString(opts.path), C.size_t(opts.nodeCacheEntries), C.size_t(opts.revisions), C.uint8_t(opts.readCacheStrategy), C.uint16_t(opts.metricsPort))
 	}
 
 	ptr := (*C.void)(db)

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -1,6 +1,6 @@
 package firewood
 
-// #cgo LDFLAGS: -L../target/release -L/usr/local/lib -lfirewood_ffi
+// #cgo LDFLAGS: -L../target/release -L/usr/local/lib -lfirewood_ffi -lm
 // #include "firewood.h"
 // #include <stdlib.h>
 import "C"

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -68,7 +68,7 @@ func WithMetricIntervalSeconds(interval_seconds uint32) OpenOption {
 // 1: Branch reads are cached
 // 2: All reads are cached
 func WithReadCacheStrategy(strategy uint8) OpenOption {
-	if (strategy < 0) || (strategy > 2) {
+	if strategy > 2 {
 		panic("Invalid read cache strategy " + strconv.Itoa(int(strategy)))
 	}
 	return func(o *openConfig) {

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -78,7 +78,8 @@ void fwd_close_db(void *db);
 void *fwd_create_db(const char *path,
                     size_t cache_size,
                     size_t revisions,
-                    uint8_t strategy);
+                    uint8_t strategy,
+                    uint32_t metrics_interval);
 
 /**
  * Frees the memory associated with a `Value`.
@@ -130,7 +131,8 @@ struct Value fwd_get(void *db, struct Value key);
 void *fwd_open_db(const char *path,
                   size_t cache_size,
                   size_t revisions,
-                  uint8_t strategy);
+                  uint8_t strategy,
+                  uint32_t metrics_interval);
 
 /**
  * Get the root hash of the latest version of the database

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -79,7 +79,7 @@ void *fwd_create_db(const char *path,
                     size_t cache_size,
                     size_t revisions,
                     uint8_t strategy,
-                    uint32_t metrics_interval);
+                    uint16_t metrics_port);
 
 /**
  * Frees the memory associated with a `Value`.
@@ -132,7 +132,7 @@ void *fwd_open_db(const char *path,
                   size_t cache_size,
                   size_t revisions,
                   uint8_t strategy,
-                  uint32_t metrics_interval);
+                  uint16_t metrics_port);
 
 /**
  * Get the root hash of the latest version of the database

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestInsert(t *testing.T) {
-	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"), WithMetricIntervalSeconds(0))
+	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"))
 	defer os.Remove("test.db")
 	defer f.Close()
 	f.Batch([]KeyValue{
@@ -21,7 +21,7 @@ func TestInsert(t *testing.T) {
 }
 
 func TestInsert100(t *testing.T) {
-	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"), WithMetricIntervalSeconds(0))
+	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"))
 	defer os.Remove("test.db")
 	defer f.Close()
 	ops := make([]KeyValue, 100)
@@ -57,7 +57,7 @@ func TestInsert100(t *testing.T) {
 
 func TestRangeDelete(t *testing.T) {
 	const N = 100
-	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"), WithMetricIntervalSeconds(0))
+	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"))
 	defer os.Remove("test.db")
 	defer f.Close()
 	ops := make([]KeyValue, N)
@@ -84,7 +84,7 @@ func TestRangeDelete(t *testing.T) {
 }
 
 func TestInvariants(t *testing.T) {
-	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"), WithMetricIntervalSeconds(0))
+	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"))
 	defer os.Remove("test.db")
 	defer f.Close()
 

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestInsert(t *testing.T) {
-	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"))
+	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"), WithMetricIntervalSeconds(0))
 	defer os.Remove("test.db")
 	defer f.Close()
 	f.Batch([]KeyValue{
@@ -21,7 +21,7 @@ func TestInsert(t *testing.T) {
 }
 
 func TestInsert100(t *testing.T) {
-	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"))
+	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"), WithMetricIntervalSeconds(0))
 	defer os.Remove("test.db")
 	defer f.Close()
 	ops := make([]KeyValue, 100)
@@ -57,7 +57,7 @@ func TestInsert100(t *testing.T) {
 
 func TestRangeDelete(t *testing.T) {
 	const N = 100
-	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"))
+	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"), WithMetricIntervalSeconds(0))
 	defer os.Remove("test.db")
 	defer f.Close()
 	ops := make([]KeyValue, N)
@@ -84,7 +84,7 @@ func TestRangeDelete(t *testing.T) {
 }
 
 func TestInvariants(t *testing.T) {
-	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"))
+	var f Firewood = NewDatabase(WithCreate(true), WithPath("test.db"), WithMetricIntervalSeconds(0))
 	defer os.Remove("test.db")
 	defer f.Close()
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -188,13 +188,13 @@ pub unsafe extern "C" fn fwd_create_db(
     cache_size: usize,
     revisions: usize,
     strategy: u8,
-    metrics_interval: u32,
+    metrics_port: u16,
 ) -> *mut Db {
     let cfg = DbConfig::builder()
         .truncate(true)
         .manager(manager_config(cache_size, revisions, strategy))
         .build();
-    common_create(path, metrics_interval, cfg)
+    common_create(path, metrics_port, cfg)
 }
 
 /// Open a database with the given cache size and maximum number of revisions
@@ -222,20 +222,20 @@ pub unsafe extern "C" fn fwd_open_db(
     cache_size: usize,
     revisions: usize,
     strategy: u8,
-    metrics_interval: u32,
+    metrics_port: u16,
 ) -> *mut Db {
     let cfg = DbConfig::builder()
         .truncate(false)
         .manager(manager_config(cache_size, revisions, strategy))
         .build();
-    common_create(path, metrics_interval, cfg)
+    common_create(path, metrics_port, cfg)
 }
 
-unsafe fn common_create(path: *const std::ffi::c_char, metric_interval: u32, cfg: DbConfig) -> *mut Db {
+unsafe fn common_create(path: *const std::ffi::c_char, metrics_port: u16, cfg: DbConfig) -> *mut Db {
     let path = unsafe { CStr::from_ptr(path) };
     let path: &Path = OsStr::from_bytes(path.to_bytes()).as_ref();
-    if metric_interval > 0 {
-        metrics::setup_metrics(Path::new("metrics.txt"), metric_interval);
+    if metrics_port > 0 {
+        metrics::setup_metrics(metrics_port);
     }
     Box::into_raw(Box::new(
         Db::new_sync(path, cfg).expect("db initialization should succeed"),

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -231,7 +231,11 @@ pub unsafe extern "C" fn fwd_open_db(
     common_create(path, metrics_port, cfg)
 }
 
-unsafe fn common_create(path: *const std::ffi::c_char, metrics_port: u16, cfg: DbConfig) -> *mut Db {
+unsafe fn common_create(
+    path: *const std::ffi::c_char,
+    metrics_port: u16,
+    cfg: DbConfig,
+) -> *mut Db {
     let path = unsafe { CStr::from_ptr(path) };
     let path: &Path = OsStr::from_bytes(path.to_bytes()).as_ref();
     if metrics_port > 0 {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -9,6 +9,8 @@ use std::path::Path;
 use firewood::db::{BatchOp as DbBatchOp, Db, DbConfig, DbViewSync as _};
 use firewood::manager::{CacheReadStrategy, RevisionManagerConfig};
 
+mod metrics;
+
 #[derive(Debug)]
 #[repr(C)]
 pub struct Value {
@@ -186,12 +188,13 @@ pub unsafe extern "C" fn fwd_create_db(
     cache_size: usize,
     revisions: usize,
     strategy: u8,
+    metrics_interval: u32,
 ) -> *mut Db {
     let cfg = DbConfig::builder()
         .truncate(true)
         .manager(manager_config(cache_size, revisions, strategy))
         .build();
-    common_create(path, cfg)
+    common_create(path, metrics_interval, cfg)
 }
 
 /// Open a database with the given cache size and maximum number of revisions
@@ -219,17 +222,21 @@ pub unsafe extern "C" fn fwd_open_db(
     cache_size: usize,
     revisions: usize,
     strategy: u8,
+    metrics_interval: u32,
 ) -> *mut Db {
     let cfg = DbConfig::builder()
         .truncate(false)
         .manager(manager_config(cache_size, revisions, strategy))
         .build();
-    common_create(path, cfg)
+    common_create(path, metrics_interval, cfg)
 }
 
-unsafe fn common_create(path: *const std::ffi::c_char, cfg: DbConfig) -> *mut Db {
+unsafe fn common_create(path: *const std::ffi::c_char, metric_interval: u32, cfg: DbConfig) -> *mut Db {
     let path = unsafe { CStr::from_ptr(path) };
     let path: &Path = OsStr::from_bytes(path.to_bytes()).as_ref();
+    if metric_interval > 0 {
+        metrics::setup_metrics(Path::new("metrics.txt"), metric_interval);
+    }
     Box::into_raw(Box::new(
         Db::new_sync(path, cfg).expect("db initialization should succeed"),
     ))

--- a/ffi/src/metrics.rs
+++ b/ffi/src/metrics.rs
@@ -45,7 +45,7 @@ pub(crate) fn setup_metrics(metrics_port: u16) {
         })
         .bind((Ipv4Addr::LOCALHOST, metrics_port))
         .bind((Ipv6Addr::LOCALHOST, metrics_port))
-        .with_global_timeout(Duration::from_secs(60*60))
+        .with_global_timeout(Duration::from_secs(60 * 60))
         .with_max_concurrent_connections(2)
         .spawn()
         .expect("failed to spawn server");
@@ -78,7 +78,12 @@ impl TextRecorder {
         for (key, counter) in counters {
             let sanitized_key_name = key.name().to_string().replace('.', "_");
             if !seen.contains(&sanitized_key_name) {
-                writeln!(output, "# TYPE {} counter", key.name().to_string().replace('.', "_")).expect("write error");
+                writeln!(
+                    output,
+                    "# TYPE {} counter",
+                    key.name().to_string().replace('.', "_")
+                )
+                .expect("write error");
                 seen.insert(sanitized_key_name.clone());
             }
             write!(output, "{sanitized_key_name}").expect("write error");

--- a/ffi/src/metrics.rs
+++ b/ffi/src/metrics.rs
@@ -1,0 +1,114 @@
+use std::{
+    fs::File,
+    io::Write,
+    ops::Deref,
+    path::Path,
+    sync::{atomic::Ordering, Arc, Mutex, Once},
+    thread::sleep,
+};
+
+use chrono::Utc;
+
+use metrics::Key;
+use metrics_util::registry::{AtomicStorage, Registry};
+
+static INIT: Once = Once::new();
+
+pub(crate) fn setup_metrics(file: &Path, metric_interval_secs: u32) {
+    INIT.call_once(|| {
+        let file = File::create(file).expect("failed to create metrics file");
+        let inner = TextRecorderInner {
+            registry: Registry::atomic(),
+            file: file.into(),
+        };
+        let recorder = TextRecorder {
+            inner: Arc::new(inner),
+        };
+        metrics::set_global_recorder(recorder.clone()).expect("failed to set recorder");
+        std::thread::spawn(move || loop {
+            sleep(std::time::Duration::from_secs(metric_interval_secs as u64));
+            let mut guard = recorder.inner.file.lock().expect("poisoned");
+            writeln!(guard, "{}", Utc::now()).unwrap();
+            let counters = recorder.registry.get_counter_handles();
+            for (key, counter) in counters {
+                writeln!(guard, "{} = {}", key, counter.load(Ordering::Relaxed)).unwrap();
+            }
+            writeln!(guard).unwrap();
+        });
+    });
+}
+
+#[derive(Debug)]
+struct TextRecorderInner {
+    registry: Registry<Key, AtomicStorage>,
+    file: Mutex<File>,
+}
+
+#[derive(Debug, Clone)]
+struct TextRecorder {
+    inner: Arc<TextRecorderInner>,
+}
+
+impl Deref for TextRecorder {
+    type Target = Arc<TextRecorderInner>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl metrics::Recorder for TextRecorder {
+    fn describe_counter(
+        &self,
+        _key: metrics::KeyName,
+        _unit: Option<metrics::Unit>,
+        _description: metrics::SharedString,
+    ) {
+    }
+
+    fn describe_gauge(
+        &self,
+        _key: metrics::KeyName,
+        _unit: Option<metrics::Unit>,
+        _description: metrics::SharedString,
+    ) {
+    }
+
+    fn describe_histogram(
+        &self,
+        _key: metrics::KeyName,
+        _unit: Option<metrics::Unit>,
+        _description: metrics::SharedString,
+    ) {
+    }
+
+    fn register_counter(
+        &self,
+        key: &metrics::Key,
+        _metadata: &metrics::Metadata<'_>,
+    ) -> metrics::Counter {
+        self.inner
+            .registry
+            .get_or_create_counter(key, |c| c.clone().into())
+    }
+
+    fn register_gauge(
+        &self,
+        key: &metrics::Key,
+        _metadata: &metrics::Metadata<'_>,
+    ) -> metrics::Gauge {
+        self.inner
+            .registry
+            .get_or_create_gauge(key, |c| c.clone().into())
+    }
+
+    fn register_histogram(
+        &self,
+        key: &metrics::Key,
+        _metadata: &metrics::Metadata<'_>,
+    ) -> metrics::Histogram {
+        self.inner
+            .registry
+            .get_or_create_histogram(key, |c| c.clone().into())
+    }
+}


### PR DESCRIPTION
Collect metrics and provide a prometheus-compatible web service when you open the database.

By default, this creates a server that listens on port 3000, which is what we're expecting for prometheus, so it just works.