### PR TITLE
chore: Update Cargo.toml add repository field

### DIFF
--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -18,6 +18,7 @@ authors = [
 description = "Firewood is an embedded key-value store, optimized to store blockchain state."
 license-file = "../LICENSE.md"
 homepage = "https://avalabs.org"
+repository = "https://github.com/ava-labs/firewood"
 readme = "../README.md"
 
 [dependencies]


### PR DESCRIPTION
To make it easier for potential contributors and automated tools to find the repository. More explanation: https://github.com/szabgab/rust-digger/issues/89