### PR TITLE
Various cleanups

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -178,11 +178,6 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	val := C.fwd_get(db.handle, values.from(key))
 	bytes, err := extractBytesThenFree(&val)
 
-	if err == nil && bytes == nil {
-		// key not found
-		return nil, nil
-	}
-
 	// If the root hash or key is not found, return nil.
 	if err != nil && strings.Contains(err.Error(), rootHashNotFound) {
 		return nil, nil

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -178,10 +178,16 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	val := C.fwd_get(db.handle, values.from(key))
 	bytes, err := extractBytesThenFree(&val)
 
-	// If the root hash or key is not found, return nil.
-	if err != nil && (strings.Contains(err.Error(), rootHashNotFound) || strings.Contains(err.Error(), keyNotFound)) {
+	if err == nil && bytes == nil {
+		// key not found
 		return nil, nil
 	}
+
+	// If the root hash or key is not found, return nil.
+	if err != nil && strings.Contains(err.Error(), rootHashNotFound) {
+		return nil, nil
+	}
+
 	return bytes, err
 }
 

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -6,17 +6,31 @@
 
 
 /**
- * A handle to the database, which contains a reference to the database and a map of proposals.
+ * A handle to the database, returned by `fwd_create_db` and `fwd_open_db`.
+ *
+ * These handles are passed to the other FFI functions.
+ *
  */
 typedef struct DatabaseHandle DatabaseHandle;
 
+/**
+ * A value returned by the FFI.
+ *
+ * This is used in several different ways:
+ *
+ * - When returning data, the length is the length of the data and the data is a pointer to the data.
+ * - When returning an error, the length is 0 and the data is a null-terminated C-style string.
+ * - When returning an ID, the length is the ID and the data is null.
+ *
+ * A `Value` with length 0 and a null data pointer indicates that the data was not found.
+ */
 typedef struct Value {
   size_t len;
   const uint8_t *data;
 } Value;
 
 /**
- * A `KeyValue` struct that represents a key-value pair in the database.
+ * A `KeyValue` represents a key-value pair, passed to the FFI.
  */
 typedef struct KeyValue {
   struct Value key;
@@ -52,6 +66,13 @@ typedef struct CreateOrOpenArgs {
  *
  * The new root hash of the database, in Value form.
  * A `Value` containing {0, "error message"} if the commit failed.
+ *
+ * # Errors
+ *
+ * * `"key-value pair is null"` - A `KeyValue` struct is null
+ * * `"db should be non-null"` - The database handle is null
+ * * `"couldn't get key-value pair"` - A `KeyValue` struct is null
+ * * `"proposed revision is empty"` - The proposed revision is empty
  *
  * # Safety
  *
@@ -154,7 +175,7 @@ void fwd_free_value(const struct Value *value);
  * There are two error cases that may be expected to be nil by the caller,
  * but should be handled externally:
  * * The database has no entries - "IO error: Root hash not found"
- * * The key is not found in the database - "key not found"
+ * * The key is not found in the database returns a `Value` with length 0 and a null data pointer.
  *
  * # Safety
  *

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -83,7 +83,7 @@ func extractIdThenFree(v *C.struct_Value) (uint32, error) {
 // Generates error if the error term is nonnull.
 func extractBytesThenFree(v *C.struct_Value) (buf []byte, err error) {
 	if v == nil {
-		return nil, errNilBuffer
+		return nil, nil
 	}
 	if v.data == nil {
 		return nil, errBadValue

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -82,11 +82,8 @@ func extractIdThenFree(v *C.struct_Value) (uint32, error) {
 // the `Value`, and returns the extracted slice.
 // Generates error if the error term is nonnull.
 func extractBytesThenFree(v *C.struct_Value) (buf []byte, err error) {
-	if v == nil {
+	if v == nil || v.data == nil {
 		return nil, nil
-	}
-	if v.data == nil {
-		return nil, errBadValue
 	}
 
 	buf = C.GoBytes(unsafe.Pointer(v.data), C.int(v.len))

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -26,11 +26,16 @@ fn next_id() -> ProposalId {
     ID_COUNTER.fetch_add(1, Ordering::Relaxed)
 }
 
-/// A handle to the database, which contains a reference to the database and a map of proposals.
-// All proposals must be dropped before the database handle is dropped due to lifetime
-// guarantees defined during database creation.
+/// A handle to the database, returned by `fwd_create_db` and `fwd_open_db`.
+///
+/// These handles are passed to the other FFI functions.
+///
 pub struct DatabaseHandle<'p> {
+    /// List of oustanding proposals, by ID
+    // Keep proposals first, as they must be dropped before the database handle is dropped due to lifetime
+    // issues.
     proposals: RwLock<HashMap<ProposalId, Arc<Proposal<'p>>>>,
+    /// The database
     db: Db,
 }
 
@@ -51,19 +56,6 @@ impl Deref for DatabaseHandle<'_> {
     }
 }
 
-#[derive(Debug)]
-#[repr(C)]
-pub struct Value {
-    pub len: usize,
-    pub data: *const u8,
-}
-
-impl Display for Value {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.as_slice())
-    }
-}
-
 /// Gets the value associated with the given key from the database.
 ///
 /// # Arguments
@@ -78,7 +70,7 @@ impl Display for Value {
 /// There are two error cases that may be expected to be nil by the caller,
 /// but should be handled externally:
 /// * The database has no entries - "IO error: Root hash not found"
-/// * The key is not found in the database - "key not found"
+/// * The key is not found in the database returns a `Value` with length 0 and a null data pointer.
 ///
 /// # Safety
 ///
@@ -113,11 +105,11 @@ fn get(db: *const DatabaseHandle, key: Value) -> Result<Value, String> {
     let value = rev
         .val_sync(key.as_slice())
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| String::from("key not found"))?;
+        .ok_or_else(|| String::from(""))?;
     Ok(value.into())
 }
 
-/// A `KeyValue` struct that represents a key-value pair in the database.
+/// A `KeyValue` represents a key-value pair, passed to the FFI.
 #[repr(C)]
 #[allow(unused)]
 #[unsafe(no_mangle)]
@@ -139,6 +131,13 @@ pub struct KeyValue {
 /// The new root hash of the database, in Value form.
 /// A `Value` containing {0, "error message"} if the commit failed.
 ///
+/// # Errors    
+///
+/// * `"key-value pair is null"` - A `KeyValue` struct is null
+/// * `"db should be non-null"` - The database handle is null
+/// * `"couldn't get key-value pair"` - A `KeyValue` struct is null
+/// * `"proposed revision is empty"` - The proposed revision is empty
+///
 /// # Safety
 ///
 /// This function is unsafe because it dereferences raw pointers.
@@ -156,10 +155,8 @@ pub unsafe extern "C" fn fwd_batch(
     batch(db, nkeys, values).unwrap_or_else(|e| e.into())
 }
 
-/// cbindgen::ignore
-///
-/// This function is not exposed to the C API.
 /// Internal call for `fwd_batch` to remove error handling from the C API
+#[doc(hidden)]
 fn batch(
     db: *const DatabaseHandle,
     nkeys: usize,
@@ -191,11 +188,17 @@ fn batch(
     let propose_time = start.elapsed().as_millis();
     counter!("firewood.ffi.propose_ms").increment(propose_time);
 
+    let hash_val = proposal
+        .root_hash_sync()
+        .map_err(|e| e.to_string())?
+        .ok_or(String::from("Proposed revision is empty"))?
+        .as_slice()
+        .into();
+
     // Commit the proposal.
     proposal.commit_sync().map_err(|e| e.to_string())?;
 
     // Get the root hash of the database post-commit.
-    let hash_val = hash(db)?;
     let propose_plus_commit_time = start.elapsed().as_millis();
     counter!("firewood.ffi.batch_ms").increment(propose_plus_commit_time);
     counter!("firewood.ffi.commit_ms").increment(propose_plus_commit_time - propose_time);
@@ -237,10 +240,9 @@ pub unsafe extern "C" fn fwd_propose_on_db(
         .unwrap_or_else(|e| e.into())
 }
 
-/// cbindgen::ignore
-///
-/// This function is not exposed to the C API.
 /// Internal call for `fwd_propose_on_db` to remove error handling from the C API
+/// cbindgen::ignore
+#[doc(hidden)]
 fn propose_on_db(
     db: *const DatabaseHandle,
     nkeys: usize,
@@ -294,6 +296,9 @@ pub unsafe extern "C" fn fwd_commit(db: *const DatabaseHandle, proposal_id: u32)
         .unwrap_or_else(|e| e.into())
 }
 
+/// Internal call for `fwd_commit` to remove error handling from the C API
+/// cbindgen::ignore
+#[doc(hidden)]
 fn commit(db: *const DatabaseHandle, proposal_id: u32) -> Result<(), String> {
     let db = unsafe { db.as_ref() }.ok_or_else(|| String::from("db should be non-null"))?;
     let proposal = db
@@ -329,10 +334,11 @@ pub unsafe extern "C" fn fwd_root_hash(db: *const DatabaseHandle) -> Value {
     root_hash(db).unwrap_or_else(|e| e.into())
 }
 
-/// cbindgen::ignore
-///
 /// This function is not exposed to the C API.
 /// Internal call for `fwd_root_hash` to remove error handling from the C API
+///
+/// cbindgen::ignore
+#[doc(hidden)]
 fn root_hash(db: *const DatabaseHandle) -> Result<Value, String> {
     // Check db is valid.
     let db = unsafe { db.as_ref() }.ok_or_else(|| String::from("db should be non-null"))?;
@@ -341,15 +347,44 @@ fn root_hash(db: *const DatabaseHandle) -> Result<Value, String> {
     hash(db)
 }
 
-/// cbindgen::ignore
-///
 /// This function is not exposed to the C API.
 /// It returns the current hash of an already-fetched database handle
+/// cbindgen::ignore
+#[doc(hidden)]
 fn hash(db: &Db) -> Result<Value, String> {
     db.root_hash_sync()
         .map_err(|e| e.to_string())?
         .ok_or_else(|| String::from("unexpected None from db.root_hash_sync"))
         .map(|root| Value::from(root.as_slice()))
+}
+
+/// A value returned by the FFI.
+///
+/// This is used in several different ways:
+///
+/// - When returning data, the length is the length of the data and the data is a pointer to the data.
+/// - When returning an error, the length is 0 and the data is a null-terminated C-style string.
+/// - When returning an ID, the length is the ID and the data is null.
+///
+/// A `Value` with length 0 and a null data pointer indicates that the data was not found.
+#[derive(Debug)]
+#[repr(C)]
+pub struct Value {
+    pub len: usize,
+    pub data: *const u8,
+}
+
+impl Display for Value {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match (self.len, self.data.is_null()) {
+            (0, true) => write!(f, "[not found]"),
+            (0, false) => write!(f, "[error] {}", unsafe {
+                CStr::from_ptr(self.data as *const i8).to_string_lossy()
+            }),
+            (len, true) => write!(f, "[id] {}", len),
+            (_, false) => write!(f, "[data] {:?}", self.as_slice()),
+        }
+    }
 }
 
 impl Value {
@@ -518,6 +553,8 @@ pub unsafe extern "C" fn fwd_open_db(args: CreateOrOpenArgs) -> *const DatabaseH
     unsafe { common_create(args.path, args.metrics_port, cfg) }
 }
 
+/// cbindgen::ignore
+#[doc(hidden)]
 unsafe fn common_create(
     path: *const std::ffi::c_char,
     metrics_port: u16,
@@ -568,4 +605,46 @@ fn manager_config(cache_size: usize, revisions: usize, strategy: u8) -> Revision
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fwd_close_db(db: *mut DatabaseHandle) {
     let _ = unsafe { Box::from_raw(db) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_value_display() {
+        let value = Value {
+            len: 0,
+            data: std::ptr::null(),
+        };
+        assert_eq!(format!("{}", value), "[not found]");
+    }
+
+    #[test]
+    fn test_value_display_with_error_string() {
+        let cstr = CString::new("test").unwrap();
+        let value = Value {
+            len: 0,
+            data: cstr.as_ptr().cast::<u8>(),
+        };
+        assert_eq!(format!("{}", value), "[error] test");
+    }
+
+    #[test]
+    fn test_value_display_with_data() {
+        let value = Value {
+            len: 4,
+            data: Box::leak(b"test".to_vec().into_boxed_slice()).as_ptr(),
+        };
+        assert_eq!(format!("{}", value), "[data] [116, 101, 115, 116]");
+    }
+
+    #[test]
+    fn test_value_display_with_id() {
+        let value = Value {
+            len: 4,
+            data: std::ptr::null(),
+        };
+        assert_eq!(format!("{}", value), "[id] 4");
+    }
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -411,6 +411,12 @@ impl From<Box<[u8]>> for Value {
 impl From<String> for Value {
     fn from(s: String) -> Self {
         // Create empty CString if s is null.
+        if s.is_empty() {
+            return Value {
+                len: 0,
+                data: std::ptr::null(),
+            };
+        }
         let cstr = CString::new(s).unwrap_or_default().into_raw();
         Value {
             len: 0,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -83,8 +83,6 @@ pub unsafe extern "C" fn fwd_get(db: *const DatabaseHandle, key: Value) -> Value
     get(db, key).unwrap_or_else(|e| e.into())
 }
 
-/// cbindgen::ignore
-///
 /// This function is not exposed to the C API.
 /// Internal call for `fwd_get` to remove error handling from the C API
 fn get(db: *const DatabaseHandle, key: Value) -> Result<Value, String> {
@@ -241,7 +239,6 @@ pub unsafe extern "C" fn fwd_propose_on_db(
 }
 
 /// Internal call for `fwd_propose_on_db` to remove error handling from the C API
-/// cbindgen::ignore
 #[doc(hidden)]
 fn propose_on_db(
     db: *const DatabaseHandle,
@@ -297,7 +294,6 @@ pub unsafe extern "C" fn fwd_commit(db: *const DatabaseHandle, proposal_id: u32)
 }
 
 /// Internal call for `fwd_commit` to remove error handling from the C API
-/// cbindgen::ignore
 #[doc(hidden)]
 fn commit(db: *const DatabaseHandle, proposal_id: u32) -> Result<(), String> {
     let db = unsafe { db.as_ref() }.ok_or_else(|| String::from("db should be non-null"))?;
@@ -336,8 +332,6 @@ pub unsafe extern "C" fn fwd_root_hash(db: *const DatabaseHandle) -> Value {
 
 /// This function is not exposed to the C API.
 /// Internal call for `fwd_root_hash` to remove error handling from the C API
-///
-/// cbindgen::ignore
 #[doc(hidden)]
 fn root_hash(db: *const DatabaseHandle) -> Result<Value, String> {
     // Check db is valid.
@@ -349,7 +343,6 @@ fn root_hash(db: *const DatabaseHandle) -> Result<Value, String> {
 
 /// This function is not exposed to the C API.
 /// It returns the current hash of an already-fetched database handle
-/// cbindgen::ignore
 #[doc(hidden)]
 fn hash(db: &Db) -> Result<Value, String> {
     db.root_hash_sync()
@@ -410,7 +403,6 @@ impl From<Box<[u8]>> for Value {
 
 impl From<String> for Value {
     fn from(s: String) -> Self {
-        // Create empty CString if s is null.
         if s.is_empty() {
             return Value {
                 len: 0,
@@ -559,7 +551,7 @@ pub unsafe extern "C" fn fwd_open_db(args: CreateOrOpenArgs) -> *const DatabaseH
     unsafe { common_create(args.path, args.metrics_port, cfg) }
 }
 
-/// cbindgen::ignore
+/// Internal call for `fwd_create_db` and `fwd_open_db` to remove error handling from the C API
 #[doc(hidden)]
 unsafe fn common_create(
     path: *const std::ffi::c_char,


### PR DESCRIPTION
Consists of
 - Changed semantics of Value when data=nil and len=0. This was previously unused and now represents a "key not found" error. This could use a litte more work to also address the case of rootHashNotFound.
 - Fixed Display trait for Value, added tests
 - Doc cleanups: cbindgen comment moved, no-doc on internal stuff
 - Documented `Value` a bit more clearly