### PR TITLE
fix(fwdctl): fix fwdctl with ethhash

### DIFF
--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -34,6 +34,9 @@ hex = "0.4.3"
 csv = "1.3.1"
 nonzero_ext = "0.3.0"
 
+[features]
+ethhash = ["firewood/ethhash"]
+
 [dev-dependencies]
 anyhow = "1.0.98"
 assert_cmd = "2.0.17"


### PR DESCRIPTION
The checker decides whether to enable ethhash at build time through feature flags. Exposing this feature flag when building `fwdctl`. 