### PR TITLE
Include a mode for cache metrics.

### DIFF
--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -63,10 +63,10 @@ impl ReadableStorage for FileBacked {
         Ok(self.fd.metadata()?.len())
     }
 
-    fn read_cached_node(&self, addr: LinearAddress) -> Option<Arc<Node>> {
+    fn read_cached_node(&self, addr: LinearAddress, source: &'static str) -> Option<Arc<Node>> {
         let mut guard = self.cache.lock().expect("poisoned lock");
         let cached = guard.get(&addr).cloned();
-        counter!("firewood.cache.node", "type" => if cached.is_some() { "hit" } else { "miss" })
+        counter!("firewood.cache.node", "mode" => source, "type" => if cached.is_some() { "hit" } else { "miss" })
             .increment(1);
         cached
     }

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -113,10 +113,10 @@ impl ReadableStorage for FileBacked {
         Ok(self.fd.metadata()?.len())
     }
 
-    fn read_cached_node(&self, addr: LinearAddress, source: &'static str) -> Option<SharedNode> {
+    fn read_cached_node(&self, addr: LinearAddress, mode: &'static str) -> Option<SharedNode> {
         let mut guard = self.cache.lock().expect("poisoned lock");
         let cached = guard.get(&addr).cloned();
-        counter!("firewood.cache.node", "mode" => source, "type" => if cached.is_some() { "hit" } else { "miss" })
+        counter!("firewood.cache.node", "mode" => mode, "type" => if cached.is_some() { "hit" } else { "miss" })
             .increment(1);
         cached
     }

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -43,7 +43,7 @@ pub trait ReadableStorage: Debug + Sync + Send {
     fn size(&self) -> Result<u64, Error>;
 
     /// Read a node from the cache (if any)
-    fn read_cached_node(&self, _addr: LinearAddress) -> Option<Arc<Node>> {
+    fn read_cached_node(&self, _addr: LinearAddress, _mode: &'static str) -> Option<Arc<Node>> {
         None
     }
 

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1119,6 +1119,9 @@ impl<S: ReadableStorage> NodeReader for NodeStore<MutableProposal, S> {
 
 impl<T: Parentable + ReadInMemoryNode, S: ReadableStorage> NodeReader for NodeStore<T, S> {
     fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, Error> {
+        if let Some(node) = self.kind.read_in_memory_node(addr) {
+            return Ok(node);
+        }
         self.read_node_from_disk(addr, "read")
     }
 }

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -210,8 +210,12 @@ impl<T: ReadInMemoryNode, S: ReadableStorage> NodeStore<T, S> {
 
     /// Read a [Node] from the provided [LinearAddress].
     /// `addr` is the address of a StoredArea in the ReadableStorage.
-    pub fn read_node_from_disk(&self, addr: LinearAddress) -> Result<Arc<Node>, Error> {
-        if let Some(node) = self.storage.read_cached_node(addr) {
+    pub fn read_node_from_disk(
+        &self,
+        addr: LinearAddress,
+        mode: &'static str,
+    ) -> Result<Arc<Node>, Error> {
+        if let Some(node) = self.storage.read_cached_node(addr, mode) {
             return Ok(node);
         }
 
@@ -272,7 +276,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
         };
 
         if let Some(root_address) = nodestore.header.root_address {
-            let node = nodestore.read_node_from_disk(root_address);
+            let node = nodestore.read_node_from_disk(root_address, "open");
             let root_hash = node.map(|n| hash_node(&n, &Path(Default::default())))?;
             nodestore.kind.root_hash = Some(root_hash);
         }
@@ -1025,13 +1029,19 @@ impl<S: ReadableStorage> From<NodeStore<MutableProposal, S>>
     }
 }
 
-impl<T: ReadInMemoryNode, S: ReadableStorage> NodeReader for NodeStore<T, S> {
+impl<S: ReadableStorage> NodeReader for NodeStore<MutableProposal, S> {
     fn read_node(&self, addr: LinearAddress) -> Result<Arc<Node>, Error> {
         if let Some(node) = self.kind.read_in_memory_node(addr) {
             return Ok(node);
         }
 
-        self.read_node_from_disk(addr)
+        self.read_node_from_disk(addr, "write")
+    }
+}
+
+impl<T: Parentable + ReadInMemoryNode, S: ReadableStorage> NodeReader for NodeStore<T, S> {
+    fn read_node(&self, addr: LinearAddress) -> Result<Arc<Node>, Error> {
+        self.read_node_from_disk(addr, "read")
     }
 }
 
@@ -1041,11 +1051,7 @@ impl<S: ReadableStorage> RootReader for NodeStore<MutableProposal, S> {
     }
 }
 
-trait Hashed {}
-impl Hashed for Committed {}
-impl Hashed for Arc<ImmutableProposal> {}
-
-impl<T: ReadInMemoryNode + Hashed, S: ReadableStorage> RootReader for NodeStore<T, S> {
+impl<T: ReadInMemoryNode + Parentable, S: ReadableStorage> RootReader for NodeStore<T, S> {
     fn root_node(&self) -> Option<Arc<Node>> {
         // TODO: If the read_node fails, we just say there is no root; this is incorrect
         self.header


### PR DESCRIPTION
There are three modes, 'read' which is for immutable nodestores, 'write' which is for mutable ones, and 'open' which happens during opening of a database and is going to be a miss.

From an end-user POV, these cache stats will correlate to read operations on committed revisions and reads that happen during proposals.