### PR TITLE
ci(attach-static-libs): add pre build command to set MACOSX_DEPLOYMENT_TARGET for static libs build

### DIFF
--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -38,10 +38,10 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - os: macos-latest
             target: aarch64-apple-darwin
-            pre-build-cmd: echo "MACOSX_DEPLOYMENT_TARGET=13.0 >> "$GITHUB_ENV"
+            pre-build-cmd: echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
           - os: macos-13
             target: x86_64-apple-darwin
-            pre-build-cmd: echo "MACOSX_DEPLOYMENT_TARGET=13.0 >> "$GITHUB_ENV"
+            pre-build-cmd: echo "MACOSX_DEPLOYMENT_TARGET=13.0" >> "$GITHUB_ENV"
     outputs:
       has_secrets: ${{ steps.check_secrets.outputs.has_secrets }}
     steps:


### PR DESCRIPTION
Adds a pre-build-command to the matrix for the GH Action building and attaching static libraries. Use this to explicitly set the `MACOSX_DEPLOYMENT_TARGET` env variable to the lowest allowed patch version as described here: https://github.com/ava-labs/firewood/issues/972#issuecomment-2984988336

Fixes https://github.com/ava-labs/firewood/issues/972 (as much as we can for firewood-go)