### PR TITLE
ci: Remove build warnings for FFI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ lto = "fat"
 debug = false
 inherits = "release"
 
+[profile.ffi]
+inherits = "maxperf"
+
 [workspace.lints.rust]
 unsafe_code = "deny"
 

--- a/ffi/build.rs
+++ b/ffi/build.rs
@@ -1,4 +1,6 @@
 use std::env;
+use std::error::Error;
+use std::fs;
 
 extern crate cbindgen;
 
@@ -6,6 +8,8 @@ fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");
 
     let config = cbindgen::Config::from_file("cbindgen.toml").expect("cbindgen.toml is present");
+
+    fixup_go().expect("couldn't fix up go");
 
     cbindgen::Builder::new()
         .with_crate(crate_dir)
@@ -21,4 +25,81 @@ fn main() {
                 bindings.write_to_file("firewood.h");
             },
         );
+    println!("cargo:rerun-if-changed=cbindgen.toml");
+    println!("cargo:rerun-if-changed=src");
+    println!("cargo:rerun-if-env-changed=PROFILE");
+}
+fn fixup_go() -> Result<(), Box<dyn Error>> {
+    for direntry in fs::read_dir(".")?.filter(|direntry| {
+        direntry.as_ref().ok().is_some_and(|entry| {
+            let path = entry.path();
+            path.extension() == Some(std::ffi::OsStr::new("go"))
+                && !path
+                    .file_stem()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .ends_with("_test")
+        })
+    }) {
+        let build_profile = get_build_profile_name();
+
+        let path = direntry?.path();
+        let contents = fs::read_to_string(&path)?;
+        let mut new_contents = String::new();
+        let mut changed = false;
+        for line in contents.lines() {
+            if line.starts_with("// #cgo LDFLAGS: -L")
+                || line.starts_with("// // ignore LDFLAGS: -L")
+            {
+                let lib = line.split(' ').next_back();
+
+                let change = match lib {
+                    Some("-L${SRCDIR}/../target/debug") if build_profile == "debug" => {
+                        Some("// #cgo LDFLAGS: -L${SRCDIR}/../target/debug")
+                    }
+                    Some("-L${SRCDIR}/../target/debug") => {
+                        Some("// // ignore LDFLAGS: -L${SRCDIR}/../target/debug")
+                    }
+                    Some("-L${SRCDIR}/../target/release") if build_profile == "release" => {
+                        Some("// #cgo LDFLAGS: -L${SRCDIR}/../target/release")
+                    }
+                    Some("-L${SRCDIR}/../target/release") => {
+                        Some("// // ignore LDFLAGS: -L${SRCDIR}/../target/release")
+                    }
+                    Some("-L${SRCDIR}/../target/maxperf") if build_profile == "maxperf" => {
+                        Some("// #cgo LDFLAGS: -L${SRCDIR}/../target/maxperf")
+                    }
+                    Some("-L${SRCDIR}/../target/maxperf") => {
+                        Some("// // ignore LDFLAGS: -L${SRCDIR}/../target/maxperf")
+                    }
+                    _ => None,
+                };
+                if let Some(change) = change {
+                    new_contents.push_str(change);
+                    changed = true;
+                } else {
+                    new_contents.push_str(line);
+                }
+            } else {
+                new_contents.push_str(line);
+            }
+            new_contents.push('\n');
+        }
+        println!("cargo::rerun-if-changed={}", path.display());
+        if changed {
+            fs::write(path, new_contents)?;
+        }
+    }
+    Ok(())
+}
+
+fn get_build_profile_name() -> String {
+    // The profile name is always the 3rd last part of the path (with 1 based indexing).
+    // e.g. /code/core/target/cli/build/my-build-info-9f91ba6f99d7a061/out
+    std::env::var("OUT_DIR")
+        .expect("OUT_DIR is not set")
+        .split(std::path::MAIN_SEPARATOR)
+        .nth_back(3)
+        .unwrap_or("unknown")
+        .to_string()
 }

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -10,10 +10,10 @@ package ffi
 // #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/libs/aarch64-apple-darwin
 // // XXX: last search path takes precedence, which means we prioritize
 // // local builds over pre-built and maxperf over release build
-// #cgo LDFLAGS: -L${SRCDIR}/../target/debug
-// #cgo LDFLAGS: -L${SRCDIR}/../target/release
-// #cgo LDFLAGS: -L${SRCDIR}/../target/maxperf
-// #cgo LDFLAGS: -L/usr/local/lib -lfirewood_ffi
+// // ignore LDFLAGS: -L${SRCDIR}/../target/debug
+// // ignore LDFLAGS: -L${SRCDIR}/../target/release
+// // ignore LDFLAGS: -L${SRCDIR}/../target/maxperf
+// #cgo LDFLAGS: -lfirewood_ffi
 // #include <stdlib.h>
 // #include "firewood.h"
 import "C"

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -4,7 +4,11 @@
 package ffi
 
 // // Note that -lm is required on Linux but not on Mac.
-// #cgo LDFLAGS: -L${SRCDIR}/../target/release -L/usr/local/lib -lfirewood_ffi -lm
+// // ignore LDFLAGS: -L${SRCDIR}/../target/debug
+// // ignore LDFLAGS: -L${SRCDIR}/../target/release
+// // ignore LDFLAGS: -L${SRCDIR}/../target/maxperf
+// #cgo LDFLAGS: -L/usr/local/lib
+// #cgo LDFLAGS: -lfirewood_ffi -lm
 // #include <stdlib.h>
 // #include "firewood.h"
 import "C"

--- a/ffi/proposal.go
+++ b/ffi/proposal.go
@@ -4,7 +4,11 @@
 package ffi
 
 // // Note that -lm is required on Linux but not on Mac.
-// #cgo LDFLAGS: -L${SRCDIR}/../target/release -L/usr/local/lib -lfirewood_ffi -lm
+// // ignore LDFLAGS: -L${SRCDIR}/../target/debug
+// // ignore LDFLAGS: -L${SRCDIR}/../target/release
+// // ignore LDFLAGS: -L${SRCDIR}/../target/maxperf
+// #cgo LDFLAGS: -L/usr/local/lib
+// #cgo LDFLAGS: -lfirewood_ffi -lm
 // #include <stdlib.h>
 // #include "firewood.h"
 import "C"

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -4,7 +4,11 @@
 package ffi
 
 // // Note that -lm is required on Linux but not on Mac.
-// #cgo LDFLAGS: -L${SRCDIR}/../target/release -L/usr/local/lib -lfirewood_ffi -lm
+// // ignore LDFLAGS: -L${SRCDIR}/../target/debug
+// // ignore LDFLAGS: -L${SRCDIR}/../target/release
+// // ignore LDFLAGS: -L${SRCDIR}/../target/maxperf
+// #cgo LDFLAGS: -L/usr/local/lib
+// #cgo LDFLAGS: -lfirewood_ffi -lm
 // #include <stdlib.h>
 // #include "firewood.h"
 import "C"

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -255,6 +255,7 @@ impl RevisionManager {
             proposal.commit_reparent(p);
         }
 
+        #[allow(clippy::used_underscore_binding)]
         if trace_enabled() {
             let _merkle = Merkle::from(committed);
             trace!("{}", _merkle.dump().expect("failed to dump merkle"));


### PR DESCRIPTION
Implements conditional LDFLAGS comment/uncomment based on cargo build profile

TODO: change the builds for ffi to use the new ffi profile in the github actions, which disables all the -L directives.