### PR TITLE
feat(ffi): Support `Get` for historical revisions

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -19,6 +19,7 @@ import (
 // These constants are used to identify errors returned by the Firewood Rust FFI.
 // These must be changed if the Rust FFI changes - should be reported by tests.
 const (
+	RootLength       = 32
 	rootHashNotFound = "IO error: Root hash not found"
 	keyNotFound      = "key not found"
 )
@@ -197,10 +198,15 @@ func (db *Database) Root() ([]byte, error) {
 
 	// If the root hash is not found, return a zeroed slice.
 	if err != nil && strings.Contains(err.Error(), rootHashNotFound) {
-		bytes = make([]byte, 32)
+		bytes = make([]byte, RootLength)
 		err = nil
 	}
 	return bytes, err
+}
+
+// Revision returns a historical revision of the database.
+func (db *Database) Revision(root []byte) (*Revision, error) {
+	return NewRevision(db.handle, root)
 }
 
 // Close closes the database and releases all held resources.

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -173,7 +173,7 @@ void fwd_free_value(const struct Value *value);
  *
  * # Returns
  *
- * A `Value` containing the root hash of the database.
+ * A `Value` containing the requested value.
  * A `Value` containing {0, "error message"} if the get failed.
  *
  * # Safety
@@ -188,6 +188,32 @@ struct Value fwd_get_from_proposal(const struct DatabaseHandle *db,
                                    struct Value key);
 
 /**
+ * Gets a value assoicated with the given historical root hash and key.
+ *
+ * # Arguments
+ *
+ * * `db` - The database handle returned by `open_db`
+ * * `root` - The root hash to look up, in `Value` form
+ * * `key` - The key to look up, in `Value` form
+ *
+ * # Returns
+ *
+ * A `Value` containing the requested value.
+ * A `Value` containing {0, "error message"} if the get failed.
+ *
+ * # Safety
+ *
+ * The caller must:
+ * * ensure that `db` is a valid pointer returned by `open_db`
+ * * ensure that `key` is a valid pointer to a `Value` struct
+ * * ensure that `root` is a valid pointer to a `Value` struct
+ * * call `free_value` to free the memory associated with the returned `Value`
+ */
+struct Value fwd_get_from_root(const struct DatabaseHandle *db,
+                               struct Value root,
+                               struct Value key);
+
+/**
  * Gets the value associated with the given key from the database.
  *
  * # Arguments
@@ -197,7 +223,7 @@ struct Value fwd_get_from_proposal(const struct DatabaseHandle *db,
  *
  * # Returns
  *
- * A `Value` containing the root hash of the database.
+ * A `Value` containing the requested value.
  * A `Value` containing {0, "error message"} if the get failed.
  * There is one error case that may be expected to be nil by the caller,
  * but should be handled externally: The database has no entries - "IO error: Root hash not found"

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -1,0 +1,67 @@
+// Package firewood provides a Go wrapper around the [Firewood] database.
+//
+// [Firewood]: https://github.com/ava-labs/firewood
+package firewood
+
+// // Note that -lm is required on Linux but not on Mac.
+// #cgo LDFLAGS: -L${SRCDIR}/../target/release -L/usr/local/lib -lfirewood_ffi -lm
+// #include <stdlib.h>
+// #include "firewood.h"
+import "C"
+import (
+	"errors"
+	"fmt"
+)
+
+var errRevisionClosed = errors.New("firewood revision already closed")
+
+type Revision struct {
+	// handle is returned and accepted by cgo functions. It MUST be treated as
+	// an opaque value without special meaning.
+	// https://en.wikipedia.org/wiki/Blinkenlights
+	handle *C.DatabaseHandle
+	// The revision root
+	root []byte
+}
+
+func NewRevision(handle *C.DatabaseHandle, root []byte) (*Revision, error) {
+	if handle == nil || root == nil {
+		return nil, errors.New("firewood error: nil handle or root")
+	}
+
+	// Check that the root is the correct length.
+	if len(root) != RootLength {
+		return nil, fmt.Errorf("firewood error: root hash must be %d bytes", RootLength)
+	}
+
+	// All other verification of the root is done during use.
+	return &Revision{
+		handle: handle,
+		root:   root,
+	}, nil
+}
+
+func (r *Revision) Get(key []byte) ([]byte, error) {
+	if r.handle == nil {
+		return nil, errDbClosed
+	}
+	if r.root == nil {
+		return nil, errRevisionClosed
+	}
+
+	// Special case for empty revision
+	if r.root == nil {
+		return nil, nil
+	}
+
+	values, cleanup := newValueFactory()
+	defer cleanup()
+
+	val := C.fwd_get_from_root(r.handle, values.from(r.root), values.from(key))
+	value, err := extractBytesThenFree(&val)
+	if err != nil {
+		// Any error from this function indicates that the revision is closed.
+		r.root = nil
+	}
+	return value, err
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -72,7 +72,7 @@ impl Deref for DatabaseHandle<'_> {
 ///
 /// # Returns
 ///
-/// A `Value` containing the root hash of the database.
+/// A `Value` containing the requested value.
 /// A `Value` containing {0, "error message"} if the get failed.
 /// There is one error case that may be expected to be nil by the caller,
 /// but should be handled externally: The database has no entries - "IO error: Root hash not found"
@@ -124,7 +124,7 @@ fn get_latest(db: *const DatabaseHandle, key: Value) -> Result<Value, String> {
 ///
 /// # Returns
 ///
-/// A `Value` containing the root hash of the database.
+/// A `Value` containing the requested value.
 /// A `Value` containing {0, "error message"} if the get failed.
 ///
 /// # Safety
@@ -161,6 +161,54 @@ fn get_from_proposal(
 
     // Get value associated with key.
     let value = proposal
+        .val_sync(key.as_slice())
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| String::from(""))?;
+    Ok(value.into())
+}
+
+/// Gets a value assoicated with the given historical root hash and key.
+///
+/// # Arguments
+///
+/// * `db` - The database handle returned by `open_db`
+/// * `root` - The root hash to look up, in `Value` form
+/// * `key` - The key to look up, in `Value` form
+///
+/// # Returns
+///
+/// A `Value` containing the requested value.
+/// A `Value` containing {0, "error message"} if the get failed.
+///
+/// # Safety
+///
+/// The caller must:
+/// * ensure that `db` is a valid pointer returned by `open_db`
+/// * ensure that `key` is a valid pointer to a `Value` struct
+/// * ensure that `root` is a valid pointer to a `Value` struct
+/// * call `free_value` to free the memory associated with the returned `Value`
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_get_from_root(
+    db: *const DatabaseHandle,
+    root: Value,
+    key: Value,
+) -> Value {
+    get_from_root(db, root, key).unwrap_or_else(|e| e.into())
+}
+
+/// Internal call for `fwd_get_from_root` to remove error handling from the C API
+#[doc(hidden)]
+fn get_from_root(db: *const DatabaseHandle, root: Value, key: Value) -> Result<Value, String> {
+    // Check db is valid.
+    let db = unsafe { db.as_ref() }.ok_or_else(|| String::from("db should be non-null"))?;
+
+    // Get the revision associated with the root hash.
+    let rev = db
+        .revision_sync(root.as_slice().try_into()?)
+        .map_err(|e| e.to_string())?;
+
+    // Get value associated with key.
+    let value = rev
         .val_sync(key.as_slice())
         .map_err(|e| e.to_string())?
         .ok_or_else(|| String::from(""))?;


### PR DESCRIPTION
This allows retrieving values from previously committed revisions.

Further steps:
- More tests once #878 is merged
- Supporting empty revisions