### PR TITLE
feat(ffi): proposal creation isolated from committing

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -24,7 +24,7 @@ const (
 	keyNotFound      = "key not found"
 )
 
-var dbClosedErr = errors.New("firewood database already closed")
+var errDbClosed = errors.New("firewood database already closed")
 
 // A Database is a handle to a Firewood database.
 // It is not safe to call these methods with a nil handle.
@@ -160,7 +160,7 @@ func extractBytesThenFree(v *C.struct_Value) (buf []byte, err error) {
 // If the key is not found, the return value will be (nil, nil).
 func (db *Database) Get(key []byte) ([]byte, error) {
 	if db.handle == nil {
-		return nil, dbClosedErr
+		return nil, errDbClosed
 	}
 
 	values, cleanup := newValueFactory()
@@ -179,7 +179,7 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 // Empty trie must return common.Hash{}.
 func (db *Database) Root() ([]byte, error) {
 	if db.handle == nil {
-		return nil, dbClosedErr
+		return nil, errDbClosed
 	}
 	hash := C.fwd_root_hash(db.handle)
 	bytes, err := extractBytesThenFree(&hash)
@@ -196,7 +196,7 @@ func (db *Database) Root() ([]byte, error) {
 // Returns an error if already closed.
 func (db *Database) Close() error {
 	if db.handle == nil {
-		return dbClosedErr
+		return errDbClosed
 	}
 	C.fwd_close_db(db.handle)
 	db.handle = nil

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -32,7 +32,7 @@ type Database struct {
 	// handle is returned and accepted by cgo functions. It MUST be treated as
 	// an opaque value without special meaning.
 	// https://en.wikipedia.org/wiki/Blinkenlights
-	handle unsafe.Pointer
+	handle *C.DatabaseHandle
 }
 
 // Config configures the opening of a [Database].
@@ -91,7 +91,7 @@ func New(filePath string, conf *Config) (*Database, error) {
 		metrics_port: C.uint16_t(conf.MetricsPort),
 	}
 
-	var db unsafe.Pointer
+	var db *C.DatabaseHandle
 	if conf.Create {
 		db = C.fwd_create_db(args)
 	} else {

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -159,6 +159,7 @@ func (db *Database) Propose(keys, vals [][]byte) (*Proposal, error) {
 		return nil, err
 	}
 
+	// The C function will never create an id of 0, unless it is an error.
 	return &Proposal{
 		handle: db.handle,
 		id:     id,

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -151,10 +151,10 @@ void fwd_free_value(const struct Value *value);
  *
  * A `Value` containing the root hash of the database.
  * A `Value` containing {0, "error message"} if the get failed.
- * There are two error cases that may be expected to be nil by the caller:
+ * There are two error cases that may be expected to be nil by the caller,
+ * but should be handled externally:
  * * The database has no entries - "IO error: Root hash not found"
  * * The key is not found in the database - "key not found"
- * This should be handled by the caller.
  *
  * # Safety
  *

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -169,9 +169,9 @@ const struct DatabaseHandle *fwd_open_db(struct CreateOrOpenArgs args);
  * The caller must ensure that `db` is a valid pointer returned by `open_db`
  *
  */
-struct Value fwd_propose(const struct DatabaseHandle *db,
-                         size_t nkeys,
-                         const struct KeyValue *values);
+struct Value fwd_propose_on_db(const struct DatabaseHandle *db,
+                               size_t nkeys,
+                               const struct KeyValue *values);
 
 /**
  * Get the root hash of the latest version of the database

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -72,6 +72,22 @@ struct Value fwd_batch(const struct DatabaseHandle *db,
 void fwd_close_db(struct DatabaseHandle *db);
 
 /**
+ * Commits a proposal to the database.
+ *
+ * # Returns
+ *
+ * The root hash of the database after the proposal is committed, or panics if it cannot be committed
+ *
+ * # Safety
+ *
+ * This function is unsafe because it dereferences raw pointers.
+ * The caller must ensure that `db` is a valid pointer returned by `open_db`
+ *
+ */
+struct Value fwd_commit(const struct DatabaseHandle *db,
+                        uint32_t proposal_id);
+
+/**
  * Create a database with the given cache size and maximum number of revisions, as well
  * as a specific cache strategy
  *
@@ -139,6 +155,23 @@ struct Value fwd_get(const struct DatabaseHandle *db, struct Value key);
  *
  */
 const struct DatabaseHandle *fwd_open_db(struct CreateOrOpenArgs args);
+
+/**
+ * Proposes a batch of operations to the database.
+ *
+ * # Returns
+ *
+ * The ID of the proposal, or panics if it cannot be created
+ *
+ * # Safety
+ *
+ * This function is unsafe because it dereferences raw pointers.
+ * The caller must ensure that `db` is a valid pointer returned by `open_db`
+ *
+ */
+struct Value fwd_propose(const struct DatabaseHandle *db,
+                         size_t nkeys,
+                         const struct KeyValue *values);
 
 /**
  * Get the root hash of the latest version of the database

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 
 
+typedef struct DatabaseHandle DatabaseHandle;
+
 typedef struct Value {
   size_t len;
   const uint8_t *data;
@@ -50,7 +52,7 @@ typedef struct CreateOrOpenArgs {
  *  * ensure that the `Value` fields of the `KeyValue` structs are valid pointers.
  *
  */
-struct Value fwd_batch(void *db,
+struct Value fwd_batch(const struct DatabaseHandle *db,
                        size_t nkeys,
                        const struct KeyValue *values);
 
@@ -67,7 +69,7 @@ struct Value fwd_batch(void *db,
  *
  * * `db` - The database handle to close, previously returned from a call to open_db()
  */
-void fwd_close_db(void *db);
+void fwd_close_db(struct DatabaseHandle *db);
 
 /**
  * Create a database with the given cache size and maximum number of revisions, as well
@@ -89,7 +91,7 @@ void fwd_close_db(void *db);
  * The caller must call `close` to free the memory associated with the returned database handle.
  *
  */
-void *fwd_create_db(struct CreateOrOpenArgs args);
+const struct DatabaseHandle *fwd_create_db(struct CreateOrOpenArgs args);
 
 /**
  * Frees the memory associated with a `Value`.
@@ -115,7 +117,7 @@ void fwd_free_value(const struct Value *value);
  *  * ensure that `key` is a valid pointer to a `Value` struct
  *  * call `free_value` to free the memory associated with the returned `Value`
  */
-struct Value fwd_get(void *db, struct Value key);
+struct Value fwd_get(const struct DatabaseHandle *db, struct Value key);
 
 /**
  * Open a database with the given cache size and maximum number of revisions
@@ -136,7 +138,7 @@ struct Value fwd_get(void *db, struct Value key);
  * The caller must call `close` to free the memory associated with the returned database handle.
  *
  */
-void *fwd_open_db(struct CreateOrOpenArgs args);
+const struct DatabaseHandle *fwd_open_db(struct CreateOrOpenArgs args);
 
 /**
  * Get the root hash of the latest version of the database
@@ -147,4 +149,4 @@ void *fwd_open_db(struct CreateOrOpenArgs args);
  * This function is unsafe because it dereferences raw pointers.
  * The caller must ensure that `db` is a valid pointer returned by `open_db`
  */
-struct Value fwd_root_hash(void *db);
+struct Value fwd_root_hash(const struct DatabaseHandle *db);

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -150,7 +150,11 @@ void fwd_free_value(const struct Value *value);
  * # Returns
  *
  * A `Value` containing the root hash of the database.
- * A `Value` containing {0, "error message"} if the commit failed.
+ * A `Value` containing {0, "error message"} if the get failed.
+ * There are two error cases that may be expected to be nil by the caller:
+ * * The database has no entries - "IO error: Root hash not found"
+ * * The key is not found in the database - "key not found"
+ * This should be handled by the caller.
  *
  * # Safety
  *
@@ -193,7 +197,8 @@ const struct DatabaseHandle *fwd_open_db(struct CreateOrOpenArgs args);
  *
  * # Returns
  *
- * The ID of the proposal, or panics if it cannot be created
+ * The new root hash of the database, in Value form.
+ * A `Value` containing {0, "error message"} if creating the proposal failed.
  *
  * # Safety
  *
@@ -219,7 +224,9 @@ struct Value fwd_propose_on_db(const struct DatabaseHandle *db,
  * # Returns
  *
  * A `Value` containing the root hash of the database.
- * A `Value` containing {0, "error message"} if the commit failed.
+ * A `Value` containing {0, "error message"} if the root hash could not be retrieved.
+ * One expected error is "IO error: Root hash not found" if the database is empty.
+ * This should be handled by the caller.
  *
  * # Safety
  *

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -261,7 +261,7 @@ func TestMultipleProposals(t *testing.T) {
 	// After attempting to commit the other proposals, they should be completely invalid.
 	for i := 1; i < numProposals; i++ {
 		err := proposals[i].Commit()
-		require.ErrorIs(t, err, errProposalInvalid, "Commit(%d)", i)
+		require.ErrorIs(t, err, errDroppedProposal, "Commit(%d)", i)
 	}
 }
 

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -86,21 +86,21 @@ func TestGetBadHandle(t *testing.T) {
 
 	// This ignores error, but still shouldn't panic.
 	_, err := db.Get([]byte("non-existent"))
-	assert.ErrorIs(t, err, dbClosedErr)
+	assert.ErrorIs(t, err, errDbClosed)
 
 	// We ignore the error, but it shouldn't panic.
 	_, err = db.Root()
-	assert.ErrorIs(t, err, dbClosedErr)
+	assert.ErrorIs(t, err, errDbClosed)
 
 	root, err := db.Update(
 		[][]byte{[]byte("key")},
 		[][]byte{[]byte("value")},
 	)
 	assert.Empty(t, root)
-	assert.ErrorIs(t, err, dbClosedErr)
+	assert.ErrorIs(t, err, errDbClosed)
 
 	err = db.Close()
-	require.ErrorIs(t, err, dbClosedErr)
+	require.ErrorIs(t, err, errDbClosed)
 }
 
 func keyForTest(i int) []byte {

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -126,7 +126,15 @@ func TestInsert100(t *testing.T) {
 		{
 			name: "Batch",
 			insert: func(db *Database, kvs []KeyValue) ([]byte, error) {
-				return db.Batch(kvs)
+				id, err := db.Propose(kvs)
+				if err != nil {
+					return nil, err
+				}
+				root, err := db.CommitProposal(id)
+				if err != nil {
+					return nil, err
+				}
+				return root, nil
 			},
 		},
 		{

--- a/ffi/kvbackend.go
+++ b/ffi/kvbackend.go
@@ -43,7 +43,7 @@ type kVBackend interface {
 // Prefetch is a no-op since we don't need to prefetch for Firewood.
 func (db *Database) Prefetch(key []byte) ([]byte, error) {
 	if db.handle == nil {
-		return nil, dbClosedErr
+		return nil, errDbClosed
 	}
 
 	return nil, nil
@@ -52,7 +52,7 @@ func (db *Database) Prefetch(key []byte) ([]byte, error) {
 // Commit is a no-op, since [Database.Update] already persists changes.
 func (db *Database) Commit(root []byte) error {
 	if db.handle == nil {
-		return dbClosedErr
+		return errDbClosed
 	}
 
 	return nil
@@ -62,7 +62,7 @@ func (db *Database) Commit(root []byte) error {
 // database.
 func (db *Database) Update(keys, vals [][]byte) ([]byte, error) {
 	if db.handle == nil {
-		return nil, dbClosedErr
+		return nil, errDbClosed
 	}
 
 	ops := make([]KeyValue, len(keys))

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -51,6 +51,7 @@ func extractIdThenFree(v *C.struct_Value) (uint32, error) {
 	}
 	// If the value is an error string, it should be freed and an error
 	// returned.
+	// Any valid ID should be non-zero.
 	if v.len == 0 {
 		go_str := C.GoString((*C.char)(unsafe.Pointer(v.data)))
 		C.fwd_free_value(v)

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -1,0 +1,104 @@
+// Package firewood provides a Go wrapper around the [Firewood] database.
+//
+// [Firewood]: https://github.com/ava-labs/firewood
+package firewood
+
+// // Note that -lm is required on Linux but not on Mac.
+// #cgo LDFLAGS: -L${SRCDIR}/../target/release -L/usr/local/lib -lfirewood_ffi -lm
+// #include <stdlib.h>
+// #include "firewood.h"
+import "C"
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+var errNilBuffer = errors.New("firewood error: nil buffer returned from cgo")
+
+// KeyValue is a key-value pair.
+type KeyValue struct {
+	Key   []byte
+	Value []byte
+}
+
+func extractErrorThenFree(v *C.struct_Value) error {
+	if v == nil {
+		return errNilBuffer
+	}
+
+	// Expected empty case for Rust's `()`
+	if v.data == nil {
+		return nil
+	}
+
+	// If the value is an error string, it should be freed and an error
+	// returned.
+	if v.len == 0 {
+		go_str := C.GoString((*C.char)(unsafe.Pointer(v.data)))
+		C.fwd_free_value(v)
+		// Pin the returned value to prevent it from being garbage collected.
+		runtime.KeepAlive(v)
+		return fmt.Errorf("firewood error: %s", go_str)
+	}
+	return nil
+}
+
+func extractIdThenFree(v *C.struct_Value) (uint32, error) {
+	if v == nil || v.len == 0 && v.data == nil {
+		return 0, errNilBuffer
+	}
+	// If the value is an error string, it should be freed and an error
+	// returned.
+	if v.len == 0 {
+		go_str := C.GoString((*C.char)(unsafe.Pointer(v.data)))
+		C.fwd_free_value(v)
+		// Pin the returned value to prevent it from being garbage collected.
+		runtime.KeepAlive(v)
+		return 0, fmt.Errorf("firewood error: %s", go_str)
+	}
+	return uint32(v.len), nil
+}
+
+// extractBytesThenFree converts the cgo `Value` payload to a byte slice, frees
+// the `Value`, and returns the extracted slice.
+// Generates error if the error term is nonnull.
+func extractBytesThenFree(v *C.struct_Value) (buf []byte, err error) {
+	if v == nil || v.data == nil {
+		return nil, errNilBuffer
+	}
+
+	buf = C.GoBytes(unsafe.Pointer(v.data), C.int(v.len))
+	if v.len == 0 {
+		errStr := C.GoString((*C.char)(unsafe.Pointer(v.data)))
+		err = fmt.Errorf("firewood error: %s", errStr)
+	}
+	C.fwd_free_value(v)
+
+	// Pin the returned value to prevent it from being garbage collected.
+	runtime.KeepAlive(v)
+	return
+}
+
+// newValueFactory returns a factory for converting byte slices into cgo `Value`
+// structs that can be passed as arguments to cgo functions. The returned
+// cleanup function MUST be called when the constructed values are no longer
+// required, after which they can no longer be used as cgo arguments.
+func newValueFactory() (*valueFactory, func()) {
+	f := new(valueFactory)
+	return f, func() { f.pin.Unpin() }
+}
+
+type valueFactory struct {
+	pin runtime.Pinner
+}
+
+func (f *valueFactory) from(data []byte) C.struct_Value {
+	if len(data) == 0 {
+		return C.struct_Value{0, nil}
+	}
+	ptr := (*C.uchar)(unsafe.SliceData(data))
+	f.pin.Pin(ptr)
+	return C.struct_Value{C.size_t(len(data)), ptr}
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -75,10 +75,10 @@ impl Display for Value {
 ///
 /// A `Value` containing the root hash of the database.
 /// A `Value` containing {0, "error message"} if the get failed.
-/// There are two error cases that may be expected to be nil by the caller:
+/// There are two error cases that may be expected to be nil by the caller,
+/// but should be handled externally:
 /// * The database has no entries - "IO error: Root hash not found"
 /// * The key is not found in the database - "key not found"
-/// This should be handled by the caller.
 ///
 /// # Safety
 ///

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -342,7 +342,7 @@ pub struct Proposal<'p> {
 impl Proposal<'_> {
     /// Get the root hash of the proposal synchronously
     pub fn root_hash_sync(&self) -> Result<Option<api::HashKey>, api::Error> {
-        self.nodestore.root_hash().map_err(api::Error::from)
+        Ok(self.nodestore.root_hash()?)
     }
 }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -339,6 +339,14 @@ pub struct Proposal<'p> {
     db: &'p Db,
 }
 
+
+impl Proposal<'_> {
+    /// Get the root hash of the proposal synchronously
+    pub fn root_hash_sync(&self) -> Result<Option<api::HashKey>, api::Error> {
+        self.nodestore.root_hash().map_err(api::Error::from)
+    }
+}
+
 #[async_trait]
 impl api::DbView for Proposal<'_> {
     type Stream<'b>

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -339,7 +339,6 @@ pub struct Proposal<'p> {
     db: &'p Db,
 }
 
-
 impl Proposal<'_> {
     /// Get the root hash of the proposal synchronously
     pub fn root_hash_sync(&self) -> Result<Option<api::HashKey>, api::Error> {


### PR DESCRIPTION
This creates a `Proposal` struct in Go, allowing the batching and committing to occur in separate steps for any consumers. Some additional tests are created to ensure that only 1 proposal can be committed and errors are returned if an invalid proposal is attempted to be committed. 

This does not represent the full implementation for proposals, as there are many next steps:
* Creating proposals from other proposals
* Reading values from proposals
* Dropping proposals when no longer needed

Additionally, there are some code-cleanliness and testing still needed:
* Test memory handling for all `Value`s - or even better, find a better way of managing data across the FFI layer without so much magic.
* Move Value implementation to one central location (like another file?)
* Testing inputs (e.g. `KeyValue` structs) to ensure they are valid from Go
* Refactoring batching logic, in both Go and Rust, to reduce duplicate code