### PR TITLE
fix(ffi): prevent undefined behavior on empty slices

### DIFF
--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -726,11 +726,11 @@ func TestGetNilCases(t *testing.T) {
 	require.NoError(t, err, "Revision")
 
 	// Create edge case keys.
-	badKeys := [][]byte{
+	specialKeys := [][]byte{
 		nil,
 		{}, // empty slice
 	}
-	for _, k := range badKeys {
+	for _, k := range specialKeys {
 		got, err := db.Get(k)
 		require.NoError(t, err, "db.Get(%q)", k)
 		assert.Empty(t, got, "db.Get(%q)", k)

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -709,45 +709,38 @@ func TestFakeRevision(t *testing.T) {
 func TestGetNilCases(t *testing.T) {
 	db := newTestDatabase(t)
 
-	// Create a proposal with 10 key-value pairs.
-	keys := make([][]byte, 10)
-	vals := make([][]byte, 10)
+	// Commit 10 key-value pairs.
+	keys := make([][]byte, 20)
+	vals := make([][]byte, 20)
 	for i := range keys {
 		keys[i] = keyForTest(i)
 		vals[i] = valForTest(i)
 	}
-	proposal, err := db.Propose(keys, vals)
+	root, err := db.Update(keys[:10], vals[:10])
+	require.NoError(t, err, "Update")
+
+	// Create the other views
+	proposal, err := db.Propose(keys[10:], vals[10:])
 	require.NoError(t, err, "Propose")
-
-	// Check that no keys panic.
-	got, err := proposal.Get(nil)
-	require.NoError(t, err, "Get(nil)")
-	require.Empty(t, got, "Get(nil)")
-	got, err = proposal.Get([]byte{})
-	require.NoError(t, err, "Get(nil)")
-	require.Empty(t, got, "Get(nil)")
-
-	// Commit the proposal.
-	err = proposal.Commit()
-	require.NoError(t, err, "Commit")
-
-	// Attempt to get a nil keys for db
-	got, err = db.Get(nil)
-	require.NoError(t, err, "Get(nil)")
-	require.Empty(t, got, "Get(nil)")
-	got, err = db.Get([]byte{})
-	require.NoError(t, err, "Get([]byte{})")
-	require.Empty(t, got, "Get([]byte{})")
-
-	// Attempt to get nil keys for revision
-	root, err := db.Root()
-	require.NoError(t, err, "%T.Root()", db)
 	revision, err := db.Revision(root)
 	require.NoError(t, err, "Revision")
-	got, err = revision.Get(nil)
-	require.NoError(t, err, "Get(nil)")
-	require.Empty(t, got, "Get(nil)")
-	got, err = revision.Get([]byte{})
-	require.NoError(t, err, "Get([]byte{})")
-	require.Empty(t, got, "Get([]byte{})")
+
+	// Create edge case keys.
+	badKeys := [][]byte{
+		nil,
+		{}, // empty slice
+	}
+	for _, k := range badKeys {
+		got, err := db.Get(k)
+		require.NoError(t, err, "db.Get(%q)", k)
+		assert.Empty(t, got, "db.Get(%q)", k)
+
+		got, err = revision.Get(k)
+		require.NoError(t, err, "Revision.Get(%q)", k)
+		assert.Empty(t, got, "Revision.Get(%q)", k)
+
+		got, err = proposal.Get(k)
+		require.NoError(t, err, "Proposal.Get(%q)", k)
+		assert.Empty(t, got, "Proposal.Get(%q)", k)
+	}
 }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -296,8 +296,11 @@ fn batch(
     values: *const KeyValue,
 ) -> Result<Value, String> {
     let start = coarsetime::Instant::now();
-    // Check db is valid.
+    // Check input is valid.
     let db = unsafe { db.as_ref() }.ok_or_else(|| String::from("db should be non-null"))?;
+    if values.is_null() {
+        return Err(String::from("key-value list is null"));
+    }
 
     // Create a batch of operations to perform.
     let key_value_ref = unsafe { std::slice::from_raw_parts(values, nkeys) };
@@ -365,7 +368,11 @@ fn propose_on_db(
     nkeys: usize,
     values: *const KeyValue,
 ) -> Result<ProposalId, String> {
+    // Check input is valid.
     let db = unsafe { db.as_ref() }.ok_or_else(|| String::from("db should be non-null"))?;
+    if values.is_null() {
+        return Err(String::from("key-value list is null"));
+    }
 
     // Create a batch of operations to perform.
     let key_value_ref = unsafe { std::slice::from_raw_parts(values, nkeys) };
@@ -423,7 +430,11 @@ fn propose_on_proposal(
     nkeys: usize,
     values: *const KeyValue,
 ) -> Result<ProposalId, String> {
+    // Check input is valid.
     let db = unsafe { db.as_ref() }.ok_or_else(|| String::from("db should be non-null"))?;
+    if values.is_null() {
+        return Err(String::from("key-value list is null"));
+    }
 
     // Create a batch of operations to perform.
     let key_value_ref = unsafe { std::slice::from_raw_parts(values, nkeys) };
@@ -594,7 +605,11 @@ impl Display for Value {
 impl Value {
     #[must_use]
     pub const fn as_slice(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.data, self.len) }
+        if self.data.is_null() {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(self.data, self.len) }
+        }
     }
 }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -296,7 +296,6 @@ fn batch(
     values: *const KeyValue,
 ) -> Result<Value, String> {
     let start = coarsetime::Instant::now();
-    // Check input is valid.
     let db = unsafe { db.as_ref() }.ok_or_else(|| String::from("db should be non-null"))?;
     if values.is_null() {
         return Err(String::from("key-value list is null"));
@@ -368,7 +367,6 @@ fn propose_on_db(
     nkeys: usize,
     values: *const KeyValue,
 ) -> Result<ProposalId, String> {
-    // Check input is valid.
     let db = unsafe { db.as_ref() }.ok_or_else(|| String::from("db should be non-null"))?;
     if values.is_null() {
         return Err(String::from("key-value list is null"));
@@ -430,7 +428,6 @@ fn propose_on_proposal(
     nkeys: usize,
     values: *const KeyValue,
 ) -> Result<ProposalId, String> {
-    // Check input is valid.
     let db = unsafe { db.as_ref() }.ok_or_else(|| String::from("db should be non-null"))?;
     if values.is_null() {
         return Err(String::from("key-value list is null"));


### PR DESCRIPTION
@aaronbuchwald found an error that only occurs in debug mode for tests, where you attempt to `Get` a `[]byte{}` or `nil`, resulting in a null pointer, which is undefined behavior in `std::slice::from_raw_parts`. The `as_slice` method now checks if the pointer is null, and tests wer added for this case.

Next steps: CI tests should be ran in debug mode to reduce the chance that this happens in the future.

Resolves #892 