### PR TITLE
Fix unneeded pull request branch pattern

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,6 @@ name: ci
 
 on:
   pull_request:
-    branches: ['*']
   push:
     branches: [main]
 


### PR DESCRIPTION
This PR removes an unneeded pattern match for what PRs we should run `ci.yaml` on. The default behavior is to run on every PR, so the wildcard pattern is not needed.