### PR TITLE
feat(delayed-persist): 2.1: Unpersisted deletions

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -567,7 +567,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
                             }
                             Some(Child::Node(child)) => child,
                             Some(Child::AddressWithHash(addr, _)) => {
-                                self.nodestore.read_for_update(addr)?
+                                self.nodestore.read_for_update(addr.into())?
                             }
                         };
 
@@ -712,7 +712,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
                             let mut child = match child {
                                 Child::Node(child_node) => std::mem::take(child_node),
                                 Child::AddressWithHash(addr, _) => {
-                                    self.nodestore.read_for_update(*addr)?
+                                    self.nodestore.read_for_update((*addr).into())?
                                 }
                             };
 
@@ -780,7 +780,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
                             }
                             Some(Child::Node(node)) => node,
                             Some(Child::AddressWithHash(addr, _)) => {
-                                self.nodestore.read_for_update(addr)?
+                                self.nodestore.read_for_update(addr.into())?
                             }
                         };
 
@@ -828,7 +828,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
                                 }),
                             ),
                             Child::AddressWithHash(addr, _) => {
-                                self.nodestore.read_for_update(*addr)?
+                                self.nodestore.read_for_update((*addr).into())?
                             }
                         };
 
@@ -928,7 +928,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
                             }
                             Some(Child::Node(node)) => node,
                             Some(Child::AddressWithHash(addr, _)) => {
-                                self.nodestore.read_for_update(addr)?
+                                self.nodestore.read_for_update(addr.into())?
                             }
                         };
 
@@ -976,7 +976,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
                                 }),
                             ),
                             Child::AddressWithHash(addr, _) => {
-                                self.nodestore.read_for_update(*addr)?
+                                self.nodestore.read_for_update((*addr).into())?
                             }
                         };
 
@@ -1014,7 +1014,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
             let child = match children {
                 Some(Child::Node(node)) => node,
                 Some(Child::AddressWithHash(addr, _)) => {
-                    &mut self.nodestore.read_for_update(*addr)?
+                    &mut self.nodestore.read_for_update((*addr).into())?
                 }
                 None => continue,
             };

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -51,6 +51,7 @@ pub use nodestore::{
 
 pub use linear::filebacked::FileBacked;
 pub use linear::memory::MemStore;
+pub use node::persist::MaybePersistedNode;
 
 pub use trie_hash::TrieHash;
 

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -36,7 +36,7 @@ use std::sync::Mutex;
 use lru::LruCache;
 use metrics::counter;
 
-use crate::{CacheReadStrategy, LinearAddress, SharedNode};
+use crate::{CacheReadStrategy, LinearAddress, MaybePersistedNode, SharedNode};
 
 use super::{FileIoError, ReadableStorage, WritableStorage};
 
@@ -223,10 +223,10 @@ impl WritableStorage for FileBacked {
         Ok(())
     }
 
-    fn invalidate_cached_nodes<'a>(&self, addresses: impl Iterator<Item = &'a LinearAddress>) {
+    fn invalidate_cached_nodes<'a>(&self, nodes: impl Iterator<Item = &'a MaybePersistedNode>) {
         let mut guard = self.cache.lock().expect("poisoned lock");
-        for addr in addresses {
-            guard.pop(addr);
+        for addr in nodes.filter_map(MaybePersistedNode::as_linear_address) {
+            guard.pop(&addr);
         }
     }
 

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -25,7 +25,7 @@ use std::num::NonZero;
 use std::ops::Deref;
 use std::path::PathBuf;
 
-use crate::{CacheReadStrategy, LinearAddress, SharedNode};
+use crate::{CacheReadStrategy, LinearAddress, MaybePersistedNode, SharedNode};
 pub(super) mod filebacked;
 pub mod memory;
 
@@ -190,7 +190,11 @@ pub trait WritableStorage: ReadableStorage {
     }
 
     /// Invalidate all nodes that are part of a specific revision, as these will never be referenced again
-    fn invalidate_cached_nodes<'a>(&self, _addresses: impl Iterator<Item = &'a LinearAddress>) {}
+    fn invalidate_cached_nodes<'a>(
+        &self,
+        _addresses: impl Iterator<Item = &'a MaybePersistedNode>,
+    ) {
+    }
 
     /// Add a new entry to the freelist cache
     fn add_to_free_list_cache(&self, _addr: LinearAddress, _next: Option<LinearAddress>) {}

--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -87,6 +87,19 @@ impl MaybePersistedNode {
         }
     }
 
+    /// Returns the linear address of the node if it is persisted on disk.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(LinearAddress)` if the node is persisted on disk, otherwise `None`.
+    #[must_use]
+    pub fn as_linear_address(&self) -> Option<LinearAddress> {
+        match self.0.load().as_ref() {
+            MaybePersisted::Unpersisted(_) => None,
+            MaybePersisted::Persisted(address) => Some(*address),
+        }
+    }
+
     /// Updates the internal state to indicate this node is persisted at the specified disk address.
     ///
     /// This method changes the internal state of the `MaybePersistedNode` from `Mem` to `Disk`,


### PR DESCRIPTION
Nodes on the delete list might be unpersisted. This can't actually happen yet, but support for it is there. This is half of making branch children unpersisted.

Reaping unpersisted nodes is easy, we just drop them. If they are persisted, they need to move to the freelist, as they did before.