### PR TITLE
feat(ffi): auto drop proposals

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -169,10 +169,7 @@ func (db *Database) Propose(keys, vals [][]byte) (*Proposal, error) {
 	}
 
 	// The C function will never create an id of 0, unless it is an error.
-	return &Proposal{
-		handle: db.handle,
-		id:     id,
-	}, nil
+	return newProposal(db.handle, id), nil
 }
 
 // Get retrieves the value for the given key. It always returns a nil error.

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -380,14 +380,14 @@ func TestParallelProposals(t *testing.T) {
 	// After attempting to commit the other proposals, they should be completely invalid.
 	for i := 1; i < numProposals; i++ {
 		err := proposals[i].Commit()
-		require.ErrorIs(t, err, errDroppedProposal, "Commit(%d)", i)
+		require.ErrorIs(t, err, errCommittedProposal, "Commit(%d)", i)
 	}
 
 	// Because they're invalid, we should not be able to get values from them.
 	for i := 1; i < numProposals; i++ {
 		for j := 0; j < numKeys; j++ {
 			got, err := proposals[i].Get(keyForTest(i*numKeys + j))
-			require.ErrorIs(t, err, errDroppedProposal, "Get(%d)", i*numKeys+j)
+			require.ErrorIs(t, err, errCommittedProposal, "Get(%d)", i*numKeys+j)
 			require.Empty(t, got, "Get(%d)", i*numKeys+j)
 		}
 	}

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -463,7 +464,10 @@ func TestDropProposal(t *testing.T) {
 	proposalID := proposal.id
 
 	// The proposal is now out of scope. Block to force cleanup
+	proposal = nil
 	runtime.GC()
+	// Finalizer runs asynchronously, so we need to wait a bit for it to finish.
+	time.Sleep(50 * time.Millisecond)
 
 	// Attempt to "emulate" the proposal to ensure it isn't internally available still.
 	newProposal := &Proposal{


### PR DESCRIPTION
Instead of relying on the user to remember to drop proposals, they must only ensure that there are no references to the proposal stored, and the Go GC will automatically call a Finalizer function.

My main questions for this:
* Is there any other/better way to test this? The finalizer is run async, so the test is kind of flaky. Adding the timeout seems to have helped, but it could still fail.
* Should we update the go version to use the newer `runtime.AddCleanup` function, which is "less error-prone" according to the [Go docs](https://pkg.go.dev/runtime#SetFinalizer)?