### PR TITLE
perf: Allow cloned proposals

### DIFF
--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -120,13 +120,9 @@ pub enum Error {
     /// A file I/O error occurred
     FileIO(#[from] FileIoError),
 
-    /// Cannot commit a cloned proposal
-    ///
-    /// Cloned proposals are problematic because if they are committed, then you could
-    /// create another proposal from this committed proposal, so we error at commit time
-    /// if there are outstanding clones
-    #[error("Cannot commit a cloned proposal")]
-    CannotCommitClonedProposal,
+    /// Cannot commit a committed proposal
+    #[error("Cannot commit a committed proposal")]
+    AlreadyCommitted,
 
     /// Internal error
     #[error("Internal error")]


### PR DESCRIPTION
We were using the Arc as a way to know if a proposal could be committed. Instead, we now allow proposals to be cloned, and just check an AtomicBool to verify whether we can commit the proposal or not.

This will allow for some additional optimizations in the ffi layer.