### PR TITLE
fix: publish firewood-macros

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,21 +13,22 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: dtolnay/rust-toolchain@stable
-      - name: publish firewood-storage crate
+      ## NOTE: keep these packages sorted in reverse topological order!
+      - name: publish firewood-macros crate
         continue-on-error: false
         run: |
           cargo login ${{ secrets.CARGO_TOKEN }}
-          cargo publish -p firewood-storage
+          cargo publish -p firewood-macros
       - name: publish firewood-triehash crate
         continue-on-error: false
         run: |
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p firewood-triehash
-      - name: publish firewood crate
+      - name: publish firewood-storage crate
         continue-on-error: false
         run: |
           cargo login ${{ secrets.CARGO_TOKEN }}
-          cargo publish -p firewood
+          cargo publish -p firewood-storage
       - name: publish firewood-ffi crate
         continue-on-error: false
         run: |
@@ -43,3 +44,8 @@ jobs:
         run: |
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p firewood-benchmark
+      - name: publish firewood crate
+        continue-on-error: false
+        run: |
+          cargo login ${{ secrets.CARGO_TOKEN }}
+          cargo publish -p firewood

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: dtolnay/rust-toolchain@stable
       ## NOTE: keep these packages sorted in reverse topological order!
+      ## cargo tree --workspace -e all | grep firewood
       - name: publish firewood-macros crate
         continue-on-error: false
         run: |
@@ -29,6 +30,11 @@ jobs:
         run: |
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p firewood-storage
+      - name: publish firewood crate
+        continue-on-error: false
+        run: |
+          cargo login ${{ secrets.CARGO_TOKEN }}
+          cargo publish -p firewood
       - name: publish firewood-ffi crate
         continue-on-error: false
         run: |
@@ -44,8 +50,3 @@ jobs:
         run: |
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p firewood-benchmark
-      - name: publish firewood crate
-        continue-on-error: false
-        run: |
-          cargo login ${{ secrets.CARGO_TOKEN }}
-          cargo publish -p firewood


### PR DESCRIPTION
The macros crate was not being published due to the missing stanza. Need to figure out a way to make this automatic in the future.

I also added a note about how the crates in the publish workflow must be sorted in reverse topological order so that the dependencies are published before the packages that depend on them.