### PR TITLE
chore: CODEOWNERS ignores wildcard if a more specific rule matches

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 # CODEOWNERS
-*       @rkuris @demosdemon
-/ffi    @alarso16
-/.github @aaronbuchwald
+# Note: more specific rules overrule wildcard
+*        @rkuris @demosdemon
+/ffi     @rkuris @demosdemon @alarso16
+/.github @rkuris @demosdemon @aaronbuchwald


### PR DESCRIPTION
I noticed I was not auto-added to reviews for the ffi and .github directories, and I discovered that this is because the wildcard rule was being ignored if a more specific rule matched.

I have updated the `CODEOWNERS` file to ensure that Ron and I are added to all reviews.