### PR TITLE
Generated newtypes for LinearAddress.

### DIFF
--- a/storage/benches/serializer.rs
+++ b/storage/benches/serializer.rs
@@ -94,7 +94,7 @@ fn branch(c: &mut Criterion) {
         children: from_fn(|i| {
             if i == 0 {
                 Some(firewood_storage::Child::AddressWithHash(
-                    NonZeroU64::new(1).unwrap(),
+                    firewood_storage::LinearAddress::new(1).unwrap(),
                     firewood_storage::HashType::from([0; 32]),
                 ))
             } else {

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -218,7 +218,7 @@ impl WritableStorage for FileBacked {
     ) -> Result<(), FileIoError> {
         let mut guard = self.cache.lock().expect("poisoned lock");
         for (addr, node) in nodes {
-            guard.put(*addr, node.clone());
+            guard.put(LinearAddress::new((*addr).get()).unwrap(), node.clone());
         }
         Ok(())
     }

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -40,7 +40,7 @@ pub mod persist;
 pub use branch::{BranchNode, Child};
 pub use leaf::LeafNode;
 
-use crate::{HashType, Path, SharedNode};
+use crate::{HashType, LinearAddress, Path, SharedNode};
 
 /// A node, either a Branch or Leaf
 
@@ -424,7 +424,7 @@ impl Node {
                         let hash = HashType::from_reader(&mut serialized)?;
 
                         *child = Some(Child::AddressWithHash(
-                            NonZero::new(address).ok_or(Error::other("zero address in child"))?,
+                            LinearAddress::new(address).ok_or(Error::other("zero address in child"))?,
                             hash,
                         ));
                     }
@@ -441,7 +441,7 @@ impl Node {
                         let hash = HashType::from_reader(&mut serialized)?;
 
                         children[position] = Some(Child::AddressWithHash(
-                            NonZero::new(address).ok_or(Error::other("zero address in child"))?,
+                            LinearAddress::new(address).ok_or(Error::other("zero address in child"))?,
                             hash,
                         ));
                     }

--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -160,6 +160,7 @@ mod test {
             Option::from(&maybe_persisted_node)
         );
 
+        let addr = LinearAddress::new(addr.get()).unwrap();
         maybe_persisted_node.persist_at(addr);
         assert!(maybe_persisted_node.as_shared_node(&store).is_err());
         assert_eq!(Some(addr), Option::from(&maybe_persisted_node));
@@ -168,7 +169,8 @@ mod test {
 
     #[test]
     fn test_from_linear_address() {
-        let addr = nonzero!(1024u64);
+        let raw_addr = nonzero!(1024u64);
+        let addr = LinearAddress::new(raw_addr.get()).unwrap();
         let maybe_persisted_node = MaybePersistedNode::from(addr);
         assert_eq!(Some(addr), Option::from(&maybe_persisted_node));
     }
@@ -196,6 +198,7 @@ mod test {
 
         // Persist the original
         let addr = nonzero!(4096u64);
+        let addr = LinearAddress::new(addr.get()).unwrap();
         original.persist_at(addr);
 
         // Both original and clone should now be persisted since they share the same ArcSwap

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -30,6 +30,7 @@ use std::io::{Error, ErrorKind, Read};
 use std::iter::FusedIterator;
 use std::num::NonZeroU64;
 use std::sync::Arc;
+use std::fmt;
 
 use crate::node::persist::MaybePersistedNode;
 use crate::node::{ByteCounter, Node};
@@ -111,9 +112,9 @@ pub const fn index_name(index: usize) -> &'static str {
 /// This is not usize because we can store this as a single byte
 pub type AreaIndex = u8;
 
-pub const NUM_AREA_SIZES: usize = AREA_SIZES.len();
-pub const MIN_AREA_SIZE: u64 = AREA_SIZES[0];
-pub const MAX_AREA_SIZE: u64 = AREA_SIZES[NUM_AREA_SIZES - 1];
+const NUM_AREA_SIZES: usize = AREA_SIZES.len();
+const MIN_AREA_SIZE: u64 = AREA_SIZES[0];
+const MAX_AREA_SIZE: u64 = AREA_SIZES[NUM_AREA_SIZES - 1];
 
 #[inline]
 pub fn new_area_index(n: usize) -> AreaIndex {
@@ -145,10 +146,58 @@ pub fn area_size_to_index(n: u64) -> Result<AreaIndex, Error> {
         })
 }
 
-/// Objects cannot be stored at the zero address, so a [`LinearAddress`] is guaranteed not
-/// to be zero. This reserved zero can be used as a [None] value for some use cases. In particular,
-/// branches can use `Option<LinearAddress>` which is the same size as a [`LinearAddress`]
-pub type LinearAddress = NonZeroU64;
+// pub type LinearAddress = NonZeroU64;
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct LinearAddress(NonZeroU64);
+
+impl LinearAddress {
+    /// Create a new LinearAddress, returns None if value is zero.
+    pub fn new(addr: u64) -> Option<Self> {
+        NonZeroU64::new(addr).map(LinearAddress)
+    }
+
+    /// Get the underlying address as u64.
+    pub fn get(&self) -> u64 {
+        self.0.get()
+    }
+
+    /// Check if the address is 8-byte aligned.
+    pub const fn is_aligned(&self) -> bool {
+        self.0.get() % 8 == 0
+    }
+
+    pub fn checked_add(&self, offset: u64) -> Option<Self> {
+        self.get().checked_add(offset).and_then(LinearAddress::new)
+    }
+
+    pub fn max_area_size() -> u64 {
+        AREA_SIZES[AREA_SIZES.len() - 1]
+    }
+    pub fn min_area_size() -> u64 {
+        AREA_SIZES[0]
+    }
+    pub fn num_area_sizes() -> usize {
+        AREA_SIZES.len()
+    }
+
+    /// Returns a reference to the inner NonZeroU64
+    pub fn as_nonzero(&self) -> &NonZeroU64 {
+        &self.0
+    }
+}
+
+impl fmt::Display for LinearAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.get())
+    }
+}
+
+impl From<LinearAddress> for u64 {
+    fn from(addr: LinearAddress) -> Self {
+        addr.get()
+    }
+}
 
 /// Each [`StoredArea`] contains an [Area] which is either a [Node] or a [`FreeArea`].
 #[repr(u8)]
@@ -187,7 +236,8 @@ impl<T> StoredArea<T> {
     }
 }
 
-pub type FreeLists = [Option<LinearAddress>; NUM_AREA_SIZES];
+/// FreeLists is an array of Option<LinearAddress> for each area size.
+pub type FreeLists = [Option<LinearAddress>; AREA_SIZES.len()];
 
 /// A [`FreeArea`] is stored at the start of the area that contained a node that
 /// has been freed.
@@ -289,7 +339,7 @@ impl<T: ReadInMemoryNode, S: ReadableStorage> NodeStore<T, S> {
             return Ok(node);
         }
 
-        debug_assert!(addr.get() % 8 == 0);
+        debug_assert!(addr.is_aligned());
 
         // saturating because there is no way we can be reading at u64::MAX
         // and this will fail very soon afterwards
@@ -429,7 +479,7 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
         let addr = LinearAddress::new(self.header.size()).expect("node store size can't be 0");
         self.header
             .set_size(self.header.size().saturating_add(area_size));
-        debug_assert!(addr.get() % 8 == 0);
+        debug_assert!(addr.is_aligned());
         trace!("Allocating from end: addr: {addr:?}, size: {index}");
         Ok((addr, index))
     }
