### PR TITLE
chore: remove remnants of no-std

### DIFF
--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT OR Apache-2.0"
 edition = "2024"
 
 [dependencies]
-hash-db = { version = "0.16.0", default-features = false }
-rlp = { version = "0.6", default-features = false }
+hash-db = "0.16.0"
+rlp = "0.6"
 
 [dev-dependencies]
 criterion = "0.6.0"
@@ -18,13 +18,6 @@ ethereum-types = { version = "0.15.1" }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 trie-standardmap = "0.16.0"
 hex-literal = "1.0.0"
-
-[features]
-default = ["std"]
-std = [
-	"hash-db/std",
-	"rlp/std",
-]
 
 [[bench]]
 name = "triehash"

--- a/triehash/src/lib.rs
+++ b/triehash/src/lib.rs
@@ -10,25 +10,9 @@
 //!
 //! This module should be used to generate trie root hash.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
-#[cfg(feature = "std")]
-mod rstd {
-    pub use std::collections::BTreeMap;
-}
-
-#[cfg(not(feature = "std"))]
-mod rstd {
-    pub use alloc::collections::BTreeMap;
-    pub use alloc::vec::Vec;
-}
-
-use core::cmp;
-use core::iter::once;
-use rstd::*;
+use std::cmp;
+use std::collections::BTreeMap;
+use std::iter::once;
 
 use hash_db::Hasher;
 use rlp::RlpStream;


### PR DESCRIPTION
We don't use no-std and it no longer works anyway

Fixes #959