### PR TITLE
If ethhash is enabled, return the hash for nil RLP

### DIFF
--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -194,6 +194,7 @@ impl<T: Hashable> Preimage for T {
 
             // we've collected all the children in bytes
 
+            #[allow(clippy::let_and_return)]
             let updated_bytes = if is_account {
                 // need to get the value again
                 if let Some(ValueDigest::Value(rlp_encoded_bytes)) = self.value_digest() {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -60,3 +60,16 @@ impl std::fmt::Display for CacheReadStrategy {
         write!(f, "{self:?}")
     }
 }
+
+/// Returns the hash of an empty trie, which is the Keccak256 hash of the RLP encoding of an empty byte array.
+///
+/// This function is slow, so callers should cache the result
+#[cfg(feature = "ethhash")]
+pub fn empty_trie_hash() -> TrieHash {
+    use sha3::Digest as _;
+
+    sha3::Keccak256::digest(rlp::NULL_RLP)
+        .as_slice()
+        .try_into()
+        .expect("empty trie hash is 32 bytes")
+}


### PR DESCRIPTION
This calculates and returns the nil RLP instead of None. None is still used internally since we need to know the difference between "there is no revision" and "there is a revision, but it consists of an empty trie".