### PR TITLE
ci: add concurrency group to attach static libs workflow

### DIFF
--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -16,6 +16,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Build, upload, and collect static libraries for each target architecture,
 # so that golang projects can import the FFI package without needing to
 # recompile Firewood locally.


### PR DESCRIPTION
Adds a concurrency group to the attach static libs workflow https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflow-syntax-for-github-actions#example-using-concurrency-and-the-default-behavior .

The attach static libs GitHub action pushes/pulls to a branch derived from the PR branch title to https://github.com/ava-labs/firewood-go-ethhash throughout the workflow. If multiple commits on the same branch concurrently attempt to push/pull the same branch they may interfere leading to unexpected results (pulled different code than it pushed) or git errors.

This change ensures that the workflow started by commit 1 will be cancelled before starting the workflow for commit 2.

This is intended to fix an issue observed in CI on https://github.com/ava-labs/firewood/pull/1024

CI running for commit 0 https://github.com/ava-labs/firewood/actions/runs/16055519899/job/45308974261#step:3:8 succeeded, but the timestamps show it ran concurrently with the next commit, which failed to push https://github.com/ava-labs/firewood/actions/runs/16055531848/job/45308958694#step:9:66.

<img width="1349" alt="Screenshot 2025-07-07 at 11 34 22" src="https://github.com/user-attachments/assets/1780572f-1b15-49c0-bbf3-b80d47b9a415" />

<img width="1346" alt="Screenshot 2025-07-07 at 11 37 49" src="https://github.com/user-attachments/assets/a36b4ccb-d27a-4920-92f6-fc2b9b7605ea" />

Subsequent workflow runs failed to check out the branch:

https://github.com/ava-labs/firewood/actions/runs/16055543248/job/45309129819

<img width="1343" alt="Screenshot 2025-07-07 at 11 39 28" src="https://github.com/user-attachments/assets/e959eaf2-a198-4267-9df4-fb0f4e141c5b" />

Conflicting attempts to push to the same branch seems to be the most likely cause given the conflicting timestamps and attempts to force push/pull to the same branch name when multiple commits can run the same workflow in parallel.