### PR TITLE
feat(checker): checker errors include reference to parent

### DIFF
--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -2,7 +2,7 @@
 // See the file LICENSE.md for licensing terms.
 
 mod range_set;
-pub use range_set::LinearAddressRangeSet;
+pub(crate) use range_set::LinearAddressRangeSet;
 
 use crate::logger::warn;
 use crate::nodestore::alloc::{AREA_SIZES, AreaIndex, FreeAreaWithMetadata};
@@ -112,7 +112,7 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
             let hash = hash_node(&node, &path_prefix);
             if hash != subtree_root_hash {
                 return Err(CheckerError::HashMismatch {
-                    partial_path: path_prefix,
+                    path_prefix,
                     address: subtree_root_address,
                     parent,
                     parent_stored_hash: subtree_root_hash,
@@ -386,13 +386,13 @@ mod test {
         err,
         CheckerError::HashMismatch {
             address,
-            partial_path,
+            path_prefix,
             parent,
             parent_stored_hash,
             computed_hash
         }
         if address == *branch_addr
-            && partial_path == *branch_path
+            && path_prefix == *branch_path
             && parent == TrieNodeParent::Parent(root_addr, 0)
             && parent_stored_hash == wrong_hash
             && computed_hash == branch_hash

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -78,10 +78,7 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
         hash_check: bool,
     ) -> Result<(), CheckerError> {
         // check that address is aligned
-        self.check_area_aligned(
-            subtree_root_address,
-            StoredAreaParent::TrieNode(parent.clone()),
-        )?;
+        self.check_area_aligned(subtree_root_address, StoredAreaParent::TrieNode(parent))?;
 
         // check that the area is within bounds and does not intersect with other areas
         let (_, area_size) = self.area_index_and_size(subtree_root_address)?;

--- a/storage/src/checker/range_set.rs
+++ b/storage/src/checker/range_set.rs
@@ -9,11 +9,11 @@ use std::ops::Range;
 
 use crate::iter::write_limited_with_sep;
 use crate::nodestore::NodeStoreHeader;
-use crate::{CheckerError, LinearAddress};
+use crate::{CheckerError, LinearAddress, StoredAreaParent};
 
 const MAX_AREAS_TO_DISPLAY: usize = 10;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 // BTreeMap: range end --> range start
 // To check if a value is in the range set, we will find the range with the smallest end that is greater than or equal to the given value
 pub struct RangeSet<T>(BTreeMap<T, T>);
@@ -214,7 +214,9 @@ impl<T: Debug> IntoIterator for RangeSet<T> {
     }
 }
 
-pub(super) struct LinearAddressRangeSet {
+/// A set of disjoint ranges of linear addresses in ascending order.
+#[derive(Debug)]
+pub struct LinearAddressRangeSet {
     range_set: RangeSet<LinearAddress>,
     max_addr: LinearAddress,
 }
@@ -247,6 +249,7 @@ impl LinearAddressRangeSet {
         &mut self,
         addr: LinearAddress,
         size: u64,
+        parent: StoredAreaParent,
     ) -> Result<(), CheckerError> {
         let start = addr;
         let end = start
@@ -255,12 +258,14 @@ impl LinearAddressRangeSet {
                 start,
                 size,
                 bounds: Self::NODE_STORE_ADDR_START..self.max_addr,
+                parent,
             })?; // This can only happen due to overflow
         if addr < Self::NODE_STORE_ADDR_START || end > self.max_addr {
             return Err(CheckerError::AreaOutOfBounds {
                 start: addr,
                 size,
                 bounds: Self::NODE_STORE_ADDR_START..self.max_addr,
+                parent,
             });
         }
 
@@ -269,6 +274,7 @@ impl LinearAddressRangeSet {
                 start: addr,
                 size,
                 intersection,
+                parent,
             });
         }
         Ok(())
@@ -548,8 +554,12 @@ mod test_range_set {
 #[expect(clippy::unwrap_used)]
 mod test_linear_address_range_set {
 
+    use crate::{FreeListParent, TrieNodeParent};
+
     use super::*;
     use test_case::test_case;
+
+    const TEST_PARENT: StoredAreaParent = StoredAreaParent::TrieNode(TrieNodeParent::Root);
 
     #[test]
     fn test_empty() {
@@ -571,7 +581,7 @@ mod test_linear_address_range_set {
 
         let mut visited = LinearAddressRangeSet::new(0x1000).unwrap();
         visited
-            .insert_area(start_addr, size)
+            .insert_area(start_addr, size, TEST_PARENT)
             .expect("the given area should be within bounds");
 
         let visited_ranges = visited
@@ -594,11 +604,11 @@ mod test_linear_address_range_set {
 
         let mut visited = LinearAddressRangeSet::new(0x1000).unwrap();
         visited
-            .insert_area(start1_addr, size1)
+            .insert_area(start1_addr, size1, TEST_PARENT)
             .expect("the given area should be within bounds");
 
         visited
-            .insert_area(start2_addr, size2)
+            .insert_area(start2_addr, size2, TEST_PARENT)
             .expect("the given area should be within bounds");
 
         let visited_ranges = visited
@@ -619,31 +629,34 @@ mod test_linear_address_range_set {
         let end1_addr = LinearAddress::new(start1 + size1).unwrap();
         let start2_addr = LinearAddress::new(start2).unwrap();
 
+        let parent1 = StoredAreaParent::TrieNode(TrieNodeParent::Parent(start1_addr, 5));
+        let parent2 = StoredAreaParent::FreeList(FreeListParent::FreeListHead(3));
+
         let mut visited = LinearAddressRangeSet::new(0x1000).unwrap();
         visited
-            .insert_area(start1_addr, size1)
+            .insert_area(start1_addr, size1, parent1)
             .expect("the given area should be within bounds");
 
         let error = visited
-            .insert_area(start2_addr, size2)
+            .insert_area(start2_addr, size2, parent2)
             .expect_err("the given area should intersect with the first area");
 
         assert!(
-            matches!(error, CheckerError::AreaIntersects { start, size, intersection } if start == start2_addr && size == size2 && intersection == vec![start2_addr..end1_addr])
+            matches!(error, CheckerError::AreaIntersects { start, size, intersection, parent } if start == start2_addr && size == size2 && intersection == vec![start2_addr..end1_addr] && parent == parent2)
         );
 
         // try inserting in opposite order
         let mut visited2 = LinearAddressRangeSet::new(0x1000).unwrap();
         visited2
-            .insert_area(start2_addr, size2)
+            .insert_area(start2_addr, size2, parent2)
             .expect("the given area should be within bounds");
 
         let error = visited2
-            .insert_area(start1_addr, size1)
+            .insert_area(start1_addr, size1, parent1)
             .expect_err("the given area should intersect with the first area");
 
         assert!(
-            matches!(error, CheckerError::AreaIntersects { start, size, intersection } if start == start1_addr && size == size1 && intersection == vec![start2_addr..end1_addr])
+            matches!(error, CheckerError::AreaIntersects { start, size, intersection, parent } if start == start1_addr && size == size1 && intersection == vec![start2_addr..end1_addr] && parent == parent1)
         );
     }
 
@@ -663,8 +676,12 @@ mod test_linear_address_range_set {
         let db_end = LinearAddress::new(db_size).unwrap();
 
         let mut visited = LinearAddressRangeSet::new(db_size).unwrap();
-        visited.insert_area(start1_addr, size1).unwrap();
-        visited.insert_area(start2_addr, size2).unwrap();
+        visited
+            .insert_area(start1_addr, size1, TEST_PARENT)
+            .unwrap();
+        visited
+            .insert_area(start2_addr, size2, TEST_PARENT)
+            .unwrap();
 
         let complement = visited.complement().into_iter().collect::<Vec<_>>();
         assert_eq!(
@@ -685,7 +702,7 @@ mod test_linear_address_range_set {
 
         let mut visited = LinearAddressRangeSet::new(db_size).unwrap();
         visited
-            .insert_area(LinearAddress::new(start).unwrap(), size)
+            .insert_area(LinearAddress::new(start).unwrap(), size, TEST_PARENT)
             .unwrap();
         let complement = visited.complement().into_iter().collect::<Vec<_>>();
         assert_eq!(complement, vec![]);
@@ -747,7 +764,7 @@ mod test_linear_address_range_set {
             #[allow(clippy::arithmetic_side_effects)]
             let offset = i as u64 * 0x20 + 0x1000;
             range_set
-                .insert_area(LinearAddress::new(offset).unwrap(), 0x10)
+                .insert_area(LinearAddress::new(offset).unwrap(), 0x10, TEST_PARENT)
                 .unwrap();
         }
         assert_eq!(format!("{range_set}"), expected);

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -19,6 +19,7 @@
 //!
 //! A [`NodeStore`] is backed by a [`ReadableStorage`] which is persisted storage.
 
+use std::fmt::{Display, Formatter, LowerHex, Result};
 use std::ops::Range;
 use thiserror::Error;
 
@@ -75,8 +76,8 @@ pub enum CacheReadStrategy {
     All,
 }
 
-impl std::fmt::Display for CacheReadStrategy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for CacheReadStrategy {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{self:?}")
     }
 }
@@ -126,37 +127,35 @@ pub enum FreeListParent {
     PrevFreeArea(LinearAddress),
 }
 
-impl std::fmt::LowerHex for StoredAreaParent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl LowerHex for StoredAreaParent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
-            StoredAreaParent::TrieNode(trie_parent) => std::fmt::LowerHex::fmt(trie_parent, f),
-            StoredAreaParent::FreeList(free_list_parent) => {
-                std::fmt::LowerHex::fmt(free_list_parent, f)
-            }
+            StoredAreaParent::TrieNode(trie_parent) => LowerHex::fmt(trie_parent, f),
+            StoredAreaParent::FreeList(free_list_parent) => LowerHex::fmt(free_list_parent, f),
         }
     }
 }
 
-impl std::fmt::LowerHex for TrieNodeParent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl LowerHex for TrieNodeParent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             TrieNodeParent::Root => f.write_str("Root"),
             TrieNodeParent::Parent(addr, index) => {
                 f.write_str("TrieNode@")?;
-                std::fmt::LowerHex::fmt(addr, f)?;
+                LowerHex::fmt(addr, f)?;
                 f.write_fmt(format_args!("[{index}]"))
             }
         }
     }
 }
 
-impl std::fmt::LowerHex for FreeListParent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl LowerHex for FreeListParent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             FreeListParent::FreeListHead(index) => f.write_fmt(format_args!("FreeLists[{index}]")),
             FreeListParent::PrevFreeArea(addr) => {
                 f.write_str("FreeArea@")?;
-                std::fmt::LowerHex::fmt(addr, f)
+                LowerHex::fmt(addr, f)
             }
         }
     }

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -42,6 +42,7 @@ impl Debug for Path {
 }
 
 impl LowerHex for Path {
+    // TODO: handle fill / alignment / etc
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         if self.0.is_empty() {
             write!(f, "[]")
@@ -50,7 +51,6 @@ impl LowerHex for Path {
                 write!(f, "0x")?;
             }
             for nib in &self.0 {
-                // TODO: delegate instead of calling write! directly
                 write!(f, "{:x}", *nib)?;
             }
             Ok(())

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -42,11 +42,18 @@ impl Debug for Path {
 
 impl LowerHex for Path {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(f, "0x")?;
-        for nib in &self.0 {
-            write!(f, "{:x}", *nib)?;
+        if self.0.is_empty() {
+            write!(f, "[]")
+        } else {
+            if f.alternate() {
+                write!(f, "0x")?;
+            }
+            for nib in &self.0 {
+                // TODO: delegate instead of calling write! directly
+                write!(f, "{:x}", *nib)?;
+            }
+            Ok(())
         }
-        Ok(())
     }
 }
 
@@ -344,5 +351,12 @@ mod test {
         );
         let to_encoded = from_encoded.iter_encoded().collect::<SmallVec<[u8; 32]>>();
         assert_eq!(encode.as_ref(), to_encoded.as_ref());
+    }
+
+    #[test_case(Path::new(), "[]", "[]")]
+    #[test_case(Path::from([0x12, 0x34, 0x56, 0x78]), "12345678", "0x12345678")]
+    fn test_fmt_lower_hex(path: Path, expected: &str, expected_with_prefix: &str) {
+        assert_eq!(format!("{path:x}"), expected);
+        assert_eq!(format!("{path:#x}"), expected_with_prefix);
     }
 }

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -17,7 +17,7 @@
 // TODO: remove bitflags, we only use one bit
 use bitflags::bitflags;
 use smallvec::SmallVec;
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, LowerHex};
 use std::iter::{FusedIterator, once};
 
 static NIBBLES: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
@@ -35,6 +35,16 @@ impl Debug for Path {
             } else {
                 write!(f, "{:x} ", *nib)?;
             }
+        }
+        Ok(())
+    }
+}
+
+impl LowerHex for Path {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "0x")?;
+        for nib in &self.0 {
+            write!(f, "{:x}", *nib)?;
         }
         Ok(())
     }

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -588,7 +588,7 @@ impl<'a, S: ReadableStorage> FreeListIterator<'a, S> {
     fn next_with_parent(
         &mut self,
     ) -> Option<Result<((LinearAddress, AreaIndex), FreeListParent), FileIoError>> {
-        let parent = self.parent.clone();
+        let parent = self.parent;
         let next_addr = self.next()?;
         Some(next_addr.map(|free_area| (free_area, parent)))
     }


### PR DESCRIPTION
This is the first step towards fixing issues reported by the checker. We will include the parent reference in the error so that we can update the parent to remove the area with issue. 