### PR TITLE
fix(ffi): Check revision is available

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -206,7 +206,7 @@ func (db *Database) Root() ([]byte, error) {
 
 // Revision returns a historical revision of the database.
 func (db *Database) Revision(root []byte) (*Revision, error) {
-	return NewRevision(db.handle, root)
+	return newRevision(db.handle, root)
 }
 
 // Close closes the database and releases all held resources.

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -690,15 +690,13 @@ func TestFakeRevision(t *testing.T) {
 	db := newTestDatabase(t)
 
 	// Create a nil revision.
-	revision, err := db.Revision(nil)
+	_, err := db.Revision(nil)
 	require.ErrorIs(t, err, errInvalidRootLength, "NewRevision(nil)")
-	assert.Nil(t, revision, "NewRevision(nil)")
 
 	// Create a fake revision with an invalid root.
 	invalidRoot := []byte("not a valid root")
-	revision, err = db.Revision(invalidRoot)
+	_, err = db.Revision(invalidRoot)
 	require.ErrorIs(t, err, errInvalidRootLength, "NewRevision(invalid root)")
-	require.Nil(t, revision, "NewRevision(invalid root)")
 
 	// Create a fake revision with an valid root.
 	validRoot := []byte("counting 32 bytes to make a hash")

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -653,7 +653,7 @@ func TestRevision(t *testing.T) {
 	require.NoError(t, err, "%T.Root()", db)
 
 	// Create a revision from this root.
-	revision, err := NewRevision(db.handle, root)
+	revision, err := db.Revision(root)
 	require.NoError(t, err, "NewRevision")
 	// Check that all keys can be retrieved from the revision.
 	for i := range keys {

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -702,5 +702,5 @@ func TestFakeRevision(t *testing.T) {
 	validRoot := []byte("counting 32 bytes to make a hash")
 	assert.Len(t, validRoot, 32, "valid root")
 	_, err = db.Revision(validRoot)
-	require.ErrorIs(t, err, errRevisionInaccessible, "Revision(valid root)")
+	require.ErrorIs(t, err, errRevisionNotFound, "Revision(valid root)")
 }

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -654,7 +654,7 @@ func TestRevision(t *testing.T) {
 
 	// Create a revision from this root.
 	revision, err := db.Revision(root)
-	require.NoError(t, err, "NewRevision")
+	require.NoError(t, err, "Revision")
 	// Check that all keys can be retrieved from the revision.
 	for i := range keys {
 		got, err := revision.Get(keys[i])
@@ -677,7 +677,7 @@ func TestRevision(t *testing.T) {
 
 	// Create a "new" revision from the first old root.
 	revision, err = db.Revision(root)
-	require.NoError(t, err, "NewRevision")
+	require.NoError(t, err, "Revision")
 	// Check that all keys can be retrieved from the revision.
 	for i := range keys {
 		got, err := revision.Get(keys[i])
@@ -691,16 +691,16 @@ func TestFakeRevision(t *testing.T) {
 
 	// Create a nil revision.
 	_, err := db.Revision(nil)
-	require.ErrorIs(t, err, errInvalidRootLength, "NewRevision(nil)")
+	require.ErrorIs(t, err, errInvalidRootLength, "Revision(nil)")
 
 	// Create a fake revision with an invalid root.
 	invalidRoot := []byte("not a valid root")
 	_, err = db.Revision(invalidRoot)
-	require.ErrorIs(t, err, errInvalidRootLength, "NewRevision(invalid root)")
+	require.ErrorIs(t, err, errInvalidRootLength, "Revision(invalid root)")
 
 	// Create a fake revision with an valid root.
 	validRoot := []byte("counting 32 bytes to make a hash")
 	assert.Len(t, validRoot, 32, "valid root")
 	_, err = db.Revision(validRoot)
-	require.ErrorIs(t, err, errRevisionInaccessible, "NewRevision(valid root)")
+	require.ErrorIs(t, err, errRevisionInaccessible, "Revision(valid root)")
 }

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -691,27 +691,18 @@ func TestFakeRevision(t *testing.T) {
 
 	// Create a nil revision.
 	revision, err := db.Revision(nil)
-	require.ErrorIs(t, err, errInvalidRoot, "NewRevision(nil)")
+	require.ErrorIs(t, err, errInvalidRootLength, "NewRevision(nil)")
 	assert.Nil(t, revision, "NewRevision(nil)")
 
 	// Create a fake revision with an invalid root.
 	invalidRoot := []byte("not a valid root")
 	revision, err = db.Revision(invalidRoot)
-	require.ErrorIs(t, err, errInvalidRoot, "NewRevision(invalid root)")
+	require.ErrorIs(t, err, errInvalidRootLength, "NewRevision(invalid root)")
 	require.Nil(t, revision, "NewRevision(invalid root)")
 
 	// Create a fake revision with an valid root.
 	validRoot := []byte("counting 32 bytes to make a hash")
 	assert.Len(t, validRoot, 32, "valid root")
-	revision, err = db.Revision(validRoot)
-	require.NoError(t, err, "NewRevision(valid root)")
-	require.NotNil(t, revision, "NewRevision(valid root)")
-
-	// Attempt to get a value from the fake revision.
-	_, err = revision.Get([]byte("non-existent"))
-	require.Contains(t, err.Error(), "Revision not found", "Get(non-existent)")
-
-	// Attempt to get from the now invalid revision.
-	_, err = revision.Get([]byte("non-existent"))
-	require.ErrorIs(t, err, errRevisionClosed, "Get(non-existent)")
+	_, err = db.Revision(validRoot)
+	require.ErrorIs(t, err, errRevisionInaccessible, "NewRevision(valid root)")
 }

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	errRevisionInaccessible = errors.New("firewood revision inaccessible")
-	errInvalidRootLength    = fmt.Errorf("firewood error: root hash must be %d bytes", RootLength)
+	errRevisionNotFound  = errors.New("firewood error: revision not found")
+	errInvalidRootLength = fmt.Errorf("firewood error: root hash must be %d bytes", RootLength)
 )
 
 type Revision struct {
@@ -46,7 +46,7 @@ func newRevision(handle *C.DatabaseHandle, root []byte) (*Revision, error) {
 	_, err := extractBytesThenFree(&val)
 	if err != nil {
 		// Any error from this function indicates that the root is inaccessible.
-		return nil, errRevisionInaccessible
+		return nil, errRevisionNotFound
 	}
 
 	// All other verification of the root is done during use.
@@ -61,7 +61,7 @@ func (r *Revision) Get(key []byte) ([]byte, error) {
 		return nil, errDbClosed
 	}
 	if r.root == nil {
-		return nil, errRevisionInaccessible
+		return nil, errRevisionNotFound
 	}
 
 	values, cleanup := newValueFactory()

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -27,7 +27,7 @@ type Revision struct {
 	root []byte
 }
 
-func NewRevision(handle *C.DatabaseHandle, root []byte) (*Revision, error) {
+func newRevision(handle *C.DatabaseHandle, root []byte) (*Revision, error) {
 	if handle == nil {
 		return nil, errors.New("firewood error: nil handle or root")
 	}


### PR DESCRIPTION
I think expected behavior for this would be to check that the revision is available - although it provides no guarantee that it will be available for the entire length of use, it should fail-fast if already unavailable.

Additionally, `newRevision` shouldn't be exported - this is only required in `db.Revision`, and that's how all consumers should use it.