### PR TITLE
Downgrade upload-artifact

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           cp -rv target/doc/* ./_site
           cp -rv docs/assets ./_site
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: pages
           path: _site


### PR DESCRIPTION
upload-artifact@v4+ is not currently supported on GHES yet. More info:

https://github.com/actions/upload-artifact?tab=readme-ov-file