### PR TITLE
feat!: auto open or create with truncate

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -54,7 +54,7 @@ type Database struct {
 
 // Config configures the opening of a [Database].
 type Config struct {
-	Create               bool
+	Truncate             bool
 	NodeCacheEntries     uint
 	FreeListCacheEntries uint
 	Revisions            uint
@@ -109,18 +109,13 @@ func New(filePath string, conf *Config) (*Database, error) {
 		free_list_cache_size: C.size_t(conf.FreeListCacheEntries),
 		revisions:            C.size_t(conf.Revisions),
 		strategy:             C.uint8_t(conf.ReadCacheStrategy),
+		truncate:             C.bool(conf.Truncate),
 	}
 	// Defer freeing the C string allocated to the heap on the other side
 	// of the FFI boundary.
 	defer C.free(unsafe.Pointer(args.path))
 
-	var dbResult C.struct_DatabaseCreationResult
-	if conf.Create {
-		dbResult = C.fwd_create_db(args)
-	} else {
-		dbResult = C.fwd_open_db(args)
-	}
-
+	dbResult := C.fwd_open_db(args)
 	db, err := databaseFromResult(&dbResult)
 	if err != nil {
 		return nil, err

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -49,6 +49,8 @@ typedef struct DatabaseCreationResult {
   uint8_t *error_str;
 } DatabaseCreationResult;
 
+typedef uint32_t ProposalId;
+
 /**
  * Common arguments, accepted by both `fwd_create_db()` and `fwd_open_db()`.
  *
@@ -59,6 +61,7 @@ typedef struct DatabaseCreationResult {
  * * `revisions` - The maximum number of revisions to keep; firewood currently requires this to be at least 2.
  * * `strategy` - The cache read strategy to use, 0 for writes only,
  *   1 for branch reads, and 2 for all reads.
+ * * `truncate` - Whether to truncate the database file if it exists.
  *   Returns an error if the value is not 0, 1, or 2.
  */
 typedef struct CreateOrOpenArgs {
@@ -67,9 +70,8 @@ typedef struct CreateOrOpenArgs {
   size_t free_list_cache_size;
   size_t revisions;
   uint8_t strategy;
+  bool truncate;
 } CreateOrOpenArgs;
-
-typedef uint32_t ProposalId;
 
 /**
  * Puts the given key-value pairs into the database.
@@ -146,28 +148,6 @@ void fwd_close_db(struct DatabaseHandle *db);
  *
  */
 struct Value fwd_commit(const struct DatabaseHandle *db, uint32_t proposal_id);
-
-/**
- * Create a database with the given cache size and maximum number of revisions, as well
- * as a specific cache strategy
- *
- * # Arguments
- *
- * See `CreateOrOpenArgs`.
- *
- * # Returns
- *
- * A database handle, or panics if it cannot be created
- *
- * # Safety
- *
- * This function uses raw pointers so it is unsafe.
- * It is the caller's responsibility to ensure that path is a valid pointer to a null-terminated string.
- * The caller must also ensure that the cache size is greater than 0 and that the number of revisions is at least 2.
- * The caller must call `close` to free the memory associated with the returned database handle.
- *
- */
-struct DatabaseCreationResult fwd_create_db(struct CreateOrOpenArgs args);
 
 /**
  * Drops a proposal from the database.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -870,6 +870,7 @@ pub extern "C" fn fwd_gather() -> Value {
 /// * `revisions` - The maximum number of revisions to keep; firewood currently requires this to be at least 2.
 /// * `strategy` - The cache read strategy to use, 0 for writes only,
 ///   1 for branch reads, and 2 for all reads.
+/// * `truncate` - Whether to truncate the database file if it exists.
 ///   Returns an error if the value is not 0, 1, or 2.
 #[repr(C)]
 pub struct CreateOrOpenArgs {
@@ -878,29 +879,7 @@ pub struct CreateOrOpenArgs {
     free_list_cache_size: usize,
     revisions: usize,
     strategy: u8,
-}
-
-/// Create a database with the given cache size and maximum number of revisions, as well
-/// as a specific cache strategy
-///
-/// # Arguments
-///
-/// See `CreateOrOpenArgs`.
-///
-/// # Returns
-///
-/// A database handle, or panics if it cannot be created
-///
-/// # Safety
-///
-/// This function uses raw pointers so it is unsafe.
-/// It is the caller's responsibility to ensure that path is a valid pointer to a null-terminated string.
-/// The caller must also ensure that the cache size is greater than 0 and that the number of revisions is at least 2.
-/// The caller must call `close` to free the memory associated with the returned database handle.
-///
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_create_db(args: CreateOrOpenArgs) -> DatabaseCreationResult {
-    unsafe { common_create(&args, true) }.into()
+    truncate: bool,
 }
 
 /// Open a database with the given cache size and maximum number of revisions
@@ -922,14 +901,14 @@ pub unsafe extern "C" fn fwd_create_db(args: CreateOrOpenArgs) -> DatabaseCreati
 ///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fwd_open_db(args: CreateOrOpenArgs) -> DatabaseCreationResult {
-    unsafe { common_create(&args, false) }.into()
+    unsafe { create(&args) }.into()
 }
 
-/// Internal call for `fwd_create_db` and `fwd_open_db` to remove error handling from the C API
+/// Internal call for `fwd_open_db` to remove error handling from the C API
 #[doc(hidden)]
-unsafe fn common_create(args: &CreateOrOpenArgs, create_file: bool) -> Result<Db, String> {
+unsafe fn create(args: &CreateOrOpenArgs) -> Result<Db, String> {
     let cfg = DbConfig::builder()
-        .truncate(create_file)
+        .truncate(args.truncate)
         .manager(manager_config(
             args.cache_size,
             args.free_list_cache_size,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -901,12 +901,12 @@ pub struct CreateOrOpenArgs {
 ///
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fwd_open_db(args: CreateOrOpenArgs) -> DatabaseCreationResult {
-    unsafe { create(&args) }.into()
+    unsafe { open_db(&args) }.into()
 }
 
 /// Internal call for `fwd_open_db` to remove error handling from the C API
 #[doc(hidden)]
-unsafe fn create(args: &CreateOrOpenArgs) -> Result<Db, String> {
+unsafe fn open_db(args: &CreateOrOpenArgs) -> Result<Db, String> {
     let cfg = DbConfig::builder()
         .truncate(args.truncate)
         .manager(manager_config(

--- a/ffi/tests/eth/eth_compatibility_test.go
+++ b/ffi/tests/eth/eth_compatibility_test.go
@@ -67,7 +67,6 @@ func newMerkleTriePair(t *testing.T) *merkleTriePair {
 
 	file := path.Join(t.TempDir(), "test.db")
 	cfg := firewood.DefaultConfig()
-	cfg.Create = true
 	db, err := firewood.New(file, cfg)
 	r.NoError(err)
 

--- a/ffi/tests/firewood/merkle_compatibility_test.go
+++ b/ffi/tests/firewood/merkle_compatibility_test.go
@@ -60,8 +60,6 @@ func newTestFirewoodDatabase(t *testing.T) *firewood.Database {
 
 func newFirewoodDatabase(dbFile string) (*firewood.Database, func() error, error) {
 	conf := firewood.DefaultConfig()
-	conf.Create = true
-
 	f, err := firewood.New(dbFile, conf)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create new database at filepath %q: %w", dbFile, err)

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -734,15 +734,20 @@ mod test {
                 .collect()
         }
         async fn reopen(self) -> Self {
-            self.reopen_truncate(false).await
-        }
-        async fn replace(self) -> Self {
-            self.reopen_truncate(true).await
-        }
-        async fn reopen_truncate(self, truncate: bool) -> Self {
             let path = self.path();
             drop(self.db);
-            let dbconfig = DbConfig::builder().truncate(truncate).build();
+            let dbconfig = DbConfig::builder().truncate(false).build();
+
+            let db = Db::new(path, dbconfig).await.unwrap();
+            TestDb {
+                db,
+                tmpdir: self.tmpdir,
+            }
+        }
+        async fn replace(self) -> Self {
+            let path = self.path();
+            drop(self.db);
+            let dbconfig = DbConfig::builder().truncate(true).build();
 
             let db = Db::new(path, dbconfig).await.unwrap();
             TestDb {

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -529,6 +529,7 @@ mod test {
     #[tokio::test]
     async fn reopen_test() {
         let db = testdb().await;
+        let initial_root = db.root_hash().await.unwrap();
         let batch = vec![
             BatchOp::Put {
                 key: b"a",
@@ -551,7 +552,7 @@ mod test {
 
         let db = db.replace().await;
         println!("{:?}", db.root_hash().await.unwrap());
-        assert!(db.root_hash().await.unwrap().is_none());
+        assert!(db.root_hash().await.unwrap() == initial_root);
     }
 
     #[tokio::test]

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -543,13 +543,13 @@ mod test {
         proposal.commit().await.unwrap();
         println!("{:?}", db.root_hash().await.unwrap().unwrap());
 
-        let db = db.reopen(false).await;
+        let db = db.reopen().await;
         println!("{:?}", db.root_hash().await.unwrap().unwrap());
         let committed = db.root_hash().await.unwrap().unwrap();
         let historical = db.revision(committed).await.unwrap();
         assert_eq!(&*historical.val(b"a").await.unwrap().unwrap(), b"1");
 
-        let db = db.reopen(true).await;
+        let db = db.replace().await;
         println!("{:?}", db.root_hash().await.unwrap());
         assert!(db.root_hash().await.unwrap().is_none());
     }
@@ -732,7 +732,13 @@ mod test {
                 .iter()
                 .collect()
         }
-        async fn reopen(self, truncate: bool) -> Self {
+        async fn reopen(self) -> Self {
+            self.reopen_truncate(false).await
+        }
+        async fn replace(self) -> Self {
+            self.reopen_truncate(true).await
+        }
+        async fn reopen_truncate(self, truncate: bool) -> Self {
             let path = self.path();
             drop(self.db);
             let dbconfig = DbConfig::builder().truncate(truncate).build();

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -84,14 +84,15 @@ impl RevisionManager {
         truncate: bool,
         config: RevisionManagerConfig,
     ) -> Result<Self, FileIoError> {
-        let storage = Arc::new(FileBacked::new(
+        let (fb, created) = FileBacked::new(
             filename,
             config.node_cache_size,
             config.free_list_cache_size,
             truncate,
             config.cache_read_strategy,
-        )?);
-        let nodestore = if truncate {
+        )?;
+        let storage = Arc::new(fb);
+        let nodestore = if created {
             Arc::new(NodeStore::new_empty_committed(storage.clone())?)
         } else {
             Arc::new(NodeStore::open(storage.clone())?)

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -84,7 +84,7 @@ impl RevisionManager {
         truncate: bool,
         config: RevisionManagerConfig,
     ) -> Result<Self, FileIoError> {
-        let (fb, created) = FileBacked::new(
+        let fb = FileBacked::new(
             filename,
             config.node_cache_size,
             config.free_list_cache_size,
@@ -92,11 +92,7 @@ impl RevisionManager {
             config.cache_read_strategy,
         )?;
         let storage = Arc::new(fb);
-        let nodestore = if created {
-            Arc::new(NodeStore::new_empty_committed(storage.clone())?)
-        } else {
-            Arc::new(NodeStore::open(storage.clone())?)
-        };
+        let nodestore = Arc::new(NodeStore::open(storage.clone())?);
         let manager = Self {
             max_revisions: config.max_revisions,
             historical: RwLock::new(VecDeque::from([nodestore.clone()])),

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -28,7 +28,7 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     let node_cache_size = nonzero!(1usize);
     let free_list_cache_size = nonzero!(1usize);
 
-    let (fb, _) = FileBacked::new(
+    let fb = FileBacked::new(
         db_path,
         node_cache_size,
         free_list_cache_size,

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -28,13 +28,14 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     let node_cache_size = nonzero!(1usize);
     let free_list_cache_size = nonzero!(1usize);
 
-    let storage = Arc::new(FileBacked::new(
+    let (fb, _) = FileBacked::new(
         db_path,
         node_cache_size,
         free_list_cache_size,
         false,
         CacheReadStrategy::WritesOnly, // we scan the database once - no need to cache anything
-    )?);
+    )?;
+    let storage = Arc::new(fb);
 
     NodeStore::open(storage)?.check().map_err(Into::into)
 }

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -24,7 +24,7 @@
 )]
 
 use std::fs::{File, OpenOptions};
-use std::io::{ErrorKind, Read};
+use std::io::Read;
 use std::num::NonZero;
 #[cfg(unix)]
 use std::os::unix::fs::FileExt;
@@ -92,39 +92,19 @@ impl FileBacked {
         free_list_cache_size: NonZero<usize>,
         truncate: bool,
         cache_read_strategy: CacheReadStrategy,
-    ) -> Result<(Self, bool), FileIoError> {
-        let mut created = true;
+    ) -> Result<Self, FileIoError> {
         let fd = OpenOptions::new()
             .read(true)
             .write(true)
-            .create_new(true)
-            .open(&path);
-        let fd = match fd {
-            Ok(fd) => fd,
-            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
-                // File already exists, we can open it
-                created = truncate;
-                OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .truncate(truncate)
-                    .open(&path)
-                    .map_err(|e| FileIoError {
-                        inner: e,
-                        filename: Some(path.clone()),
-                        offset: 0,
-                        context: Some("file create".to_string()),
-                    })?
-            }
-            Err(e) => {
-                return Err(FileIoError {
-                    inner: e,
-                    filename: Some(path.clone()),
-                    offset: 0,
-                    context: Some("file open".to_string()),
-                });
-            }
-        };
+            .truncate(truncate)
+            .create(true)
+            .open(&path)
+            .map_err(|e| FileIoError {
+                inner: e,
+                filename: Some(path.clone()),
+                offset: 0,
+                context: Some("file open".to_string()),
+            })?;
 
         #[cfg(feature = "io-uring")]
         let ring = {
@@ -148,18 +128,15 @@ impl FileBacked {
                 })?
         };
 
-        Ok((
-            Self {
-                fd,
-                cache: Mutex::new(LruCache::new(node_cache_size)),
-                free_list_cache: Mutex::new(LruCache::new(free_list_cache_size)),
-                cache_read_strategy,
-                filename: path,
-                #[cfg(feature = "io-uring")]
-                ring: ring.into(),
-            },
-            created,
-        ))
+        Ok(Self {
+            fd,
+            cache: Mutex::new(LruCache::new(node_cache_size)),
+            free_list_cache: Mutex::new(LruCache::new(free_list_cache_size)),
+            cache_read_strategy,
+            filename: path,
+            #[cfg(feature = "io-uring")]
+            ring: ring.into(),
+        })
     }
 }
 
@@ -336,7 +313,7 @@ mod test {
 
         // whole thing at once, this is always less than 1K so it should
         // read the whole thing in
-        let (fb, created) = FileBacked::new(
+        let fb = FileBacked::new(
             path,
             nonzero!(10usize),
             nonzero!(10usize),
@@ -344,10 +321,6 @@ mod test {
             CacheReadStrategy::WritesOnly,
         )
         .unwrap();
-        assert!(
-            !created,
-            "File should not have been created, it already exists"
-        );
 
         let mut reader = fb.stream_from(0).unwrap();
         let mut buf: String = String::new();
@@ -381,7 +354,7 @@ mod test {
             write!(output, "hello world").unwrap();
         }
 
-        let (fb, created) = FileBacked::new(
+        let fb = FileBacked::new(
             path,
             nonzero!(10usize),
             nonzero!(10usize),
@@ -389,10 +362,7 @@ mod test {
             CacheReadStrategy::WritesOnly,
         )
         .unwrap();
-        assert!(
-            !created,
-            "File should not have been created, it already exists"
-        );
+
         let mut reader = fb.stream_from(0).unwrap();
         let mut buf: String = String::new();
         assert_eq!(reader.read_to_string(&mut buf).unwrap(), 11000);


### PR DESCRIPTION
It's cumbersome (and more prone to TOCTOU issues) for users to validate whether a file exists, and if it does, set a flag. This should be handled internally. The `truncate` config now more closely resembles it's actual meaning. If the file already exists, it will be wiped and re-created.

There are unit tests in Rust and in Go for this.

Close #1039 