### PR TITLE
test(ffi): Add memory checks for `Value`

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -130,7 +130,8 @@ func (db *Database) Batch(ops []KeyValue) ([]byte, error) {
 		C.size_t(len(ffiOps)),
 		(*C.struct_KeyValue)(unsafe.SliceData(ffiOps)), // implicitly pinned
 	)
-	return extractBytesThenFree(&hash)
+	_, bytes, err := extractValueThenFree(&hash)
+	return bytes, err
 }
 
 func (db *Database) Propose(keys, vals [][]byte) (*Proposal, error) {
@@ -153,7 +154,7 @@ func (db *Database) Propose(keys, vals [][]byte) (*Proposal, error) {
 		C.size_t(len(ffiOps)),
 		(*C.struct_KeyValue)(unsafe.SliceData(ffiOps)), // implicitly pinned
 	)
-	id, err := extractIdThenFree(&id_or_err)
+	id, _, err := extractValueThenFree(&id_or_err)
 
 	if err != nil {
 		return nil, err
@@ -176,7 +177,7 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	values, cleanup := newValueFactory()
 	defer cleanup()
 	val := C.fwd_get(db.handle, values.from(key))
-	bytes, err := extractBytesThenFree(&val)
+	_, bytes, err := extractValueThenFree(&val)
 
 	// If the root hash or key is not found, return nil.
 	if err != nil && strings.Contains(err.Error(), rootHashNotFound) {
@@ -193,7 +194,7 @@ func (db *Database) Root() ([]byte, error) {
 		return nil, errDbClosed
 	}
 	hash := C.fwd_root_hash(db.handle)
-	bytes, err := extractBytesThenFree(&hash)
+	_, bytes, err := extractValueThenFree(&hash)
 
 	// If the root hash is not found, return a zeroed slice.
 	if err != nil && strings.Contains(err.Error(), rootHashNotFound) {

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -56,7 +56,20 @@ typedef struct CreateOrOpenArgs {
 /**
  * fwd_alloc_test is a test function that allocates data in a Value struct.
  * This is used to test the allocation and deallocation of memory
- * in Go.
+ * in Go, and should not be used in production code.
+ *
+ * # Arguments
+ *
+ * * `input` - A pointer to a null-terminated C-style string.
+ *
+ * # Returns
+ *
+ * A `Value` containing a copy of the input string.
+ *
+ * # Safety
+ *
+ * This function is unsafe because it dereferences raw pointers.
+ * The caller must ensure that `input` is a valid pointer to a null-terminated C-style string.
  *
  */
 struct Value fwd_alloc_test(const char *input);

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -40,6 +40,14 @@ typedef struct CreateOrOpenArgs {
 } CreateOrOpenArgs;
 
 /**
+ * fwd_alloc_test is a test function that allocates data in a Value struct.
+ * This is used to test the allocation and deallocation of memory
+ * in Go.
+ *
+ */
+struct Value fwd_alloc_test(const char *input);
+
+/**
  * Puts the given key-value pairs into the database.
  *
  * # Arguments

--- a/ffi/memory_test.go
+++ b/ffi/memory_test.go
@@ -1,0 +1,159 @@
+// Package firewood provides a Go wrapper around the [Firewood] database.
+//
+// [Firewood]: https://github.com/ava-labs/firewood
+package firewood
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// This checks all inputs for `extractErrorThenFree`
+func TestExtractError(t *testing.T) {
+	valueTests := []struct {
+		name          string
+		expectedError string
+		value         *testValue
+	}{
+		{
+			name:          "nil",
+			expectedError: errNilValue.Error(),
+			value:         nil,
+		},
+		{
+			name:          "length zero",
+			expectedError: "",
+			value:         newCValueLen(0),
+		},
+		{
+			name:          "length nonzero",
+			expectedError: errBadValue.Error(),
+			value:         newCValueLen(1),
+		},
+		{
+			name:          "data length nonzero",
+			expectedError: errBadValue.Error(),
+			value:         newCValueData(11, "test bytes"), // count null pointer created by C
+		},
+		{
+			name:          "data zero",
+			expectedError: "test bytes",
+			value:         newCValueData(0, "test bytes"),
+		},
+	}
+
+	for _, v := range valueTests {
+		t.Run(v.name, func(t *testing.T) {
+			err := extractErrorThenFree(v.value)
+			if err == nil {
+				assert.Equal(t, v.expectedError, "")
+			} else {
+				assert.Equal(t, v.expectedError, err.Error())
+			}
+		})
+	}
+}
+
+func TestExtractIntError(t *testing.T) {
+	valueTests := []struct {
+		name          string
+		expectedValue uint32
+		expectedError string
+		value         *testValue
+	}{
+		{
+			name:          "nil",
+			expectedValue: 0,
+			expectedError: errNilValue.Error(),
+			value:         nil,
+		},
+		{
+			name:          "length zero",
+			expectedValue: 0,
+			expectedError: errBadValue.Error(),
+			value:         newCValueLen(0),
+		},
+		{
+			name:          "length nonzero",
+			expectedValue: 1,
+			expectedError: "",
+			value:         newCValueLen(1),
+		},
+		{
+			name:          "data length nonzero",
+			expectedValue: 0,
+			expectedError: errBadValue.Error(),
+			value:         newCValueData(11, "test bytes"), // count null pointer created by C
+		},
+		{
+			name:          "data zero",
+			expectedValue: 0,
+			expectedError: "test bytes",
+			value:         newCValueData(0, "test bytes"),
+		},
+	}
+
+	for _, v := range valueTests {
+		t.Run(v.name, func(t *testing.T) {
+			id, err := extractIdThenFree(v.value)
+			assert.Equal(t, v.expectedValue, id)
+			if err == nil {
+				assert.Equal(t, v.expectedError, "")
+			} else {
+				assert.Equal(t, v.expectedError, err.Error())
+			}
+		})
+	}
+}
+
+func TestExtractBytesError(t *testing.T) {
+	valueTests := []struct {
+		name          string
+		expectedValue []byte
+		expectedError string
+		value         *testValue
+	}{
+		{
+			name:          "nil",
+			expectedValue: nil,
+			expectedError: errNilValue.Error(),
+			value:         nil,
+		},
+		{
+			name:          "length zero",
+			expectedValue: nil,
+			expectedError: errBadValue.Error(),
+			value:         newCValueLen(0),
+		},
+		{
+			name:          "length nonzero",
+			expectedValue: nil,
+			expectedError: errBadValue.Error(),
+			value:         newCValueLen(1),
+		},
+		{
+			name:          "data length nonzero",
+			expectedValue: []byte("test bytes\x00"), // count null pointer created by C
+			expectedError: "",
+			value:         newCValueData(11, "test bytes"), // count null pointer created by C
+		},
+		{
+			name:          "data zero",
+			expectedValue: nil,
+			expectedError: "test bytes",
+			value:         newCValueData(0, "test bytes"),
+		},
+	}
+	for _, v := range valueTests {
+		t.Run(v.name, func(t *testing.T) {
+			bytes, err := extractBytesThenFree(v.value)
+			assert.Equal(t, v.expectedValue, bytes)
+			if err == nil {
+				assert.Equal(t, v.expectedError, "")
+			} else {
+				assert.Equal(t, v.expectedError, err.Error())
+			}
+		})
+	}
+}

--- a/ffi/memory_test.go
+++ b/ffi/memory_test.go
@@ -9,146 +9,55 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// This checks all inputs for `extractErrorThenFree`
-func TestExtractError(t *testing.T) {
+func TestExtractValue(t *testing.T) {
 	valueTests := []struct {
 		name          string
+		expectedInt   uint32
+		expectedBytes []byte
 		expectedError string
 		value         *testValue
 	}{
 		{
 			name:          "nil",
+			expectedInt:   0,
+			expectedBytes: nil,
 			expectedError: errNilValue.Error(),
 			value:         nil,
 		},
 		{
 			name:          "length zero",
+			expectedInt:   0,
+			expectedBytes: nil,
 			expectedError: "",
 			value:         newCValueLen(0),
 		},
 		{
 			name:          "length nonzero",
-			expectedError: errBadValue.Error(),
-			value:         newCValueLen(1),
-		},
-		{
-			name:          "data length nonzero",
-			expectedError: errBadValue.Error(),
-			value:         newCValueData(11, "test bytes"), // count null pointer created by C
-		},
-		{
-			name:          "data zero",
-			expectedError: "test bytes",
-			value:         newCValueData(0, "test bytes"),
-		},
-	}
-
-	for _, v := range valueTests {
-		t.Run(v.name, func(t *testing.T) {
-			err := extractErrorThenFree(v.value)
-			if err == nil {
-				assert.Equal(t, v.expectedError, "")
-			} else {
-				assert.Equal(t, v.expectedError, err.Error())
-			}
-		})
-	}
-}
-
-func TestExtractIntError(t *testing.T) {
-	valueTests := []struct {
-		name          string
-		expectedValue uint32
-		expectedError string
-		value         *testValue
-	}{
-		{
-			name:          "nil",
-			expectedValue: 0,
-			expectedError: errNilValue.Error(),
-			value:         nil,
-		},
-		{
-			name:          "length zero",
-			expectedValue: 0,
-			expectedError: errBadValue.Error(),
-			value:         newCValueLen(0),
-		},
-		{
-			name:          "length nonzero",
-			expectedValue: 1,
+			expectedInt:   1,
+			expectedBytes: nil,
 			expectedError: "",
 			value:         newCValueLen(1),
 		},
 		{
 			name:          "data length nonzero",
-			expectedValue: 0,
-			expectedError: errBadValue.Error(),
-			value:         newCValueData(11, "test bytes"), // count null pointer created by C
-		},
-		{
-			name:          "data zero",
-			expectedValue: 0,
-			expectedError: "test bytes",
-			value:         newCValueData(0, "test bytes"),
-		},
-	}
-
-	for _, v := range valueTests {
-		t.Run(v.name, func(t *testing.T) {
-			id, err := extractIdThenFree(v.value)
-			assert.Equal(t, v.expectedValue, id)
-			if err == nil {
-				assert.Equal(t, v.expectedError, "")
-			} else {
-				assert.Equal(t, v.expectedError, err.Error())
-			}
-		})
-	}
-}
-
-func TestExtractBytesError(t *testing.T) {
-	valueTests := []struct {
-		name          string
-		expectedValue []byte
-		expectedError string
-		value         *testValue
-	}{
-		{
-			name:          "nil",
-			expectedValue: nil,
-			expectedError: errNilValue.Error(),
-			value:         nil,
-		},
-		{
-			name:          "length zero",
-			expectedValue: nil,
-			expectedError: errBadValue.Error(),
-			value:         newCValueLen(0),
-		},
-		{
-			name:          "length nonzero",
-			expectedValue: nil,
-			expectedError: errBadValue.Error(),
-			value:         newCValueLen(1),
-		},
-		{
-			name:          "data length nonzero",
-			expectedValue: []byte("test bytes\x00"), // count null pointer created by C
+			expectedInt:   0,
+			expectedBytes: []byte("test bytes\x00"), // count null pointer created by C
 			expectedError: "",
 			value:         newCValueData(11, "test bytes"), // count null pointer created by C
 		},
 		{
 			name:          "data zero",
-			expectedValue: nil,
+			expectedInt:   0,
+			expectedBytes: nil,
 			expectedError: "test bytes",
 			value:         newCValueData(0, "test bytes"),
 		},
 	}
 	for _, v := range valueTests {
 		t.Run(v.name, func(t *testing.T) {
-			bytes, err := extractBytesThenFree(v.value)
-			assert.Equal(t, v.expectedValue, bytes)
+			id, bytes, err := extractValueThenFree(v.value)
+			assert.Equal(t, v.expectedInt, id)
+			assert.Equal(t, v.expectedBytes, bytes)
 			if err == nil {
 				assert.Equal(t, v.expectedError, "")
 			} else {

--- a/ffi/proposal.go
+++ b/ffi/proposal.go
@@ -36,7 +36,7 @@ func (p *Proposal) Commit() error {
 
 	// Commit the proposal and return the hash.
 	err_val := C.fwd_commit(p.handle, C.uint32_t(p.id))
-	err := extractErrorThenFree(&err_val)
+	_, _, err := extractValueThenFree(&err_val)
 	if err != nil {
 		// this is unrecoverable due to Rust's ownership model
 		// The underlying proposal is no longer valid.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -458,7 +458,7 @@ impl From<()> for Value {
 ///
 #[doc(hidden)]
 #[unsafe(no_mangle)]
-pub extern "C" fn fwd_alloc_test(input: *const c_char) -> Value {
+pub unsafe extern "C" fn fwd_alloc_test(input: *const c_char) -> Value {
     // Create a valid CStr from the input pointer.
     let cstr = unsafe { CStr::from_ptr(input) };
     // Use cstr to create a Rust String copying all data.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -441,7 +441,20 @@ impl From<()> for Value {
 
 /// fwd_alloc_test is a test function that allocates data in a Value struct.
 /// This is used to test the allocation and deallocation of memory
-/// in Go.
+/// in Go, and should not be used in production code.
+///
+/// # Arguments
+///
+/// * `input` - A pointer to a null-terminated C-style string.
+///
+/// # Returns
+///
+/// A `Value` containing a copy of the input string.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers.
+/// The caller must ensure that `input` is a valid pointer to a null-terminated C-style string.
 ///
 #[doc(hidden)]
 #[unsafe(no_mangle)]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -406,6 +406,21 @@ impl From<()> for Value {
     }
 }
 
+/// fwd_alloc_test is a test function that allocates data in a Value struct.
+/// This is used to test the allocation and deallocation of memory
+/// in Go.
+///
+#[doc(hidden)]
+#[unsafe(no_mangle)]
+pub extern "C" fn fwd_alloc_test(input: *const c_char) -> Value {
+    // Create a valid CStr from the input pointer.
+    let cstr = unsafe { CStr::from_ptr(input) };
+    // Use cstr to create a Rust String copying all data.
+    let string = cstr.to_string_lossy().into_owned();
+    // Convert the string to a Value.
+    string.into()
+}
+
 /// Frees the memory associated with a `Value`.
 ///
 /// # Arguments


### PR DESCRIPTION
This refactors the `extractXXXXThenFree` to be used in all scenarios, so that the caller must explicitly recognize what values are being returned, and all decisions about how the `Value` may be formatted is dictated to a single function in `memory.go`. This also adds a function in `Rust` to test allocations and deallocations to ensure all possible `Value` structs are handled without panicking and with expected behavior.