### PR TITLE
build: Cargo.toml upgrades and fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,25 +63,25 @@ firewood-ffi = { path = "ffi", version = "0.0.9" }
 firewood-triehash = { path = "triehash", version = "0.0.9" }
 
 # common dependencies
-metrics = "0.24.2"
-metrics-util = "0.20.0"
-sha2 = "0.10.9"
-tokio = "1.46.1"
-clap = { version = "4.5.41", features = ["derive"] }
-fastrace = "0.7.14"
-thiserror = "2.0.12"
 coarsetime = "0.1.36"
 env_logger = "0.11.8"
-smallvec = "1.15.1"
-log = "0.4.27"
+fastrace = "0.7.14"
 hex = "0.4.3"
+log = "0.4.27"
+metrics = "0.24.2"
+metrics-util = "0.20.0"
 rand_distr = "0.5.1"
+sha2 = "0.10.9"
+smallvec = "1.15.1"
 test-case = "3.3.1"
+thiserror = "2.0.12"
+tokio = "1.46.1"
+clap = { version = "4.5.41", features = ["derive"] }
 
 # common dev dependencies
-rand = "0.9.2"
 criterion = "0.6.0"
-pprof = "0.15.0"
-tempfile = "3.20.0"
 ethereum-types = "0.15.1"
 hex-literal = "1.0.0"
+pprof = "0.15.0"
+rand = "0.9.2"
+tempfile = "3.20.0"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -18,24 +18,26 @@ name = "benchmark"
 path = "src/main.rs"
 
 [dependencies]
+# Workspace dependencies
+clap = { workspace = true, features = ['string'] }
+env_logger.workspace = true
+fastrace = { workspace = true, features = ["enable"] }
 firewood.workspace = true
 hex.workspace = true
-clap = { workspace = true, features = ['string'] }
-sha2.workspace = true
+log.workspace = true
 metrics.workspace = true
 metrics-util.workspace = true
-metrics-exporter-prometheus = "0.17.2"
-tokio = { workspace = true, features = ["rt", "sync", "macros", "rt-multi-thread"] }
 rand.workspace = true
 rand_distr.workspace = true
-pretty-duration = "0.1.1"
-env_logger.workspace = true
-log.workspace = true
-fastrace = { workspace = true, features = ["enable"] }
+sha2.workspace = true
+tokio = { workspace = true, features = ["rt", "sync", "macros", "rt-multi-thread"] }
+# Regular dependencies
 fastrace-opentelemetry = { version = "0.13.0" }
-opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic"] }
+metrics-exporter-prometheus = "0.17.2"
 opentelemetry = "0.30.0"
+opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic"] }
 opentelemetry_sdk = "0.30.0"
+pretty-duration = "0.1.1"
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = "0.6.0"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -20,12 +20,15 @@ rust-version.workspace = true
 crate-type = ["staticlib"]
 
 [dependencies]
+# Workspace dependencies
+coarsetime.workspace = true
 firewood.workspace = true
 metrics.workspace = true
 metrics-util.workspace = true
+# Regular dependencies
 chrono = "0.4.41"
 oxhttp = "0.3.1"
-coarsetime.workspace = true
+# Optional dependencies
 env_logger = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/firewood-macros/Cargo.toml
+++ b/firewood-macros/Cargo.toml
@@ -15,14 +15,17 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
+# Regular dependencies
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
-trybuild = "1.0"
-metrics.workspace = true
+# Workspace dependencies
 coarsetime.workspace = true
+metrics.workspace = true
+# Regular dependencies
+trybuild = "1.0"
 
 [lints]
 workspace = true

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -23,19 +23,21 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-aquamarine = "0.6.0"
-async-trait = "0.1.88"
-futures = "0.3.31"
+# Workspace dependencies
+coarsetime.workspace = true
+fastrace.workspace = true
+firewood-macros.workspace = true
 hex.workspace = true
 metrics.workspace = true
 sha2.workspace = true
 test-case.workspace = true
 thiserror.workspace = true
-typed-builder = "0.21.0"
-fastrace.workspace = true
-coarsetime.workspace = true
-firewood-macros.workspace = true
 tokio.workspace = true
+# Regular dependencies
+aquamarine = "0.6.0"
+async-trait = "0.1.88"
+futures = "0.3.31"
+typed-builder = "0.21.0"
 
 [features]
 default = []
@@ -46,20 +48,22 @@ branch_factor_256 = [ "firewood-storage/branch_factor_256" ]
 ethhash = [ "firewood-storage/ethhash" ]
 
 [dev-dependencies]
-firewood-triehash.workspace = true
+# Workspace dependencies
+clap = { workspace = true, features = ['derive'] }
 criterion = { workspace = true, features = ["async_tokio"] }
+env_logger.workspace = true
+ethereum-types.workspace = true
+firewood-triehash.workspace = true
+hex-literal.workspace = true
+pprof = { workspace = true, features = ["flamegraph"] }
 rand.workspace = true
 rand_distr.workspace = true
-clap = { workspace = true, features = ['derive'] }
-pprof = { workspace = true, features = ["flamegraph"] }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt", "sync", "macros", "rt-multi-thread"] }
-ethereum-types.workspace = true
-sha3 = "0.10.8"
-plain_hasher = "0.2.3"
-hex-literal.workspace = true
-env_logger.workspace = true
+# Regular dependencies
 hash-db = "0.16.0"
