### PR TITLE
feat: Render the commit sha in fwdctl

### DIFF
--- a/fwdctl/build.rs
+++ b/fwdctl/build.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+
+fn main() {
+    // Get the git commit SHA
+    let git_sha = match Command::new("git").args(["rev-parse", "HEAD"]).output() {
+        Ok(output) => {
+            if output.status.success() {
+                String::from_utf8_lossy(&output.stdout).trim().to_string()
+            } else {
+                let error_msg = String::from_utf8_lossy(&output.stderr);
+                format!("git error: {}", error_msg.trim())
+            }
+        }
+        Err(e) => {
+            format!("git not found: {}", e)
+        }
+    };
+
+    // Make the git SHA available to the main.rs file
+    println!("cargo:rustc-env=GIT_COMMIT_SHA={}", git_sha);
+
+    // Re-run this build script if the git HEAD changes
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
+}

--- a/fwdctl/build.rs
+++ b/fwdctl/build.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
 use std::process::Command;
 
 fn main() {
@@ -12,12 +15,20 @@ fn main() {
             }
         }
         Err(e) => {
-            format!("git not found: {}", e)
+            format!("git not found: {e}")
         }
     };
 
-    // Make the git SHA available to the main.rs file
-    println!("cargo:rustc-env=GIT_COMMIT_SHA={}", git_sha);
+    // Check if ethhash feature is enabled
+    let ethhash_feature = if cfg!(feature = "ethhash") {
+        "ethhash"
+    } else {
+        "-ethhash"
+    };
+
+    // Make the git SHA and ethhash status available to the main.rs file
+    println!("cargo:rustc-env=GIT_COMMIT_SHA={git_sha}");
+    println!("cargo:rustc-env=ETHHASH_FEATURE={ethhash_feature}");
 
     // Re-run this build script if the git HEAD changes
     println!("cargo:rerun-if-changed=.git/HEAD");

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -18,6 +18,7 @@ pub mod root;
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
+#[command(version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_COMMIT_SHA"), ")"))]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -18,7 +18,7 @@ pub mod root;
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
-#[command(version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_COMMIT_SHA"), ")"))]
+#[command(version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_COMMIT_SHA"), ", ", env!("ETHHASH_FEATURE"), ")"))]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -24,7 +24,7 @@ fn fwdctl_delete_db() -> Result<()> {
 #[test]
 #[serial]
 fn fwdctl_prints_version() -> Result<()> {
-    let expected_version_output: String = format!("{PRG} {VERSION}\n");
+    let expected_version_output: String = format!("{PRG} {VERSION}");
 
     // version is defined and succeeds with the desired output
     Command::cargo_bin(PRG)?


### PR DESCRIPTION
Sample output:

```text
$ target/debug/fwdctl --version
firewood-fwdctl 0.0.9 (234cf6a9a5d8956cef0d19b9a40e1f00026bc516, -ethhash)
```

Output, when git is not on the path:

```text
$ target/debug/fwdctl --version
firewood-fwdctl 0.0.9 (git not found: No such file or directory (os error 2), -ethhash)
```

Closes #1107