### PR TITLE
build: move lints to the workspace

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,6 @@ jobs:
       - name: Build
         run: cargo build ${{ matrix.profile-args }} --workspace --all-targets
 
-
   no-rust-cache-lint:
     runs-on: ubuntu-latest
     steps:
@@ -58,6 +57,35 @@ jobs:
           strict: true
       - name: Format
         run: cargo fmt -- --check
+
+  rust-lint-pr-comments:
+    # caveat emptor: actions-rs/clippy-check can only write comments on pull requests
+    # not originating from a fork.
+    if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - profile-key: debug-no-features
+            profile-args: ""
+          - profile-key: debug-ethhash-logger
+            profile-args: "--features ethhash,logger"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: "false"
+          shared-key: ${{ matrix.profile-key }}
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ matrix.profile-key }}
+          args: ${{ matrix.profile-args }} --workspace --all-targets
 
   rust-lint:
     needs: build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,9 +40,9 @@ jobs:
         with:
           shared-key: ${{ matrix.profile-key }}
       - name: Check
-        run: cargo check ${{ matrix.profile-args }} --workspace --tests --examples --benches
+        run: cargo check ${{ matrix.profile-args }} --workspace --all-targets
       - name: Build
-        run: cargo build ${{ matrix.profile-args }} --workspace --tests --examples --benches
+        run: cargo build ${{ matrix.profile-args }} --workspace --all-targets
 
 
   no-rust-cache-lint:
@@ -80,7 +80,7 @@ jobs:
           save-if: "false"
           shared-key: ${{ matrix.profile-key }}
       - name: Clippy
-        run: cargo clippy ${{ matrix.profile-args }} --tests --examples --benches -- -D warnings
+        run: cargo clippy ${{ matrix.profile-args }} --workspace --all-targets -- -D warnings
 
   test:
     needs: build
@@ -191,7 +191,7 @@ jobs:
         working-directory: ffi
         # cgocheck2 is expensive but provides complete pointer checks
         run: GOEXPERIMENT=cgocheck2 TEST_FIREWOOD_HASH_MODE=firewood go test ./...
-      
+
   firewood-ethhash-differential-fuzz:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/default-branch-cache.yaml
+++ b/.github/workflows/default-branch-cache.yaml
@@ -25,6 +25,6 @@ jobs:
           save-if: "false"
           shared-key: "debug-no-features"
       - name: Check
-        run: cargo check --workspace --tests --examples --benches
+        run: cargo check --workspace --all-targets
       - name: Build
-        run: cargo build --workspace --tests --examples --benches
+        run: cargo build --workspace --all-targets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,15 @@ codegen-units = 1
 lto = "fat"
 debug = false
 inherits = "release"
+
+[workspace.lints.rust]
+unsafe_code = "deny"
+
+[workspace.lints.clippy]
+unwrap_used = "warn"
+indexing_slicing = "warn"
+explicit_deref_methods = "warn"
+missing_const_for_fn = "warn"
+arithmetic_side_effects = "warn"
+# lower the priority of pedantic to allow overriding the lints it includes
+pedantic = { level = "warn", priority = -1 }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -42,3 +42,6 @@ tikv-jemallocator = "0.6.0"
 
 [features]
 logger = ["firewood/logger"]
+
+[lints]
+workspace = true

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -130,7 +130,7 @@ If you want to install grafana and prometheus on an AWS host (using Ubuntu as a 
 4. Run the scripts as described above, including the grafana installation.
 5. Log in to grafana on <http://YOUR-AWS-IP>
    a. username: admin, password: admin
-6. When prompted, change the password (firewood_is_fast)
+6. When prompted, change the password (`firewood_is_fast`)
 7. On the left panel, click "Data Sources"
    a. Select "Prometheus"
    b. For the URL, use <http://localhost:9090>

--- a/benchmark/src/create.rs
+++ b/benchmark/src/create.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/benchmark/src/create.rs
+++ b/benchmark/src/create.rs
@@ -1,6 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use std::error::Error;
 use std::time::Instant;
 

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -2,15 +2,15 @@
 // See the file LICENSE.md for licensing terms.
 //
 
-#![allow(
+#![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 2 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::match_same_arms,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -202,9 +202,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         fastrace::set_reporter(reporter, Config::default());
     }
 
-    if args.test_name == TestName::Single && args.global_opts.batch_size > 1000 {
-        panic!("Single test is not designed to handle batch sizes > 1000");
-    }
+    assert!(
+        !(args.test_name == TestName::Single && args.global_opts.batch_size > 1000),
+        "Single test is not designed to handle batch sizes > 1000"
+    );
 
     env_logger::Builder::new()
         .filter_level(match args.global_opts.log_level.as_str() {

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -2,6 +2,18 @@
 // See the file LICENSE.md for licensing terms.
 //
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::match_same_arms,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
 #![doc = include_str!("../README.md")]
 
 use clap::{Parser, Subcommand, ValueEnum};

--- a/benchmark/src/single.rs
+++ b/benchmark/src/single.rs
@@ -1,15 +1,15 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 2 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::cast_sign_loss,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/benchmark/src/single.rs
+++ b/benchmark/src/single.rs
@@ -1,6 +1,19 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_sign_loss,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use crate::TestRunner;
 use firewood::db::{BatchOp, Db};
 use firewood::v2::api::{Db as _, Proposal as _};

--- a/benchmark/src/tenkrandom.rs
+++ b/benchmark/src/tenkrandom.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 7 occurrences after enabling the lint."
 )]

--- a/benchmark/src/tenkrandom.rs
+++ b/benchmark/src/tenkrandom.rs
@@ -1,6 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 7 occurrences after enabling the lint."
+)]
+
 use std::error::Error;
 use std::time::Instant;
 

--- a/benchmark/src/zipf.rs
+++ b/benchmark/src/zipf.rs
@@ -1,6 +1,27 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_precision_loss,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_sign_loss,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unwrap_used,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use crate::TestRunner;
 use firewood::db::{BatchOp, Db};
 use firewood::v2::api::{Db as _, Proposal as _};

--- a/benchmark/src/zipf.rs
+++ b/benchmark/src/zipf.rs
@@ -1,23 +1,23 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 2 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
     reason = "Found 2 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::cast_precision_loss,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::cast_sign_loss,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::unwrap_used,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -38,10 +38,5 @@ ethhash = ["firewood/ethhash"]
 [build-dependencies]
 cbindgen = "0.29.0"
 
-[lints.clippy]
-unwrap_used = "warn"
-indexing_slicing = "warn"
-explicit_deref_methods = "warn"
-missing_const_for_fn = "warn"
-pedantic = "warn"
-arithmetic_side_effects = "warn"
+[lints]
+workspace = true

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -729,7 +729,7 @@ pub unsafe extern "C" fn fwd_free_value(value: *mut Value) {
         };
         drop(recreated_box);
     } else {
-        let raw_str = value.data.cast_mut();
+        let raw_str = value.data.cast_mut().cast::<c_char>();
         let cstr = unsafe { CString::from_raw(raw_str) };
         drop(cstr);
     }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -729,7 +729,7 @@ pub unsafe extern "C" fn fwd_free_value(value: *mut Value) {
         };
         drop(recreated_box);
     } else {
-        let raw_str = value.data as *mut c_char;
+        let raw_str = value.data.cast_mut();
         let cstr = unsafe { CString::from_raw(raw_str) };
         drop(cstr);
     }

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -1,5 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
+
+#![allow(
+    unsafe_code,
+    reason = "This is an FFI library, so unsafe code is expected."
+)]
+
 use std::collections::HashMap;
 use std::ffi::{CStr, CString, OsStr, c_char};
 use std::fmt::{self, Display, Formatter};
@@ -240,7 +246,7 @@ pub struct KeyValue {
 /// The new root hash of the database, in Value form.
 /// A `Value` containing {0, "error message"} if the commit failed.
 ///
-/// # Errors    
+/// # Errors
 ///
 /// * `"key-value pair is null"` - A `KeyValue` struct is null
 /// * `"db should be non-null"` - The database handle is null

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -64,15 +64,11 @@ hash-db = "0.16.0"
 name = "hashops"
 harness = false
 
-[lints.clippy]
-unwrap_used = "warn"
-indexing_slicing = "warn"
-explicit_deref_methods = "warn"
-missing_const_for_fn = "warn"
-arithmetic_side_effects = "warn"
-
 [target.'cfg(target_os = "linux")'.dependencies]
 firewood-storage = { version = "0.0.5", path = "../storage", features = ["io-uring"] }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 firewood-storage = { version = "0.0.5", path = "../storage" }
+
+[lints]
+workspace = true

--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -131,7 +131,7 @@ fn bench_db<const N: usize>(criterion: &mut Criterion) {
                             .await
                             .unwrap();
 
-                        db.propose(batch_ops).await.unwrap().commit().await.unwrap()
+                        db.propose(batch_ops).await.unwrap().commit().await.unwrap();
                     },
                     BatchSize::SmallInput,
                 );

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -1,6 +1,27 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::default_trait_access,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "Found 12 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_panics_doc,
+    reason = "Found 5 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unused_async,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+
 use crate::merkle::Merkle;
 use crate::proof::{Proof, ProofNode};
 use crate::range_proof::RangeProof;

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -1,23 +1,19 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
-    clippy::default_trait_access,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
+#![expect(
     clippy::missing_errors_doc,
     reason = "Found 12 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::missing_panics_doc,
     reason = "Found 5 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::needless_pass_by_value,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::unused_async,
     reason = "Found 2 occurrences after enabling the lint."
 )]
