### PR TITLE
Fix tag handling for attach static libs

### DIFF
--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -121,7 +121,7 @@ jobs:
           
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             git tag -a "${GITHUB_REF#refs/tags/}" -m "firewood ci ${{ github.sha }}: attach firewood static libs"
-            git push origin "${GITHUB_REF#refs/tags/}"
+            git push origin "refs/tags/${GITHUB_REF#refs/tags/}"
           else
             git push -u origin ${{ steps.determine_branch.outputs.target_branch }} --force
           fi

--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -74,9 +74,9 @@ jobs:
             export target_branch="${{ github.event.inputs.create_branch_name }}"
             echo "Using workflow input as target branch: $target_branch"
             echo "target_branch=$target_branch" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            export target_branch="${GITHUB_REF#refs/heads/}"
-            echo "Using tag/branch name as target_branch: $target_branch"
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            export target_branch="${GITHUB_REF#refs/tags/}"
+            echo "Using tag name as target_branch: $target_branch"
             echo "target_branch=$target_branch" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             export target_branch="${{ github.event.pull_request.head.ref }}"
@@ -118,10 +118,12 @@ jobs:
           git checkout -b ${{ steps.determine_branch.outputs.target_branch }}
           git add .
           git commit -m "firewood ci ${{ github.sha }}: attach firewood static libs"
-          git push -u origin ${{ steps.determine_branch.outputs.target_branch }} --force
+          
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             git tag -a "${GITHUB_REF#refs/tags/}" -m "firewood ci ${{ github.sha }}: attach firewood static libs"
             git push origin "${GITHUB_REF#refs/tags/}"
+          else
+            git push -u origin ${{ steps.determine_branch.outputs.target_branch }} --force
           fi
 
   # Check out the branch created in the previous job on a matrix of


### PR DESCRIPTION
This PR fixes the issue causing GitHub tags to fail to push a tag to firewood-go: https://github.com/ava-labs/firewood/actions/runs/15048414833/job/42297146591?pr=868

The problem was we were incorrectly parsing the `target_branch` from the tag event. Below are the GitHub Action runs and the corresponding results using this PR for a manual GitHub Action and tag event.

Manual GitHub Action: https://github.com/ava-labs/firewood/actions/runs/15074003444
Result: https://github.com/ava-labs/firewood-go/tree/attach-static-libs-test/

Tag event: https://github.com/ava-labs/firewood/actions/runs/15074410742
Result: https://github.com/ava-labs/firewood-go/tree/golang-ffi-static-test
