### PR TITLE
fix: Report IO errors

### DIFF
--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -1318,35 +1318,50 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
     #[fastrace::trace(short_name = true)]
     #[cfg(feature = "io-uring")]
     pub fn flush_nodes(&self) -> Result<(), FileIoError> {
+        use std::pin::Pin;
+
+        #[derive(Clone, Debug)]
+        struct PinnedBufferEntry {
+            pinned_buffer: Pin<Box<[u8]>>,
+            offset: Option<u64>,
+        }
+
         const RINGSIZE: usize = FileBacked::RINGSIZE as usize;
 
         let flush_start = Instant::now();
 
         let mut ring = self.storage.ring.lock().expect("poisoned lock");
-        let mut saved_pinned_buffers = vec![(false, std::pin::Pin::new(Box::default())); RINGSIZE];
+        let mut saved_pinned_buffers = vec![
+            PinnedBufferEntry {
+                pinned_buffer: Pin::new(Box::new([0; 0])),
+                offset: None,
+            };
+            RINGSIZE
+        ];
         for (&addr, &(area_size_index, ref node)) in &self.kind.new {
             let mut serialized = Vec::with_capacity(100); // TODO: better size? we can guess branches are larger
             node.as_bytes(area_size_index, &mut serialized);
             let mut serialized = serialized.into_boxed_slice();
             loop {
                 // Find the first available write buffer, enumerate to get the position for marking it completed
-                if let Some((pos, (busy, found))) = saved_pinned_buffers
+                if let Some((pos, pbe)) = saved_pinned_buffers
                     .iter_mut()
                     .enumerate()
-                    .find(|(_, (busy, _))| !*busy)
+                    .find(|(_, pbe)| pbe.offset.is_none())
                 {
-                    *found = std::pin::Pin::new(std::mem::take(&mut serialized));
+                    pbe.pinned_buffer = std::pin::Pin::new(std::mem::take(&mut serialized));
+                    pbe.offset = Some(addr.get());
+
                     let submission_queue_entry = self
                         .storage
-                        .make_op(found)
+                        .make_op(&pbe.pinned_buffer)
                         .offset(addr.get())
                         .build()
                         .user_data(pos as u64);
 
-                    *busy = true;
                     // SAFETY: the submission_queue_entry's found buffer must not move or go out of scope
-                    // until the operation has been completed. This is ensured by marking the slot busy,
-                    // and not marking it !busy until the kernel has said it's done below.
+                    // until the operation has been completed. This is ensured by having a Some(offset)
+                    // and not marking it None until the kernel has said it's done below.
                     #[expect(unsafe_code)]
                     while unsafe { ring.submission().push(&submission_queue_entry) }.is_err() {
                         ring.submitter().squeue_wait().map_err(|e| {
@@ -1372,16 +1387,34 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
                 trace!("competion queue length: {}", completion_queue.len());
                 for entry in completion_queue {
                     let item = entry.user_data() as usize;
-                    saved_pinned_buffers
+                    let pbe = saved_pinned_buffers
                         .get_mut(item)
-                        .expect("should be an index into the array")
-                        .0 = false;
+                        .expect("should be an index into the array");
+                    if entry.result()
+                        != pbe
+                            .pinned_buffer
+                            .len()
+                            .try_into()
+                            .expect("buffer should be small enough")
+                    {
+                        let error = if entry.result() >= 0 {
+                            std::io::Error::other("Partial write")
+                        } else {
+                            std::io::Error::from_raw_os_error(0 - entry.result())
+                        };
+                        return Err(self.storage.file_io_error(
+                            error,
+                            pbe.offset.expect("offset should be Some"),
+                            Some("write failure".to_string()),
+                        ));
+                    }
+                    pbe.offset = None;
                 }
             }
         }
         let pending = saved_pinned_buffers
             .iter()
-            .filter(|(busy, _)| *busy)
+            .filter(|pbe| pbe.offset.is_some())
             .count();
         ring.submit_and_wait(pending).map_err(|e| {
             self.storage
@@ -1390,13 +1423,35 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
 
         for entry in ring.completion() {
             let item = entry.user_data() as usize;
-            saved_pinned_buffers
+            let pbe = saved_pinned_buffers
                 .get_mut(item)
-                .expect("should be an index into the array")
-                .0 = false;
+                .expect("should be an index into the array");
+            if entry.result()
+                != pbe
+                    .pinned_buffer
+                    .len()
+                    .try_into()
+                    .expect("buffer should be small enough")
+            {
+                let error = if entry.result() >= 0 {
+                    std::io::Error::other("Partial write")
+                } else {
+                    std::io::Error::from_raw_os_error(0 - entry.result())
+                };
+                return Err(self.storage.file_io_error(
+                    error,
+                    pbe.offset.expect("offset should be Some"),
+                    Some("write failure".to_string()),
+                ));
+            }
+            pbe.offset = None;
         }
 
-        debug_assert_eq!(saved_pinned_buffers.iter().find(|(busy, _)| *busy), None);
+        debug_assert!(
+            !saved_pinned_buffers.iter().any(|pbe| pbe.offset.is_some()),
+            "Found entry with offset still set: {:?}",
+            saved_pinned_buffers.iter().find(|pbe| pbe.offset.is_some())
+        );
 
         self.storage
             .write_cached_nodes(self.kind.new.iter().map(|(addr, (_, node))| (addr, node)))?;


### PR DESCRIPTION
Previously, if an error occurred while flushing nodes, it was silently ignored during io-uring processing. To reproduce this, I created a tiny filesystem using an AWS instance running ubuntu:

    sudo mkdir /mnt/tmpfs
    sudo mount -t tmpfs -o size=5k,mode=1777,noatime tmpfs /mnt/tmpfs

I then ran a few fwdctl commands, which passed on main:

    cargo run --bin fwdctl --features logger -- create /mnt/tmpfs/test.db
    target/debug/fwdctl insert --db /mnt/tmpfs/test.db a "$(tr -d '\n' < /etc/passwd)"
    target/debug/fwdctl insert --db /mnt/tmpfs/test.db b "$(tr -d '\n' < /etc/passwd)"
    target/debug/fwdctl insert --db /mnt/tmpfs/test.db c "$(tr -d '\n' < /etc/passwd)"

When running this after these fixes, the following is produced from the final insert, which fills the disk:

    Error: FileIO(FileIoError { inner: Os { code: 28, kind: StorageFull, message: "No space left on device" }, filename: Some("/mnt/tmpfs/test.db"), offset: 8544, context: Some("write failure") })

This fix restructures the pinned buffer pool to add an offset, which is only used for error reporting. This offset is also used as a flag indicating the entry is in use rather than using a bool.