### PR TITLE
Rust 1.86 lint cleanups

### DIFF
--- a/benchmark/src/tenkrandom.rs
+++ b/benchmark/src/tenkrandom.rs
@@ -61,7 +61,7 @@ fn generate_deletes(start: u64, count: u64) -> impl Iterator<Item = BatchOp<Box<
         .map(|key| {
             let digest = Sha256::digest(key.to_ne_bytes())[..].into();
             debug!("deleting {:?} with digest {}", key, hex::encode(&digest));
-            #[expect(clippy::let_and_return)]
+            #[allow(clippy::let_and_return)]
             digest
         })
         .map(|key| BatchOp::Delete { key })

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -22,7 +22,7 @@ typedef struct KeyValue {
  * Common arguments, accepted by both `fwd_create_db()` and `fwd_open_db()`.
  *
  * * `path` - The path to the database file, which will be truncated if passed to `fwd_create_db()`
- *    otherwise should exist if passed to `fwd_open_db()`.
+ *   otherwise should exist if passed to `fwd_open_db()`.
  * * `cache_size` - The size of the node cache, panics if <= 0
  * * `revisions` - The maximum number of revisions to keep; firewood currently requires this to be at least 2
  */

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -179,7 +179,7 @@ pub unsafe extern "C" fn fwd_free_value(value: *const Value) {
 /// Common arguments, accepted by both `fwd_create_db()` and `fwd_open_db()`.
 ///
 /// * `path` - The path to the database file, which will be truncated if passed to `fwd_create_db()`
-///    otherwise should exist if passed to `fwd_open_db()`.
+///   otherwise should exist if passed to `fwd_open_db()`.
 /// * `cache_size` - The size of the node cache, panics if <= 0
 /// * `revisions` - The maximum number of revisions to keep; firewood currently requires this to be at least 2
 #[repr(C)]

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -7,7 +7,7 @@ use enum_as_inner::EnumAsInner;
 use integer_encoding::{VarIntReader as _, VarIntWriter as _};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
-use std::io::{Error, ErrorKind, Read, Write};
+use std::io::{Error, Read, Write};
 use std::num::NonZero;
 use std::vec;
 
@@ -330,7 +330,7 @@ impl Node {
         match first_byte[0] {
             255 => {
                 // this is a freed area
-                Err(Error::new(ErrorKind::Other, "attempt to read freed area"))
+                Err(Error::other("attempt to read freed area"))
             }
             leaf_first_byte if leaf_first_byte & 1 == 1 => {
                 let partial_path_len = if leaf_first_byte < 255 {

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1016,7 +1016,7 @@ impl<T, S: WritableStorage> NodeStore<T, S> {
         let header_bytes = bytemuck::bytes_of(&self.header)
             .iter()
             .copied()
-            .chain(std::iter::repeat(0u8).take(NodeStoreHeader::EXTRA_BYTES))
+            .chain(std::iter::repeat_n(0u8, NodeStoreHeader::EXTRA_BYTES))
             .collect::<Box<[u8]>>();
         debug_assert_eq!(header_bytes.len(), NodeStoreHeader::SIZE as usize);
 


### PR DESCRIPTION
Also included future fixes from `cargo +nightly clippy`