### PR TITLE
fix(ci): include submodule name in ffi tag

### DIFF
--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -154,8 +154,8 @@ jobs:
           git push -u origin ${{ steps.determine_branch.outputs.target_branch }} --force
           
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            git tag -a "${GITHUB_REF#refs/tags/}" -m "firewood ci ${{ github.sha }}: attach firewood static libs"
-            git push origin "refs/tags/${GITHUB_REF#refs/tags/}"
+            git tag -a "ffi/${GITHUB_REF#refs/tags/}" -m "firewood ci ${{ github.sha }}: attach firewood static libs"
+            git push origin "refs/tags/ffi/${GITHUB_REF#refs/tags/}"
           fi
 
   # Check out the branch created in the previous job on a matrix of


### PR DESCRIPTION
This PR updates the tag pushed to https://github.com/ava-labs/firewood-go-ethhash to include the prefix the submodule name `ffi` as a prefix ie.`ffi/vX.X.X`.

This ensures that `go get` successfully finds the submodule.

`go get` exhibits some funny behavior. It supports fetching modules/submodules by commit, but treats semver tags as a special case.

Specifically, https://github.com/ava-labs/firewood/pull/944 manually tested fetching the ffi submodule by both commit (manual GH action) and a tag, but this tag was not a semantic version it was a string to avoid creating a bogus release that may be permanently cached by the go module proxy server.

However, after publishing v0.0.6, @alarso16 found that the ffi submodule could not be fetched via:

```
go get github.com/ava-labs/firewood-go-ethhash/ffi@v0.0.6
```

Instead, this resulted in the error:

```
$ go get github.com/ava-labs/firewood-go-ethhash/ffi@v0.0.6
go: downloading github.com/ava-labs/firewood-go-ethhash v0.0.6
go: module github.com/ava-labs/firewood-go-ethhash@v0.0.6 found, but does not contain package github.com/ava-labs/firewood-go-ethhash/ffi
```

Providing the submodule name as a prefix to the tag ensures that `go get` correctly finds the submodule. The exact handling `go get` performs that causes this is a bit of a rabbit hole.