@@ -480,7 +530,7 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
         let Some(addr) = node.as_linear_address() else {
             return Ok(());
         };
-        debug_assert!(addr.get() % 8 == 0);
+        debug_assert!(addr.is_aligned());
 
         let (area_size_index, _) = self.area_index_and_size(addr)?;
         trace!("Deleting node at {addr:?} of size {area_size_index}");
@@ -643,9 +693,9 @@ pub mod test_utils {
         header.set_size(size);
         header.set_root_address(root_addr);
         *header.free_lists_mut() = free_lists;
-        let header_bytes = bytemuck::bytes_of(&header);
+        let header_bytes = bincode::serialize(&header).unwrap();
         nodestore.header = header;
-        nodestore.storage.write(0, header_bytes).unwrap();
+        nodestore.storage.write(0, &header_bytes).unwrap();
     }
 }
 

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -101,12 +101,16 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
     /// Returns a [`FileIoError`] if the header cannot be read or validated.
     pub fn open(storage: Arc<S>) -> Result<Self, FileIoError> {
         let mut stream = storage.stream_from(0)?;
-        let mut header = NodeStoreHeader::new();
-        let header_bytes = bytemuck::bytes_of_mut(&mut header);
-        stream
-            .read_exact(header_bytes)
+        let mut header_bytes = vec![0u8; bincode::serialized_size(&NodeStoreHeader::new()).unwrap() as usize];
+        stream.read_exact(&mut header_bytes)
             .map_err(|e| storage.file_io_error(e, 0, Some("header read".to_string())))?;
-
+       
+        let header: NodeStoreHeader = bincode::deserialize(&header_bytes)
+            .map_err(|e| storage.file_io_error(
+                std::io::Error::new(std::io::ErrorKind::InvalidData, e),
+                0,
+                Some("header read".to_string())
+            ))?;
         drop(stream);
 
         header
@@ -273,9 +277,9 @@ impl<S: WritableStorage> NodeStore<MutableProposal, S> {
     /// Panics if the header cannot be written.
     pub fn new_empty_proposal(storage: Arc<S>) -> Self {
         let header = NodeStoreHeader::new();
-        let header_bytes = bytemuck::bytes_of(&header);
+        let header_bytes = bincode::serialize(&header).expect("failed to serialize header");
         storage
-            .write(0, header_bytes)
+            .write(0, &header_bytes)
             .expect("failed to write header");
         NodeStore {
             header,
@@ -711,7 +715,7 @@ mod tests {
     use test_case::test_case;
 
     use super::*;
-    use alloc::{AREA_SIZES, MAX_AREA_SIZE, MIN_AREA_SIZE, NUM_AREA_SIZES, area_size_to_index};
+    use alloc::{AREA_SIZES, area_size_to_index};
 
     #[test]
     fn test_area_size_to_index() {
@@ -725,7 +729,7 @@ mod tests {
                 assert_eq!(area_size_to_index(area_size - 1).unwrap(), i as AreaIndex);
             }
 
-            if i < NUM_AREA_SIZES - 1 {
+            if i < LinearAddress::num_area_sizes() - 1 {
                 // 1 more than top of range goes to next range
                 assert_eq!(
                     area_size_to_index(area_size + 1).unwrap(),
@@ -734,11 +738,11 @@ mod tests {
             }
         }
 
-        for i in 0..=MIN_AREA_SIZE {
+        for i in 0..=LinearAddress::min_area_size() {
             assert_eq!(area_size_to_index(i).unwrap(), 0);
         }
 
-        assert!(area_size_to_index(MAX_AREA_SIZE + 1).is_err());
+        assert!(area_size_to_index(LinearAddress::max_area_size() + 1).is_err());
     }
 
     #[test]
@@ -779,7 +783,7 @@ mod tests {
         value: Some(vec![9, 10, 11].into_boxed_slice()),
         children: from_fn(|i| {
             if i == 15 {
-                Some(Child::AddressWithHash(nonzero!(1u64), std::array::from_fn::<u8, 32, _>(|i| i as u8).into()))
+                Some(Child::AddressWithHash(LinearAddress::new(1).unwrap(), std::array::from_fn::<u8, 32, _>(|i| i as u8).into()))
             } else {
                 None
             }
@@ -789,7 +793,7 @@ mod tests {
         partial_path: Path::from([6, 7, 8]),
         value: Some(vec![9, 10, 11].into_boxed_slice()),
         children: from_fn(|_|
-            Some(Child::AddressWithHash(nonzero!(1u64), std::array::from_fn::<u8, 32, _>(|i| i as u8).into()))
+            Some(Child::AddressWithHash(LinearAddress::new(1).unwrap(), std::array::from_fn::<u8, 32, _>(|i| i as u8).into()))
         ),
     }; "branch node with all child")]
     #[test_case(

--- a/storage/src/range_set.rs
+++ b/storage/src/range_set.rs
@@ -209,7 +209,9 @@ pub(super) struct LinearAddressRangeSet {
 }
 
 impl LinearAddressRangeSet {
-    const NODE_STORE_ADDR_START: LinearAddress = LinearAddress::new(NodeStoreHeader::SIZE).unwrap();
+    fn node_store_addr_start() -> LinearAddress {
+        LinearAddress::new(NodeStoreHeader::SIZE).unwrap()
+    }
 
     pub(super) fn new(db_size: u64) -> Result<Self, CheckerError> {
         if db_size < NodeStoreHeader::SIZE {
@@ -227,7 +229,7 @@ impl LinearAddressRangeSet {
 
         Ok(Self {
             range_set: RangeSet::new(),
-            max_addr, // STORAGE_AREA_START..U64::MAX
+            max_addr: max_addr, // STORAGE_AREA_START..U64::MAX
         })
     }
 
@@ -242,13 +244,13 @@ impl LinearAddressRangeSet {
             .ok_or(CheckerError::AreaOutOfBounds {
                 start,
                 size,
-                bounds: Self::NODE_STORE_ADDR_START..self.max_addr,
+                bounds: Self::node_store_addr_start()..self.max_addr,
             })?; // This can only happen due to overflow
-        if addr < Self::NODE_STORE_ADDR_START || end > self.max_addr {
+        if addr < Self::node_store_addr_start() || end > self.max_addr {
             return Err(CheckerError::AreaOutOfBounds {
                 start: addr,
                 size,
-                bounds: Self::NODE_STORE_ADDR_START..self.max_addr,
+                bounds: Self::node_store_addr_start()..self.max_addr,
             });
         }
 
@@ -265,7 +267,7 @@ impl LinearAddressRangeSet {
     pub(super) fn complement(&self) -> Self {
         let complement_set = self
             .range_set
-            .complement(&Self::NODE_STORE_ADDR_START, &self.max_addr);
+            .complement(&Self::node_store_addr_start(), &self.max_addr);
 
         Self {
             range_set: complement_set,
@@ -614,7 +616,7 @@ mod test_linear_address_range_set {
         let size2 = 1024;
         let db_size = 0x2000;
 
-        let db_begin = LinearAddressRangeSet::NODE_STORE_ADDR_START;
+        let db_begin = LinearAddressRangeSet::node_store_addr_start();
         let start1_addr = LinearAddress::new(start1).unwrap();
         let end1_addr = LinearAddress::new(start1 + size1).unwrap();
         let start2_addr = LinearAddress::new(start2).unwrap();
@@ -652,7 +654,7 @@ mod test_linear_address_range_set {
 
     #[test]
     fn test_complement_with_empty() {
-        let db_size = LinearAddressRangeSet::NODE_STORE_ADDR_START;
+        let db_size = LinearAddressRangeSet::node_store_addr_start();
         let visited = LinearAddressRangeSet::new(db_size.get()).unwrap();
         let complement = visited.complement().into_iter().collect::<Vec<_>>();
         assert_eq!(complement, vec![]);


### PR DESCRIPTION
Refactor : Use LinearAddress newtype for trie addresses.

- Replaced all usages of the NonZeroU64 type alias for addresses with a LinearAddress newtype struct, enabling method implementations and improved type safety.
- Updated all code, tests, and benchmarks to construct and use LinearAddress where an address is required.
- Added accessor methods to LinearAddress for ergonomic and type-safe access to the inner value.
- Switched serialization and deserialization of nodestore headers and freelists from bytemuck to bincode/serde, as the newtype and option types are not Pod.
- Removed all bytemuck derives and usages for non-Pod types.
- Updated all relevant code paths to use bincode for reading and writing headers and freelists.