### PR TITLE
feat(delayed-persist): Part 2.2: Branch Children

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -2,10 +2,6 @@
 // See the file LICENSE.md for licensing terms.
 
 #![expect(
-    clippy::match_same_arms,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::missing_errors_doc,
     reason = "Found 6 occurrences after enabling the lint."
 )]
@@ -392,14 +388,11 @@ impl<T: HashedNodeReader> Merkle<T> {
                 for (childidx, child) in b.children.iter().enumerate() {
                     let (child_addr, child_hash) = match child {
                         None => continue,
-                        Some(Child::Node(_)) => continue, // TODO
-                        Some(Child::AddressWithHash(addr, hash)) => (*addr, Some(hash)),
-                        Some(Child::MaybePersisted(maybe_persisted, hash)) => {
-                            // For MaybePersisted, we need the address if it's persisted
-                            match maybe_persisted.as_linear_address() {
-                                Some(addr) => (addr, Some(hash)),
-                                None => continue, // Skip if not persisted
-                            }
+                        Some(node) => {
+                            let (Some(addr), hash) = (node.persisted_address(), node.hash()) else {
+                                continue;
+                            };
+                            (addr, hash)
                         }
                     };
 

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -82,6 +82,38 @@ pub enum Child {
     MaybePersisted(MaybePersistedNode, HashType),
 }
 
+impl Child {
+    /// Return a mutable reference to the underlying Node if the child
+    /// is a [`Child::Node`] variant, otherwise None.
+    #[must_use]
+    pub const fn as_mut_node(&mut self) -> Option<&mut Node> {
+        match self {
+            Child::Node(node) => Some(node),
+            _ => None,
+        }
+    }
+
+    /// Return the persisted address of the child if it is a [`Child::AddressWithHash`] or [`Child::MaybePersisted`] variant, otherwise None.
+    #[must_use]
+    pub fn persisted_address(&self) -> Option<LinearAddress> {
+        match self {
+            Child::AddressWithHash(addr, _) => Some(*addr),
+            Child::MaybePersisted(maybe_persisted, _) => maybe_persisted.as_linear_address(),
+            Child::Node(_) => None,
+        }
+    }
+
+    /// Return the hash of the child if it is a [`Child::AddressWithHash`] or [`Child::MaybePersisted`] variant, otherwise None.
+    #[must_use]
+    pub const fn hash(&self) -> Option<&HashType> {
+        match self {
+            Child::AddressWithHash(_, hash) => Some(hash),
+            Child::MaybePersisted(_, hash) => Some(hash),
+            Child::Node(_) => None,
+        }
+    }
+}
+
 #[cfg(feature = "ethhash")]
 mod ethhash {
     use serde::{Deserialize, Serialize};

--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -40,6 +40,14 @@ use crate::{FileIoError, LinearAddress, NodeReader, SharedNode};
 #[derive(Debug, Clone)]
 pub struct MaybePersistedNode(Arc<ArcSwap<MaybePersisted>>);
 
+impl PartialEq<MaybePersistedNode> for MaybePersistedNode {
+    fn eq(&self, other: &MaybePersistedNode) -> bool {
+        self.0.load().as_ref() == other.0.load().as_ref()
+    }
+}
+
+impl Eq for MaybePersistedNode {}
+
 impl From<SharedNode> for MaybePersistedNode {
     fn from(node: SharedNode) -> Self {
         MaybePersistedNode(Arc::new(ArcSwap::new(Arc::new(
@@ -120,7 +128,7 @@ impl MaybePersistedNode {
 /// This enum represents the two possible states of a `MaybePersisted`:
 /// - `Unpersisted(SharedNode)`: The node is currently in memory
 /// - `Persisted(LinearAddress)`: The node is currently on disk at the specified address
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum MaybePersisted {
     Unpersisted(SharedNode),
     Persisted(LinearAddress),


### PR DESCRIPTION
Branch children might also not be persisted.

This also splits up hash_helper which got too long for clippy.

- [x] Roots may not be persisted (Part 1: #1041)
- [x] BranchNode children can now be Node, LinearAddress or a
MaybePersistedNode (Part 2: #1045 and this PR #1047)
- [ ] When converting a `MutableProposal` to an `ImmutableProposal`,
don't actually allocate space, just create `SharedNode`s from the
`Node`s.
- [ ] Remove `NodeStoreHeader` from `NodeStore`. The header should move
into the `RevisionManager`.
- [ ] Allocate new nodes from the recently-freed nodes from an expired
revision, then from the freelist. This can be done by maintaining a
local freelist from the nodes deleted in the expiring revision and
falling back to the actual freelist. Deleted nodes that are not reused
must still be pushed onto the freelist.