@@ -487,8 +483,13 @@ impl Proposal<'_> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used)]
 mod test {
+    #![expect(clippy::unwrap_used)]
+    #![expect(
+        clippy::default_trait_access,
+        reason = "Found 1 occurrences after enabling the lint."
+    )]
+
     use std::ops::{Deref, DerefMut};
     use std::path::PathBuf;
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -312,7 +312,7 @@ impl Db {
         let merkle = Merkle::from(latest_rev_nodestore);
         // TODO: This should be a stream
         let output = merkle.dump()?;
-        write!(w, "{}", output)
+        write!(w, "{output}")
     }
 
     /// Get a copy of the database metrics

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -63,13 +63,13 @@
 //! Firewood is built by layers of abstractions that totally decouple the layout/representation
 //! of the data on disk from the actual logical data structure it retains:
 //!
-//! - The storage module has a [firewood_storage::NodeStore] which has a generic parameter identifying
+//! - The storage module has a [`firewood_storage::NodeStore`] which has a generic parameter identifying
 //!   the state of the nodestore, and a storage type.
 //!
 //!   There are three states for a nodestore:
-//!    - [firewood_storage::Committed] for revisions that are on disk
-//!    - [firewood_storage::ImmutableProposal] for revisions that are proposals against committed versions
-//!    - [firewood_storage::MutableProposal] for revisions where nodes are still being added.
+//!    - [`firewood_storage::Committed`] for revisions that are on disk
+//!    - [`firewood_storage::ImmutableProposal`] for revisions that are proposals against committed versions
+//!    - [`firewood_storage::MutableProposal`] for revisions where nodes are still being added.
 //!
 //!  For more information on these node states, see their associated documentation.
 //!
@@ -85,17 +85,17 @@
 //!
 //! In short, a Read-Modify-Write (RMW) style normal operation flow is as follows in Firewood:
 //!
-//! - Create a [firewood_storage::MutableProposal] [firewood_storage::NodeStore] from the most recent [firewood_storage::Committed] one.
+//! - Create a [`firewood_storage::MutableProposal`] [`firewood_storage::NodeStore`] from the most recent [`firewood_storage::Committed`] one.
 //! - Traverse the trie, starting at the root. Make a new root node by duplicating the existing
 //!   root from the committed one and save that in memory. As you continue traversing, make copies
 //!   of each node accessed if they are not already in memory.
 //!
 //! - Make changes to the trie, in memory. Each node you've accessed is currently in memory and is
-//!   owned by the [firewood_storage::MutableProposal]. Adding a node simply means adding a reference to it.
+//!   owned by the [`firewood_storage::MutableProposal`]. Adding a node simply means adding a reference to it.
 //!
 //! - If you delete a node, mark it as deleted in the proposal and remove the child reference to it.
 //!
-//! - After making all mutations, convert the [firewood_storage::MutableProposal] to an [firewood_storage::ImmutableProposal]. This
+//! - After making all mutations, convert the [`firewood_storage::MutableProposal`] to an [`firewood_storage::ImmutableProposal`]. This
 //!   involves walking the in-memory trie and looking for nodes without disk addresses, then assigning
 //!   them from the freelist of the parent. This gives the node an address, but it is stil in
 //!   memory.

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -1,28 +1,65 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::unnecessary_wraps,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::unused_self,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::used_underscore_binding,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    feature = "ethhash",
+    expect(
+        clippy::unnecessary_wraps,
+        reason = "Found 2 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    feature = "ethhash",
+    expect(
+        clippy::used_underscore_binding,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    expect(
+        clippy::unnecessary_wraps,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    expect(
+        clippy::unused_self,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![expect(
     clippy::cast_precision_loss,
     reason = "Found 2 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::default_trait_access,
     reason = "Found 3 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::needless_pass_by_value,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
-    clippy::unnecessary_wraps,
-    reason = "Found 2 occurrences after enabling the lint."
-)]
-#![allow(
-    clippy::unused_self,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
-    clippy::used_underscore_binding,
     reason = "Found 1 occurrences after enabling the lint."
 )]
 

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -82,9 +82,10 @@ impl RevisionManager {
             truncate,
             config.cache_read_strategy,
         )?);
-        let nodestore = match truncate {
-            true => Arc::new(NodeStore::new_empty_committed(storage.clone())?),
-            false => Arc::new(NodeStore::open(storage.clone())?),
+        let nodestore = if truncate {
+            Arc::new(NodeStore::new_empty_committed(storage.clone())?)
+        } else {
+            Arc::new(NodeStore::open(storage.clone())?)
         };
         let mut manager = Self {
             max_revisions: config.max_revisions,
@@ -219,7 +220,7 @@ impl RevisionManager {
             .retain(|p| !Arc::ptr_eq(&proposal, p) && Arc::strong_count(p) > 1);
 
         // then reparent any proposals that have this proposal as a parent
-        for p in self.proposals.iter() {
+        for p in &self.proposals {
             proposal.commit_reparent(p);
         }
 

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -1,6 +1,31 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::cast_precision_loss,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::default_trait_access,
+    reason = "Found 3 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unnecessary_wraps,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unused_self,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::used_underscore_binding,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use std::collections::{HashMap, VecDeque};
 use std::num::NonZero;
 use std::path::PathBuf;

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -2,27 +2,6 @@
 // See the file LICENSE.md for licensing terms.
 
 #![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::unnecessary_wraps,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::unused_self,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::used_underscore_binding,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
     feature = "ethhash",
     expect(
         clippy::unnecessary_wraps,
@@ -37,14 +16,14 @@
     )
 )]
 #![cfg_attr(
-    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    not(feature = "ethhash"),
     expect(
         clippy::unnecessary_wraps,
         reason = "Found 1 occurrences after enabling the lint."
     )
 )]
 #![cfg_attr(
-    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    not(feature = "ethhash"),
     expect(
         clippy::unused_self,
         reason = "Found 1 occurrences after enabling the lint."

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -1,24 +1,14 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![cfg_attr(
-    feature = "ethhash",
-    expect(
-        clippy::unnecessary_wraps,
-        reason = "Found 2 occurrences after enabling the lint."
-    )
+#![expect(
+    clippy::unnecessary_wraps,
+    reason = "Found 2 occurrences after enabling the lint."
 )]
 #![cfg_attr(
     feature = "ethhash",
     expect(
         clippy::used_underscore_binding,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    not(feature = "ethhash"),
-    expect(
-        clippy::unnecessary_wraps,
         reason = "Found 1 occurrences after enabling the lint."
     )
 )]

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -193,7 +193,7 @@ impl<T: TrieReader> Merkle<T> {
                     .value()
                     .map(|value| ValueDigest::Value(value.to_vec().into_boxed_slice())),
                 child_hashes,
-            })
+            });
         }
 
         Ok(Proof(proof.into_boxed_slice()))
@@ -369,7 +369,11 @@ impl<T: HashedNodeReader> Merkle<T> {
                     };
 
                     let inserted = seen.insert(child_addr);
-                    if !inserted {
+                    if inserted {
+                        writeln!(writer, "  {addr} -> {child_addr}[label=\"{childidx}\"]")
+                            .map_err(|e| FileIoError::from_generic_no_file(e, "write branch"))?;
+                        self.dump_node(child_addr, child_hash, seen, writer)?;
+                    } else {
                         // We have already seen this child, which shouldn't happen.
                         // Indicate this with a red edge.
                         writeln!(
@@ -377,10 +381,6 @@ impl<T: HashedNodeReader> Merkle<T> {
                             "  {addr} -> {child_addr}[label=\"{childidx} (dup)\" color=red]"
                         )
                         .map_err(|e| FileIoError::from_generic_no_file(e, "write branch"))?;
-                    } else {
-                        writeln!(writer, "  {addr} -> {child_addr}[label=\"{childidx}\"]")
-                            .map_err(|e| FileIoError::from_generic_no_file(e, "write branch"))?;
-                        self.dump_node(child_addr, child_hash, seen, writer)?;
                     }
                 }
             }
@@ -389,7 +389,7 @@ impl<T: HashedNodeReader> Merkle<T> {
                 writeln!(writer, "\" shape=rect]")
                     .map_err(|e| FileIoError::from_generic_no_file(e, "write leaf"))?;
             }
-        };
+        }
         Ok(())
     }
 
@@ -433,8 +433,9 @@ impl<S: ReadableStorage> TryFrom<Merkle<NodeStore<MutableProposal, S>>>
 }
 
 impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
-    /// Convert a merkle backed by an MutableProposal into an ImmutableProposal
+    /// Convert a merkle backed by an `MutableProposal` into an `ImmutableProposal`
     /// TODO: We probably don't need this function
+    #[must_use]
     pub fn hash(self) -> Merkle<NodeStore<Arc<ImmutableProposal>, S>> {
         // I think this is only used in testing
         self.try_into().expect("failed to convert")
@@ -883,7 +884,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
                         // the prefix matched only a leaf, so we remove it and indicate only one item was removed
                         *deleted = deleted.saturating_add(1);
                     }
-                };
+                }
                 Ok(None)
             }
             (_, Some(_)) => {
@@ -984,7 +985,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
             // a KV pair was in the branch itself
             *deleted = deleted.saturating_add(1);
         }
