### PR TITLE
fix: Avoid reference to LinearAddress

### DIFF
--- a/storage/src/checker.rs
+++ b/storage/src/checker.rs
@@ -63,7 +63,7 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
         if let Node::Branch(branch) = self.read_node(subtree_root_address)?.as_ref() {
             // this is an internal node, traverse the children
             for (_, address) in branch.children_addresses() {
-                self.visit_trie(*address, visited)?;
+                self.visit_trie(address, visited)?;
             }
         }
 

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -310,14 +310,14 @@ impl BranchNode {
     }
 
     // Helper to iterate over only valid children
-    fn children_iter(&self) -> impl Iterator<Item = (usize, (&LinearAddress, &HashType))> + Clone {
+    fn children_iter(&self) -> impl Iterator<Item = (usize, (LinearAddress, &HashType))> + Clone {
         self.children
             .iter()
             .enumerate()
             .filter_map(|(i, child)| match child {
                 None => None,
                 Some(Child::Node(_)) => unreachable!("TODO make unreachable"),
-                Some(Child::AddressWithHash(address, hash)) => Some((i, (address, hash))),
+                Some(Child::AddressWithHash(address, hash)) => Some((i, (*address, hash))),
             })
     }
 
@@ -327,7 +327,7 @@ impl BranchNode {
     }
 
     /// Returns (index, address) for each child that has a hash set.
-    pub fn children_addresses(&self) -> impl Iterator<Item = (usize, &LinearAddress)> + Clone {
+    pub fn children_addresses(&self) -> impl Iterator<Item = (usize, LinearAddress)> + Clone {
         self.children_iter()
             .map(|(idx, (address, _))| (idx, address))
     }


### PR DESCRIPTION
Upcoming changes make supporting this harder, and it's not necessary, as the size of a LinearAddress and the size of a pointer are the same, so it's more efficient to return the actual value rather than a pointer to the value.