### PR TITLE
fix: Fix empty hash values

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -155,7 +155,7 @@ where
     }
 
     async fn root_hash(&self) -> Result<Option<TrieHash>, api::Error> {
-        Ok(self.manager.read().expect("poisoned lock").root_hash()?)
+        self.root_hash_sync()
     }
 
     async fn all_hashes(&self) -> Result<Vec<TrieHash>, api::Error> {
@@ -254,7 +254,11 @@ impl Db {
 
     /// Synchronously get the root hash of the latest revision.
     pub fn root_hash_sync(&self) -> Result<Option<TrieHash>, api::Error> {
-        Ok(self.manager.read().expect("poisoned lock").root_hash()?)
+        let hash = self.manager.read().expect("poisoned lock").root_hash()?;
+        #[cfg(not(feature = "ethhash"))]
+        return Ok(hash);
+        #[cfg(feature = "ethhash")]
+        return Ok(Some(hash.unwrap_or_else(storage::empty_trie_hash)));
     }
 
     /// Synchronously get a revision from a root hash
@@ -342,7 +346,10 @@ pub struct Proposal<'p> {
 impl Proposal<'_> {
     /// Get the root hash of the proposal synchronously
     pub fn root_hash_sync(&self) -> Result<Option<api::HashKey>, api::Error> {
-        Ok(self.nodestore.root_hash()?)
+        #[cfg(not(feature = "ethhash"))]
+        return Ok(self.nodestore.root_hash()?);
+        #[cfg(feature = "ethhash")]
+        return Ok(Some(self.nodestore.root_hash()?.unwrap_or_else(storage::empty_trie_hash)));
     }
 }
 

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -244,15 +244,9 @@ impl RevisionManager {
     }
 
     pub fn root_hash(&self) -> Result<Option<HashKey>, RevisionManagerError> {
-        self.current_revision()
+        Ok(self.current_revision()
             .kind
-            .root_hash()
-            .or_else(|| self.empty_trie_hash())
-            .map(Option::Some)
-            .ok_or(RevisionManagerError::IO(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "Root hash not found",
-            )))
+            .root_hash())
     }
 
     pub fn current_revision(&self) -> CommittedRevision {

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -175,6 +175,11 @@ pub trait Db {
     async fn revision(&self, hash: TrieHash) -> Result<Arc<Self::Historical>, Error>;
 
     /// Get the hash of the most recently committed version
+    ///
+    /// # Note
+    ///
+    /// If the database is empty, this will return None, unless the ethhash feature is enabled.
+    /// In that case, we return the special ethhash compatible empty trie hash.
     async fn root_hash(&self) -> Result<Option<TrieHash>, Error>;
 
     /// Get all the hashes available
@@ -214,6 +219,11 @@ pub trait DbView {
         Self: 'a;
 
     /// Get the root hash for the current DbView
+    ///
+    /// # Note
+    ///
+    /// If the database is empty, this will return None, unless the ethhash feature is enabled.
+    /// In that case, we return the special ethhash compatible empty trie hash.
     async fn root_hash(&self) -> Result<Option<HashKey>, Error>;
 
     /// Get the value of a specific key


### PR DESCRIPTION
When the trie is empty, be consistent about returning the same thing. This fix makes the "same thing" be:

 - If ethhash is enabled, always return the ethereum-compatible empty hash
 - If ethhash is disabled, return None.

If ethhash is disabled, the caller can easily map None to whatever empty hash they want. In hindsight, probably ethhash should return None as well for empty hashes, but that would require the callers to know what the magic hash is for ethhash.