### PR TITLE
feat: Improve error handling and add sync iterator

### DIFF
--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -3,7 +3,8 @@
 
 use sha2::{Digest, Sha256};
 use storage::{
-    BranchNode, HashType, Hashable, NibblesIterator, PathIterItem, Preimage, TrieHash, ValueDigest,
+    BranchNode, FileIoError, HashType, Hashable, NibblesIterator, PathIterItem, Preimage, TrieHash,
+    ValueDigest,
 };
 use thiserror::Error;
 
@@ -56,7 +57,7 @@ pub enum ProofError {
 
     /// Error from the merkle package
     #[error("{0:?}")]
-    IO(#[from] std::io::Error),
+    IO(#[from] FileIoError),
 
     /// Empty range
     #[error("empty range")]

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -23,7 +23,7 @@ pub mod logger;
 
 // re-export these so callers don't need to know where they are
 pub use hashednode::{Hashable, Preimage, ValueDigest, hash_node, hash_preimage};
-pub use linear::{ReadableStorage, WritableStorage};
+pub use linear::{FileIoError, ReadableStorage, WritableStorage};
 pub use node::path::{NibblesIterator, Path};
 pub use node::{BranchNode, Child, LeafNode, Node, PathIterItem, branch::HashType};
 pub use nodestore::{

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -102,7 +102,13 @@ impl FileBacked {
                 .setup_cqsize(FileBacked::RINGSIZE * 2)
                 // start a kernel thread to do the IO
                 .setup_sqpoll(IDLETIME_MS)
-                .build(FileBacked::RINGSIZE)?
+                .build(FileBacked::RINGSIZE)
+                .map_err(|e| FileIoError {
+                    inner: e,
+                    filename: Some(path.clone()),
+                    offset: 0,
+                    context: Some("IO-uring setup".to_string()),
+                })?
         };
 
         Ok(Self {

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -7,7 +7,7 @@
 // read/write operations at once
 
 use std::fs::{File, OpenOptions};
-use std::io::{Error, Read};
+use std::io::Read;
 use std::num::NonZero;
 #[cfg(unix)]
 use std::os::unix::fs::FileExt;
@@ -21,11 +21,12 @@ use metrics::counter;
 
 use crate::{CacheReadStrategy, LinearAddress, SharedNode};
 
-use super::{ReadableStorage, WritableStorage};
+use super::{FileIoError, ReadableStorage, WritableStorage};
 
-/// A [ReadableStorage] backed by a file
+/// A [ReadableStorage] and [WritableStorage] backed by a file
 pub struct FileBacked {
     fd: File,
+    filename: PathBuf,
     cache: Mutex<LruCache<LinearAddress, SharedNode>>,
     free_list_cache: Mutex<LruCache<LinearAddress, Option<LinearAddress>>>,
     cache_read_strategy: CacheReadStrategy,
@@ -40,6 +41,7 @@ impl std::fmt::Debug for FileBacked {
             .field("fd", &self.fd)
             .field("cache", &self.cache)
             .field("free_list_cache", &self.free_list_cache)
+            .field("cache_read_strategy", &self.cache_read_strategy)
             .finish()
     }
 }
@@ -73,13 +75,19 @@ impl FileBacked {
         free_list_cache_size: NonZero<usize>,
         truncate: bool,
         cache_read_strategy: CacheReadStrategy,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, FileIoError> {
         let fd = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(truncate)
-            .open(path)?;
+            .open(&path)
+            .map_err(|inner| FileIoError {
+                inner,
+                filename: Some(path.clone()),
+                offset: 0,
+                context: Some("file open".to_string()),
+            })?;
 
         #[cfg(feature = "io-uring")]
         let ring = {
@@ -102,6 +110,7 @@ impl FileBacked {
             cache: Mutex::new(LruCache::new(node_cache_size)),
             free_list_cache: Mutex::new(LruCache::new(free_list_cache_size)),
             cache_read_strategy,
+            filename: path,
             #[cfg(feature = "io-uring")]
             ring: ring.into(),
         })
@@ -109,12 +118,16 @@ impl FileBacked {
 }
 
 impl ReadableStorage for FileBacked {
-    fn stream_from(&self, addr: u64) -> Result<Box<dyn Read + '_>, Error> {
+    fn stream_from(&self, addr: u64) -> Result<Box<dyn Read + '_>, FileIoError> {
         Ok(Box::new(PredictiveReader::new(self, addr)))
     }
 
-    fn size(&self) -> Result<u64, Error> {
-        Ok(self.fd.metadata()?.len())
+    fn size(&self) -> Result<u64, FileIoError> {
+        Ok(self
+            .fd
+            .metadata()
+            .map_err(|e| self.file_io_error(e, 0, Some("size".to_string())))?
+            .len())
     }
 
     fn read_cached_node(&self, addr: LinearAddress, mode: &'static str) -> Option<SharedNode> {
@@ -153,24 +166,32 @@ impl ReadableStorage for FileBacked {
             }
         }
     }
+
+    fn filename(&self) -> Option<PathBuf> {
+        Some(self.filename.clone())
+    }
 }
 
 impl WritableStorage for FileBacked {
-    fn write(&self, offset: u64, object: &[u8]) -> Result<usize, Error> {
+    fn write(&self, offset: u64, object: &[u8]) -> Result<usize, FileIoError> {
         #[cfg(unix)]
         {
-            self.fd.write_at(object, offset)
+            self.fd
+                .write_at(object, offset)
+                .map_err(|e| self.file_io_error(e, offset, Some("write".to_string())))
         }
         #[cfg(windows)]
         {
-            self.fd.seek_write(object, offset)
+            self.fd
+                .seek_write(object, offset)
+                .map_err(|e| self.file_io_error(e, offset, Some("write".to_string())))
         }
     }
 
     fn write_cached_nodes<'a>(
         &self,
         nodes: impl Iterator<Item = (&'a std::num::NonZero<u64>, &'a SharedNode)>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), FileIoError> {
         let mut guard = self.cache.lock().expect("poisoned lock");
         for (addr, node) in nodes {
             guard.put(*addr, node.clone());

--- a/storage/src/linear/memory.rs
+++ b/storage/src/linear/memory.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use super::{ReadableStorage, WritableStorage};
+use super::{FileIoError, ReadableStorage, WritableStorage};
 use std::io::{Cursor, Read};
 use std::sync::Mutex;
 
@@ -21,7 +21,7 @@ impl MemStore {
 }
 
 impl WritableStorage for MemStore {
-    fn write(&self, offset: u64, object: &[u8]) -> Result<usize, std::io::Error> {
+    fn write(&self, offset: u64, object: &[u8]) -> Result<usize, FileIoError> {
         let offset = offset as usize;
         let mut guard = self.bytes.lock().expect("poisoned lock");
         if offset + object.len() > guard.len() {
@@ -33,7 +33,7 @@ impl WritableStorage for MemStore {
 }
 
 impl ReadableStorage for MemStore {
-    fn stream_from(&self, addr: u64) -> Result<Box<dyn Read>, std::io::Error> {
+    fn stream_from(&self, addr: u64) -> Result<Box<dyn Read>, FileIoError> {
         let bytes = self
             .bytes
             .lock()
@@ -45,7 +45,7 @@ impl ReadableStorage for MemStore {
         Ok(Box::new(Cursor::new(bytes)))
     }
 
-    fn size(&self) -> Result<u64, std::io::Error> {
+    fn size(&self) -> Result<u64, FileIoError> {
         Ok(self.bytes.lock().expect("poisoned lock").len() as u64)
     }
 }

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -15,13 +15,57 @@
 //! Each type is described in more detail below.
 
 use std::fmt::Debug;
-use std::io::{Error, Read};
+use std::io::Read;
 use std::num::NonZero;
+use std::ops::Deref;
+use std::path::PathBuf;
 
 use crate::{CacheReadStrategy, LinearAddress, SharedNode};
 pub(super) mod filebacked;
 pub mod memory;
 
+/// An error that occurs when reading or writing to a [ReadableStorage] or [WritableStorage]   
+///
+/// This error is used to wrap errors that occur when reading or writing to a file.
+/// It contains the filename, offset, and context of the error.
+#[derive(Debug)]
+pub struct FileIoError {
+    inner: std::io::Error,
+    filename: Option<PathBuf>,
+    offset: u64,
+    context: Option<String>,
+}
+
+impl std::error::Error for FileIoError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.inner)
+    }
+}
+
+impl std::fmt::Display for FileIoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{inner} at offset {offset} of file '{filename}' {context}",
+            inner = self.inner,
+            offset = self.offset,
+            filename = self
+                .filename
+                .as_ref()
+                .unwrap_or(&PathBuf::from("[unknown]"))
+                .display(),
+            context = self.context.as_ref().unwrap_or(&String::from(""))
+        )
+    }
+}
+
+impl Deref for FileIoError {
+    type Target = std::io::Error;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
 /// Trait for readable storage.
 pub trait ReadableStorage: Debug + Sync + Send {
     /// Stream data from the specified address.
@@ -33,10 +77,10 @@ pub trait ReadableStorage: Debug + Sync + Send {
     /// # Returns
     ///
     /// A `Result` containing a boxed `Read` trait object, or an `Error` if the operation fails.
-    fn stream_from(&self, addr: u64) -> Result<Box<dyn Read + '_>, Error>;
+    fn stream_from(&self, addr: u64) -> Result<Box<dyn Read + '_>, FileIoError>;
 
     /// Return the size of the underlying storage, in bytes
-    fn size(&self) -> Result<u64, Error>;
+    fn size(&self) -> Result<u64, FileIoError>;
 
     /// Read a node from the cache (if any)
     fn read_cached_node(&self, _addr: LinearAddress, _mode: &'static str) -> Option<SharedNode> {
@@ -55,6 +99,26 @@ pub trait ReadableStorage: Debug + Sync + Send {
 
     /// Cache a node for future reads
     fn cache_node(&self, _addr: LinearAddress, _node: SharedNode) {}
+
+    /// Return the filename of the underlying storage
+    fn filename(&self) -> Option<PathBuf> {
+        None
+    }
+
+    /// Convert an io::Error into a FileIoError
+    fn file_io_error(
+        &self,
+        error: std::io::Error,
+        offset: u64,
+        context: Option<String>,
+    ) -> FileIoError {
+        FileIoError {
+            inner: error,
+            filename: self.filename(),
+            offset,
+            context,
+        }
+    }
 }
 
 /// Trait for writable storage.
@@ -69,13 +133,13 @@ pub trait WritableStorage: ReadableStorage {
     /// # Returns
     ///
     /// The number of bytes written, or an error if the write operation fails.
-    fn write(&self, offset: u64, object: &[u8]) -> Result<usize, Error>;
+    fn write(&self, offset: u64, object: &[u8]) -> Result<usize, FileIoError>;
 
     /// Write all nodes to the cache (if any)
     fn write_cached_nodes<'a>(
         &self,
         _nodes: impl Iterator<Item = (&'a NonZero<u64>, &'a SharedNode)>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), FileIoError> {
         Ok(())
     }
 

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -36,6 +36,46 @@ pub struct FileIoError {
     context: Option<String>,
 }
 
+impl FileIoError {
+    /// Create a new [FileIoError] from a generic error
+    ///
+    /// Only use this constructor if you do not have any file or line information.
+    ///
+    /// # Arguments
+    ///
+    /// * `error` - The error to wrap
+    pub fn from_generic_no_file<T: std::error::Error>(error: T, context: &str) -> Self {
+        Self {
+            inner: std::io::Error::other(error.to_string()),
+            filename: None,
+            offset: 0,
+            context: Some(context.into()),
+        }
+    }
+
+    /// Create a new [FileIoError]
+    ///
+    /// # Arguments
+    ///
+    /// * `inner` - The inner error
+    /// * `filename` - The filename of the file that caused the error
+    /// * `offset` - The offset of the file that caused the error
+    /// * `context` - The context of this error
+    pub fn new(
+        inner: std::io::Error,
+        filename: Option<PathBuf>,
+        offset: u64,
+        context: Option<String>,
+    ) -> Self {
+        Self {
+            inner,
+            filename,
+            offset,
+            context,
+        }
+    }
+}
+
 impl std::error::Error for FileIoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.inner)

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -324,7 +324,7 @@ impl Node {
     }
 
     /// Given a reader, return a [Node] from those bytes
-    pub fn from_reader(mut serialized: impl Read) -> Result<Self, std::io::Error> {
+    pub fn from_reader(mut serialized: impl Read) -> Result<Self, Error> {
         let mut first_byte: [u8; 1] = [0];
         serialized.read_exact(&mut first_byte)?;
         match first_byte[0] {

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use crate::linear::FileIoError;
 use crate::logger::trace;
 use arc_swap::ArcSwap;
 use arc_swap::access::DynAccess;
@@ -183,19 +184,31 @@ struct StoredArea<T> {
 }
 
 impl<T: ReadInMemoryNode, S: ReadableStorage> NodeStore<T, S> {
-    /// Returns (index, area_size) for the [StoredArea] at `addr`.
-    /// `index` is the index of `area_size` in [AREA_SIZES].
-    fn area_index_and_size(&self, addr: LinearAddress) -> Result<(AreaIndex, u64), Error> {
+    /// Returns (index, area_size) for the stored area at `addr`.
+    /// `index` is the index of `area_size` in the array of valid block sizes.
+    pub fn area_index_and_size(
+        &self,
+        addr: LinearAddress,
+    ) -> Result<(AreaIndex, u64), FileIoError> {
         let mut area_stream = self.storage.stream_from(addr.get())?;
 
         let index: AreaIndex = serializer()
             .deserialize_from(&mut area_stream)
-            .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+            .map_err(|e| {
+                self.storage.file_io_error(
+                    Error::new(ErrorKind::InvalidData, e),
+                    addr.get(),
+                    Some("deserialize".to_string()),
+                )
+            })?;
 
-        let size = *AREA_SIZES.get(index as usize).ok_or(Error::new(
-            ErrorKind::InvalidData,
-            format!("Invalid area size index {}", index),
-        ))?;
+        let size = *AREA_SIZES
+            .get(index as usize)
+            .ok_or(self.storage.file_io_error(
+                Error::other(format!("Invalid area size index {index}")),
+                addr.get(),
+                None,
+            ))?;
 
         Ok((index, size))
     }
@@ -206,7 +219,7 @@ impl<T: ReadInMemoryNode, S: ReadableStorage> NodeStore<T, S> {
         &self,
         addr: LinearAddress,
         mode: &'static str,
-    ) -> Result<SharedNode, Error> {
+    ) -> Result<SharedNode, FileIoError> {
         if let Some(node) = self.storage.read_cached_node(addr, mode) {
             return Ok(node);
         }
@@ -218,7 +231,12 @@ impl<T: ReadInMemoryNode, S: ReadableStorage> NodeStore<T, S> {
         let _span = LocalSpan::enter_with_local_parent("read_and_deserialize");
 
         let area_stream = self.storage.stream_from(actual_addr)?;
-        let node: SharedNode = Node::from_reader(area_stream)?.into();
+        let node: SharedNode = Node::from_reader(area_stream)
+            .map_err(|e| {
+                self.storage
+                    .file_io_error(e, actual_addr, Some("read_node_from_disk".to_string()))
+            })?
+            .into();
         match self.storage.cache_read_strategy() {
             CacheReadStrategy::All => {
                 self.storage.cache_node(addr, node.clone());
@@ -232,52 +250,109 @@ impl<T: ReadInMemoryNode, S: ReadableStorage> NodeStore<T, S> {
         }
         Ok(node)
     }
+
+    /// Read a [Node] from the provided [LinearAddress] and size.
+    /// This is an uncached read, primarily used by check utilities
+    pub fn uncached_read_node_and_size(
+        &self,
+        addr: LinearAddress,
+    ) -> Result<(SharedNode, u8), FileIoError> {
+        let mut area_stream = self.storage.stream_from(addr.get())?;
+        let mut size = [0u8];
+        area_stream.read_exact(&mut size).map_err(|e| {
+            self.storage.file_io_error(
+                e,
+                addr.get(),
+                Some("uncached_read_node_and_size".to_string()),
+            )
+        })?;
+        self.storage.stream_from(addr.get() + 1)?;
+        let node: SharedNode = Node::from_reader(area_stream)
+            .map_err(|e| {
+                self.storage.file_io_error(
+                    e,
+                    addr.get(),
+                    Some("uncached_read_node_and_size".to_string()),
+                )
+            })?
+            .into();
+        Ok((node, size[0]))
+    }
+
+    /// Get a reference to the header of this nodestore
+    pub fn header(&self) -> &NodeStoreHeader {
+        &self.header
+    }
+
+    /// Get the size of an area index (used by the checker)
+    pub fn size_from_area_index(&self, index: AreaIndex) -> u64 {
+        AREA_SIZES[index as usize]
+    }
 }
 
 impl<S: ReadableStorage> NodeStore<Committed, S> {
     /// Open an existing [NodeStore]
     /// Assumes the header is written in the [ReadableStorage].
-    pub fn open(storage: Arc<S>) -> Result<Self, Error> {
+    pub fn open(storage: Arc<S>) -> Result<Self, FileIoError> {
         let mut stream = storage.stream_from(0)?;
         let mut header = NodeStoreHeader::new();
         let header_bytes = bytemuck::bytes_of_mut(&mut header);
-        stream.read_exact(header_bytes)?;
+        stream
+            .read_exact(header_bytes)
+            .map_err(|e| storage.file_io_error(e, 0, Some("header read".to_string())))?;
 
         drop(stream);
 
         if header.version != Version::new() {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "Incompatible firewood version",
+            return Err(storage.file_io_error(
+                Error::new(ErrorKind::InvalidData, "Incompatible firewood version"),
+                0,
+                Some("header read".to_string()),
             ));
         }
         if header.endian_test != 1 {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "Database cannot be opened due to difference in endianness",
+            return Err(storage.file_io_error(
+                Error::new(
+                    ErrorKind::InvalidData,
+                    "Database cannot be opened due to difference in endianness",
+                ),
+                0,
+                Some("header read".to_string()),
             ));
         }
 
         if header.area_size_hash != area_size_hash().as_slice() {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "Database cannot be opened due to difference in area size hash",
+            return Err(storage.file_io_error(
+                Error::new(
+                    ErrorKind::InvalidData,
+                    "Database cannot be opened due to difference in area size hash",
+                ),
+                0,
+                Some("header read".to_string()),
             ));
         }
 
         #[cfg(not(feature = "ethhash"))]
         if header.ethhash != 0 {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "Database cannot be opened as it was created with ethhash enabled",
+            return Err(storage.file_io_error(
+                Error::new(
+                    ErrorKind::InvalidData,
+                    "Database cannot be opened as it was created with ethhash enabled",
+                ),
+                0,
+                Some("header read".to_string()),
             ));
         }
 
         #[cfg(feature = "ethhash")]
         if header.ethhash != 1 {
-            return Err(Error::new(
-                ErrorKind::InvalidData,
-                "Database cannot be opened as it was created without ethhash enabled",
+            return Err(storage.file_io_error(
+                Error::new(
+                    ErrorKind::InvalidData,
+                    "Database cannot be opened as it was created without ethhash enabled",
+                ),
+                0,
+                Some("header read".to_string()),
             ));
         }
 
@@ -301,7 +376,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
 
     /// Create a new, empty, Committed [NodeStore] and clobber
     /// the underlying store with an empty freelist and no root node
-    pub fn new_empty_committed(storage: Arc<S>) -> Result<Self, Error> {
+    pub fn new_empty_committed(storage: Arc<S>) -> Result<Self, FileIoError> {
         let header = NodeStoreHeader::new();
 
         Ok(Self {
@@ -340,7 +415,7 @@ impl Parentable for Arc<ImmutableProposal> {
 impl<S> NodeStore<Arc<ImmutableProposal>, S> {
     /// When an immutable proposal commits, we need to reparent any proposal that
     /// has the committed proposal as it's parent
-    pub fn commit_reparent(&self, other: &Arc<NodeStore<Arc<ImmutableProposal>, S>>) -> bool {
+    pub fn commit_reparent(&self, other: &Arc<NodeStore<Arc<ImmutableProposal>, S>>) {
         match *other.kind.parent.load() {
             NodeStoreParent::Proposed(ref parent) => {
                 if Arc::ptr_eq(&self.kind, parent) {
@@ -348,12 +423,9 @@ impl<S> NodeStore<Arc<ImmutableProposal>, S> {
                         .kind
                         .parent
                         .store(NodeStoreParent::Committed(self.kind.root_hash()).into());
-                    true
-                } else {
-                    false
                 }
             }
-            NodeStoreParent::Committed(_) => false,
+            NodeStoreParent::Committed(_) => {}
         }
     }
 }
@@ -371,7 +443,7 @@ impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
     /// Create a new MutableProposal [NodeStore] from a parent [NodeStore]
     pub fn new<F: Parentable + ReadInMemoryNode>(
         parent: Arc<NodeStore<F, S>>,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, FileIoError> {
         let mut deleted: Vec<_> = Default::default();
         let root = if let Some(root_addr) = parent.header.root_address {
             deleted.push(root_addr);
@@ -401,7 +473,7 @@ impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
     /// Reads a node for update, marking it as deleted in this proposal.
     /// We get an arc from cache (reading it from disk if necessary) then
     /// copy/clone the node and return it.
-    pub fn read_for_update(&mut self, addr: LinearAddress) -> Result<Node, Error> {
+    pub fn read_for_update(&mut self, addr: LinearAddress) -> Result<Node, FileIoError> {
         self.delete_node(addr);
         let arc_wrapped_node = self.read_node(addr)?;
         Ok((*arc_wrapped_node).clone())
@@ -440,9 +512,15 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
     /// and the index of the free list that was used.
     /// If there are no free areas big enough for `n` bytes, returns None.
     /// TODO danlaine: If we return a larger area than requested, we should split it.
-    fn allocate_from_freed(&mut self, n: u64) -> Result<Option<(LinearAddress, AreaIndex)>, Error> {
+    fn allocate_from_freed(
+        &mut self,
+        n: u64,
+    ) -> Result<Option<(LinearAddress, AreaIndex)>, FileIoError> {
         // Find the smallest free list that can fit this size.
-        let index_wanted = area_size_to_index(n)?;
+        let index_wanted = area_size_to_index(n).map_err(|e| {
+            self.storage
+                .file_io_error(e, 0, Some("allocate_from_freed".to_string()))
+        })?;
 
         if let Some((index, free_stored_area_addr)) = self
             .header
@@ -464,15 +542,22 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
                 let free_head_stream = self.storage.stream_from(free_area_addr)?;
                 let free_head: StoredArea<Area<Node, FreeArea>> = serializer()
                     .deserialize_from(free_head_stream)
-                    .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+                    .map_err(|e| {
+                        self.storage.file_io_error(
+                            Error::new(ErrorKind::InvalidData, e),
+                            free_area_addr,
+                            Some("allocate_from_freed".to_string()),
+                        )
+                    })?;
                 let StoredArea {
                     area: Area::Free(free_head),
                     area_size_index: read_index,
                 } = free_head
                 else {
-                    return Err(Error::new(
-                        ErrorKind::InvalidData,
-                        "Attempted to read a non-free area",
+                    return Err(self.storage.file_io_error(
+                        Error::new(ErrorKind::InvalidData, "Attempted to read a non-free area"),
+                        free_area_addr,
+                        Some("allocate_from_freed".to_string()),
                     ));
                 };
                 debug_assert_eq!(read_index as usize, index);
@@ -500,8 +585,11 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
         Ok(None)
     }
 
-    fn allocate_from_end(&mut self, n: u64) -> Result<(LinearAddress, AreaIndex), Error> {
-        let index = area_size_to_index(n)?;
+    fn allocate_from_end(&mut self, n: u64) -> Result<(LinearAddress, AreaIndex), FileIoError> {
+        let index = area_size_to_index(n).map_err(|e| {
+            self.storage
+                .file_io_error(e, 0, Some("allocate_from_end".to_string()))
+        })?;
         let area_size = AREA_SIZES[index as usize];
         let addr = LinearAddress::new(self.header.size).expect("node store size can't be 0");
         self.header.size += area_size;
@@ -520,7 +608,10 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
     /// Returns an address that can be used to store the given `node` and updates
     /// `self.header` to reflect the allocation. Doesn't actually write the node to storage.
     /// Also returns the index of the free list the node was allocated from.
-    pub fn allocate_node(&mut self, node: &Node) -> Result<(LinearAddress, AreaIndex), Error> {
+    pub fn allocate_node(
+        &mut self,
+        node: &Node,
+    ) -> Result<(LinearAddress, AreaIndex), FileIoError> {
         let stored_area_size = Self::stored_len(node);
 
         // Attempt to allocate from a free list.
@@ -539,7 +630,7 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
     /// Deletes the [Node] at the given address, updating the next pointer at
     /// the given addr, and changing the header of this committed nodestore to
     /// have the address on the freelist
-    pub fn delete_node(&mut self, addr: LinearAddress) -> Result<(), Error> {
+    pub fn delete_node(&mut self, addr: LinearAddress) -> Result<(), FileIoError> {
         debug_assert!(addr.get() % 8 == 0);
 
         let (area_size_index, _) = self.area_index_and_size(addr)?;
@@ -558,9 +649,13 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
             area,
         };
 
-        let stored_area_bytes = serializer()
-            .serialize(&stored_area)
-            .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+        let stored_area_bytes = serializer().serialize(&stored_area).map_err(|e| {
+            self.storage.file_io_error(
+                Error::new(ErrorKind::InvalidData, e),
+                addr.get(),
+                Some("delete_node".to_string()),
+            )
+        })?;
 
         self.storage.write(addr.into(), &stored_area_bytes)?;
 
@@ -617,7 +712,7 @@ pub type FreeLists = [Option<LinearAddress>; NUM_AREA_SIZES];
 /// The [NodeStoreHeader] is at the start of the ReadableStorage.
 #[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone, NoUninit, AnyBitPattern)]
 #[repr(C)]
-struct NodeStoreHeader {
+pub struct NodeStoreHeader {
     /// Identifies the version of firewood used to create this [NodeStore].
     version: Version,
     /// always "1"; verifies endianness
@@ -659,6 +754,11 @@ impl NodeStoreHeader {
             ethhash: 0,
         }
     }
+
+    // return the size of this nodestore
+    pub fn size(&self) -> u64 {
+        self.size
+    }
 }
 
 /// A [FreeArea] is stored at the start of the area that contained a node that
@@ -671,10 +771,10 @@ struct FreeArea {
 /// Reads from an immutable (i.e. already hashed) merkle trie.
 pub trait HashedNodeReader: TrieReader {
     /// Gets the address and hash of the root node of an immutable merkle trie.
-    fn root_address_and_hash(&self) -> Result<Option<(LinearAddress, TrieHash)>, Error>;
+    fn root_address_and_hash(&self) -> Result<Option<(LinearAddress, TrieHash)>, FileIoError>;
 
     /// Gets the hash of the root node of an immutable merkle trie.
-    fn root_hash(&self) -> Result<Option<TrieHash>, Error> {
+    fn root_hash(&self) -> Result<Option<TrieHash>, FileIoError> {
         Ok(self.root_address_and_hash()?.map(|(_, hash)| hash))
     }
 }
@@ -686,7 +786,7 @@ impl<T> TrieReader for T where T: NodeReader + RootReader {}
 /// Reads nodes from a merkle trie.
 pub trait NodeReader {
     /// Returns the node at `addr`.
-    fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, Error>;
+    fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError>;
 }
 
 impl<T> NodeReader for T
@@ -694,7 +794,7 @@ where
     T: Deref,
     T::Target: NodeReader,
 {
-    fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, Error> {
+    fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
         self.deref().read_node(addr)
     }
 }
@@ -902,7 +1002,7 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
         path_prefix: &mut Path,
         new_nodes: &mut HashMap<LinearAddress, (u8, SharedNode)>,
         #[cfg(feature = "ethhash")] fake_root_extra_nibble: Option<u8>,
-    ) -> Result<(LinearAddress, HashType), Error> {
+    ) -> Result<(LinearAddress, HashType), FileIoError> {
         // If this is a branch, find all unhashed children and recursively call hash_helper on them.
         trace!("hashing {node:?} at {path_prefix:?}");
         if let Node::Branch(ref mut b) = node {
@@ -1028,7 +1128,7 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
 
 impl<T, S: WritableStorage> NodeStore<T, S> {
     /// Persist the header from this proposal to storage.
-    pub fn flush_header(&self) -> Result<(), Error> {
+    pub fn flush_header(&self) -> Result<(), FileIoError> {
         let header_bytes = bytemuck::bytes_of(&self.header);
         self.storage.write(0, header_bytes)?;
         Ok(())
@@ -1036,7 +1136,7 @@ impl<T, S: WritableStorage> NodeStore<T, S> {
 
     /// Persist the header, including all the padding
     /// This is only done the first time we write the header
-    pub fn flush_header_with_padding(&self) -> Result<(), Error> {
+    pub fn flush_header_with_padding(&self) -> Result<(), FileIoError> {
         let header_bytes = bytemuck::bytes_of(&self.header)
             .iter()
             .copied()
@@ -1052,7 +1152,7 @@ impl<T, S: WritableStorage> NodeStore<T, S> {
 impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
     /// Persist the freelist from this proposal to storage.
     #[fastrace::trace(short_name = true)]
-    pub fn flush_freelist(&self) -> Result<(), Error> {
+    pub fn flush_freelist(&self) -> Result<(), FileIoError> {
         // Write the free lists to storage
         let free_list_bytes = bytemuck::bytes_of(&self.header.free_lists);
         let free_list_offset = offset_of!(NodeStoreHeader, free_lists) as u64;
@@ -1063,7 +1163,7 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
     /// Persist all the nodes of a proposal to storage.
     #[fastrace::trace(short_name = true)]
     #[cfg(not(feature = "io-uring"))]
-    pub fn flush_nodes(&self) -> Result<(), Error> {
+    pub fn flush_nodes(&self) -> Result<(), FileIoError> {
         let flush_start = Instant::now();
 
         for (addr, (area_size_index, node)) in self.kind.new.iter() {
@@ -1183,7 +1283,7 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
 impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
     for NodeStore<Arc<ImmutableProposal>, S>
 {
-    type Error = std::io::Error;
+    type Error = FileIoError;
 
     fn try_from(val: NodeStore<MutableProposal, S>) -> Result<Self, Self::Error> {
         let NodeStore {
@@ -1233,7 +1333,7 @@ impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
 }
 
 impl<S: ReadableStorage> NodeReader for NodeStore<MutableProposal, S> {
-    fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, Error> {
+    fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
         if let Some(node) = self.kind.read_in_memory_node(addr) {
             return Ok(node);
         }
@@ -1243,7 +1343,7 @@ impl<S: ReadableStorage> NodeReader for NodeStore<MutableProposal, S> {
 }
 
 impl<T: Parentable + ReadInMemoryNode, S: ReadableStorage> NodeReader for NodeStore<T, S> {
-    fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, Error> {
+    fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
         if let Some(node) = self.kind.read_in_memory_node(addr) {
             return Ok(node);
         }
@@ -1272,7 +1372,7 @@ where
     T: ReadInMemoryNode,
     S: ReadableStorage,
 {
-    fn root_address_and_hash(&self) -> Result<Option<(LinearAddress, TrieHash)>, Error> {
+    fn root_address_and_hash(&self) -> Result<Option<(LinearAddress, TrieHash)>, FileIoError> {
         if let Some(root_addr) = self.header.root_address {
             let root_node = self.read_node(root_addr)?;
             let root_hash = hash_node(&root_node, &Path::new());
@@ -1289,7 +1389,7 @@ where
     T: ReadInMemoryNode,
     S: ReadableStorage,
 {
-    fn root_address_and_hash(&self) -> Result<Option<(LinearAddress, TrieHash)>, Error> {
+    fn root_address_and_hash(&self) -> Result<Option<(LinearAddress, TrieHash)>, FileIoError> {
         if let Some(root_addr) = self.header.root_address {
             let root_node = self.read_node(root_addr)?;
             let root_hash = hash_node(&root_node, &Path::new());
@@ -1302,7 +1402,10 @@ where
 
 impl<S: WritableStorage> NodeStore<Committed, S> {
     /// adjust the freelist of this proposal to reflect the freed nodes in the oldest proposal
-    pub fn reap_deleted(mut self, proposal: &mut NodeStore<Committed, S>) -> Result<(), Error> {
+    pub fn reap_deleted(
+        mut self,
+        proposal: &mut NodeStore<Committed, S>,
+    ) -> Result<(), FileIoError> {
         self.storage
             .invalidate_cached_nodes(self.kind.deleted.iter());
         trace!("There are {} nodes to reap", self.kind.deleted.len());


### PR DESCRIPTION
While debugging, I couldn't figure out where the error was coming from, so I revamped the error handling to include the filename and line number everywhere an IO error could happen.

Many places that previously used std::io::Error now use FileIoError to include the additional context information.

Also, this change adds support for synchronous iterators for both nodes and key/values, which is needed for synchronous range and change proofs.