### PR TITLE
Remove unreachable test cases

### DIFF
--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -162,28 +162,26 @@ func TestInsert(t *testing.T) {
 	require.Equal(t, val, string(got), "Recover lone batch-inserted value")
 }
 
-// Attempt to make a call to a nil or invalid handle.
-// Each function should return an error and not panic.
-func TestGetBadHandle(t *testing.T) {
-	db := &Database{handle: nil}
+func TestClosedDatabase(t *testing.T) {
+	r := require.New(t)
+	dbFile := filepath.Join(t.TempDir(), "test.db")
+	db, _, err := newDatabase(dbFile)
+	r.NoError(err)
 
-	// This ignores error, but still shouldn't panic.
-	_, err := db.Get([]byte("non-existent"))
-	require.ErrorIs(t, err, errDBClosed)
+	r.NoError(db.Close())
 
-	// We ignore the error, but it shouldn't panic.
 	_, err = db.Root()
-	require.ErrorIs(t, err, errDBClosed)
+	r.ErrorIs(err, errDBClosed)
 
 	root, err := db.Update(
 		[][]byte{[]byte("key")},
 		[][]byte{[]byte("value")},
 	)
-	require.Empty(t, root)
-	require.ErrorIs(t, err, errDBClosed)
+	r.Empty(root)
+	r.ErrorIs(err, errDBClosed)
 
 	err = db.Close()
-	require.ErrorIs(t, err, errDBClosed)
+	r.ErrorIs(err, errDBClosed)
 }
 
 func keyForTest(i int) []byte {

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -430,21 +430,6 @@ func TestDeleteAll(t *testing.T) {
 	require.Equalf(t, expectedHash, hash, "%T.Root() of empty trie", db)
 }
 
-// Tests that a proposal with an invalid ID cannot be committed.
-func TestCommitFakeProposal(t *testing.T) {
-	db := newTestDatabase(t)
-
-	// Create a fake proposal with an invalid ID.
-	proposal := &Proposal{
-		handle: db.handle,
-		id:     1, // note that ID 0 is reserved for invalid proposals
-	}
-
-	// Attempt to get a value from the fake proposal.
-	_, err := proposal.Get([]byte("non-existent"))
-	require.Contains(t, err.Error(), "proposal not found", "Get(fake proposal)")
-}
-
 func TestDropProposal(t *testing.T) {
 	db := newTestDatabase(t)
 


### PR DESCRIPTION
This PR removes two unreachable test cases. Both test cases create an invalid instance of a type that we should have a guarantee is never constructed with a bad handle or proposal id.

In both cases, we have an alternative path to test when an instance of that type reaches such an invalid state, so we rely on those tests rather than constructing an invalid instance.