### PR TITLE
chore(ffi): rename ffi package to match dir

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -1,7 +1,7 @@
-// Package firewood provides a Go wrapper around the [Firewood] database.
+// Package ffi provides a Go wrapper around the [Firewood] database.
 //
 // [Firewood]: https://github.com/ava-labs/firewood
-package firewood
+package ffi
 
 // // Note that -lm is required on Linux but not on Mac.
 // #cgo linux,amd64 LDFLAGS: -L${SRCDIR}/libs/x86_64-unknown-linux-gnu -lm

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -1,4 +1,4 @@
-package firewood
+package ffi
 
 import (
 	"bytes"

--- a/ffi/kvbackend.go
+++ b/ffi/kvbackend.go
@@ -1,4 +1,4 @@
-package firewood
+package ffi
 
 // implement a specific interface for firewood
 // this is used for some of the firewood performance tests

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -1,7 +1,7 @@
-// Package firewood provides a Go wrapper around the [Firewood] database.
+// Package ffi provides a Go wrapper around the [Firewood] database.
 //
 // [Firewood]: https://github.com/ava-labs/firewood
-package firewood
+package ffi
 
 // // Note that -lm is required on Linux but not on Mac.
 // #cgo LDFLAGS: -L${SRCDIR}/../target/release -L/usr/local/lib -lfirewood_ffi -lm

--- a/ffi/proposal.go
+++ b/ffi/proposal.go
@@ -1,7 +1,7 @@
-// Package firewood provides a Go wrapper around the [Firewood] database.
+// Package ffi provides a Go wrapper around the [Firewood] database.
 //
 // [Firewood]: https://github.com/ava-labs/firewood
-package firewood
+package ffi
 
 // // Note that -lm is required on Linux but not on Mac.
 // #cgo LDFLAGS: -L${SRCDIR}/../target/release -L/usr/local/lib -lfirewood_ffi -lm

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -1,7 +1,7 @@
-// Package firewood provides a Go wrapper around the [Firewood] database.
+// Package ffi provides a Go wrapper around the [Firewood] database.
 //
 // [Firewood]: https://github.com/ava-labs/firewood
-package firewood
+package ffi
 
 // // Note that -lm is required on Linux but not on Mac.
 // #cgo LDFLAGS: -L${SRCDIR}/../target/release -L/usr/local/lib -lfirewood_ffi -lm


### PR DESCRIPTION
This PR renames the FFI package to match the directory.

Ref https://github.com/ava-labs/coreth/pull/959#discussion_r2143285308