### PR TITLE
Remove an allocation

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -784,11 +784,9 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
 
                         // The child's partial path is the concatenation of its (now removed) parent,
                         // its (former) child index, and its partial path.
-                        let branch_partial_path =
-                            std::mem::replace(&mut branch.partial_path, Path::new());
-
                         let child_partial_path = Path::from_nibbles_iterator(
-                            branch_partial_path
+                            branch
+                                .partial_path
                                 .iter()
                                 .chain(once(&(child_index as u8)))
                                 .chain(child.partial_path().iter())
@@ -934,11 +932,9 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
 
                         // The child's partial path is the concatenation of its (now removed) parent,
                         // its (former) child index, and its partial path.
-                        let branch_partial_path =
-                            std::mem::replace(&mut branch.partial_path, Path::new());
-
                         let child_partial_path = Path::from_nibbles_iterator(
-                            branch_partial_path
+                            branch
+                                .partial_path
                                 .iter()
                                 .chain(once(&(child_index as u8)))
                                 .chain(child.partial_path().iter())


### PR DESCRIPTION
No reason to replace the partial path with an empty one before we compute and overwrite it. This saves a call to `Smallvec::new`, which only allocates on the stack, but it's still some extra work and stack space that we don't need.