### PR TITLE
feat(delayed-persist): dump unpersisted nodestore

### DIFF
--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::node::ExtendableBytes;
-use crate::{LeafNode, LinearAddress, MaybePersistedNode, Node, Path};
+use crate::{LeafNode, LinearAddress, MaybePersistedNode, Node, Path, SharedNode};
 use std::fmt::{Debug, Formatter};
 
 /// The type of a hash. For ethereum compatible hashes, this might be a RLP encoded
@@ -110,6 +110,19 @@ impl Child {
             Child::AddressWithHash(_, hash) => Some(hash),
             Child::MaybePersisted(_, hash) => Some(hash),
             Child::Node(_) => None,
+        }
+    }
+
+    /// Return a `MaybePersistedNode` from a child
+    ///
+    /// This is used in the dump utility, but otherwise should be avoided,
+    /// as it may create an unnecessary `MaybePersistedNode`
+    #[must_use]
+    pub fn as_maybe_persisted_node(&self) -> MaybePersistedNode {
+        match self {
+            Child::Node(node) => MaybePersistedNode::from(SharedNode::from(node.clone())),
+            Child::AddressWithHash(addr, _) => MaybePersistedNode::from(*addr),
+            Child::MaybePersisted(maybe_persisted, _) => maybe_persisted.clone(),
         }
     }
 }

--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use std::sync::Arc;
+use std::{fmt::Display, sync::Arc};
 
 use arc_swap::ArcSwap;
 
@@ -120,6 +120,24 @@ impl MaybePersistedNode {
     /// * `addr` - The `LinearAddress` where the node has been persisted on disk
     pub fn persist_at(&self, addr: LinearAddress) {
         self.0.store(Arc::new(MaybePersisted::Persisted(addr)));
+    }
+}
+
+/// Display the `MaybePersistedNode` as a string.
+///
+/// This is used in the dump utility.
+///
+/// We render these:
+///   For disk addresses, just the address
+///   For shared nodes, the address of the [`SharedNode`] object, prefixed with a 'M'
+///
+/// If instead you want the node itself, use [`MaybePersistedNode::as_shared_node`] first.
+impl Display for MaybePersistedNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0.load().as_ref() {
+            MaybePersisted::Unpersisted(node) => write!(f, "M{:p}", (*node).as_ptr()),
+            MaybePersisted::Persisted(addr) => write!(f, "{addr}"),
+        }
     }
 }
 


### PR DESCRIPTION
dump has to work with unpersisted nodes, as there are a bunch of tests that assume an immutable proposal can be dumped. This was useful anyway while debugging some tests in the next commit, and small enough to commit separately.