### PR TITLE
Add matrix to build job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
         include:
           - profile-key: debug-no-features
             profile-args: ""
-          - profile-key: debug-ethhash
-            profile-args: "--features ethhash"
           - profile-key: debug-ethhash-logger
             profile-args: "--features ethhash,logger"
+          - profile-key: maxperf-ethhash-logger
+            profile-args: "--profile maxperf --features ethhash,logger"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,6 @@ jobs:
 
   no-rust-cache-lint:
     runs-on: ubuntu-latest
-
     steps:
       - name: Check license headers
         uses: viperproject/check-license-header@v2
@@ -80,10 +79,10 @@ jobs:
         include:
           - profile-key: debug-no-features
             profile-args: ""
-          - profile-key: debug-ethhash
-            profile-args: "--features ethhash"
           - profile-key: debug-ethhash-logger
             profile-args: "--features ethhash,logger"
+          - profile-key: maxperf-ethhash-logger
+            profile-args: "--profile maxperf --features ethhash,logger"
           # TODO: enable testing with branch_factor_256
     steps:
       - uses: actions/checkout@v4
@@ -105,10 +104,10 @@ jobs:
         include:
           - profile-key: debug-no-features
             profile-args: ""
-          - profile-key: debug-ethhash
-            profile-args: "--features ethhash"
           - profile-key: debug-ethhash-logger
             profile-args: "--features ethhash,logger"
+          - profile-key: maxperf-ethhash-logger
+            profile-args: "--profile maxperf --features ethhash,logger"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -120,9 +119,9 @@ jobs:
           save-if: "false"
           shared-key: ${{ matrix.profile-key}}
       - name: Run benchmark example
-        run: RUST_BACKTRACE=1 cargo run ${{ matrix.profile-args }} --release --bin benchmark -- --number-of-batches 100 --batch-size 1000 create
+        run: RUST_BACKTRACE=1 cargo run ${{ matrix.profile-args }} --bin benchmark -- --number-of-batches 100 --batch-size 1000 create
       - name: Run insert example
-        run: RUST_BACKTRACE=1 cargo run ${{ matrix.profile-args }} --release --example insert
+        run: RUST_BACKTRACE=1 cargo run ${{ matrix.profile-args }} --example insert
 
   docs:
     needs: build
@@ -184,9 +183,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: "false"
-          shared-key: "debug-ethhash"
+          shared-key: "debug-ethhash-logger"
       - name: Build Firewood FFI (with ethhash)
-        run: cargo build --release --features ethhash
+        run: cargo build --features ethhash
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,8 @@ jobs:
   no-rust-cache-lint:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: Check license headers
         uses: viperproject/check-license-header@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,14 +13,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - profile-name: debug with no features
-            profile-key: debug-no-features
+          - profile-key: debug-no-features
             profile-args: ""
-          - profile-name: debug with ethhash
-            profile-key: debug-ethhash
+          - profile-key: debug-ethhash
             profile-args: "--features ethhash"
-          - profile-name: debug with ethhash and logger
-            profile-key: debug-ethhash-logger
+          - profile-key: debug-ethhash-logger
             profile-args: "--features ethhash,logger"
     runs-on: ubuntu-latest
     steps:
@@ -48,9 +45,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: "false"
-          shared-key: "build"
       - name: Check license headers
         uses: viperproject/check-license-header@v2
         with:
@@ -59,8 +53,10 @@ jobs:
           strict: true
       - name: Format
         run: cargo fmt -- --check
-      - name: Clippy
+      - name: Clippy (no features)
         run: cargo clippy --tests --examples --benches -- -D warnings
+      - name: Clippy (all features)
+        run: cargo clippy --tests --examples --benches --all-features -- -D warnings
 
   test:
     needs: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,18 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+          - profile-name: debug with no features
+            profile-key: debug-no-features
+            profile-args: ""
+          - profile-name: debug with ethhash
+            profile-key: debug-ethhash
+            profile-args: "--features ethhash"
+          - profile-name: debug with ethhash and logger
+            profile-key: debug-ethhash-logger
+            profile-args: "--features ethhash,logger"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,10 +30,12 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.profile-key }}
       - name: Check
-        run: cargo check --workspace --tests --examples --benches
+        run: cargo check ${{ matrix.profile-args }} --workspace --tests --examples --benches
       - name: Build
-        run: cargo build --workspace --tests --examples --benches
+        run: cargo build ${{ matrix.profile-args }} --workspace --tests --examples --benches
 
   lint:
     needs: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,17 +34,11 @@ jobs:
       - name: Build
         run: cargo build ${{ matrix.profile-args }} --workspace --tests --examples --benches
 
-  lint:
-    needs: build
+
+  no-rust-cache-lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: Swatinem/rust-cache@v2
       - name: Check license headers
         uses: viperproject/check-license-header@v2
         with:
@@ -53,15 +47,44 @@ jobs:
           strict: true
       - name: Format
         run: cargo fmt -- --check
-      - name: Clippy (no features)
-        run: cargo clippy --tests --examples --benches -- -D warnings
-      - name: Clippy (all features)
-        run: cargo clippy --tests --examples --benches --all-features -- -D warnings
+
+  rust-lint:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - profile-key: debug-no-features
+            profile-args: ""
+          - profile-key: debug-ethhash-logger
+            profile-args: "--features ethhash,logger"
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: "false"
+          shared-key: ${{ matrix.profile-key }}
+      - name: Clippy
+        run: cargo clippy ${{ matrix.profile-args }} --tests --examples --benches -- -D warnings
 
   test:
     needs: build
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        include:
+          - profile-key: debug-no-features
+            profile-args: ""
+          - profile-key: debug-ethhash
+            profile-args: "--features ethhash"
+          - profile-key: debug-ethhash-logger
+            profile-args: "--features ethhash,logger"
+          # TODO: enable testing with branch_factor_256
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -71,18 +94,21 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: "false"
-          shared-key: "build"
-      - name: Run tests with ethhash disabled
-        run: cargo test --verbose
+          shared-key: ${{ matrix.profile-key }}
       - name: Run tests with features enabled
