### PR TITLE
fix(attach-static-libs): push commit/branch to remote on tag events

### DIFF
--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -131,12 +131,11 @@ jobs:
           git checkout -b ${{ steps.determine_branch.outputs.target_branch }}
           git add .
           git commit -m "firewood ci ${{ github.sha }}: attach firewood static libs"
+          git push -u origin ${{ steps.determine_branch.outputs.target_branch }} --force
           
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             git tag -a "${GITHUB_REF#refs/tags/}" -m "firewood ci ${{ github.sha }}: attach firewood static libs"
             git push origin "refs/tags/${GITHUB_REF#refs/tags/}"
-          else
-            git push -u origin ${{ steps.determine_branch.outputs.target_branch }} --force
           fi
 
   # Check out the branch created in the previous job on a matrix of


### PR DESCRIPTION
This moves the first push outside of an if/else branch checking whether the trigger was a tag.

The previous behavior was to only push the branch to the firewood-go remote if it was _not_ a tag event. This changes it to always push the branch and therefore the commit to the repo to avoid creating a dangling/orphaned commit on firewood-go.

When go downloads a tagged dependency, it seems to get confused by dangling commits as it tries to translate from a tag to a canonical version: "go command will automatically convert revision names that don’t follow this standard into canonical versions" ([ref](https://go.dev/ref/mod#versions)).