### PR TITLE
chore: skeleton of ffi proofs

### DIFF
--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -162,12 +162,14 @@ struct ProofResponse fwd_commit_change_proof(const struct DatabaseHandle *db,
                                              struct Value start_root,
                                              struct Value end_root,
                                              struct Value start_key,
-                                             struct Value end_key);
+                                             struct Value end_key,
+                                             struct Value proof_bytes);
 
 struct ProofResponse fwd_commit_range_proof(const struct DatabaseHandle *db,
                                             struct Value root,
                                             struct Value start,
-                                            struct Value end);
+                                            struct Value end,
+                                            struct Value proof_bytes);
 
 /**
  * Drops a proposal from the database.

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -42,6 +42,15 @@ typedef struct KeyValue {
 } KeyValue;
 
 /**
+ * Proof response!!!!
+ */
+typedef struct ProofResponse {
+  struct Value *proof_data;
+  uint8_t *db_error;
+  uint8_t *request_error;
+} ProofResponse;
+
+/**
  * Struct returned by `fwd_create_db` and `fwd_open_db`
  */
 typedef struct DatabaseCreationResult {
@@ -149,6 +158,17 @@ void fwd_close_db(struct DatabaseHandle *db);
  */
 struct Value fwd_commit(const struct DatabaseHandle *db, uint32_t proposal_id);
 
+struct ProofResponse fwd_commit_change_proof(const struct DatabaseHandle *db,
+                                             struct Value start_root,
+                                             struct Value end_root,
+                                             struct Value start_key,
+                                             struct Value end_key);
+
+struct ProofResponse fwd_commit_range_proof(const struct DatabaseHandle *db,
+                                            struct Value root,
+                                            struct Value start,
+                                            struct Value end);
+
 /**
  * Drops a proposal from the database.
  * The propopsal's data is now inaccessible, and can be freed by the `RevisionManager`.
@@ -186,6 +206,8 @@ struct Value fwd_drop_proposal(const struct DatabaseHandle *db, uint32_t proposa
  */
 void fwd_free_database_error_result(struct DatabaseCreationResult *result);
 
+void fwd_free_proof_response(struct ProofResponse *resp);
+
 /**
  * Frees the memory associated with a `Value`.
  *
@@ -214,6 +236,12 @@ void fwd_free_value(struct Value *value);
  * A `Value` containing {0, "error message"} if unable to get the latest metrics.
  */
 struct Value fwd_gather(void);
+
+struct ProofResponse fwd_get_change_proof(const struct DatabaseHandle *db,
+                                          struct Value start_root,
+                                          struct Value end_root,
+                                          struct Value start_key,
+                                          struct Value end_key);
 
 /**
  * Gets the value associated with the given key from the proposal provided.
@@ -295,6 +323,11 @@ struct Value fwd_get_from_root(const struct DatabaseHandle *db,
  *
  */
 struct Value fwd_get_latest(const struct DatabaseHandle *db, struct Value key);
+
+struct ProofResponse fwd_get_range_proof(const struct DatabaseHandle *db,
+                                         struct Value root,
+                                         struct Value start,
+                                         struct Value end);
 
 /**
  * Open a database with the given cache size and maximum number of revisions

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -5,6 +5,13 @@
 #include <stdlib.h>
 
 
+enum ErrorType {
+  NoError,
+  RequestError,
+  DbError,
+};
+typedef uint8_t ErrorType;
+
 /**
  * A handle to the database, returned by `fwd_create_db` and `fwd_open_db`.
  *
@@ -46,8 +53,8 @@ typedef struct KeyValue {
  */
 typedef struct ProofResponse {
   struct Value *proof_data;
-  uint8_t *db_error;
-  uint8_t *request_error;
+  ErrorType error_type;
+  uint8_t *error_str;
 } ProofResponse;
 
 /**
@@ -159,16 +166,12 @@ void fwd_close_db(struct DatabaseHandle *db);
 struct Value fwd_commit(const struct DatabaseHandle *db, uint32_t proposal_id);
 
 struct ProofResponse fwd_commit_change_proof(const struct DatabaseHandle *db,
-                                             struct Value start_root,
-                                             struct Value end_root,
-                                             struct Value start_key,
-                                             struct Value end_key,
+                                             struct Value target_start_root,
+                                             struct Value target_end_root,
                                              struct Value proof_bytes);
 
 struct ProofResponse fwd_commit_range_proof(const struct DatabaseHandle *db,
-                                            struct Value root,
-                                            struct Value start,
-                                            struct Value end,
+                                            struct Value target_root,
                                             struct Value proof_bytes);
 
 /**

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -19,8 +19,8 @@ var (
 	errNilStruct = errors.New("nil struct pointer cannot be freed")
 	errBadValue  = errors.New("value from cgo formatted incorrectly")
 
-	DBError      = errors.New("db error")
-	RequestError = errors.New("db non-fatal error")
+	ErrDB      = errors.New("db error")
+	ErrRequest = errors.New("db non-fatal error")
 )
 
 // KeyValue is a key-value pair.
@@ -42,12 +42,12 @@ func parseProofResponse(resp *C.struct_ProofResponse) (proofBytes []byte, dbErro
 	proofBytes, _ = bytesFromValue(resp.proof_data)
 	if resp.db_error != nil {
 		errStr := C.GoString((*C.char)(unsafe.Pointer(resp.db_error)))
-		dbError = fmt.Errorf("%w: %s", DBError, errStr)
+		dbError = fmt.Errorf("%w: %s", ErrDB, errStr)
 	}
 
 	if resp.request_error != nil {
 		errStr := C.GoString((*C.char)(unsafe.Pointer(resp.request_error)))
-		requestError = fmt.Errorf("%w: %s", RequestError, errStr)
+		requestError = fmt.Errorf("%w: %s", ErrRequest, errStr)
 	}
 
 	return proofBytes, dbError, requestError

--- a/ffi/proof_client.go
+++ b/ffi/proof_client.go
@@ -1,0 +1,84 @@
+// Package ffi provides a Go wrapper around the [Firewood] database.
+//
+// [Firewood]: https://github.com/ava-labs/firewood
+package ffi
+
+// // Note that -lm is required on Linux but not on Mac.
+// #include <stdlib.h>
+// #include "firewood.h"
+import "C"
+
+import (
+	"bytes"
+)
+
+type ProofClient struct {
+	db *Database
+}
+
+func NewProofClient(db *Database) *ProofClient {
+	return &ProofClient{db: db}
+}
+
+func (c *ProofClient) CommitRangeProof(root, startKey, endKey []byte) ([]byte, error) {
+	if c.db.handle == nil {
+		return nil, errDBClosed
+	}
+
+	if len(root) == 0 || bytes.Equal(root, EmptyRoot) {
+		return nil, nil
+	}
+
+	values, cleanup := newValueFactory()
+	defer cleanup()
+
+	proofResult := C.fwd_commit_range_proof(
+		c.db.handle,
+		values.from(root),
+		values.from(startKey),
+		values.from(endKey),
+	)
+
+	proofBytes, dbErr, reqErr := parseProofResponse(&proofResult)
+
+	// Any fatal error should take precedence.
+	if dbErr != nil {
+		return nil, dbErr
+	}
+	if reqErr != nil {
+		return nil, reqErr
+	}
+	return proofBytes, nil
+}
+
+func (c *ProofClient) CommitChangeProof(startRoot, endRoot, startKey, endKey []byte) ([]byte, error) {
+	if c.db.handle == nil {
+		return nil, errDBClosed
+	}
+
+	if len(endRoot) == 0 || bytes.Equal(endRoot, EmptyRoot) {
+		return nil, nil
+	}
+
+	values, cleanup := newValueFactory()
+	defer cleanup()
+
+	proofResult := C.fwd_commit_change_proof(
+		c.db.handle,
+		values.from(startRoot),
+		values.from(endRoot),
+		values.from(startKey),
+		values.from(endKey),
+	)
+
+	proofBytes, dbErr, reqErr := parseProofResponse(&proofResult)
+
+	// Any fatal error should take precedence.
+	if dbErr != nil {
+		return nil, dbErr
+	}
+	if reqErr != nil {
+		return nil, reqErr
+	}
+	return proofBytes, nil
+}

--- a/ffi/proof_client.go
+++ b/ffi/proof_client.go
@@ -20,7 +20,7 @@ func NewProofClient(db *Database) *ProofClient {
 	return &ProofClient{db: db}
 }
 
-func (c *ProofClient) CommitRangeProof(root, startKey, endKey []byte) ([]byte, error) {
+func (c *ProofClient) CommitRangeProof(root, startKey, endKey, proofBytes []byte) ([]byte, error) {
 	if c.db.handle == nil {
 		return nil, errDBClosed
 	}
@@ -37,9 +37,10 @@ func (c *ProofClient) CommitRangeProof(root, startKey, endKey []byte) ([]byte, e
 		values.from(root),
 		values.from(startKey),
 		values.from(endKey),
+		values.from(proofBytes),
 	)
 
-	proofBytes, dbErr, reqErr := parseProofResponse(&proofResult)
+	nextKey, dbErr, reqErr := parseProofResponse(&proofResult)
 
 	// Any fatal error should take precedence.
 	if dbErr != nil {
@@ -48,10 +49,10 @@ func (c *ProofClient) CommitRangeProof(root, startKey, endKey []byte) ([]byte, e
 	if reqErr != nil {
 		return nil, reqErr
 	}
-	return proofBytes, nil
+	return nextKey, nil
 }
 
-func (c *ProofClient) CommitChangeProof(startRoot, endRoot, startKey, endKey []byte) ([]byte, error) {
+func (c *ProofClient) CommitChangeProof(startRoot, endRoot, startKey, endKey, proofBytes []byte) ([]byte, error) {
 	if c.db.handle == nil {
 		return nil, errDBClosed
 	}
@@ -69,9 +70,10 @@ func (c *ProofClient) CommitChangeProof(startRoot, endRoot, startKey, endKey []b
 		values.from(endRoot),
 		values.from(startKey),
 		values.from(endKey),
+		values.from(proofBytes),
 	)
 
-	proofBytes, dbErr, reqErr := parseProofResponse(&proofResult)
+	nextKey, dbErr, reqErr := parseProofResponse(&proofResult)
 
 	// Any fatal error should take precedence.
 	if dbErr != nil {
@@ -80,5 +82,5 @@ func (c *ProofClient) CommitChangeProof(startRoot, endRoot, startKey, endKey []b
 	if reqErr != nil {
 		return nil, reqErr
 	}
-	return proofBytes, nil
+	return nextKey, nil
 }

--- a/ffi/proof_server.go
+++ b/ffi/proof_server.go
@@ -20,6 +20,10 @@ func NewProofServer(db *Database) *ProofServer {
 	return &ProofServer{db: db}
 }
 
+// GetRangeProof retrieves a range proof for the specified root and key range.
+// It returns the proof bytes if successful, or an error if the operation fails.
+// If the root isn't available, it returns an `ErrRequest`.
+// If there is a database error, it returns an `ErrDB`.
 func (s *ProofServer) GetRangeProof(root, startKey, endKey []byte) ([]byte, error) {
 	if s.db.handle == nil {
 		return nil, errDBClosed
@@ -38,19 +42,13 @@ func (s *ProofServer) GetRangeProof(root, startKey, endKey []byte) ([]byte, erro
 		values.from(startKey),
 		values.from(endKey),
 	)
-
-	proofBytes, dbErr, reqErr := parseProofResponse(&proofResult)
-
-	// Any fatal error should take precedence.
-	if dbErr != nil {
-		return nil, dbErr
-	}
-	if reqErr != nil {
-		return nil, reqErr
-	}
-	return proofBytes, nil
+	return parseProofResponse(&proofResult)
 }
 
+// GetChangeProof retrieves a change proof for the specified start and end roots and key range.
+// It returns the proof bytes if successful, or an error if the operation fails.
+// If the start and/or end roots aren't available, it returns an `ErrRequest`.
+// If there is a database error, it returns an `ErrDB`.
 func (s *ProofServer) GetChangeProof(startRoot, endRoot, startKey, endKey []byte) ([]byte, error) {
 	if s.db.handle == nil {
 		return nil, errDBClosed
@@ -71,14 +69,5 @@ func (s *ProofServer) GetChangeProof(startRoot, endRoot, startKey, endKey []byte
 		values.from(endKey),
 	)
 
-	proofBytes, dbErr, reqErr := parseProofResponse(&proofResult)
-
-	// Any fatal error should take precedence.
-	if dbErr != nil {
-		return nil, dbErr
-	}
-	if reqErr != nil {
-		return nil, reqErr
-	}
-	return proofBytes, nil
+	return parseProofResponse(&proofResult)
 }

--- a/ffi/proof_server.go
+++ b/ffi/proof_server.go
@@ -1,0 +1,84 @@
+// Package ffi provides a Go wrapper around the [Firewood] database.
+//
+// [Firewood]: https://github.com/ava-labs/firewood
+package ffi
+
+// // Note that -lm is required on Linux but not on Mac.
+// #include <stdlib.h>
+// #include "firewood.h"
+import "C"
+
+import (
+	"bytes"
+)
+
+type ProofServer struct {
+	db *Database
+}
+
+func NewProofServer(db *Database) *ProofServer {
+	return &ProofServer{db: db}
+}
+
+func (s *ProofServer) GetRangeProof(root, startKey, endKey []byte) ([]byte, error) {
+	if s.db.handle == nil {
+		return nil, errDBClosed
+	}
+
+	if len(root) == 0 || bytes.Equal(root, EmptyRoot) {
+		return nil, nil
+	}
+
+	values, cleanup := newValueFactory()
+	defer cleanup()
+
+	proofResult := C.fwd_get_range_proof(
+		s.db.handle,
+		values.from(root),
+		values.from(startKey),
+		values.from(endKey),
+	)
+
+	proofBytes, dbErr, reqErr := parseProofResponse(&proofResult)
+
+	// Any fatal error should take precedence.
+	if dbErr != nil {
+		return nil, dbErr
+	}
+	if reqErr != nil {
+		return nil, reqErr
+	}
+	return proofBytes, nil
+}
+
+func (s *ProofServer) GetChangeProof(startRoot, endRoot, startKey, endKey []byte) ([]byte, error) {
+	if s.db.handle == nil {
+		return nil, errDBClosed
+	}
+
+	if len(endRoot) == 0 || bytes.Equal(endRoot, EmptyRoot) {
+		return nil, nil
+	}
+
+	values, cleanup := newValueFactory()
+	defer cleanup()
+
+	proofResult := C.fwd_get_change_proof(
+		s.db.handle,
+		values.from(startRoot),
+		values.from(endRoot),
+		values.from(startKey),
+		values.from(endKey),
+	)
+
+	proofBytes, dbErr, reqErr := parseProofResponse(&proofResult)
+
+	// Any fatal error should take precedence.
+	if dbErr != nil {
+		return nil, dbErr
+	}
+	if reqErr != nil {
+		return nil, reqErr
+	}
+	return proofBytes, nil
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -732,65 +732,6 @@ impl From<()> for Value {
     }
 }
 
-/// Proof response!!!!
-#[derive(Debug, Default)]
-#[repr(C)]
-pub struct ProofResponse {
-    pub proof_data: Option<std::ptr::NonNull<Value>>,
-    pub db_error: Option<std::ptr::NonNull<u8>>,
-    pub request_error: Option<std::ptr::NonNull<u8>>,
-}
-
-#[unsafe(no_mangle)]
-#[allow(unused_variables)]
-pub unsafe extern "C" fn fwd_get_range_proof(
-    db: Option<&DatabaseHandle<'_>>,
-    root: Value,
-    start: Value,
-    end: Value,
-) -> ProofResponse {
-    ProofResponse::default()
-}
-
-#[unsafe(no_mangle)]
-#[allow(unused_variables)]
-pub unsafe extern "C" fn fwd_commit_range_proof(
-    db: Option<&DatabaseHandle<'_>>,
-    root: Value,
-    start: Value,
-    end: Value,
-) -> ProofResponse {
-    ProofResponse::default()
-}
-
-#[unsafe(no_mangle)]
-#[allow(unused_variables)]
-pub unsafe extern "C" fn fwd_get_change_proof(
-    db: Option<&DatabaseHandle<'_>>,
-    start_root: Value,
-    end_root: Value,
-    start_key: Value,
-    end_key: Value,
-) -> ProofResponse {
-    ProofResponse::default()
-}
-
-#[unsafe(no_mangle)]
-#[allow(unused_variables)]
-pub unsafe extern "C" fn fwd_commit_change_proof(
-    db: Option<&DatabaseHandle<'_>>,
-    start_root: Value,
-    end_root: Value,
-    start_key: Value,
-    end_key: Value,
-) -> ProofResponse {
-    ProofResponse::default()
-}
-
-#[unsafe(no_mangle)]
-#[allow(unused_variables)]
-pub unsafe extern "C" fn fwd_free_proof_response(resp: Option<&mut ProofResponse>) {}
-
 /// Frees the memory associated with a `Value`.
 ///
 /// # Arguments
@@ -823,6 +764,67 @@ pub unsafe extern "C" fn fwd_free_value(value: Option<&mut Value>) {
         }
     }
 }
+
+/// Proof response!!!!
+#[derive(Debug, Default)]
+#[repr(C)]
+pub struct ProofResponse {
+    pub proof_data: Option<std::ptr::NonNull<Value>>,
+    pub db_error: Option<std::ptr::NonNull<u8>>,
+    pub request_error: Option<std::ptr::NonNull<u8>>,
+}
+
+#[unsafe(no_mangle)]
+#[allow(unused_variables)]
+pub unsafe extern "C" fn fwd_get_range_proof(
+    db: Option<&DatabaseHandle<'_>>,
+    root: Value,
+    start: Value,
+    end: Value,
+) -> ProofResponse {
+    ProofResponse::default()
+}
+
+#[unsafe(no_mangle)]
+#[allow(unused_variables)]
+pub unsafe extern "C" fn fwd_commit_range_proof(
+    db: Option<&DatabaseHandle<'_>>,
+    root: Value,
+    start: Value,
+    end: Value,
+    proof_bytes: Value,
+) -> ProofResponse {
+    ProofResponse::default()
+}
+
+#[unsafe(no_mangle)]
+#[allow(unused_variables)]
+pub unsafe extern "C" fn fwd_get_change_proof(
+    db: Option<&DatabaseHandle<'_>>,
+    start_root: Value,
+    end_root: Value,
+    start_key: Value,
+    end_key: Value,
+) -> ProofResponse {
+    ProofResponse::default()
+}
+
+#[unsafe(no_mangle)]
+#[allow(unused_variables)]
+pub unsafe extern "C" fn fwd_commit_change_proof(
+    db: Option<&DatabaseHandle<'_>>,
+    start_root: Value,
+    end_root: Value,
+    start_key: Value,
+    end_key: Value,
+    proof_bytes: Value,
+) -> ProofResponse {
+    ProofResponse::default()
+}
+
+#[unsafe(no_mangle)]
+#[allow(unused_variables)]
+pub unsafe extern "C" fn fwd_free_proof_response(resp: Option<&mut ProofResponse>) {}
 
 /// Struct returned by `fwd_create_db` and `fwd_open_db`
 #[derive(Debug)]

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -765,13 +765,22 @@ pub unsafe extern "C" fn fwd_free_value(value: Option<&mut Value>) {
     }
 }
 
+#[derive(Debug, Default)]
+#[repr(u8)]
+pub enum ErrorType {
+    #[default]
+    NoError,
+    RequestError,
+    DbError,
+}
+
 /// Proof response!!!!
 #[derive(Debug, Default)]
 #[repr(C)]
 pub struct ProofResponse {
     pub proof_data: Option<std::ptr::NonNull<Value>>,
-    pub db_error: Option<std::ptr::NonNull<u8>>,
-    pub request_error: Option<std::ptr::NonNull<u8>>,
+    pub error_type: ErrorType,
+    pub error_str: Option<std::ptr::NonNull<u8>>,
 }
 
 #[unsafe(no_mangle)]
@@ -789,9 +798,7 @@ pub unsafe extern "C" fn fwd_get_range_proof(
 #[allow(unused_variables)]
 pub unsafe extern "C" fn fwd_commit_range_proof(
     db: Option<&DatabaseHandle<'_>>,
-    root: Value,
-    start: Value,
-    end: Value,
+    target_root: Value,
     proof_bytes: Value,
 ) -> ProofResponse {
     ProofResponse::default()
@@ -813,10 +820,8 @@ pub unsafe extern "C" fn fwd_get_change_proof(
 #[allow(unused_variables)]
 pub unsafe extern "C" fn fwd_commit_change_proof(
     db: Option<&DatabaseHandle<'_>>,
-    start_root: Value,
-    end_root: Value,
-    start_key: Value,
-    end_key: Value,
+    target_start_root: Value,
+    target_end_root: Value,
     proof_bytes: Value,
 ) -> ProofResponse {
     ProofResponse::default()

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -732,6 +732,65 @@ impl From<()> for Value {
     }
 }
 
+/// Proof response!!!!
+#[derive(Debug, Default)]
+#[repr(C)]
+pub struct ProofResponse {
+    pub proof_data: Option<std::ptr::NonNull<Value>>,
+    pub db_error: Option<std::ptr::NonNull<u8>>,
+    pub request_error: Option<std::ptr::NonNull<u8>>,
+}
+
+#[unsafe(no_mangle)]
+#[allow(unused_variables)]
+pub unsafe extern "C" fn fwd_get_range_proof(
+    db: Option<&DatabaseHandle<'_>>,
+    root: Value,
+    start: Value,
+    end: Value,
+) -> ProofResponse {
+    ProofResponse::default()
+}
+
+#[unsafe(no_mangle)]
+#[allow(unused_variables)]
+pub unsafe extern "C" fn fwd_commit_range_proof(
+    db: Option<&DatabaseHandle<'_>>,
+    root: Value,
+    start: Value,
+    end: Value,
+) -> ProofResponse {
+    ProofResponse::default()
+}
+
+#[unsafe(no_mangle)]
+#[allow(unused_variables)]
+pub unsafe extern "C" fn fwd_get_change_proof(
+    db: Option<&DatabaseHandle<'_>>,
+    start_root: Value,
+    end_root: Value,
+    start_key: Value,
+    end_key: Value,
+) -> ProofResponse {
+    ProofResponse::default()
+}
+
+#[unsafe(no_mangle)]
+#[allow(unused_variables)]
+pub unsafe extern "C" fn fwd_commit_change_proof(
+    db: Option<&DatabaseHandle<'_>>,
+    start_root: Value,
+    end_root: Value,
+    start_key: Value,
+    end_key: Value,
+) -> ProofResponse {
+    ProofResponse::default()
+}
+
+#[unsafe(no_mangle)]
+#[allow(unused_variables)]
+pub unsafe extern "C" fn fwd_free_proof_response(resp: Option<&mut ProofResponse>) {}
+
 /// Frees the memory associated with a `Value`.
 ///
 /// # Arguments


### PR DESCRIPTION
This is a skeleton of what the interface might look like for range/change proofs. Rather than saying what's here, let me say what is missing:

- Config: Both the client and server should be able to set some config options, probably just request size limits
- An interface between x/sync and this (proposed interface in ava-labs/avalanchego#4064)
  - This would have to include some error parsing, probably something like `errors.As()` using the exported error types to determine whether to quit the syncer on some fatal error or simply re-request the data
  - It would also definitely have to convert between avalanchego types (e.g. `ids.ID => []byte`)
- Any implementation in Rust. The functions are only stubs
- Any decent comments describing what things mean on the Rust-side.