-        for children in branch.children.iter_mut() {
+        for children in &mut branch.children {
             // read the child node
             let child = match children {
                 Some(Child::Node(node)) => node,
@@ -1101,7 +1102,7 @@ mod tests {
     #[test]
     fn insert_one() {
         let mut merkle = create_in_memory_merkle();
-        merkle.insert(b"abc", Box::new([])).unwrap()
+        merkle.insert(b"abc", Box::new([])).unwrap();
     }
 
     fn create_in_memory_merkle() -> Merkle<NodeStore<MutableProposal, MemStore>> {
@@ -1913,8 +1914,8 @@ mod tests {
             let (len0, len1): (usize, usize) = {
                 let mut rng = rng.borrow_mut();
                 (
-                    rng.random_range(1..max_len0 + 1),
-                    rng.random_range(1..max_len1 + 1),
+                    rng.random_range(1..=max_len0),
+                    rng.random_range(1..=max_len1),
                 )
             };
             let key: Vec<u8> = (0..len0)
@@ -1954,8 +1955,8 @@ mod tests {
     fn test_delete_some() {
         let items = (0..100)
             .map(|n| {
-                let key = format!("key{}", n);
-                let val = format!("value{}", n);
+                let key = format!("key{n}");
+                let val = format!("value{n}");
                 (key.as_bytes().to_vec(), val.as_bytes().to_vec())
             })
             .collect::<Vec<(Vec<u8>, Vec<u8>)>>();
@@ -1983,8 +1984,8 @@ mod tests {
             let (len0, len1): (usize, usize) = {
                 let mut rng = rng.borrow_mut();
                 (
-                    rng.random_range(1..max_len0 + 1),
-                    rng.random_range(1..max_len1 + 1),
+                    rng.random_range(1..=max_len0),
+                    rng.random_range(1..=max_len1),
                 )
             };
             let key: Vec<u8> = (0..len0)
@@ -2009,7 +2010,7 @@ mod tests {
 
             let mut hashes = Vec::new();
 
-            for (k, v) in items.iter() {
+            for (k, v) in &items {
                 let root_hash = merkle
                     .nodestore
                     .root_address_and_hash()?
@@ -2038,7 +2039,7 @@ mod tests {
                 #[allow(clippy::indexing_slicing)]
                 let expected_hash = &hashes[i];
                 let key = key.iter().fold(String::new(), |mut s, b| {
-                    let _ = write!(s, "{:02x}", b);
+                    let _ = write!(s, "{b:02x}");
                     s
                 });
                 assert_eq!(

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1,6 +1,47 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 5 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::items_after_statements,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::large_stack_arrays,
+    reason = "Found 3 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::match_same_arms,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "Found 6 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_panics_doc,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::too_many_lines,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unnecessary_wraps,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    unused_variables,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+
 use crate::proof::{Proof, ProofError, ProofNode};
 use crate::range_proof::RangeProof;
 use crate::stream::{MerkleKeyValueStream, PathIterator};

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1,13 +1,6 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::large_stack_arrays,
-        reason = "Found 3 occurrences after enabling the lint."
-    )
-)]
 #![expect(
     clippy::cast_possible_truncation,
     reason = "Found 5 occurrences after enabling the lint."
@@ -1084,10 +1077,6 @@ mod tests {
     #![expect(
         clippy::unnecessary_wraps,
         reason = "Found 1 occurrences after enabling the lint."
-    )]
-    #![cfg_attr(
-        feature = "branch_factor_256",
-        expect(unused_variables, clippy::needless_pass_by_value)
     )]
 
     use super::*;

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1,45 +1,32 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::large_stack_arrays,
+        reason = "Found 3 occurrences after enabling the lint."
+    )
+)]
+#![expect(
     clippy::cast_possible_truncation,
     reason = "Found 5 occurrences after enabling the lint."
 )]
-#![allow(
-    clippy::items_after_statements,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
-    clippy::large_stack_arrays,
-    reason = "Found 3 occurrences after enabling the lint."
-)]
-#![allow(
+#![expect(
     clippy::match_same_arms,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::missing_errors_doc,
     reason = "Found 6 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::missing_panics_doc,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
-    clippy::needless_pass_by_value,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
+#![expect(
     clippy::too_many_lines,
     reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
-    clippy::unnecessary_wraps,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
-    unused_variables,
-    reason = "Found 2 occurrences after enabling the lint."
 )]
 
 use crate::proof::{Proof, ProofError, ProofNode};
@@ -1088,8 +1075,21 @@ impl<'a, T: PartialEq> PrefixOverlap<'a, T> {
 }
 
 #[cfg(test)]
-#[expect(clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
+    #![expect(clippy::indexing_slicing, clippy::unwrap_used)]
+    #![expect(
+        clippy::items_after_statements,
+        reason = "Found 1 occurrences after enabling the lint."
+    )]
+    #![expect(
+        clippy::unnecessary_wraps,
+        reason = "Found 1 occurrences after enabling the lint."
+    )]
+    #![cfg_attr(
+        feature = "branch_factor_256",
+        expect(unused_variables, clippy::needless_pass_by_value)
+    )]
+
     use super::*;
     use firewood_storage::{MemStore, MutableProposal, NodeStore, RootReader, TrieHash};
     use rand::rngs::StdRng;

