### PR TITLE
Update metrics port special case handling

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -15,6 +15,7 @@ package firewood
 // #cgo LDFLAGS: -L${SRCDIR}/../target/maxperf
 // #cgo LDFLAGS: -L/usr/local/lib -lfirewood_ffi
 // #include <stdlib.h>
+// #include <stdint.h>
 // #include "firewood.h"
 import "C"
 
@@ -50,7 +51,7 @@ type Config struct {
 	NodeCacheEntries  uint
 	Revisions         uint
 	ReadCacheStrategy CacheStrategy
-	MetricsPort       uint16
+	MetricsPort       int16
 }
 
 // DefaultConfig returns a sensible default Config.
@@ -97,7 +98,7 @@ func New(filePath string, conf *Config) (*Database, error) {
 		cache_size:   C.size_t(conf.NodeCacheEntries),
 		revisions:    C.size_t(conf.Revisions),
 		strategy:     C.uint8_t(conf.ReadCacheStrategy),
-		metrics_port: C.uint16_t(conf.MetricsPort),
+		metrics_port: C.int16_t(conf.MetricsPort),
 	}
 
 	var db *C.DatabaseHandle

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -44,13 +44,16 @@ typedef struct KeyValue {
  *   otherwise should exist if passed to `fwd_open_db()`.
  * * `cache_size` - The size of the node cache, panics if <= 0
  * * `revisions` - The maximum number of revisions to keep; firewood currently requires this to be at least 2
+ * * `metrics_port` - The port to use for the metrics server.
+ *    0 selects a random, available port.
+ *    -1 disables the metrics server.
  */
 typedef struct CreateOrOpenArgs {
   const char *path;
   size_t cache_size;
   size_t revisions;
   uint8_t strategy;
-  uint16_t metrics_port;
+  int16_t metrics_port;
 } CreateOrOpenArgs;
 
 typedef uint32_t ProposalId;


### PR DESCRIPTION
This PR updates the handling of special case ports in the Firewood FFI code:
- port 0 selects a random, available port
- negative port disables the metrics server