### PR TITLE
fix(src): drop unused revisions

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -623,15 +623,15 @@ mod test {
         let historical = db.revision(committed).await.unwrap();
         assert_eq!(&*historical.val(b"k1").await.unwrap().unwrap(), b"v1");
 
-        // the first nodestore shouldn't be available to commit anymore
+        // the second proposal shouldn't be available to commit anymore
         assert!(!db.all_hashes().await.unwrap().contains(&p2hash));
 
         // the third proposal should still be contained within the all_hashes list
-        // would be deleted if another proposal was committed and proposal3 was dropped here
         let hash3 = proposal3.root_hash().await.unwrap().unwrap();
         assert!(db.manager.read().unwrap().all_hashes().contains(&hash3));
 
         // moreover, the data from the second and third proposals should still be available
+        // through proposal3
         assert_eq!(&*proposal3.val(b"k2").await.unwrap().unwrap(), b"v2");
         assert_eq!(&*proposal3.val(b"k3").await.unwrap().unwrap(), b"v3");
     }

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -447,8 +447,6 @@ mod test {
     use std::ops::{Deref, DerefMut};
     use std::path::PathBuf;
 
-    use storage::HashedNodeReader;
-
     use crate::db::Db;
     use crate::v2::api::{Db as _, DbView as _, Error, Proposal as _};
 
@@ -572,11 +570,7 @@ mod test {
 
         // the third proposal should still be contained within the all_hashes list
         // would be deleted if another proposal was committed and proposal3 was dropped here
-        let hash3 = proposal3
-            .nodestore
-            .root_hash()
-            .unwrap()
-            .expect("should have a root hash");
+        let hash3 = proposal3.root_hash().await.unwrap().unwrap();
         assert!(db.manager.read().unwrap().all_hashes().contains(&hash3));
     }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -446,7 +446,6 @@ impl Proposal<'_> {
 mod test {
     use std::ops::{Deref, DerefMut};
     use std::path::PathBuf;
-    use std::sync::Arc;
 
     use storage::HashedNodeReader;
 
@@ -527,7 +526,11 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_proposal_scope() {
+    // test that dropping a proposal removes it from the list of known proposals
+    //    /-> P1 - will get committed
+    // R1 --> P2 - will get dropped
+    //    \-> P3 - will get orphaned, but it's still known
+    async fn test_proposal_scope_historic() {
         let db = testdb().await;
         let batch1 = vec![BatchOp::Put {
             key: b"k1",
@@ -551,11 +554,11 @@ mod test {
         assert_eq!(&*proposal3.val(b"k3").await.unwrap().unwrap(), b"v3");
 
         // the proposal is dropped here, but the underlying
-        // nodestore is still alive because it's referenced by the revision manager
+        // nodestore is still accessible because it's referenced by the revision manager
         // The third proposal remains referenced
-        let weak2 = Arc::downgrade(&proposal2.nodestore);
+        let p2hash = proposal2.root_hash().await.unwrap().unwrap();
+        assert!(db.all_hashes().await.unwrap().contains(&p2hash));
         drop(proposal2);
-        assert!(weak2.upgrade().is_some());
 
         // commit the first proposal
         proposal1.commit().await.unwrap();
@@ -564,8 +567,8 @@ mod test {
         let historical = db.revision(committed).await.unwrap();
         assert_eq!(&*historical.val(b"k1").await.unwrap().unwrap(), b"v1");
 
-        // the first nodestore shouldn't be alive anymore
-        assert!(weak2.upgrade().is_none());
+        // the second proposal shouldn't be available to commit anymore
+        assert!(!db.all_hashes().await.unwrap().contains(&p2hash));
 
         // the third proposal should still be contained within the all_hashes list
         // would be deleted if another proposal was committed and proposal3 was dropped here
@@ -575,6 +578,62 @@ mod test {
             .unwrap()
             .expect("should have a root hash");
         assert!(db.manager.read().unwrap().all_hashes().contains(&hash3));
+    }
+
+    #[tokio::test]
+    // test that dropping a proposal removes it from the list of known proposals
+    // R1 - base revision
+    //  \-> P1 - will get committed
+    //   \-> P2 - will get dropped
+    //    \-> P3 - will get orphaned, but it's still known
+    async fn test_proposal_scope_orphan() {
+        let db = testdb().await;
+        let batch1 = vec![BatchOp::Put {
+            key: b"k1",
+            value: b"v1",
+        }];
+        let proposal1 = db.propose(batch1).await.unwrap();
+        assert_eq!(&*proposal1.val(b"k1").await.unwrap().unwrap(), b"v1");
+
+        let batch2 = vec![BatchOp::Put {
+            key: b"k2",
+            value: b"v2",
+        }];
+        let proposal2 = proposal1.clone().propose(batch2).await.unwrap();
+        assert_eq!(&*proposal2.val(b"k2").await.unwrap().unwrap(), b"v2");
+
+        let batch3 = vec![BatchOp::Put {
+            key: b"k3",
+            value: b"v3",
+        }];
+        let proposal3 = proposal2.clone().propose(batch3).await.unwrap();
+        assert_eq!(&*proposal3.val(b"k3").await.unwrap().unwrap(), b"v3");
+
+        // the proposal is dropped here, but the underlying
+        // nodestore is still accessible because it's referenced by the revision manager
+        // The third proposal remains referenced
+        let p2hash = proposal2.root_hash().await.unwrap().unwrap();
+        assert!(db.all_hashes().await.unwrap().contains(&p2hash));
+        drop(proposal2);
+
+        // commit the first proposal
+        proposal1.commit().await.unwrap();
+        // Ensure we committed the first proposal's data
+        let committed = db.root_hash().await.unwrap().unwrap();
+        let historical = db.revision(committed).await.unwrap();
+        assert_eq!(&*historical.val(b"k1").await.unwrap().unwrap(), b"v1");
+
+        // the first nodestore shouldn't be available to commit anymore
+        assert!(!db.all_hashes().await.unwrap().contains(&p2hash));
+
+        // the third proposal should still be contained within the all_hashes list
+        // would be deleted if another proposal was committed and proposal3 was dropped here
+        let hash3 = proposal3.root_hash().await.unwrap().unwrap();
+        assert!(db.manager.read().unwrap().all_hashes().contains(&hash3));
+
+        // moreover, the data from the second and third proposals should still be available
+        assert_eq!(&*proposal3.val(b"k2").await.unwrap().unwrap(), b"v2");
+        assert_eq!(&*proposal3.val(b"k3").await.unwrap().unwrap(), b"v3");
     }
 
     // Testdb is a helper struct for testing the Db. Once it's dropped, the directory and file disappear

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -191,7 +191,9 @@ impl RevisionManager {
 
         // 8. Proposal Cleanup
         // first remove the committing proposal from the list of outstanding proposals
-        self.proposals.retain(|p| !Arc::ptr_eq(&proposal, p));
+        // Any proposals that are only referenced in this list will be freed
+        self.proposals
+            .retain(|p| !Arc::ptr_eq(&proposal, p) && Arc::strong_count(p) > 1);
 
         // then reparent any proposals that have this proposal as a parent
         for p in self.proposals.iter() {

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -190,8 +190,8 @@ impl RevisionManager {
         proposal.flush_header()?;
 
         // 8. Proposal Cleanup
-        // first remove the committing proposal from the list of outstanding proposals
-        // Any proposals that are only referenced in this list will be freed
+        // Free proposal that is being committed as well as any proposals no longer
+        // referenced by anyone else.
         self.proposals
             .retain(|p| !Arc::ptr_eq(&proposal, p) && Arc::strong_count(p) > 1);
 


### PR DESCRIPTION
As described in #865, even after a consumer drops an `Arc` to a proposal, the `RevisionManager` maintains a clone of all uncommitted proposals, which will cause the memory throughout runtime to grow, even though no users have access to the data anymore. A test is added to check that once a user-side `Arc<Proposal<'_>>` is dropped, and another proposal is committed, it will be removed from the list, and the `NodeStore` is no longer accessible. This is implemented by checking the number of strong references on commit for all proposals.