--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -1,6 +1,15 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::needless_continue,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use firewood_storage::{
     BranchNode, FileIoError, HashType, Hashable, NibblesIterator, PathIterItem, Preimage, TrieHash,
     ValueDigest,

--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -1,11 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::missing_errors_doc,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::needless_continue,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -1,17 +1,17 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::unnecessary_wraps,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::used_underscore_binding,
-    reason = "Found 4 occurrences after enabling the lint."
+    reason = "Found 3 occurrences after enabling the lint."
 )]
 
 use crate::merkle::{Key, Value};

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -1,6 +1,19 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unnecessary_wraps,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::used_underscore_binding,
+    reason = "Found 4 occurrences after enabling the lint."
+)]
+
 use crate::merkle::{Key, Value};
 use crate::v2::api;
 

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -49,13 +49,13 @@ impl std::fmt::Debug for IterationNode {
 
 #[derive(Debug)]
 enum NodeStreamState {
-    /// The iterator state is lazily initialized when poll_next is called
+    /// The iterator state is lazily initialized when `poll_next` is called
     /// for the first time. The iteration start key is stored here.
     StartFromKey(Key),
     Iterating {
         /// Each element is a node that will be visited (i.e. returned)
         /// or has been visited but has unvisited children.
-        /// On each call to poll_next we pop the next element.
+        /// On each call to `poll_next` we pop the next element.
         /// If it's unvisited, we visit it.
         /// If it's visited, we push its next child onto this stack.
         iter_stack: Vec<IterationNode>,
@@ -285,7 +285,7 @@ fn get_iterator_intial_state<T: TrieReader>(
 
 #[derive(Debug)]
 enum MerkleKeyValueStreamState<'a, T> {
-    /// The iterator state is lazily initialized when poll_next is called
+    /// The iterator state is lazily initialized when `poll_next` is called
     /// for the first time. The iteration start key is stored here.
     _Uninitialized(Key),
     /// The iterator works by iterating over the nodes in the merkle trie
@@ -329,7 +329,7 @@ impl<T: TrieReader> FusedStream for MerkleKeyValueStream<'_, T> {
 }
 
 impl<'a, T: TrieReader> MerkleKeyValueStream<'a, T> {
-    /// Construct a [MerkleKeyValueStream] that will iterate over all the key-value pairs in `merkle`
+    /// Construct a [`MerkleKeyValueStream`] that will iterate over all the key-value pairs in `merkle`
     /// starting from a particular key
     pub fn from_key<K: AsRef<[u8]>>(merkle: &'a T, key: K) -> Self {
         Self {
@@ -547,9 +547,9 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
 /// Takes in an iterator over a node's partial path and an iterator over the
 /// unmatched portion of a key.
 /// The first returned element is:
-/// * [Ordering::Less] if the node is before the key.
-/// * [Ordering::Equal] if the node is a prefix of the key.
-/// * [Ordering::Greater] if the node is after the key.
+/// * [`Ordering::Less`] if the node is before the key.
+/// * [`Ordering::Equal`] if the node is a prefix of the key.
+/// * [`Ordering::Greater`] if the node is after the key.
 ///
 /// The second returned element is the unmatched portion of the key after the
 /// partial path has been matched.
@@ -649,7 +649,7 @@ mod tests {
         let mut stream = merkle.path_iter(key).unwrap();
         let node = match stream.next() {
             Some(Ok(item)) => item,
-            Some(Err(e)) => panic!("{:?}", e),
+            Some(Err(e)) => panic!("{e:?}"),
             None => {
                 assert!(!should_yield_elt);
                 return;
@@ -680,7 +680,7 @@ mod tests {
 
         let node = match stream.next() {
             Some(Ok(node)) => node,
-            Some(Err(e)) => panic!("{:?}", e),
+            Some(Err(e)) => panic!("{e:?}"),
             None => panic!("unexpected end of iterator"),
         };
         #[cfg(not(feature = "branch_factor_256"))]
@@ -692,7 +692,7 @@ mod tests {
 
         let node = match stream.next() {
             Some(Ok(node)) => node,
-            Some(Err(e)) => panic!("{:?}", e),
+            Some(Err(e)) => panic!("{e:?}"),
             None => panic!("unexpected end of iterator"),
         };
         #[cfg(not(feature = "branch_factor_256"))]
@@ -715,7 +715,7 @@ mod tests {
 
         let node = match stream.next() {
             Some(Ok(node)) => node,
-            Some(Err(e)) => panic!("{:?}", e),
+            Some(Err(e)) => panic!("{e:?}"),
             None => panic!("unexpected end of iterator"),
         };
         #[cfg(not(feature = "branch_factor_256"))]
@@ -742,7 +742,7 @@ mod tests {
 
         let node = match stream.next() {
             Some(Ok(node)) => node,
-            Some(Err(e)) => panic!("{:?}", e),
+            Some(Err(e)) => panic!("{e:?}"),
             None => panic!("unexpected end of iterator"),
         };
         // TODO: make this branch factor 16 compatible
@@ -754,7 +754,7 @@ mod tests {
 
         let node = match stream.next() {
             Some(Ok(node)) => node,
-            Some(Err(e)) => panic!("{:?}", e),
+            Some(Err(e)) => panic!("{e:?}"),
             None => panic!("unexpected end of iterator"),
         };
         #[cfg(not(feature = "branch_factor_256"))]
@@ -1051,9 +1051,7 @@ mod tests {
                         .unwrap()
                         .unwrap(),
                     (expected_key.into_boxed_slice(), expected_value),
-                    "i: {}, j: {}",
-                    i,
-                    j,
+                    "i: {i}, j: {j}",
                 );
             }
         }
@@ -1071,9 +1069,7 @@ mod tests {
                         .unwrap()
                         .unwrap(),
                     (expected_key.into_boxed_slice(), expected_value),
-                    "i: {}, j: {}",
-                    i,
-                    j,
+                    "i: {i}, j: {j}",
                 );
             }
             if i == max {
@@ -1085,8 +1081,7 @@ mod tests {
                         .unwrap()
                         .unwrap(),
                     (vec![i + 1, 0].into_boxed_slice(), vec![i + 1, 0]),
-                    "i: {}",
-                    i,
+                    "i: {i}",
                 );
             }
         }
@@ -1107,13 +1102,13 @@ mod tests {
             key_values.push(last);
         }
 
-        for kv in key_values.iter() {
+        for kv in &key_values {
             merkle.insert(kv, kv.clone().into_boxed_slice()).unwrap();
         }
 
         let mut stream = merkle.key_value_iter();
 
-        for kv in key_values.iter() {
+        for kv in &key_values {
             let next = futures::StreamExt::next(&mut stream)
                 .await
                 .unwrap()
@@ -1192,7 +1187,7 @@ mod tests {
         assert!(key_values[0] < key_values[1]);
         assert!(key_values[1] < key_values[2]);
 
-        for key in key_values.iter() {
+        for key in &key_values {
             merkle.insert(key, key.clone().into_boxed_slice()).unwrap();
         }
 

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -127,11 +127,11 @@ pub enum Error {
     #[error("Range too small")]
     RangeTooSmall,
 
-    /// Request RangeProof for empty trie
+    /// Request `RangeProof` for empty trie
     #[error("request RangeProof for empty trie")]
     RangeProofOnEmptyTrie,
 
-    /// Request RangeProof for empty range
+    /// Request `RangeProof` for empty range
     #[error("the latest revision is empty and has no root hash")]
     LatestIsEmpty,
 

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -1,6 +1,15 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::iter_not_returning_iterator,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "Found 3 occurrences after enabling the lint."
+)]
+
 use crate::manager::RevisionManagerError;
 use crate::proof::{Proof, ProofError, ProofNode};
 pub use crate::range_proof::RangeProof;

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -1,11 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::iter_not_returning_iterator,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::missing_errors_doc,
     reason = "Found 3 occurrences after enabling the lint."
 )]

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -10,14 +10,14 @@ use async_trait::async_trait;
 use futures::Stream;
 use std::sync::Arc;
 
-/// An EmptyDb is a simple implementation of api::Db
+/// An `EmptyDb` is a simple implementation of `api::Db`
 /// that doesn't store any data. It contains a single
-/// HistoricalImpl that has no keys or values
+/// `HistoricalImpl` that has no keys or values
 #[derive(Debug)]
 pub struct EmptyDb;
 
-/// HistoricalImpl is always empty, and there is only one,
-/// since nothing can be committed to an EmptyDb.
+/// `HistoricalImpl` is always empty, and there is only one,
+/// since nothing can be committed to an `EmptyDb`.
 #[derive(Debug)]
 pub struct HistoricalImpl;
 

--- a/firewood/src/v2/propose.rs
+++ b/firewood/src/v2/propose.rs
@@ -36,10 +36,10 @@ impl<T: api::DbView> Clone for ProposalBase<T> {
     }
 }
 
-/// A proposal is created either from the [[crate::v2::api::Db]] object
+/// A proposal is created either from the [[`crate::v2::api::Db`]] object
 /// or from another proposal. Proposals are owned by the
 /// caller. A proposal can only be committed if it has a
-/// base of the current revision of the [[crate::v2::api::Db]].
+/// base of the current revision of the [[`crate::v2::api::Db`]].
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// ```mermaid
 /// graph LR

--- a/firewood/tests/common/mod.rs
+++ b/firewood/tests/common/mod.rs
@@ -1,6 +1,19 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::missing_panics_doc,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::used_underscore_binding,
+    reason = "Found 3 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::used_underscore_items,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use std::env::temp_dir;
 use std::fs::remove_file;
 use std::ops::Deref;

--- a/firewood/tests/common/mod.rs
+++ b/firewood/tests/common/mod.rs
@@ -57,7 +57,7 @@ impl Deref for TestDb {
 }
 
 impl TestDb {
-    /// reopen the database, consuming the old TestDb and giving you a new one
+    /// reopen the database, consuming the old `TestDb` and giving you a new one
     pub async fn _reopen(mut self) -> Self {
         let mut creator = self.creator.clone();
         self.preserve_on_drop = true;

--- a/firewood/tests/common/mod.rs
+++ b/firewood/tests/common/mod.rs
@@ -1,15 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
-    clippy::missing_panics_doc,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
+#![expect(
     clippy::used_underscore_binding,
     reason = "Found 3 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::used_underscore_items,
     reason = "Found 1 occurrences after enabling the lint."
 )]
@@ -40,6 +36,10 @@ pub struct TestDb {
 
 impl TestDbCreator {
     #[expect(clippy::unwrap_used)]
+    #[allow(
+        clippy::missing_panics_doc,
+        reason = "Found 1 occurrences after enabling the lint."
+    )]
     pub async fn _create(self) -> TestDb {
         let path = self.path.clone().unwrap_or_else(|| {
             let mut path: PathBuf = std::env::var_os("CARGO_TARGET_DIR")

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -38,12 +38,5 @@ assert_cmd = "2.0.13"
 predicates = "3.1.0"
 serial_test = "3.0.0"
 
-[lints.rust]
-unsafe_code = "deny"
-
-[lints.clippy]
-unwrap_used = "warn"
-indexing_slicing = "warn"
-explicit_deref_methods = "warn"
-missing_const_for_fn = "warn"
-arithmetic_side_effects = "warn"
+[lints]
+workspace = true

--- a/fwdctl/src/create.rs
+++ b/fwdctl/src/create.rs
@@ -54,7 +54,7 @@ pub(super) fn new(opts: &Options) -> DbConfig {
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     let db_config = new(opts);
-    log::debug!("database configuration parameters: \n{:?}\n", db_config);
+    log::debug!("database configuration parameters: \n{db_config:?}\n");
 
     Db::new(opts.name.clone(), db_config).await?;
     println!("created firewood database in {:?}", opts.name);

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -23,7 +23,7 @@ pub struct Options {
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
-    log::debug!("deleting key {:?}", opts);
+    log::debug!("deleting key {opts:?}");
     let cfg = DbConfig::builder().truncate(false);
 
     let db = Db::new(opts.db.clone(), cfg.build()).await?;

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -116,7 +116,7 @@ pub struct Options {
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
-    log::debug!("dump database {:?}", opts);
+    log::debug!("dump database {opts:?}");
 
     let cfg = DbConfig::builder().truncate(false);
     let db = Db::new(opts.db.clone(), cfg.build()).await?;
@@ -161,7 +161,7 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
 }
 
 fn key_count_exceeded(max: Option<u32>, key_count: u32) -> bool {
-    max.map(|max| key_count >= max).unwrap_or(false)
+    max.is_some_and(|max| key_count >= max)
 }
 
 fn u8_to_string(data: &[u8]) -> Cow<'_, str> {
@@ -203,7 +203,7 @@ async fn handle_next_key(next_key: KeyFromStream) {
             );
         }
         Some(Err(e)) => {
-            eprintln!("Error occurred while fetching the next key: {}.", e);
+            eprintln!("Error occurred while fetching the next key: {e}.");
         }
         None => {
             println!("There is no next key. Data dump completed.");
@@ -268,7 +268,7 @@ struct StdoutOutputHandler {
 impl OutputHandler for StdoutOutputHandler {
     fn handle_record(&mut self, key: &[u8], value: &[u8]) -> Result<(), std::io::Error> {
         let (key_str, value_str) = key_value_to_string(key, value, self.hex);
-        println!("'{}': '{}'", key_str, value_str);
+        println!("'{key_str}': '{value_str}'");
         Ok(())
     }
     fn flush(&mut self) -> Result<(), std::io::Error> {

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -1,15 +1,15 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::doc_link_with_quotes,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::unnecessary_wraps,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::unused_async,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -1,6 +1,19 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::doc_link_with_quotes,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unnecessary_wraps,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unused_async,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use clap::Args;
 use firewood::db::{Db, DbConfig};
 use firewood::merkle::Key;

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -25,7 +25,7 @@ pub struct Options {
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
-    log::debug!("get key value pair {:?}", opts);
+    log::debug!("get key value pair {opts:?}");
     let cfg = DbConfig::builder().truncate(false);
 
     let db = Db::new(opts.db.clone(), cfg.build()).await?;

--- a/fwdctl/src/graph.rs
+++ b/fwdctl/src/graph.rs
@@ -18,7 +18,7 @@ pub struct Options {
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
-    log::debug!("dump database {:?}", opts);
+    log::debug!("dump database {opts:?}");
     let cfg = DbConfig::builder().truncate(false);
 
     let db = Db::new(opts.db.clone(), cfg.build()).await?;

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -27,7 +27,7 @@ pub struct Options {
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
-    log::debug!("inserting key value pair {:?}", opts);
+    log::debug!("inserting key value pair {opts:?}");
     let cfg = DbConfig::builder().truncate(false);
 
     let db = Db::new(opts.db.clone(), cfg.build()).await?;

--- a/grpc-testtool/Cargo.toml
+++ b/grpc-testtool/Cargo.toml
@@ -37,20 +37,12 @@ criterion = {version = "0.6.0", features = ["async_tokio"]}
 rand = "0.9.1"
 rand_distr = "0.5.0"
 
-[lints.rust]
-unsafe_code = "deny"
-
 [[bench]]
 name = "insert"
 harness = false
 
-[lints.clippy]
-unwrap_used = "warn"
-indexing_slicing = "warn"
-explicit_deref_methods = "warn"
-missing_const_for_fn = "warn"
-arithmetic_side_effects = "warn"
-
 [package.metadata.cargo-machete]
 ignored = ["prost", "tonic_build"]
 
+[lints]
+workspace = true

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -55,3 +55,6 @@ ethhash = [ "dep:rlp", "dep:sha3", "dep:bytes" ]
 [[bench]]
 name = "serializer"
 harness = false
+
+[lints]
+workspace = true

--- a/storage/benches/serializer.rs
+++ b/storage/benches/serializer.rs
@@ -1,6 +1,15 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::assigning_clones,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unwrap_used,
+    reason = "Found 7 occurrences after enabling the lint."
+)]
+
 use std::array::from_fn;
 use std::fs::File;
 use std::num::NonZeroU64;

--- a/storage/benches/serializer.rs
+++ b/storage/benches/serializer.rs
@@ -1,11 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::assigning_clones,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::unwrap_used,
     reason = "Found 7 occurrences after enabling the lint."
 )]

--- a/storage/benches/serializer.rs
+++ b/storage/benches/serializer.rs
@@ -65,14 +65,14 @@ fn leaf(c: &mut Criterion) {
     group.bench_with_input("serde", &input, |b, input| {
         b.iter(|| {
             serializer.serialize(input).unwrap();
-        })
+        });
     });
 
     group.bench_with_input("manual", &input, |b, input| {
         b.iter(|| {
             let mut bytes = Vec::<u8>::new();
             input.as_bytes(0, &mut bytes);
-        })
+        });
     });
     group.finish();
 }
@@ -97,14 +97,14 @@ fn branch(c: &mut Criterion) {
     let serde_serializer = |b: &mut criterion::Bencher, input: &firewood_storage::Node| {
         b.iter(|| {
             serializer.serialize(input).unwrap();
-        })
+        });
     };
 
     let manual_serializer = |b: &mut criterion::Bencher, input: &firewood_storage::Node| {
         b.iter(|| {
             let mut bytes = Vec::new();
             input.as_bytes(0, &mut bytes);
-        })
+        });
     };
 
     group.bench_with_input("serde", &input, serde_serializer);

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -11,6 +11,7 @@ use smallvec::SmallVec;
 use crate::{BranchNode, HashType, LeafNode, Node, Path};
 
 /// Returns the hash of `node`, which is at the given `path_prefix`.
+#[must_use]
 pub fn hash_node(node: &Node, path_prefix: &Path) -> HashType {
     match node {
         Node::Branch(node) => {
@@ -40,6 +41,7 @@ pub fn hash_node(node: &Node, path_prefix: &Path) -> HashType {
 
 /// Returns the serialized representation of `node` used as the pre-image
 /// when hashing the node. The node is at the given `path_prefix`.
+#[must_use]
 pub fn hash_preimage(node: &Node, path_prefix: &Path) -> Box<[u8]> {
     // Key, 3 options, value digest
     let est_len = node.partial_path().len() + path_prefix.len() + 3 + HashType::default().len();
@@ -85,7 +87,7 @@ impl HasUpdate for SmallVec<[u8; 32]> {
 }
 
 #[derive(Clone, Debug)]
-/// A ValueDigest is either a node's value or the hash of its value.
+/// A `ValueDigest` is either a node's value or the hash of its value.
 pub enum ValueDigest<T> {
     /// The node's value.
     Value(T),

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -1,6 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use std::{
     iter::{self},
     ops::Deref,

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -20,7 +20,7 @@ use rlp::{Rlp, RlpStream};
 
 impl HasUpdate for Keccak256 {
     fn update<T: AsRef<[u8]>>(&mut self, data: T) {
-        sha3::Digest::update(self, data)
+        sha3::Digest::update(self, data);
     }
 }
 
@@ -138,7 +138,7 @@ impl<T: Hashable> Preimage for T {
                     None => {
                         rlp.append_empty_data();
                     }
-                };
+                }
             } else {
                 match self.value_digest() {
                     Some(ValueDigest::Value(bytes)) => rlp.append(&bytes),

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -3,13 +3,19 @@
 
 // Ethereum compatible hashing algorithm.
 
-#![allow(
-    clippy::indexing_slicing,
-    reason = "Found 4 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "ethhash",
+    expect(
+        clippy::indexing_slicing,
+        reason = "Found 4 occurrences after enabling the lint."
+    )
 )]
-#![allow(
-    clippy::too_many_lines,
-    reason = "Found 1 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "ethhash",
+    expect(
+        clippy::too_many_lines,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
 )]
 
 use std::iter::once;

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -3,6 +3,15 @@
 
 // Ethereum compatible hashing algorithm.
 
+#![allow(
+    clippy::indexing_slicing,
+    reason = "Found 4 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::too_many_lines,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use std::iter::once;
 
 use crate::logger::warn;

--- a/storage/src/hashers/merkledb.rs
+++ b/storage/src/hashers/merkledb.rs
@@ -2,28 +2,14 @@
 // See the file LICENSE.md for licensing terms.
 
 #![cfg_attr(
-    feature = "branch_factor_256",
+    not(feature = "ethhash"),
     expect(
         clippy::arithmetic_side_effects,
         reason = "Found 1 occurrences after enabling the lint."
     )
 )]
 #![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::cast_possible_truncation,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    not(any(feature = "ethhash", feature = "branch_factor_256")),
-    expect(
-        clippy::arithmetic_side_effects,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    not(feature = "ethhash"),
     expect(
         clippy::cast_possible_truncation,
         reason = "Found 1 occurrences after enabling the lint."

--- a/storage/src/hashers/merkledb.rs
+++ b/storage/src/hashers/merkledb.rs
@@ -1,6 +1,15 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use crate::hashednode::{HasUpdate, Hashable, Preimage};
 use crate::{TrieHash, ValueDigest};
 /// Merkledb compatible hashing algorithm.

--- a/storage/src/hashers/merkledb.rs
+++ b/storage/src/hashers/merkledb.rs
@@ -12,7 +12,7 @@ const BITS_PER_NIBBLE: u64 = 4;
 
 impl HasUpdate for Sha256 {
     fn update<T: AsRef<[u8]>>(&mut self, data: T) {
-        sha2::Digest::update(self, data)
+        sha2::Digest::update(self, data);
     }
 }
 

--- a/storage/src/hashers/merkledb.rs
+++ b/storage/src/hashers/merkledb.rs
@@ -1,13 +1,33 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
-    clippy::arithmetic_side_effects,
-    reason = "Found 1 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::arithmetic_side_effects,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
 )]
-#![allow(
-    clippy::cast_possible_truncation,
-    reason = "Found 1 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::cast_possible_truncation,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    expect(
+        clippy::arithmetic_side_effects,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    expect(
+        clippy::cast_possible_truncation,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
 )]
 
 use crate::hashednode::{HasUpdate, Hashable, Preimage};

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -3,13 +3,13 @@
 #![warn(missing_debug_implementations, rust_2018_idioms, missing_docs)]
 #![deny(unsafe_code)]
 
-//! # storage implements the storage of a [Node] on top of a LinearStore
+//! # storage implements the storage of a [Node] on top of a `LinearStore`
 //!
-//! Nodes are stored at a [LinearAddress] within a [ReadableStorage].
+//! Nodes are stored at a [`LinearAddress`] within a [`ReadableStorage`].
 //!
-//! The [NodeStore] maintains a free list and the [LinearAddress] of a root node.
+//! The [`NodeStore`] maintains a free list and the [`LinearAddress`] of a root node.
 //!
-//! A [NodeStore] is backed by a [ReadableStorage] which is persisted storage.
+//! A [`NodeStore`] is backed by a [`ReadableStorage`] which is persisted storage.
 
 mod hashednode;
 mod hashers;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,5 +1,9 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
+#![allow(
+    clippy::missing_panics_doc,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
 #![warn(missing_debug_implementations, rust_2018_idioms, missing_docs)]
 #![deny(unsafe_code)]
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,8 +1,11 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
-#![allow(
-    clippy::missing_panics_doc,
-    reason = "Found 1 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "ethhash",
+    expect(
+        clippy::missing_panics_doc,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
 )]
 #![warn(missing_debug_implementations, rust_2018_idioms, missing_docs)]
 #![deny(unsafe_code)]

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,12 +1,6 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
-#![cfg_attr(
-    feature = "ethhash",
-    expect(
-        clippy::missing_panics_doc,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
+
 #![warn(missing_debug_implementations, rust_2018_idioms, missing_docs)]
 #![deny(unsafe_code)]
 
@@ -73,6 +67,10 @@ impl std::fmt::Display for CacheReadStrategy {
 /// This function is slow, so callers should cache the result
 #[cfg(feature = "ethhash")]
 #[must_use]
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
 pub fn empty_trie_hash() -> TrieHash {
     use sha3::Digest as _;
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -65,6 +65,7 @@ impl std::fmt::Display for CacheReadStrategy {
 ///
 /// This function is slow, so callers should cache the result
 #[cfg(feature = "ethhash")]
+#[must_use]
 pub fn empty_trie_hash() -> TrieHash {
     use sha3::Digest as _;
 

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -23,7 +23,7 @@ use crate::{CacheReadStrategy, LinearAddress, SharedNode};
 
 use super::{FileIoError, ReadableStorage, WritableStorage};
 
-/// A [ReadableStorage] and [WritableStorage] backed by a file
+/// A [`ReadableStorage`] and [`WritableStorage`] backed by a file
 pub struct FileBacked {
     fd: File,
     filename: PathBuf,

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -6,29 +6,25 @@
 // object. Instead, we probably should use an IO system that can perform multiple
 // read/write operations at once
 
-#![allow(
+#![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 5 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![expect(
+    clippy::indexing_slicing,
     reason = "Found 3 occurrences after enabling the lint."
 )]
-#![allow(
-    clippy::indexing_slicing,
-    reason = "Found 4 occurrences after enabling the lint."
-)]
-#![allow(
+#![expect(
     clippy::missing_errors_doc,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::missing_fields_in_debug,
     reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
-    clippy::unwrap_used,
-    reason = "Found 18 occurrences after enabling the lint."
 )]
 
 use std::fs::{File, OpenOptions};
@@ -305,6 +301,8 @@ impl Read for PredictiveReader<'_> {
 
 #[cfg(test)]
 mod test {
+    #![expect(clippy::unwrap_used)]
+
     use super::*;
     use std::io::Write;
     use tempfile::NamedTempFile;

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -6,6 +6,31 @@
 // object. Instead, we probably should use an IO system that can perform multiple
 // read/write operations at once
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 5 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 3 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::indexing_slicing,
+    reason = "Found 4 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_fields_in_debug,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unwrap_used,
+    reason = "Found 18 occurrences after enabling the lint."
+)]
+
 use std::fs::{File, OpenOptions};
 use std::io::Read;
 use std::num::NonZero;

--- a/storage/src/linear/memory.rs
+++ b/storage/src/linear/memory.rs
@@ -7,13 +7,14 @@ use std::io::{Cursor, Read};
 use std::sync::Mutex;
 
 #[derive(Debug, Default)]
-/// An in-memory impelementation of [WritableStorage] and [ReadableStorage]
+/// An in-memory impelementation of [`WritableStorage`] and [`ReadableStorage`]
 pub struct MemStore {
     bytes: Mutex<Vec<u8>>,
 }
 
 impl MemStore {
-    /// Create a new, empty [MemStore]
+    /// Create a new, empty [`MemStore`]
+    #[must_use]
     pub const fn new(bytes: Vec<u8>) -> Self {
         Self {
             bytes: Mutex::new(bytes),

--- a/storage/src/linear/memory.rs
+++ b/storage/src/linear/memory.rs
@@ -1,6 +1,19 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 3 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::indexing_slicing,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use super::{FileIoError, ReadableStorage, WritableStorage};
 use metrics::counter;
 use std::io::{Cursor, Read};

--- a/storage/src/linear/memory.rs
+++ b/storage/src/linear/memory.rs
@@ -1,15 +1,15 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 3 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
     reason = "Found 2 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::indexing_slicing,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-//! A LinearStore provides a view of a set of bytes at
-//! a given time. A LinearStore has three different types,
+//! A `LinearStore` provides a view of a set of bytes at
+//! a given time. A `LinearStore` has three different types,
 //! which refer to another base type, as follows:
 //! ```mermaid
 //! stateDiagram-v2
@@ -24,7 +24,7 @@ use crate::{CacheReadStrategy, LinearAddress, SharedNode};
 pub(super) mod filebacked;
 pub mod memory;
 
-/// An error that occurs when reading or writing to a [ReadableStorage] or [WritableStorage]   
+/// An error that occurs when reading or writing to a [`ReadableStorage`] or [`WritableStorage`]   
 ///
 /// This error is used to wrap errors that occur when reading or writing to a file.
 /// It contains the filename, offset, and context of the error.
@@ -37,7 +37,7 @@ pub struct FileIoError {
 }
 
 impl FileIoError {
-    /// Create a new [FileIoError] from a generic error
+    /// Create a new [`FileIoError`] from a generic error
     ///
     /// Only use this constructor if you do not have any file or line information.
     ///
@@ -53,7 +53,7 @@ impl FileIoError {
         }
     }
 
-    /// Create a new [FileIoError]
+    /// Create a new [`FileIoError`]
     ///
     /// # Arguments
     ///
@@ -61,7 +61,8 @@ impl FileIoError {
     /// * `filename` - The filename of the file that caused the error
     /// * `offset` - The offset of the file that caused the error
     /// * `context` - The context of this error
-    pub fn new(
+    #[must_use]
+    pub const fn new(
         inner: std::io::Error,
         filename: Option<PathBuf>,
         offset: u64,
@@ -94,7 +95,7 @@ impl std::fmt::Display for FileIoError {
                 .as_ref()
                 .unwrap_or(&PathBuf::from("[unknown]"))
                 .display(),
-            context = self.context.as_ref().unwrap_or(&String::from(""))
+            context = self.context.as_ref().unwrap_or(&String::new())
         )
     }
 }
@@ -145,7 +146,7 @@ pub trait ReadableStorage: Debug + Sync + Send {
         None
     }
 
-    /// Convert an io::Error into a FileIoError
+    /// Convert an `io::Error` into a `FileIoError`
     fn file_io_error(
         &self,
         error: std::io::Error,

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! Each type is described in more detail below.
 
-#![allow(
+#![expect(
     clippy::missing_errors_doc,
     reason = "Found 4 occurrences after enabling the lint."
 )]

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -14,6 +14,11 @@
 //!
 //! Each type is described in more detail below.
 
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "Found 4 occurrences after enabling the lint."
+)]
+
 use std::fmt::Debug;
 use std::io::Read;
 use std::num::NonZero;

--- a/storage/src/logger.rs
+++ b/storage/src/logger.rs
@@ -10,6 +10,7 @@ pub use log::{debug, error, info, trace, warn};
 
 /// Returns true if the trace log level is enabled
 #[cfg(feature = "logger")]
+#[must_use]
 pub fn trace_enabled() -> bool {
     log::log_enabled!(log::Level::Trace)
 }

--- a/storage/src/logger.rs
+++ b/storage/src/logger.rs
@@ -31,9 +31,10 @@ mod noop_logger {
     pub use noop as trace;
     pub use noop as warn;
 
-    /// trace_enabled for a noop logger is always false
+    /// `trace_enabled` for a noop logger is always false
     #[inline]
-    pub fn trace_enabled() -> bool {
+    #[must_use]
+    pub const fn trace_enabled() -> bool {
         false
     }
 }

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -1,54 +1,13 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::cast_possible_truncation,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
+#![expect(
+    clippy::cast_possible_truncation,
+    reason = "Found 2 occurrences after enabling the lint."
 )]
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::indexing_slicing,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::large_stack_arrays,
-        reason = "Found 2 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    feature = "ethhash",
-    expect(
-        clippy::cast_possible_truncation,
-        reason = "Found 2 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    feature = "ethhash",
-    expect(
-        clippy::indexing_slicing,
-        reason = "Found 2 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    not(any(feature = "ethhash", feature = "branch_factor_256")),
-    expect(
-        clippy::cast_possible_truncation,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    not(any(feature = "ethhash", feature = "branch_factor_256")),
-    expect(
-        clippy::indexing_slicing,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
+#![expect(
+    clippy::indexing_slicing,
+    reason = "Found 2 occurrences after enabling the lint."
 )]
 #![expect(
     clippy::match_same_arms,

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -1,6 +1,27 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::indexing_slicing,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::large_stack_arrays,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::match_same_arms,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_panics_doc,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+
 use serde::ser::SerializeStruct as _;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -10,7 +10,7 @@ use std::fmt::{Debug, Formatter};
 
 /// The type of a hash. For ethereum compatible hashes, this might be a RLP encoded
 /// value if it's small enough to fit in less than 32 bytes. For merkledb compatible
-/// hashes, it's always a TrieHash.
+/// hashes, it's always a `TrieHash`.
 #[cfg(feature = "ethhash")]
 pub type HashType = ethhash::HashOrRlp;
 
@@ -45,7 +45,6 @@ mod ethhash {
     use std::{
         fmt::{Display, Formatter},
         io::Read,
-        ops::Deref as _,
     };
 
     use crate::TrieHash;
@@ -62,7 +61,7 @@ mod ethhash {
 
     impl HashOrRlp {
         pub fn as_slice(&self) -> &[u8] {
-            self.deref()
+            self
         }
 
         pub(crate) fn into_triehash(self) -> TrieHash {
@@ -144,7 +143,7 @@ mod ethhash {
         fn deref(&self) -> &Self::Target {
             match self {
                 HashOrRlp::Hash(h) => h,
-                HashOrRlp::Rlp(r) => r.deref(),
+                HashOrRlp::Rlp(r) => r,
             }
         }
     }
@@ -152,7 +151,7 @@ mod ethhash {
     impl Display for HashOrRlp {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             match self {
-                HashOrRlp::Hash(h) => write!(f, "{}", h),
+                HashOrRlp::Hash(h) => write!(f, "{h}"),
                 HashOrRlp::Rlp(r) => {
                     let width = f.precision().unwrap_or(32);
                     write!(f, "{:.*}", width, hex::encode(r))

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -15,7 +15,7 @@ use std::fmt::{Debug, Formatter};
 pub type HashType = ethhash::HashOrRlp;
 
 #[cfg(not(feature = "ethhash"))]
-/// The type of a hash. For non-ethereum compatible hashes, this is always a TrieHash.
+/// The type of a hash. For non-ethereum compatible hashes, this is always a `TrieHash`.
 pub type HashType = crate::TrieHash;
 
 pub(crate) trait Serializable {
@@ -179,8 +179,8 @@ pub struct BranchNode {
 
     /// The children of this branch.
     /// Element i is the child at index i, or None if there is no child at that index.
-    /// Each element is (child_hash, child_address).
-    /// child_address is None if we don't know the child's hash.
+    /// Each element is (`child_hash`, `child_address`).
+    /// `child_address` is None if we don't know the child's hash.
     pub children: [Option<Child>; Self::MAX_CHILDREN],
 }
 
@@ -227,7 +227,7 @@ impl<'de> Deserialize<'de> for BranchNode {
 
         let mut children: [Option<Child>; BranchNode::MAX_CHILDREN] =
             [const { None }; BranchNode::MAX_CHILDREN];
-        for (offset, addr, hash) in s.children.iter() {
+        for (offset, addr, hash) in &s.children {
             children[*offset as usize] = Some(Child::AddressWithHash(*addr, hash.clone()));
         }
 
@@ -249,7 +249,7 @@ impl Debug for BranchNode {
                 None => {}
                 Some(Child::Node(_)) => {} //TODO
                 Some(Child::AddressWithHash(addr, hash)) => {
-                    write!(f, "({i:?}: address={addr:?} hash={})", hash)?
+                    write!(f, "({i:?}: address={addr:?} hash={hash})")?;
                 }
             }
         }
@@ -270,12 +270,13 @@ impl BranchNode {
     #[cfg(feature = "branch_factor_256")]
     pub const MAX_CHILDREN: usize = 256;
 
-    /// The maximum number of children in a [BranchNode]
+    /// The maximum number of children in a [`BranchNode`]
     #[cfg(not(feature = "branch_factor_256"))]
     pub const MAX_CHILDREN: usize = 16;
 
     /// Returns the address of the child at the given index.
-    /// Panics if `child_index` >= [BranchNode::MAX_CHILDREN].
+    /// Panics if `child_index` >= [`BranchNode::MAX_CHILDREN`].
+    #[must_use]
     pub fn child(&self, child_index: u8) -> &Option<Child> {
         self.children
             .get(child_index as usize)

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -1,23 +1,60 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
-    clippy::cast_possible_truncation,
-    reason = "Found 2 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::cast_possible_truncation,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
 )]
-#![allow(
-    clippy::indexing_slicing,
-    reason = "Found 2 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::indexing_slicing,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
 )]
-#![allow(
-    clippy::large_stack_arrays,
-    reason = "Found 2 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::large_stack_arrays,
+        reason = "Found 2 occurrences after enabling the lint."
+    )
 )]
-#![allow(
+#![cfg_attr(
+    feature = "ethhash",
+    expect(
+        clippy::cast_possible_truncation,
+        reason = "Found 2 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    feature = "ethhash",
+    expect(
+        clippy::indexing_slicing,
+        reason = "Found 2 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    expect(
+        clippy::cast_possible_truncation,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    expect(
+        clippy::indexing_slicing,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![expect(
     clippy::match_same_arms,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::missing_panics_doc,
     reason = "Found 2 occurrences after enabling the lint."
 )]

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -265,7 +265,7 @@ impl Debug for BranchNode {
 }
 
 impl BranchNode {
-    /// The maximum number of children in a [BranchNode]
+    /// The maximum number of children in a [`BranchNode`]
     #[cfg(feature = "branch_factor_256")]
     pub const MAX_CHILDREN: usize = 256;
 

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -1,41 +1,36 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::large_stack_arrays,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 4 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::cast_possible_truncation,
-    reason = "Found 7 occurrences after enabling the lint."
+    reason = "Found 6 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::indexing_slicing,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::items_after_statements,
     reason = "Found 2 occurrences after enabling the lint."
 )]
-#![allow(
-    clippy::large_stack_arrays,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
+#![expect(
     clippy::missing_errors_doc,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::missing_panics_doc,
     reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
-    clippy::needless_pass_by_value,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
-    clippy::unwrap_used,
-    reason = "Found 3 occurrences after enabling the lint."
 )]
 
 use bitfield::bitfield;
@@ -490,6 +485,8 @@ pub struct PathIterItem {
 
 #[cfg(test)]
 mod test {
+    #![expect(clippy::needless_pass_by_value, clippy::unwrap_used)]
+
     use crate::node::{BranchNode, LeafNode, Node};
     use crate::{Child, LinearAddress, Path};
     use test_case::test_case;

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -1,13 +1,6 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::large_stack_arrays,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
 #![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 4 occurrences after enabling the lint."

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -246,7 +246,7 @@ impl Node {
                 );
                 #[cfg(feature = "branch_factor_256")]
                 let first_byte: BranchFirstByte =
-                    BranchFirstByte::new(b.value.is_some() as u8, pp_len);
+                    BranchFirstByte::new(u8::from(b.value.is_some()), pp_len);
 
                 // create an output stack item, which can overflow to memory for very large branch nodes
                 const OPTIMIZE_BRANCHES_FOR_SIZE: usize = 1024;

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -1,6 +1,43 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 4 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 7 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::indexing_slicing,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::items_after_statements,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::large_stack_arrays,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_panics_doc,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unwrap_used,
+    reason = "Found 3 occurrences after enabling the lint."
+)]
+
 use bitfield::bitfield;
 use branch::Serializable as _;
 use enum_as_inner::EnumAsInner;

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -1,34 +1,9 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-// TODO: remove bitflags, we only use one bit
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::arithmetic_side_effects,
-        reason = "Found 7 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::indexing_slicing,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    feature = "ethhash",
-    expect(
-        clippy::arithmetic_side_effects,
-        reason = "Found 8 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    not(any(feature = "ethhash", feature = "branch_factor_256")),
-    expect(
-        clippy::arithmetic_side_effects,
-        reason = "Found 8 occurrences after enabling the lint."
-    )
+#![expect(
+    clippy::arithmetic_side_effects,
+    reason = "Found 8 occurrences after enabling the lint."
 )]
 #![expect(
     clippy::from_iter_instead_of_collect,
@@ -39,6 +14,7 @@
     reason = "Found 1 occurrences after enabling the lint."
 )]
 
+// TODO: remove bitflags, we only use one bit
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -2,24 +2,40 @@
 // See the file LICENSE.md for licensing terms.
 
 // TODO: remove bitflags, we only use one bit
-#![allow(
-    clippy::arithmetic_side_effects,
-    reason = "Found 9 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::arithmetic_side_effects,
+        reason = "Found 7 occurrences after enabling the lint."
+    )
 )]
-#![allow(
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::indexing_slicing,
+        reason = "Found 1 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    feature = "ethhash",
+    expect(
+        clippy::arithmetic_side_effects,
+        reason = "Found 8 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    expect(
+        clippy::arithmetic_side_effects,
+        reason = "Found 8 occurrences after enabling the lint."
+    )
+)]
+#![expect(
     clippy::from_iter_instead_of_collect,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
-    clippy::indexing_slicing,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
+#![expect(
     clippy::inline_always,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![allow(
-    clippy::needless_pass_by_value,
     reason = "Found 1 occurrences after enabling the lint."
 )]
 
@@ -264,6 +280,8 @@ impl DoubleEndedIterator for NibblesIterator<'_> {
 
 #[cfg(test)]
 mod test {
+    #![expect(clippy::needless_pass_by_value)]
+
     use super::*;
     use std::fmt::Debug;
     use test_case::test_case;

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -2,6 +2,27 @@
 // See the file LICENSE.md for licensing terms.
 
 // TODO: remove bitflags, we only use one bit
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 9 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::from_iter_instead_of_collect,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::indexing_slicing,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::inline_always,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -17,7 +17,7 @@ pub struct Path(pub SmallVec<[u8; 64]>);
 
 impl Debug for Path {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        for nib in self.0.iter() {
+        for nib in &self.0 {
             if *nib > 0xf {
                 write!(f, "[invalid {:02x}] ", *nib)?;
             } else {
@@ -75,13 +75,14 @@ impl Path {
     }
 
     /// Creates an empty Path
+    #[must_use]
     pub fn new() -> Self {
         Path(SmallVec::new())
     }
 
     /// Read from an iterator that returns nibbles with a prefix
     /// The prefix is one optional byte -- if not present, the Path is empty
-    /// If there is one byte, and the byte contains a [Flags::ODD_LEN] (0x1)
+    /// If there is one byte, and the byte contains a [`Flags::ODD_LEN`] (0x1)
     /// then there is another discarded byte after that.
     #[cfg(test)]
     pub fn from_encoded_iter<Iter: Iterator<Item = u8>>(mut iter: Iter) -> Self {
@@ -96,11 +97,12 @@ impl Path {
 
     /// Add nibbles to the end of a path
     pub fn extend<T: IntoIterator<Item = u8>>(&mut self, iter: T) {
-        self.0.extend(iter)
+        self.0.extend(iter);
     }
 
     /// Create an iterator that returns the bytes from the underlying nibbles
     /// If there is an odd nibble at the end, it is dropped
+    #[must_use]
     pub fn bytes_iter(&self) -> BytesIterator<'_> {
         BytesIterator {
             nibbles_iter: self.iter(),
@@ -108,6 +110,7 @@ impl Path {
     }
 
     /// Create a boxed set of bytes from the Path
+    #[must_use]
     pub fn bytes(&self) -> Box<[u8]> {
         self.bytes_iter().collect()
     }
@@ -204,6 +207,7 @@ impl<'a> NibblesIterator<'a> {
 
     /// Returns a new `NibblesIterator` over the given `data`.
     /// Each byte in `data` is converted to two nibbles.
+    #[must_use]
     pub const fn new(data: &'a [u8]) -> Self {
         NibblesIterator {
             data,

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1,47 +1,13 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::arithmetic_side_effects,
-        reason = "Found 4 occurrences after enabling the lint."
-    )
+#![expect(
+    clippy::arithmetic_side_effects,
+    reason = "Found 5 occurrences after enabling the lint."
 )]
-#![cfg_attr(
-    feature = "branch_factor_256",
-    expect(
-        clippy::cast_possible_truncation,
-        reason = "Found 13 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    feature = "ethhash",
-    expect(
-        clippy::arithmetic_side_effects,
-        reason = "Found 5 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    feature = "ethhash",
-    expect(
-        clippy::cast_possible_truncation,
-        reason = "Found 16 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    not(any(feature = "ethhash", feature = "branch_factor_256")),
-    expect(
-        clippy::arithmetic_side_effects,
-        reason = "Found 4 occurrences after enabling the lint."
-    )
-)]
-#![cfg_attr(
-    not(any(feature = "ethhash", feature = "branch_factor_256")),
-    expect(
-        clippy::cast_possible_truncation,
-        reason = "Found 13 occurrences after enabling the lint."
-    )
+#![expect(
+    clippy::cast_possible_truncation,
+    reason = "Found 16 occurrences after enabling the lint."
 )]
 #![expect(
     clippy::default_trait_access,

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1,6 +1,43 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 5 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 20 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::default_trait_access,
+    reason = "Found 6 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::indexing_slicing,
+    reason = "Found 9 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::match_wildcard_for_single_variants,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_errors_doc,
+    reason = "Found 15 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::missing_panics_doc,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::needless_pass_by_value,
+    reason = "Found 3 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::unwrap_used,
+    reason = "Found 2 occurrences after enabling the lint."
+)]
+
 use crate::linear::FileIoError;
 use crate::logger::trace;
 use arc_swap::ArcSwap;

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1164,7 +1164,7 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
     pub fn flush_nodes(&self) -> Result<(), FileIoError> {
         let flush_start = Instant::now();
 
-        for (addr, (area_size_index, node)) in self.kind.new.iter() {
+        for (addr, (area_size_index, node)) in &self.kind.new {
             let mut stored_area_bytes = Vec::new();
             node.as_bytes(*area_size_index, &mut stored_area_bytes);
             self.storage

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1,39 +1,73 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(
-    clippy::arithmetic_side_effects,
-    reason = "Found 5 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::arithmetic_side_effects,
+        reason = "Found 4 occurrences after enabling the lint."
+    )
 )]
-#![allow(
-    clippy::cast_possible_truncation,
-    reason = "Found 20 occurrences after enabling the lint."
+#![cfg_attr(
+    feature = "branch_factor_256",
+    expect(
+        clippy::cast_possible_truncation,
+        reason = "Found 13 occurrences after enabling the lint."
+    )
 )]
-#![allow(
+#![cfg_attr(
+    feature = "ethhash",
+    expect(
+        clippy::arithmetic_side_effects,
+        reason = "Found 5 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    feature = "ethhash",
+    expect(
+        clippy::cast_possible_truncation,
+        reason = "Found 16 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    expect(
+        clippy::arithmetic_side_effects,
+        reason = "Found 4 occurrences after enabling the lint."
+    )
+)]
+#![cfg_attr(
+    not(any(feature = "ethhash", feature = "branch_factor_256")),
+    expect(
+        clippy::cast_possible_truncation,
+        reason = "Found 13 occurrences after enabling the lint."
+    )
+)]
+#![expect(
     clippy::default_trait_access,
     reason = "Found 6 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::indexing_slicing,
-    reason = "Found 9 occurrences after enabling the lint."
+    reason = "Found 10 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::match_wildcard_for_single_variants,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::missing_errors_doc,
     reason = "Found 15 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::missing_panics_doc,
     reason = "Found 1 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::needless_pass_by_value,
     reason = "Found 3 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::unwrap_used,
     reason = "Found 2 occurrences after enabling the lint."
 )]

--- a/storage/src/trie_hash.rs
+++ b/storage/src/trie_hash.rs
@@ -70,13 +70,14 @@ impl From<GenericArray<u8, typenum::U32>> for TrieHash {
 }
 
 impl TrieHash {
-    /// Return the length of a TrieHash
+    /// Return the length of a `TrieHash`
     pub(crate) const fn len() -> usize {
         std::mem::size_of::<TrieHash>()
     }
 
-    /// Some code needs a TrieHash even though it only has a HashType.
-    /// This function is a no-op, as HashType is a TrieHash in this context.
+    /// Some code needs a `TrieHash` even though it only has a `HashType`.
+    /// This function is a no-op, as `HashType` is a `TrieHash` in this context.
+    #[must_use]
     pub const fn into_triehash(self) -> Self {
         self
     }

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -30,3 +30,6 @@ std = [
 name = "triehash"
 path = "benches/triehash.rs"
 harness = false
+
+[lints]
+workspace = true

--- a/triehash/benches/triehash.rs
+++ b/triehash/benches/triehash.rs
@@ -6,6 +6,15 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 5 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::indexing_slicing,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use ethereum_types::H256;
 use firewood_triehash::trie_root;

--- a/triehash/benches/triehash.rs
+++ b/triehash/benches/triehash.rs
@@ -78,7 +78,7 @@ fn bench_insertions(c: &mut Criterion) {
         for _ in 0..1000 {
             let k = random_bytes(6, 0, &mut seed);
             let v = random_value(&mut seed);
-            d.push((k, v))
+            d.push((k, v));
         }
         b.iter(|| trie_root::<KeccakHasher, _, _, _>(d.clone()));
     });
@@ -90,7 +90,7 @@ fn bench_insertions(c: &mut Criterion) {
         for _ in 0..1000 {
             let k = random_word(alphabet, 6, 0, &mut seed);
             let v = random_value(&mut seed);
-            d.push((k, v))
+            d.push((k, v));
         }
         b.iter(|| trie_root::<KeccakHasher, _, _, _>(d.clone()));
     });
@@ -102,7 +102,7 @@ fn bench_insertions(c: &mut Criterion) {
         for _ in 0..1000 {
             let k = random_word(alphabet, 1, 5, &mut seed);
             let v = random_value(&mut seed);
-            d.push((k, v))
+            d.push((k, v));
         }
         b.iter(|| trie_root::<KeccakHasher, _, _, _>(d.clone()));
     });
@@ -114,7 +114,7 @@ fn bench_insertions(c: &mut Criterion) {
         for _ in 0..1000 {
             let k = random_word(alphabet, 6, 0, &mut seed);
             let v = random_value(&mut seed);
-            d.push((k, v))
+            d.push((k, v));
         }
         b.iter(|| trie_root::<KeccakHasher, _, _, _>(d.clone()));
     });

--- a/triehash/benches/triehash.rs
+++ b/triehash/benches/triehash.rs
@@ -6,11 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![allow(
+#![expect(
     clippy::arithmetic_side_effects,
     reason = "Found 5 occurrences after enabling the lint."
 )]
-#![allow(
+#![expect(
     clippy::indexing_slicing,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/triehash/src/lib.rs
+++ b/triehash/src/lib.rs
@@ -10,6 +10,22 @@
 //!
 //! This module should be used to generate trie root hash.
 
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "Found 7 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::bool_to_int_with_if,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::cast_possible_truncation,
+    reason = "Found 1 occurrences after enabling the lint."
+)]
+#![allow(
+    clippy::indexing_slicing,
+    reason = "Found 13 occurrences after enabling the lint."
+)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]

--- a/triehash/src/lib.rs
+++ b/triehash/src/lib.rs
@@ -28,7 +28,7 @@ mod rstd {
 
 use core::cmp;
 use core::iter::once;
-use rstd::*;
+use rstd::BTreeMap;
 
 use hash_db::Hasher;
 use rlp::RlpStream;
@@ -171,7 +171,7 @@ fn hex_prefix_encode(nibbles: &[u8], leaf: bool) -> impl Iterator<Item = u8> + '
     let oddness_factor = inlen % 2;
 
     let first_byte = {
-        let mut bits = ((inlen as u8 & 1) + (2 * leaf as u8)) << 4;
+        let mut bits = ((inlen as u8 & 1) + (2 * u8::from(leaf))) << 4;
         if oddness_factor == 1 {
             bits += nibbles[0];
         }


### PR DESCRIPTION
Previously, the lints were defined in each crate's `Cargo.toml`. This commit moves the lints to the workspace's `Cargo.toml` file. This allows for a more consistent linting configuration across all crates in the workspace and simplifies the management of lint rules. This change also ensures that all crates in the workspace adhere to the same linting standards, improving code quality and maintainability.

New crates added to the workspace via `cargo new` will automatically inherit the linting rules defined in the workspace's `Cargo.toml`. However, manually crafted crates will need to ensure the stanza

```toml
[lints]
workspace = true
```

is included in `Cargo.toml`to benefit from the workspace-wide linting rules.

Caveats:
  - This change adds an excessive amount of warnings because `clippy::pedantic` is very easy to violate and is now enabled workspace wide. This is also why I included pedantic lints with a lower priority, so that any individual lint within pedantic can be separately disabled with an `allow`.
  - Packages cannot override the workspace lints within their `Cargo.toml`. This can be worked around by adding the lint rule change via a crate attribute in the crate's `lib.rs` or `main.rs`. See the `ffi` crate for an example of this workaround.

Resolves #951