### PR TITLE
Cleanup Nodestore Public Interface

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -81,7 +81,7 @@ impl api::DbView for HistoricalRev {
         Self: 'a;
 
     async fn root_hash(&self) -> Result<Option<api::HashKey>, api::Error> {
-        HashedNodeReader::root_hash(self).map_err(api::Error::FileIO)
+        Ok(HashedNodeReader::root_hash(self))
     }
 
     async fn val<K: api::KeyType>(&self, key: K) -> Result<Option<Box<[u8]>>, api::Error> {
@@ -349,7 +349,7 @@ impl Proposal<'_> {
     /// Get the root hash of the proposal synchronously
     pub fn root_hash_sync(&self) -> Result<Option<api::HashKey>, api::Error> {
         #[cfg(not(feature = "ethhash"))]
-        return Ok(self.nodestore.root_hash()?);
+        return Ok(self.nodestore.root_hash());
         #[cfg(feature = "ethhash")]
         return Ok(Some(
             self.nodestore
@@ -367,7 +367,7 @@ impl api::DbView for Proposal<'_> {
         Self: 'b;
 
     async fn root_hash(&self) -> Result<Option<api::HashKey>, api::Error> {
-        self.nodestore.root_hash().map_err(api::Error::from)
+        Ok(self.nodestore.root_hash())
     }
 
     async fn val<K: KeyType>(&self, key: K) -> Result<Option<Box<[u8]>>, api::Error> {

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -353,7 +353,7 @@ impl Proposal<'_> {
         #[cfg(feature = "ethhash")]
         return Ok(Some(
             self.nodestore
-                .root_hash()?
+                .root_hash()
                 .unwrap_or_else(firewood_storage::empty_trie_hash),
         ));
     }

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -417,11 +417,7 @@ impl<T: HashedNodeReader> Merkle<T> {
     pub(crate) fn dump(&self) -> Result<String, Error> {
         let mut result = String::new();
         writeln!(result, "digraph Merkle {{\n  rankdir=LR;").map_err(Error::other)?;
-        if let Some((root_addr, root_hash)) = self
-            .nodestore
-            .root_address_and_hash()
-            .expect("failed to get root address and hash")
-        {
+        if let Some((root_addr, root_hash)) = self.nodestore.root_address_and_hash() {
             writeln!(result, " root -> {root_addr}")
                 .map_err(Error::other)
                 .map_err(|e| FileIoError::new(e, None, 0, None))
@@ -1365,7 +1361,7 @@ mod tests {
 
         let merkle = merkle.hash();
 
-        let root_hash = merkle.nodestore.root_hash().unwrap().unwrap();
+        let root_hash = merkle.nodestore.root_hash().unwrap();
 
         for (key, value) in kvs {
             let proof = merkle.prove(&key).unwrap();
@@ -1805,7 +1801,7 @@ mod tests {
         #[cfg(not(feature = "branch_factor_256"))]
         {
             let merkle = merkle_build_test(kvs).unwrap().hash();
-            let Some(got_hash) = merkle.nodestore.root_hash().unwrap() else {
+            let Some(got_hash) = merkle.nodestore.root_hash() else {
                 assert!(expected_hash.is_none());
                 return;
             };
@@ -2043,7 +2039,7 @@ mod tests {
             for (k, v) in &items {
                 let root_hash = merkle
                     .nodestore
-                    .root_address_and_hash()?
+                    .root_address_and_hash()
                     .map(|(_, hash)| hash);
                 hashes.push((root_hash, merkle.dump().unwrap()));
                 merkle.insert(k, v.clone())?;
@@ -2056,7 +2052,7 @@ mod tests {
                 merkle.remove(k)?;
                 let root_hash = merkle
                     .nodestore
-                    .root_address_and_hash()?
+                    .root_address_and_hash()
                     .map(|(_, hash)| hash);
                 new_hashes.push((root_hash, k, before, merkle.dump().unwrap()));
             }

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -2093,8 +2093,7 @@ mod tests {
                 });
                 assert_eq!(
                     actual_hash, expected_hash,
-                    "\n\nkey: {key}\nbefore:\n{before_removal}\nafter:\n{after_removal}\n\nexpected:\n{:?}\n",
-                    expected_hash
+                    "\n\nkey: {key}\nbefore:\n{before_removal}\nafter:\n{after_removal}\n\nexpected:\n{expected_hash:?}\nactual:\n{actual_hash:?}\n",
                 );
             }
         }

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -2084,8 +2084,6 @@ mod tests {
                 },
             );
 
-            // hashes.reverse();
-
             for (expected, actual) in hashes.into_iter().rev().zip(new_hashes) {
                 let (new_hash, key, before_removal, after_removal) = actual;
                 let expected_hash = expected;

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -417,11 +417,9 @@ impl<T: HashedNodeReader> Merkle<T> {
     pub(crate) fn dump(&self) -> Result<String, Error> {
         let mut result = String::new();
         writeln!(result, "digraph Merkle {{\n  rankdir=LR;").map_err(Error::other)?;
-        if let Some(root_addr) = self.nodestore.root_address() {
-            let root_hash = self
-                .nodestore
-                .root_hash()
-                .expect("root hash should be present");
+        if let (Some(root_addr), Some(root_hash)) =
+            (self.nodestore.root_address(), self.nodestore.root_hash())
+        {
             writeln!(result, " root -> {root_addr}")
                 .map_err(Error::other)
                 .map_err(|e| FileIoError::new(e, None, 0, None))

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -2041,7 +2041,7 @@ mod tests {
             let init_immutable_merkle: Merkle<NodeStore<Arc<ImmutableProposal>, _>> =
                 init_merkle.try_into().unwrap();
 
-            let (mut hashes, complete_immutable_merkle) = items.iter().fold(
+            let (hashes, complete_immutable_merkle) = items.iter().fold(
                 (vec![], init_immutable_merkle),
                 |(mut hashes, immutable_merkle), (k, v)| {
                     let root_hash = immutable_merkle.nodestore.root_hash();
@@ -2052,8 +2052,6 @@ mod tests {
                     (hashes, merkle.try_into().unwrap())
                 },
             );
-
-            // let mut new_hashes = Vec::new();
 
             let (new_hashes, _) = items.iter().rev().fold(
                 (vec![], complete_immutable_merkle),
@@ -2077,13 +2075,11 @@ mod tests {
                 },
             );
 
-            hashes.reverse();
+            // hashes.reverse();
 
-            for i in 0..hashes.len() {
-                #[allow(clippy::indexing_slicing)]
-                let (new_hash, key, before_removal, after_removal) = &new_hashes[i];
-                #[allow(clippy::indexing_slicing)]
-                let expected_hash = &hashes[i];
+            for (expected, actual) in hashes.into_iter().rev().zip(new_hashes) {
+                let (new_hash, key, before_removal, after_removal) = actual;
+                let expected_hash = expected;
                 let key = key.iter().fold(String::new(), |mut s, b| {
                     let _ = write!(s, "{b:02x}");
                     s

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -2007,7 +2007,18 @@ mod tests {
     fn test_root_hash_reversed_deletions() -> Result<(), FileIoError> {
         use rand::rngs::StdRng;
         use rand::{Rng, SeedableRng};
-        let rng = std::cell::RefCell::new(StdRng::seed_from_u64(42));
+
+        let seed = std::env::var("FIREWOOD_TEST_SEED")
+            .ok()
+            .map_or_else(
+                || None,
+                |s| Some(str::parse(&s).expect("couldn't parse FIREWOOD_TEST_SEED; must be a u64")),
+            )
+            .unwrap_or_else(|| rng().random());
+
+        eprintln!("Seed {seed}: to rerun with this data, export FIREWOOD_TEST_SEED={seed}");
+        let rng = std::cell::RefCell::new(StdRng::seed_from_u64(seed));
+
         let max_len0 = 8;
         let max_len1 = 4;
         let keygen = || {

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -2054,7 +2054,7 @@ mod tests {
                 (vec![], init_immutable_merkle),
                 |(mut hashes, immutable_merkle), (k, v)| {
                     let root_hash = immutable_merkle.nodestore.root_hash();
-                    hashes.push((root_hash, immutable_merkle.dump().unwrap()));
+                    hashes.push(root_hash);
                     let mut merkle =
                         Merkle::from(NodeStore::new(Arc::new(immutable_merkle.nodestore)).unwrap());
                     merkle.insert(k, v.clone()).unwrap();
@@ -2084,18 +2084,17 @@ mod tests {
                 },
             );
 
-            for (expected, actual) in hashes.into_iter().rev().zip(new_hashes) {
-                let (new_hash, key, before_removal, after_removal) = actual;
-                let expected_hash = expected;
+            for (expected_hash, (actual_hash, key, before_removal, after_removal)) in
+                hashes.into_iter().rev().zip(new_hashes)
+            {
                 let key = key.iter().fold(String::new(), |mut s, b| {
                     let _ = write!(s, "{b:02x}");
                     s
                 });
                 assert_eq!(
-                    new_hash.clone(),
-                    expected_hash.0,
+                    actual_hash, expected_hash,
                     "\n\nkey: {key}\nbefore:\n{before_removal}\nafter:\n{after_removal}\n\nexpected:\n{:?}\n",
-                    expected_hash.0
+                    expected_hash
                 );
             }
         }

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -1851,7 +1851,7 @@ mod tests {
         use firewood_triehash::trie_root;
 
         let merkle = merkle_build_test(kvs.to_vec()).unwrap().hash();
-        let firewood_hash = merkle.nodestore.root_hash().unwrap().unwrap_or_default();
+        let firewood_hash = merkle.nodestore.root_hash().unwrap_or_default();
         let eth_hash = trie_root::<KeccakHasher, _, _, _>(kvs.to_vec());
         let firewood_hash = H256::from_slice(firewood_hash.as_ref());
 
@@ -1915,7 +1915,7 @@ mod tests {
         .collect::<Vec<(Box<_>, Box<_>)>>();
 
         let merkle = merkle_build_test(items).unwrap().hash();
-        let firewood_hash = merkle.nodestore.root_hash().unwrap();
+        let firewood_hash = merkle.nodestore.root_hash();
 
         assert_eq!(
             firewood_hash,

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -417,7 +417,11 @@ impl<T: HashedNodeReader> Merkle<T> {
     pub(crate) fn dump(&self) -> Result<String, Error> {
         let mut result = String::new();
         writeln!(result, "digraph Merkle {{\n  rankdir=LR;").map_err(Error::other)?;
-        if let Some((root_addr, root_hash)) = self.nodestore.root_address_and_hash() {
+        if let Some(root_addr) = self.nodestore.root_address() {
+            let root_hash = self
+                .nodestore
+                .root_hash()
+                .expect("root hash should be present");
             writeln!(result, " root -> {root_addr}")
                 .map_err(Error::other)
                 .map_err(|e| FileIoError::new(e, None, 0, None))
@@ -2037,10 +2041,7 @@ mod tests {
             let mut hashes = Vec::new();
 
             for (k, v) in &items {
-                let root_hash = merkle
-                    .nodestore
-                    .root_address_and_hash()
-                    .map(|(_, hash)| hash);
+                let root_hash = merkle.nodestore.root_hash();
                 hashes.push((root_hash, merkle.dump().unwrap()));
                 merkle.insert(k, v.clone())?;
             }
@@ -2050,10 +2051,7 @@ mod tests {
             for (k, _) in items.iter().rev() {
                 let before = merkle.dump().unwrap();
                 merkle.remove(k)?;
-                let root_hash = merkle
-                    .nodestore
-                    .root_address_and_hash()
-                    .map(|(_, hash)| hash);
+                let root_hash = merkle.nodestore.root_hash();
                 new_hashes.push((root_hash, k, before, merkle.dump().unwrap()));
             }
 

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -625,7 +625,7 @@ fn key_from_nibble_iter<Iter: Iterator<Item = u8>>(mut nibbles: Iter) -> Key {
 mod tests {
     use std::sync::Arc;
 
-    use firewood_storage::{MemStore, MutableProposal, NodeStore};
+    use firewood_storage::{ImmutableProposal, MemStore, MutableProposal, NodeStore};
 
     use crate::merkle::Merkle;
 
@@ -1160,9 +1160,12 @@ mod tests {
 
         merkle.insert(&branch, branch.into()).unwrap();
 
-        let mut stream = merkle.key_value_iter();
+        let immutable_merkle: Merkle<NodeStore<Arc<ImmutableProposal>, _>> =
+            merkle.try_into().unwrap();
+        println!("{}", immutable_merkle.dump().unwrap());
+        merkle = Merkle::from(NodeStore::new(Arc::new(immutable_merkle.into_inner())).unwrap());
 
-        println!("{}", merkle.dump().unwrap());
+        let mut stream = merkle.key_value_iter();
 
         assert_eq!(
             stream.next().await.unwrap().unwrap(),

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -987,7 +987,7 @@ pub struct ImmutableProposal {
 impl ImmutableProposal {
     /// Returns true if the parent of this proposal is committed and has the given hash.
     #[must_use]
-    pub fn parent_hash_is(&self, hash: Option<TrieHash>) -> bool {
+    fn parent_hash_is(&self, hash: Option<TrieHash>) -> bool {
         match <Arc<ArcSwap<NodeStoreParent>> as arc_swap::access::DynAccess<Arc<_>>>::load(
             &self.parent,
         )

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1252,12 +1252,8 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
         Ok((addr, hash))
     }
 
-    /// Re-export the root_hash function of ImmutableProposal.
-    // pub fn root_hash(&self) -> Option<TrieHash> {
-    //     self.kind.root_hash()
-    // }
-
-    /// Re-export the parent_hash_is function of ImmutableProposal.
+    /// Re-export the `parent_hash_is` function of [`ImmutableProposal`].
+    #[must_use]
     pub fn parent_hash_is(&self, hash: Option<TrieHash>) -> bool {
         self.kind.parent_hash_is(hash)
     }

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1510,9 +1510,10 @@ impl<T: ReadInMemoryNode + Parentable, S: ReadableStorage> RootReader for NodeSt
     }
 }
 
-impl<S> HashedNodeReader for NodeStore<Arc<ImmutableProposal>, S>
+impl<T, S> HashedNodeReader for NodeStore<T, S>
 where
-    NodeStore<Arc<ImmutableProposal>, S>: TrieReader,
+    NodeStore<T, S>: TrieReader,
+    T: Parentable,
     S: ReadableStorage,
 {
     fn root_address(&self) -> Option<LinearAddress> {
@@ -1521,35 +1522,6 @@ where
 
     fn root_hash(&self) -> Option<TrieHash> {
         self.kind.root_hash()
-    }
-}
-
-impl<S> HashedNodeReader for NodeStore<Committed, S>
-where
-    NodeStore<Committed, S>: TrieReader,
-    S: ReadableStorage,
-{
-    fn root_address(&self) -> Option<LinearAddress> {
-        self.header.root_address
-    }
-
-    fn root_hash(&self) -> Option<TrieHash> {
-        self.kind.root_hash()
-    }
-}
-
-impl<S> HashedNodeReader for NodeStore<MutableProposal, S>
-where
-    NodeStore<MutableProposal, S>: TrieReader,
-    S: ReadableStorage,
-{
-    fn root_address(&self) -> Option<LinearAddress> {
-        self.header.root_address
-    }
-
-    fn root_hash(&self) -> Option<TrieHash> {
-        self.root_node()
-            .map(|root_node| hash_node(&root_node, &Path::new()).into_triehash())
     }
 }
 


### PR DESCRIPTION
The `kind` and `storage` fields of `Nodestore` are public so that `firewood` can read the root hash - but it is already stored in memory when the `Nodestore` is created. This diff converts these two fields back to private. 