### PR TITLE
chore: suppress clippy::cast_possible_truncation across the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ missing_const_for_fn = "warn"
 arithmetic_side_effects = "warn"
 # lower the priority of pedantic to allow overriding the lints it includes
 pedantic = { level = "warn", priority = -1 }
+# Ignore interger casts. This is to avoid unnecessary `try_into` calls for usize
+# to u64 and vice versa and should be re-enabled if/when clippy has a separate
+# lint for usize vs non-usize truncation.
+cast_possible_truncation = { level = "allow" }
 
 [workspace.dependencies]
 metrics = "0.24.2"

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -7,10 +7,6 @@
     reason = "Found 2 occurrences after enabling the lint."
 )]
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::match_same_arms,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/benchmark/src/single.rs
+++ b/benchmark/src/single.rs
@@ -6,10 +6,6 @@
     reason = "Found 2 occurrences after enabling the lint."
 )]
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::cast_sign_loss,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/benchmark/src/zipf.rs
+++ b/benchmark/src/zipf.rs
@@ -6,10 +6,6 @@
     reason = "Found 2 occurrences after enabling the lint."
 )]
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 2 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::cast_precision_loss,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -5,6 +5,13 @@
     unsafe_code,
     reason = "This is an FFI library, so unsafe code is expected."
 )]
+#![cfg_attr(
+    not(target_pointer_width = "64"),
+    forbid(
+        clippy::cast_possible_truncation,
+        reason = "non-64 bit target likely to cause issues during u64 to usize conversions"
+    )
+)]
 
 use std::collections::HashMap;
 use std::ffi::{CStr, CString, OsStr, c_char};

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -106,6 +106,18 @@
 //! abandoned, nothing has actually been written to disk.
 //!
 #![warn(missing_debug_implementations, rust_2018_idioms, missing_docs)]
+// Instead of using a `compile_error!`, cause clippy to hard fail if the target is not 64-bit. This
+// is a workaround for the fact that the `clippy::cast_possible_truncation` lint does not delineate
+// between 64-bit and non-64-bit targets with respect to `usize -> u64` casts and vice versa which
+// leads to a lot of unecessary `TryInto` casts. This also allows 32-bit builds to compile as long
+// as `clippy` is not part of the build process albeit with the risk of truncation errors.
+#![cfg_attr(
+    not(target_pointer_width = "64"),
+    forbid(
+        clippy::cast_possible_truncation,
+        reason = "non-64 bit target likely to cause issues during u64 to usize conversions"
+    )
+)]
 
 #[cfg(all(feature = "ethhash", feature = "branch_factor_256"))]
 compile_error!(

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -2,10 +2,6 @@
 // See the file LICENSE.md for licensing terms.
 
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 5 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::match_same_arms,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -2,10 +2,6 @@
 // See the file LICENSE.md for licensing terms.
 
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::unnecessary_wraps,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/storage/src/hashers/merkledb.rs
+++ b/storage/src/hashers/merkledb.rs
@@ -8,13 +8,6 @@
         reason = "Found 1 occurrences after enabling the lint."
     )
 )]
-#![cfg_attr(
-    not(feature = "ethhash"),
-    expect(
-        clippy::cast_possible_truncation,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
 
 use crate::hashednode::{HasUpdate, Hashable, Preimage};
 use crate::{TrieHash, ValueDigest};

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -3,6 +3,13 @@
 
 #![warn(missing_debug_implementations, rust_2018_idioms, missing_docs)]
 #![deny(unsafe_code)]
+#![cfg_attr(
+    not(target_pointer_width = "64"),
+    forbid(
+        clippy::cast_possible_truncation,
+        reason = "non-64 bit target likely to cause issues during u64 to usize conversions"
+    )
+)]
 
 //! # storage implements the storage of a [Node] on top of a `LinearStore`
 //!

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -11,10 +11,6 @@
     reason = "Found 5 occurrences after enabling the lint."
 )]
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::indexing_slicing,
     reason = "Found 3 occurrences after enabling the lint."
 )]

--- a/storage/src/linear/memory.rs
+++ b/storage/src/linear/memory.rs
@@ -6,10 +6,6 @@
     reason = "Found 3 occurrences after enabling the lint."
 )]
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 2 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::indexing_slicing,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -2,10 +2,6 @@
 // See the file LICENSE.md for licensing terms.
 
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 2 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::indexing_slicing,
     reason = "Found 2 occurrences after enabling the lint."
 )]

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -6,10 +6,6 @@
     reason = "Found 4 occurrences after enabling the lint."
 )]
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 6 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::indexing_slicing,
     reason = "Found 1 occurrences after enabling the lint."
 )]

--- a/storage/src/nodestore.rs
+++ b/storage/src/nodestore.rs
@@ -6,10 +6,6 @@
     reason = "Found 5 occurrences after enabling the lint."
 )]
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 16 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::default_trait_access,
     reason = "Found 6 occurrences after enabling the lint."
 )]
@@ -1617,7 +1613,6 @@ pub(crate) mod nodestore_test_utils {
     use super::*;
 
     // Helper function to wrap the node in a StoredArea and write it to the given offset. Returns the size of the area on success.
-    #[allow(clippy::cast_possible_truncation)]
     pub(crate) fn write_new_node<S: WritableStorage>(
         nodestore: &NodeStore<Committed, S>,
         node: &Node,

--- a/triehash/src/lib.rs
+++ b/triehash/src/lib.rs
@@ -19,10 +19,6 @@
     reason = "Found 1 occurrences after enabling the lint."
 )]
 #![expect(
-    clippy::cast_possible_truncation,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::indexing_slicing,
     reason = "Found 13 occurrences after enabling the lint."
 )]


### PR DESCRIPTION
As noted in the comment in `firewood/src/lib.rs`, this is to avoid the unecessary try_into calls for `u64 -> usize`.