### PR TITLE
feat(metrics): Add read_node counters

### DIFF
--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -125,6 +125,7 @@ impl FileBacked {
 
 impl ReadableStorage for FileBacked {
     fn stream_from(&self, addr: u64) -> Result<Box<dyn Read + '_>, FileIoError> {
+        counter!("firewood.read_node", "from" => "file").increment(1);
         Ok(Box::new(PredictiveReader::new(self, addr)))
     }
 

--- a/storage/src/linear/memory.rs
+++ b/storage/src/linear/memory.rs
@@ -2,6 +2,7 @@
 // See the file LICENSE.md for licensing terms.
 
 use super::{FileIoError, ReadableStorage, WritableStorage};
+use metrics::counter;
 use std::io::{Cursor, Read};
 use std::sync::Mutex;
 
@@ -34,6 +35,7 @@ impl WritableStorage for MemStore {
 
 impl ReadableStorage for MemStore {
     fn stream_from(&self, addr: u64) -> Result<Box<dyn Read>, FileIoError> {
+        counter!("firewood.read_node", "from" => "memory").increment(1);
         let bytes = self
             .bytes
             .lock()


### PR DESCRIPTION
I need these counters for some tests, and they are generally useful anyway, so adding them as a separate PR.