### PR TITLE
style: remove unnecessary string in error

### DIFF
--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	errNilStruct = errors.New("firewood error: nil struct pointer cannot be freed")
-	errBadValue  = errors.New("firewood error: value from cgo formatted incorrectly")
+	errNilStruct = errors.New("nil struct pointer cannot be freed")
+	errBadValue  = errors.New("value from cgo formatted incorrectly")
 )
 
 // KeyValue is a key-value pair.

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	errRevisionNotFound  = errors.New("firewood error: revision not found")
-	errInvalidRootLength = fmt.Errorf("firewood error: root hash must be %d bytes", RootLength)
+	errRevisionNotFound  = errors.New("revision not found")
+	errInvalidRootLength = fmt.Errorf("root hash must be %d bytes", RootLength)
 )
 
 type Revision struct {
@@ -28,7 +28,7 @@ type Revision struct {
 
 func newRevision(handle *C.DatabaseHandle, root []byte) (*Revision, error) {
 	if handle == nil {
-		return nil, errors.New("firewood error: nil handle or root")
+		return nil, errDBClosed
 	}
 
 	// Check that the root is the correct length.


### PR DESCRIPTION
Obviously any error returned from Firewood is a "Firewood error"...