### PR TITLE
fix: logger macros causing linting warnings

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -1,13 +1,6 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![cfg_attr(
-    feature = "ethhash",
-    expect(
-        clippy::used_underscore_binding,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
-)]
 #![expect(
     clippy::cast_precision_loss,
     reason = "Found 2 occurrences after enabling the lint."
@@ -24,7 +17,7 @@ use std::sync::Arc;
 #[cfg(feature = "ethhash")]
 use std::sync::OnceLock;
 
-use firewood_storage::logger::{trace, trace_enabled, warn};
+use firewood_storage::logger::{trace, warn};
 use metrics::gauge;
 use typed_builder::TypedBuilder;
 
@@ -230,9 +223,9 @@ impl RevisionManager {
             proposal.commit_reparent(p);
         }
 
-        if trace_enabled() {
-            let _merkle = Merkle::from(committed);
-            trace!("{}", _merkle.dump().expect("failed to dump merkle"));
+        if crate::logger::trace_enabled() {
+            let merkle = Merkle::from(committed);
+            trace!("{}", merkle.dump().expect("failed to dump merkle"));
         }
 
         Ok(())

--- a/storage/src/logger.rs
+++ b/storage/src/logger.rs
@@ -23,7 +23,14 @@ mod noop_logger {
     #[macro_export]
     /// A noop logger, when the logger feature is disabled
     macro_rules! noop {
-        ($($arg:tt)+) => {};
+        ($($arg:tt)+) => {
+            if $crate::logger::trace_enabled() {
+                // This is a no-op. `trace_enabled` is always false. However, this
+                // branch exists to satisfy lints that complain about unused variables
+                // passed into the macro.
+                let _ = format!($($arg)+);
+            }
+        };
     }
 
     pub use noop as debug;


### PR DESCRIPTION
Previously, the logger macros were empty when logging was disabled. This caused no code to be generated which resulted in warnings from clippy around dead code.

This change bypasses those warnings by generating code that lexically uses the parameters passed in however at runtime will never be executed and will be elided by the compiler when optimizations are enabled and logging is disabled.