### PR TITLE
Disable metrics during ffi unit tests

### DIFF
--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -44,6 +44,7 @@ func newTestDatabase(t *testing.T) *Database {
 	t.Helper()
 
 	conf := DefaultConfig()
+	conf.MetricsPort = 0
 	conf.Create = true
 	// The TempDir directory is automatically cleaned up so there's no need to
 	// remove test.db.


### PR DESCRIPTION
This PR disables Firewood metrics collection by setting `MetricsPort=0` https://github.com/ava-labs/firewood/blob/b432ee9920c032fc909f4d2e1b8ac994ab11c861/ffi/src/lib.rs#L577

This avoids test failures on machines where the default port may be occupied.