### PR TITLE
chore: Implement newtype for LInearAddress

### DIFF
--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -39,7 +39,9 @@ sha3 = { version = "0.10.8", optional = true }
 bytes = { version = "1.10.1", optional = true }
 thiserror = { workspace = true }
 semver = "1.0.26"
+
 nonzero_ext = "0.3.0"
+num-traits = "0.2.19"
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -39,7 +39,6 @@ sha3 = { version = "0.10.8", optional = true }
 bytes = { version = "1.10.1", optional = true }
 thiserror = { workspace = true }
 semver = "1.0.26"
-
 nonzero_ext = "0.3.0"
 num-traits = "0.2.19"
 

--- a/storage/benches/serializer.rs
+++ b/storage/benches/serializer.rs
@@ -12,7 +12,6 @@
 
 use std::array::from_fn;
 use std::fs::File;
-use std::num::NonZeroU64;
 use std::os::raw::c_int;
 
 use criterion::profiler::Profiler;

--- a/storage/benches/serializer.rs
+++ b/storage/benches/serializer.rs
@@ -101,7 +101,7 @@ fn branch(c: &mut Criterion) {
         children: from_fn(|i| {
             if i == 0 {
                 Some(firewood_storage::Child::AddressWithHash(
-                    NonZeroU64::new(1).unwrap(),
+                    firewood_storage::LinearAddress::new(1).unwrap(),
                     firewood_storage::HashType::from([0; 32]),
                 ))
             } else {

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -6,7 +6,6 @@ use range_set::LinearAddressRangeSet;
 
 use crate::logger::warn;
 use crate::nodestore::alloc::{AREA_SIZES, AreaIndex, FreeAreaWithMetadata};
-use crate::nodestore::is_aligned;
 use crate::{
     CheckerError, Committed, HashType, HashedNodeReader, LinearAddress, Node, NodeReader,
     NodeStore, Path, StoredAreaParent, TrieNodeParent, WritableStorage, hash_node,
@@ -154,7 +153,7 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
         address: LinearAddress,
         parent_ptr: StoredAreaParent,
     ) -> Result<(), CheckerError> {
-        if !is_aligned(address) {
+        if !address.is_aligned() {
             return Err(CheckerError::AreaMisaligned {
                 address,
                 parent_ptr,

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -194,7 +194,7 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
             };
 
             let next_addr = current_addr
-                .checked_add(area_size)
+                .advance(area_size)
                 .expect("address overflow is impossible");
             match next_addr.cmp(&leaked_range.end) {
                 Ordering::Equal => {
@@ -212,8 +212,7 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
                 Ordering::Less => {
                     // continue to the next area
                     leaked.push((current_addr, area_index));
-                    current_addr =
-                        LinearAddress::new(next_addr.get()).expect("next_addr is non-zero");
+                    current_addr = next_addr;
                 }
             }
         }
@@ -223,12 +222,11 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
         for (area_index, area_size) in AREA_SIZES.iter().enumerate().rev() {
             loop {
                 let next_addr = current_addr
-                    .checked_add(*area_size)
+                    .advance(*area_size)
                     .expect("address overflow is impossible");
-                if next_addr <= *leaked_range.end {
+                if next_addr <= leaked_range.end {
                     leaked.push((current_addr, area_index as AreaIndex));
-                    current_addr =
-                        LinearAddress::new(next_addr.get()).expect("next_addr is non-zero");
+                    current_addr = next_addr;
                 } else {
                     break;
                 }

--- a/storage/src/checker/range_set.rs
+++ b/storage/src/checker/range_set.rs
@@ -221,9 +221,7 @@ pub(super) struct LinearAddressRangeSet {
 
 #[expect(clippy::result_large_err)]
 impl LinearAddressRangeSet {
-    fn node_store_addr_start() -> LinearAddress {
-        LinearAddress::new(NodeStoreHeader::SIZE).expect("NodeStoreHeader::SIZE is non-zero")
-    }
+    const NODE_STORE_START_ADDR: LinearAddress = LinearAddress::new(NodeStoreHeader::SIZE).unwrap();
 
     pub(super) fn new(db_size: u64) -> Result<Self, CheckerError> {
         if db_size < NodeStoreHeader::SIZE {
@@ -256,13 +254,13 @@ impl LinearAddressRangeSet {
             .ok_or(CheckerError::AreaOutOfBounds {
                 start,
                 size,
-                bounds: Self::node_store_addr_start()..self.max_addr,
+                bounds: Self::NODE_STORE_START_ADDR..self.max_addr,
             })?; // This can only happen due to overflow
-        if addr < Self::node_store_addr_start() || end > *self.max_addr {
+        if addr < Self::NODE_STORE_START_ADDR || end > *self.max_addr {
             return Err(CheckerError::AreaOutOfBounds {
                 start: addr,
                 size,
-                bounds: Self::node_store_addr_start()..self.max_addr,
+                bounds: Self::NODE_STORE_START_ADDR..self.max_addr,
             });
         }
 
@@ -281,7 +279,7 @@ impl LinearAddressRangeSet {
     pub(super) fn complement(&self) -> Self {
         let complement_set = self
             .range_set
-            .complement(&Self::node_store_addr_start(), &self.max_addr);
+            .complement(&Self::NODE_STORE_START_ADDR, &self.max_addr);
 
         Self {
             range_set: complement_set,
@@ -659,7 +657,7 @@ mod test_linear_address_range_set {
         let size2 = 1024;
         let db_size = 0x2000;
 
-        let db_begin = LinearAddressRangeSet::node_store_addr_start();
+        let db_begin = LinearAddressRangeSet::NODE_STORE_START_ADDR;
         let start1_addr = LinearAddress::new(start1).unwrap();
         let end1_addr = LinearAddress::new(start1 + size1).unwrap();
         let start2_addr = LinearAddress::new(start2).unwrap();
@@ -697,7 +695,7 @@ mod test_linear_address_range_set {
 
     #[test]
     fn test_complement_with_empty() {
-        let db_size = LinearAddressRangeSet::node_store_addr_start();
+        let db_size = LinearAddressRangeSet::NODE_STORE_START_ADDR;
         let visited = LinearAddressRangeSet::new(db_size.get()).unwrap();
         let complement = visited.complement().into_iter().collect::<Vec<_>>();
         assert_eq!(complement, vec![]);

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -196,7 +196,7 @@ pub enum CheckerError {
     /// The start address of a stored area is not a multiple of 16
     #[error(
         "The start address of a stored area is not a multiple of {}: {address} (parent: {parent_ptr:?})",
-        nodestore::alloc::LinearAddress::min_area_size()
+        nodestore::alloc::LinearAddress::MIN_AREA_SIZE
     )]
     AreaMisaligned {
         /// The start address of the stored area

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -196,7 +196,7 @@ pub enum CheckerError {
     /// The start address of a stored area is not a multiple of 16
     #[error(
         "The start address of a stored area is not a multiple of {}: {address} (parent: {parent_ptr:?})",
-        nodestore::alloc::MIN_AREA_SIZE
+        nodestore::alloc::LinearAddress::min_area_size()
     )]
     AreaMisaligned {
         /// The start address of the stored area

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -214,11 +214,11 @@ impl WritableStorage for FileBacked {
 
     fn write_cached_nodes<'a>(
         &self,
-        nodes: impl Iterator<Item = (&'a std::num::NonZero<u64>, &'a SharedNode)>,
+        nodes: impl Iterator<Item = (&'a LinearAddress, &'a SharedNode)>,
     ) -> Result<(), FileIoError> {
         let mut guard = self.cache.lock().expect("poisoned lock");
         for (&addr, node) in nodes {
-            guard.put(addr.into(), node.clone());
+            guard.put(addr, node.clone());
         }
         Ok(())
     }

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -217,8 +217,8 @@ impl WritableStorage for FileBacked {
         nodes: impl Iterator<Item = (&'a std::num::NonZero<u64>, &'a SharedNode)>,
     ) -> Result<(), FileIoError> {
         let mut guard = self.cache.lock().expect("poisoned lock");
-        for (addr, node) in nodes {
-            guard.put(LinearAddress::new((*addr).get()).unwrap(), node.clone());
+        for (&addr, node) in nodes {
+            guard.put(addr.into(), node.clone());
         }
         Ok(())
     }

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -214,10 +214,10 @@ impl WritableStorage for FileBacked {
 
     fn write_cached_nodes<'a>(
         &self,
-        nodes: impl Iterator<Item = (&'a LinearAddress, &'a SharedNode)>,
+        nodes: impl Iterator<Item = (LinearAddress, &'a SharedNode)>,
     ) -> Result<(), FileIoError> {
         let mut guard = self.cache.lock().expect("poisoned lock");
-        for (&addr, node) in nodes {
+        for (addr, node) in nodes {
             guard.put(addr, node.clone());
         }
         Ok(())

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -218,7 +218,7 @@ impl WritableStorage for FileBacked {
     ) -> Result<(), FileIoError> {
         let mut guard = self.cache.lock().expect("poisoned lock");
         for (addr, node) in nodes {
-            guard.put(*addr, node.clone());
+            guard.put(LinearAddress::new((*addr).get()).unwrap(), node.clone());
         }
         Ok(())
     }

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -183,7 +183,7 @@ pub trait WritableStorage: ReadableStorage {
     /// Write all nodes to the cache (if any)
     fn write_cached_nodes<'a>(
         &self,
-        _nodes: impl Iterator<Item = (&'a LinearAddress, &'a SharedNode)>,
+        _nodes: impl Iterator<Item = (LinearAddress, &'a SharedNode)>,
     ) -> Result<(), FileIoError> {
         Ok(())
     }

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -21,7 +21,6 @@
 
 use std::fmt::Debug;
 use std::io::Read;
-use std::num::NonZero;
 use std::ops::Deref;
 use std::path::PathBuf;
 
@@ -184,7 +183,7 @@ pub trait WritableStorage: ReadableStorage {
     /// Write all nodes to the cache (if any)
     fn write_cached_nodes<'a>(
         &self,
-        _nodes: impl Iterator<Item = (&'a NonZero<u64>, &'a SharedNode)>,
+        _nodes: impl Iterator<Item = (&'a LinearAddress, &'a SharedNode)>,
     ) -> Result<(), FileIoError> {
         Ok(())
     }

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -32,7 +32,6 @@ use integer_encoding::{VarInt, VarIntReader as _};
 pub use leaf::LeafNode;
 use std::fmt::Debug;
 use std::io::{Error, Read, Write};
-use std::num::NonZero;
 
 pub mod branch;
 mod leaf;

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -23,7 +23,7 @@
 )]
 
 use crate::node::branch::ReadSerializable;
-use crate::{HashType, Path, SharedNode};
+use crate::{HashType, LinearAddress, Path, SharedNode};
 use bitfield::bitfield;
 use branch::Serializable as _;
 pub use branch::{BranchNode, Child};
@@ -38,7 +38,6 @@ pub mod branch;
 mod leaf;
 pub mod path;
 pub mod persist;
-
 /// A node, either a Branch or Leaf
 
 // TODO: explain why Branch is boxed but Leaf is not
@@ -412,7 +411,8 @@ impl Node {
                         let hash = HashType::from_reader(&mut serialized)?;
 
                         *child = Some(Child::AddressWithHash(
-                            NonZero::new(address).ok_or(Error::other("zero address in child"))?,
+                            LinearAddress::new(address)
+                                .ok_or(Error::other("zero address in child"))?,
                             hash,
                         ));
                     }
@@ -429,7 +429,8 @@ impl Node {
                         let hash = HashType::from_reader(&mut serialized)?;
 
                         children[position] = Some(Child::AddressWithHash(
-                            NonZero::new(address).ok_or(Error::other("zero address in child"))?,
+                            LinearAddress::new(address)
+                                .ok_or(Error::other("zero address in child"))?,
                             hash,
                         ));
                     }

--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -200,8 +200,7 @@ mod test {
 
     #[test]
     fn test_from_linear_address() {
-        let raw_addr = nonzero!(1024u64);
-        let addr = LinearAddress::new(raw_addr.get()).unwrap();
+        let addr: LinearAddress = nonzero!(1024u64).into();
         let maybe_persisted_node = MaybePersistedNode::from(addr);
         assert_eq!(Some(addr), Option::from(&maybe_persisted_node));
     }
@@ -228,8 +227,7 @@ mod test {
         assert_eq!(triomphe::Arc::strong_count(&node), 2);
 
         // Persist the original
-        let addr = nonzero!(4096u64);
-        let addr = LinearAddress::new(addr.get()).unwrap();
+        let addr = nonzero!(1024u64).into();
         original.persist_at(addr);
 
         // Both original and clone should now be persisted since they share the same ArcSwap

--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -191,6 +191,7 @@ mod test {
             Option::from(&maybe_persisted_node)
         );
 
+        let addr = LinearAddress::new(addr.get()).unwrap();
         maybe_persisted_node.persist_at(addr);
         assert!(maybe_persisted_node.as_shared_node(&store).is_err());
         assert_eq!(Some(addr), Option::from(&maybe_persisted_node));
@@ -199,7 +200,8 @@ mod test {
 
     #[test]
     fn test_from_linear_address() {
-        let addr = nonzero!(1024u64);
+        let raw_addr = nonzero!(1024u64);
+        let addr = LinearAddress::new(raw_addr.get()).unwrap();
         let maybe_persisted_node = MaybePersistedNode::from(addr);
         assert_eq!(Some(addr), Option::from(&maybe_persisted_node));
     }
@@ -227,6 +229,7 @@ mod test {
 
         // Persist the original
         let addr = nonzero!(4096u64);
+        let addr = LinearAddress::new(addr.get()).unwrap();
         original.persist_at(addr);
 
         // Both original and clone should now be persisted since they share the same ArcSwap

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -162,13 +162,12 @@ unsafe impl bytemuck::PodInOption for LinearAddress {}
 
 impl LinearAddress {
     /// Create a new `LinearAddress`, returns None if value is zero.
-    #[expect(clippy::missing_panics_doc)]
     #[inline]
     #[must_use]
     pub const fn new(addr: u64) -> Option<Self> {
-        match addr {
-            0 => None,
-            _ => Some(LinearAddress(NonZeroU64::new(addr).expect("non zero"))),
+        match NonZeroU64::new(addr) {
+            Some(addr) => Some(LinearAddress(addr)),
+            None => None,
         }
     }
 
@@ -182,7 +181,7 @@ impl LinearAddress {
     /// Check if the address is 8-byte aligned.
     #[inline]
     #[must_use]
-    pub const fn is_aligned(&self) -> bool {
+    pub const fn is_aligned(self) -> bool {
         self.0.get() % (Self::MIN_AREA_SIZE) == 0
     }
 
@@ -202,8 +201,8 @@ impl LinearAddress {
     /// Returns a reference to the inner `NonZeroU64`
     #[inline]
     #[must_use]
-    pub const fn as_nonzero(&self) -> &NonZeroU64 {
-        &self.0
+    pub const fn as_nonzero(self) -> NonZeroU64 {
+        self.0
     }
 
     /// Advances a `LinearAddress` by `n` bytes.

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -198,10 +198,10 @@ impl LinearAddress {
         const { AREA_SIZES.len() }
     }
 
-    /// Returns a reference to the inner `NonZeroU64`
+    /// Returns the inner `NonZeroU64`
     #[inline]
     #[must_use]
-    pub const fn as_nonzero(self) -> NonZeroU64 {
+    pub const fn into_nonzero(self) -> NonZeroU64 {
         self.0
     }
 

--- a/storage/src/nodestore/header.rs
+++ b/storage/src/nodestore/header.rs
@@ -26,6 +26,7 @@
 
 use bytemuck_derive::{AnyBitPattern, NoUninit};
 use std::io::{Error, ErrorKind};
+use std::num::NonZeroU64;
 
 use super::alloc::{FreeLists, LinearAddress, area_size_hash};
 use crate::logger::{debug, trace};
@@ -148,7 +149,7 @@ impl Version {
 
 /// Persisted metadata for a `NodeStore`.
 /// The [`NodeStoreHeader`] is at the start of the `ReadableStorage`.
-#[derive(Copy, Debug, PartialEq, Eq, Clone, NoUninit, AnyBitPattern)]
+#[derive(Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[repr(C)]
 pub struct NodeStoreHeader {
     /// Identifies the version of firewood used to create this `NodeStore`.
@@ -223,22 +224,22 @@ impl NodeStoreHeader {
     }
 
     /// Get the free lists
-    pub const fn free_lists(&self) -> &FreeLists {
+    pub fn free_lists(&self) -> &FreeLists {
         &self.free_lists
     }
 
     /// Get mutable access to the free lists
-    pub const fn free_lists_mut(&mut self) -> &mut FreeLists {
+    pub fn free_lists_mut(&mut self) -> &mut FreeLists {
         &mut self.free_lists
     }
 
     /// Get the root address
-    pub const fn root_address(&self) -> Option<LinearAddress> {
+    pub fn root_address(&self) -> Option<LinearAddress> {
         self.root_address
     }
 
     /// Set the root address
-    pub const fn set_root_address(&mut self, root_address: Option<LinearAddress>) {
+    pub fn set_root_address(&mut self, root_address: Option<LinearAddress>) {
         self.root_address = root_address;
     }
 
@@ -292,6 +293,16 @@ impl NodeStoreHeader {
             ))
         }
     }
+
+    /// Helper to get free list as LinearAddress
+    pub fn free_list_linear(&self, idx: usize) -> Option<LinearAddress> {
+        self.free_lists[idx]
+    }
+
+    /// Helper to set free list as LinearAddress
+    pub fn set_free_list_linear(&mut self, idx: usize, addr: Option<LinearAddress>) {
+        self.free_lists[idx] = addr;
+    }
 }
 
 #[cfg(test)]
@@ -324,12 +335,13 @@ mod tests {
         let node_store = NodeStore::new_empty_proposal(memstore.into());
 
         // Check the empty header is written at the start of the ReadableStorage.
-        let mut header = NodeStoreHeader::new();
         let mut header_stream = node_store.storage.stream_from(0).unwrap();
-        let header_bytes = bytemuck::bytes_of_mut(&mut header);
-        header_stream.read_exact(header_bytes).unwrap();
+        let mut header_bytes =
+            vec![0u8; bincode::serialized_size(&NodeStoreHeader::new()).unwrap() as usize];
+        header_stream.read_exact(&mut header_bytes).unwrap();
+        let header: NodeStoreHeader = bincode::deserialize(&header_bytes).unwrap();
         assert_eq!(header.version, Version::new());
-        let empty_free_list: super::FreeLists = Default::default();
+        let empty_free_list: FreeLists = Default::default();
         assert_eq!(*header.free_lists(), empty_free_list);
     }
 }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -762,7 +762,7 @@ mod tests {
     #[test]
     fn area_sizes_aligned() {
         for area_size in &AREA_SIZES {
-            assert_eq!(area_size % LinearAddress::min_area_size(), 0);
+            assert_eq!(area_size % LinearAddress::MIN_AREA_SIZE, 0);
         }
     }
 
@@ -787,11 +787,11 @@ mod tests {
             }
         }
 
-        for i in 0..=LinearAddress::min_area_size() {
+        for i in 0..=LinearAddress::MIN_AREA_SIZE {
             assert_eq!(area_size_to_index(i).unwrap(), 0);
         }
 
-        assert!(area_size_to_index(LinearAddress::max_area_size() + 1).is_err());
+        assert!(area_size_to_index(LinearAddress::MAX_AREA_SIZE + 1).is_err());
     }
 
     #[test]

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -91,11 +91,6 @@ use crate::{FileBacked, FileIoError, Path, ReadableStorage, SharedNode, TrieHash
 
 use super::linear::WritableStorage;
 
-#[inline]
-pub(crate) const fn is_aligned(addr: LinearAddress) -> bool {
-    addr.is_aligned()
-}
-
 impl<S: ReadableStorage> NodeStore<Committed, S> {
     /// Open an existing [`NodeStore`]
     /// Assumes the header is written in the [`ReadableStorage`].

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -219,7 +219,7 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
         }
 
         self.storage
-            .write_cached_nodes(self.kind.new.iter().map(|(addr, (_, node))| (addr, node)))?;
+            .write_cached_nodes(self.kind.new.iter().map(|(&addr, (_, node))| (addr, node)))?;
         let flush_time = flush_start.elapsed().as_millis();
         counter!("firewood.flush_nodes").increment(flush_time);
 
@@ -363,7 +363,7 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
         );
 
         self.storage
-            .write_cached_nodes(self.kind.new.iter().map(|(addr, (_, node))| (addr, node)))?;
+            .write_cached_nodes(self.kind.new.iter().map(|(&addr, (_, node))| (addr, node)))?;
         debug_assert!(ring.completion().is_empty());
 
         let flush_time = flush_start.elapsed().as_millis();

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -56,8 +56,8 @@ impl<T, S: WritableStorage> NodeStore<T, S> {
     ///
     /// Returns a [`FileIoError`] if the header cannot be written.
     pub fn flush_header(&self) -> Result<(), FileIoError> {
-        let header_bytes = bytemuck::bytes_of(&self.header);
-        self.storage.write(0, header_bytes)?;
+        let header_bytes = bincode::serialize(&self.header).expect("failed to serialize header");
+        self.storage.write(0, &header_bytes)?;
         Ok(())
     }
 
@@ -68,12 +68,9 @@ impl<T, S: WritableStorage> NodeStore<T, S> {
     ///
     /// Returns a [`FileIoError`] if the header cannot be written.
     pub fn flush_header_with_padding(&self) -> Result<(), FileIoError> {
-        let header_bytes = bytemuck::bytes_of(&self.header)
-            .iter()
-            .copied()
-            .chain(std::iter::repeat_n(0u8, NodeStoreHeader::EXTRA_BYTES))
-            .collect::<Box<[u8]>>();
-        debug_assert_eq!(header_bytes.len(), NodeStoreHeader::SIZE as usize);
+        let mut header_bytes = bincode::serialize(&self.header).expect("failed to serialize header");
+            header_bytes.resize(NodeStoreHeader::SIZE as usize, 0);
+            debug_assert_eq!(header_bytes.len(), NodeStoreHeader::SIZE as usize);
 
         self.storage.write(0, &header_bytes)?;
         Ok(())
@@ -194,9 +191,9 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
     #[fastrace::trace(short_name = true)]
     pub fn flush_freelist(&self) -> Result<(), FileIoError> {
         // Write the free lists to storage
-        let free_list_bytes = bytemuck::bytes_of(self.header.free_lists());
+        let free_list_bytes = bincode::serialize(self.header.free_lists()).expect("failed to serialize free_lists");
         let free_list_offset = NodeStoreHeader::free_lists_offset();
-        self.storage.write(free_list_offset, free_list_bytes)?;
+        self.storage.write(free_list_offset, &free_list_bytes)?;
         Ok(())
     }
 
@@ -214,8 +211,8 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
         }
 
         self.storage
-            .write_cached_nodes(self.kind.new.iter().map(|(addr, (_, node))| (addr, node)))?;
-
+        .write_cached_nodes(self.kind.new.iter().map(|(addr, (_, node))| (addr.as_nonzero(), node)))?;
+    
         let flush_time = flush_start.elapsed().as_millis();
         counter!("firewood.flush_nodes").increment(flush_time);
 
@@ -355,7 +352,7 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
         );
 
         self.storage
-            .write_cached_nodes(self.kind.new.iter().map(|(addr, (_, node))| (addr, node)))?;
+            .write_cached_nodes(self.kind.new.iter().map(|(addr, (_, node))| (addr.as_nonzero(), node)))?;
         debug_assert!(ring.completion().is_empty());
 
         let flush_time = flush_start.elapsed().as_millis();

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -218,12 +218,8 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
                 .write(addr.get(), stored_area_bytes.as_slice())?;
         }
 
-        self.storage.write_cached_nodes(
-            self.kind
-                .new
-                .iter()
-                .map(|(addr, (_, node))| (addr.as_nonzero(), node)),
-        )?;
+        self.storage
+            .write_cached_nodes(self.kind.new.iter().map(|(addr, (_, node))| (addr, node)))?;
         let flush_time = flush_start.elapsed().as_millis();
         counter!("firewood.flush_nodes").increment(flush_time);
 
@@ -366,12 +362,8 @@ impl NodeStore<Arc<ImmutableProposal>, FileBacked> {
             saved_pinned_buffers.iter().find(|pbe| pbe.offset.is_some())
         );
 
-        self.storage.write_cached_nodes(
-            self.kind
-                .new
-                .iter()
-                .map(|(addr, (_, node))| (addr.as_nonzero(), node)),
-        )?;
+        self.storage
+            .write_cached_nodes(self.kind.new.iter().map(|(addr, (_, node))| (addr, node)))?;
         debug_assert!(ring.completion().is_empty());
 
         let flush_time = flush_start.elapsed().as_millis();


### PR DESCRIPTION
Took over the diff from @Salonii02 <devkss2000@gmail.com>, see PR#1062 or the commit history for their original commit and my changes.

Basically the same as PR#1062 with these changes:
  - Warning cleanups
  - serde->bytemuck
  - array dereference
  - more liberal use of into()
  - Implement LowerHex and delegate Display handling
  
I'm not happy with where LinearAddress lives, it probably belongs one level up, but it can move later. This adds a lot of value.