-        run: cargo test --verbose --features logger,ethhash
-      # TODO: Enable testing with branch_factor_256
-      # - name: Run tests with branch_factor_256
-      #   run: cargo test --verbose --features branch_factor_256
+        run: cargo test --verbose ${{ matrix.profile-args }}
 
   examples:
-    needs: ethhash
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - profile-key: debug-no-features
+            profile-args: ""
+          - profile-key: debug-ethhash
+            profile-args: "--features ethhash"
+          - profile-key: debug-ethhash-logger
+            profile-args: "--features ethhash,logger"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -92,11 +118,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: "false"
-          shared-key: "ethhash"
+          shared-key: ${{ matrix.profile-key}}
       - name: Run benchmark example
-        run: RUST_BACKTRACE=1 cargo run --features ethhash --release --bin benchmark -- --number-of-batches 100 --batch-size 1000 create
+        run: RUST_BACKTRACE=1 cargo run ${{ matrix.profile-args }} --release --bin benchmark -- --number-of-batches 100 --batch-size 1000 create
       - name: Run insert example
-        run: RUST_BACKTRACE=1 cargo run --features ethhash --release --example insert
+        run: RUST_BACKTRACE=1 cargo run ${{ matrix.profile-args }} --release --example insert
 
   docs:
     needs: build
@@ -110,7 +136,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: "false"
-          shared-key: "build"
+          shared-key: "debug-no-features"
       - run: RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps
 
   ffi:
@@ -128,7 +154,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: "false"
-          shared-key: "build"
+          shared-key: "debug-no-features"
       - name: Build Firewood FFI
         working-directory: ffi
         run: cargo build --release
@@ -147,7 +173,7 @@ jobs:
         # cgocheck2 is expensive but provides complete pointer checks
         run: GOEXPERIMENT=cgocheck2 TEST_FIREWOOD_HASH_MODE=firewood go test ./...
       
-  ethhash:
+  ethhash-compatibility-go:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -156,6 +182,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: "false"
+          shared-key: "debug-ethhash"
       - name: Build Firewood FFI (with ethhash)
         run: cargo build --release --features ethhash
       - name: Set up Go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,16 @@ env:
 
 jobs:
   build:
+    # To optimize cargo performance and caching throughout the CI pipeline, we use Swatinem/rust-cache
+    # and set up an initial build job that writes the cache for a matrix of joint build profiles and
+    # feature sets.
+    # Future jobs specify the job they "need" (block to ensure the cache has been populated), the shared-key
+    # to read the cache and can set save-if: "false" to skip an expensive and unnecessary cache write.
+    #
+    # GitHub Actions does not provide easy support to define and re-use a matrix across multiple jobs
+    # and later jobs may also want to execute with only a subset of this matrix. Therefore, we define
+    # the matrix here and later jobs must re-specify the full matrix, a subset, or declare a single
+    # shared-key to read the cache.
     strategy:
       matrix:
         include:
@@ -59,7 +69,6 @@ jobs:
             profile-args: ""
           - profile-key: debug-ethhash-logger
             profile-args: "--features ethhash,logger"
-
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -187,7 +196,7 @@ jobs:
           save-if: "false"
           shared-key: "debug-ethhash-logger"
       - name: Build Firewood FFI (with ethhash)
-        run: cargo build --features ethhash
+        run: cargo build --features ethhash,logger
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/default-branch-cache.yaml
+++ b/.github/workflows/default-branch-cache.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: "false"
-          shared-key: "build"
+          shared-key: "debug-no-features"
       - name: Check
         run: cargo check --workspace --tests --examples --benches
       - name: Build

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -478,6 +478,8 @@ mod test {
                 Some(Child::AddressWithHash(LinearAddress::new(1).unwrap(), std::array::from_fn::<u8, 32, _>(|i| i as u8).into()))
         )})), 652; "full branch node with long partial path and value"
     )]
+    // When ethhash is enabled, we don't actually check the `expected_length`
+    #[allow(unused_variables)]
     fn test_serialize_deserialize(node: Node, expected_length: usize) {
         use crate::node::Node;
         use std::io::Cursor;


### PR DESCRIPTION
Propose an alternative to https://github.com/ava-labs/firewood/pull/897

Rather than breaking up GitHub Actions into individual jobs that specify the build profile and enabled feature flags, this uses a GitHub Actions matrix to specify a shared key and flags to pass to cargo to specify the build profile and feature flags.

This follows the existing semantics where the first `build` job generates a rust cache and writes it and future jobs depend on the first job to read the cache and disables cache writes to avoid an expensive and unnecessary write.

The current CI pipeline time is ~8 minutes (note: observed time is not a reliable measure as it's highly dependent on the number of machines allocated to Firewood's CI, which depends on the number of machines in use across the GitHub org and org-level settings, which I'm not aware of).

GitHub Actions does not allow re-usable matrix definitions, so subsequent jobs copy-paste either the same matrix, a subset, or explicitly use the same shared-key and feature flags as desired. The choice of what jobs to run in each configuration is based on what was laid out in this PR: https://github.com/ava-labs/firewood/pull/897.

Rather than providing the full map in a comment as in https://github.com/ava-labs/firewood/pull/897, this PR includes a single comment explaining the rationale for the matrix and ordering and leaves to the reader to see the individual choices for each subsequent job.