+plain_hasher = "0.2.3"
+sha3 = "0.10.8"
 
 [[bench]]
 name = "hashops"

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -23,26 +23,30 @@ name = "fwdctl"
 path = "src/main.rs"
 
 [dependencies]
-firewood.workspace = true
-firewood-storage.workspace = true
+# Workspace dependencies
 clap = { workspace = true, features = ["cargo"] }
 env_logger.workspace = true
+firewood.workspace = true
+firewood-storage.workspace = true
+hex.workspace = true
 log.workspace = true
 tokio = { workspace = true, features = ["full"] }
-futures-util = "0.3.31"
-hex.workspace = true
+# Regular dependencies
 csv = "1.3.1"
+futures-util = "0.3.31"
 nonzero_ext = "0.3.0"
 
 [features]
 ethhash = ["firewood/ethhash"]
 
 [dev-dependencies]
+# Workspace dependencies
+rand.workspace = true
+# Regular dependencies
 anyhow = "1.0.98"
 assert_cmd = "2.0.17"
 predicates = "3.1.3"
 serial_test = "3.2.0"
-rand.workspace = true
 
 [lints]
 workspace = true

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -17,36 +17,40 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitflags = "2.9.1"
-enum-as-inner = "0.6.1"
+# Workspace dependencies
+coarsetime.workspace = true
+fastrace.workspace = true
 hex.workspace = true
-smallvec = { workspace = true, features = ["write", "union"] }
-sha2.workspace = true
-integer-encoding = "4.0.2"
-arc-swap = "1.7.1"
-lru = "0.16.0"
 metrics.workspace = true
-log = { version = "0.4.27", optional = true }
+sha2.workspace = true
+smallvec = { workspace = true, features = ["write", "union"] }
+thiserror.workspace = true
+# Regular dependencies
+arc-swap = "1.7.1"
+bitfield = "0.19.1"
+bitflags = "2.9.1"
 bytemuck = "1.23.1"
 bytemuck_derive = "1.10.0"
-bitfield = "0.19.1"
-fastrace.workspace = true
-io-uring = { version = "0.7.8", optional = true }
+enum-as-inner = "0.6.1"
+integer-encoding = "4.0.2"
+lru = "0.16.0"
+nonzero_ext = "0.3.0"
+semver = "1.0.26"
 triomphe = "0.1.14"
-coarsetime.workspace = true
+# Optional dependencies
+bytes = { version = "1.10.1", optional = true }
+io-uring = { version = "0.7.8", optional = true }
+log = { version = "0.4.27", optional = true }
 rlp = { version = "0.6.1", optional = true }
 sha3 = { version = "0.10.8", optional = true }
-bytes = { version = "1.10.1", optional = true }
-thiserror.workspace = true
-semver = "1.0.26"
-nonzero_ext = "0.3.0"
 
 [dev-dependencies]
-rand.workspace = true
-test-case.workspace = true
+# Workspace dependencies
 criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
 pprof = { workspace = true, features = ["flamegraph"] }
+rand.workspace = true
 tempfile.workspace = true
+test-case.workspace = true
 
 [features]
 logger = ["log"]

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -9,16 +9,19 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+# Regular dependencies
 hash-db = "0.16.0"
 rlp = "0.6"
 
 [dev-dependencies]
+# Workspace dependencies
 criterion.workspace = true
-keccak-hasher = "0.16.0"
 ethereum-types.workspace = true
+hex-literal.workspace = true
+# Regular dependencies
+keccak-hasher = "0.16.0"
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 trie-standardmap = "0.16.0"
-hex-literal.workspace = true
 
 [[bench]]
 name = "triehash"


### PR DESCRIPTION
For reviewers, there are two commits, one with just the edits and the second with the reordering only. 

tokio in firewood was set to version "1.0.0" which created some interesting debugging sessions.
  
Other changes:
   - Added log, hex, rand_distr and test-case to workspace level
   - switched from `dependency = { workspace = true }` to
     `dependency.workspace = true` when possible
  
`cargo upgrade --incmpatible` output:
  
```text
      Checking virtual workspace's dependencies
  name  old req compatible latest new req
  ====  ======= ========== ====== =======
  tokio 1.46.0  1.46.1     1.46.1 1.46.1
  clap  4.5.40  4.5.41     4.5.41 4.5.41
  rand  0.9.1   0.9.2      0.9.2  0.9.2
      Checking firewood's dependencies
  name  old req compatible latest new req
  ====  ======= ========== ====== =======
  tokio 1.0.0   1.46.1     1.46.1 1.46.1
  clap  4.5.40  4.5.41     4.5.41 4.5.41
  tokio 1.46.0  1.46.1     1.46.1 1.46.1
      Checking firewood-benchmark's dependencies
  name                   old req compatible latest new req
  ====                   ======= ========== ====== =======
  fastrace-opentelemetry 0.12.0  0.12.0     0.13.0 0.13.0
  rand                   0.9.1   0.9.2      0.9.2  0.9.2
      Checking firewood-ffi's dependencies
      Checking firewood-fwdctl's dependencies
      Checking firewood-macros's dependencies
      Checking firewood-storage's dependencies
  name            old req compatible latest new req
  ====            ======= ========== ====== =======
  bytemuck_derive 1.9.3   1.10.0     1.10.0 1.10.0
      Checking firewood-triehash's dependencies
```