### PR TITLE
fix(checker): avoid checking physical file size for compatibility

### DIFF
--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -32,15 +32,6 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
     pub fn check(&self) -> Result<(), CheckerError> {
         // 1. Check the header
         let db_size = self.size();
-        let file_size = self.physical_size()?;
-        if db_size < file_size {
-            return Err(CheckerError::InvalidDBSize {
-                db_size,
-                description: format!(
-                    "db size should not be smaller than the file size ({file_size})"
-                ),
-            });
-        }
 
         let mut visited = LinearAddressRangeSet::new(db_size)?;
 

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -729,10 +729,6 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
         self.header.size()
     }
 
-    pub(crate) fn physical_size(&self) -> Result<u64, FileIoError> {
-        self.storage.size()
-    }
-
     // Find the area index and size of the stored area at the given address if the area is valid.
     // TODO: there should be a way to read stored area directly instead of try reading as a free area then as a node
     pub(crate) fn read_leaked_area(


### PR DESCRIPTION
The size of the underlying file is not reliable on certain OS, and the high watermark can be either larger or smaller than the actual file size. Therefore, the checker should not compare the high watermark against the actual file size. 