### PR TITLE
ci: Upgrade actions/checkout

### DIFF
--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cleanup
         run: |

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: webiny/action-conventional-commits@v1.3.0
         with:

--- a/.github/workflows/default-branch-cache.yaml
+++ b/.github/workflows/default-branch-cache.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: arduino/setup-protoc@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Was v3 and v2 in some places, now v4 everywhere