### PR TITLE
Skip attach static libs if required secret is missing for external PRs

### DIFF
--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -27,7 +27,6 @@ jobs:
   # them as artifacts to collect and attach in the next job.
   build-firewood-ffi-libs:
     runs-on: ${{ matrix.os }}
-    if: secrets.FIREWOOD_GO_GITHUB_TOKEN != ''
     strategy:
       matrix:
         include:
@@ -39,6 +38,8 @@ jobs:
             target: aarch64-apple-darwin
           - os: macos-13
             target: x86_64-apple-darwin
+    outputs:
+      has_secrets: ${{ steps.check_secrets.outputs.has_secrets }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -57,12 +58,24 @@ jobs:
           path: target/${{ matrix.target }}/maxperf/libfirewood_ffi.a
           if-no-files-found: error
 
+      - name: Check if FIREWOOD_GO_GITHUB_TOKEN is set
+        id: check_secrets
+        run: |
+          if [ -z "${{ secrets.FIREWOOD_GO_GITHUB_TOKEN }}" ]; then
+            echo "FIREWOOD_GO_GITHUB_TOKEN is not set"
+            echo "has_secrets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "FIREWOOD_GO_GITHUB_TOKEN is set"
+            echo "has_secrets=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # Collect all the static libraries built on the previous matrix of jobs
   # and add them into ffi/libs directory.
   # We commit and push this as a new branch with "--force" to overwrite
   # the previous static libs that will not be on our branch.
   push-firewood-ffi-libs:
     needs: build-firewood-ffi-libs
+    if: needs.build-firewood-ffi-libs.outputs.has_secrets == 'true'
     runs-on: ubuntu-latest
     outputs:
       target_branch: ${{ steps.determine_branch.outputs.target_branch }}


### PR DESCRIPTION
This PR fixes the attach static libraries workflow to ensure that it skips the first job (and subsequent jobs) that depend on the ability to push a firewood go library to an external repo if secrets are not available.

PRs made from external forks and via dependabot (special case where secrets are not made available) will fail on this workflow because it depends on GitHub secrets to push to a separate repo.

To handle this, we
1. Add a step to the first job that checks if the required secret is available
2. Push an output based on the result
3. Skip the next job if the secret is not available (automatically skips subsequent jobs, which need `push`)

This fixes the issue for the following dependabot PRs:

- https://github.com/ava-labs/firewood/pull/899
- https://github.com/ava-labs/firewood/pull/898

Skipping runs from external forks is a common pattern as described [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository) and we may even opt to run this job less frequently in the future, so disabling for all external forks seems like the best choice here (possible alternative would be to push an artifact including the source code and pull that instead of cloning the repo in order to run the same tests using the artifact instead of checking out a branch).