### PR TITLE
test: Port TestDeepPropose from go->rust

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -833,6 +833,76 @@ mod test {
         }
     }
 
+    #[tokio::test]
+    async fn test_deep_propose() {
+        const NUM_KEYS: usize = 2;
+        const NUM_PROPOSALS: usize = 100;
+
+        let db = testdb().await;
+
+        // create NUM_KEYS * NUM_PROPOSALS keys and values
+        let (keys, vals): (Vec<_>, Vec<_>) = (0..NUM_KEYS * NUM_PROPOSALS)
+            .map(|i| {
+                (
+                    format!("key{i}").into_bytes(),
+                    Box::from(format!("value{i}").as_bytes()),
+                )
+            })
+            .unzip();
+
+        // create batches of NUM_KEYS keys and values
+        let batches: Vec<_> = keys
+            .chunks(NUM_KEYS)
+            .zip(vals.chunks(NUM_KEYS))
+            .map(|(k, v)| {
+                k.iter()
+                    .zip(v.iter())
+                    .map(|(k, v)| BatchOp::Put { key: k, value: v })
+                    .collect()
+            })
+            .collect();
+
+        // better me correct
+        assert_eq!(batches.len(), NUM_PROPOSALS);
+
+        // create proposals from the batches. The first one is created from the db, the others are
+        // children
+        let mut batches_iter = batches.into_iter();
+        let mut proposals = vec![db.propose(batches_iter.next().unwrap()).await.unwrap()];
+
+        for batch in batches_iter {
+            let proposal = proposals
+                .last()
+                .unwrap()
+                .clone()
+                .propose(batch)
+                .await
+                .unwrap();
+            proposals.push(proposal);
+        }
+
+        // check that each value is present in the final proposal
+        for (k, v) in keys.iter().zip(vals.iter()) {
+            assert_eq!(&proposals.last().unwrap().val(k).await.unwrap().unwrap(), v);
+        }
+
+        // commit the proposals
+        for proposal in proposals {
+            proposal.commit().await.unwrap();
+        }
+
+        // get the last committed revision
+        let committed = db
+            .revision(db.root_hash().await.unwrap().unwrap())
+            .await
+            .unwrap();
+
+        // check that all the keys and values are still present
+        for (k, v) in keys.iter().zip(vals.iter()) {
+            assert_eq!(&committed.val(k).await.unwrap().unwrap(), v);
+        }
+    }
+
     // Testdb is a helper struct for testing the Db. Once it's dropped, the directory and file disappear
     struct TestDb {
         db: Db,

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -862,7 +862,7 @@ mod test {
             })
             .collect();
 
-        // better me correct
+        // better be correct
         assert_eq!(batches.len(), NUM_PROPOSALS);
 
         // create proposals from the batches. The first one is created from the db, the others are

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -887,7 +887,13 @@ mod test {
         }
 
         // save the last proposal root hash for comparison with the final database root hash
-        let last_proposal_root_hash = proposals.last().unwrap().root_hash().await.unwrap().unwrap();
+        let last_proposal_root_hash = proposals
+            .last()
+            .unwrap()
+            .root_hash()
+            .await
+            .unwrap()
+            .unwrap();
 
         // commit the proposals
         for proposal in proposals {

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -886,16 +886,20 @@ mod test {
             assert_eq!(&proposals.last().unwrap().val(k).await.unwrap().unwrap(), v);
         }
 
+        // save the last proposal root hash for comparison with the final database root hash
+        let last_proposal_root_hash = proposals.last().unwrap().root_hash().await.unwrap().unwrap();
+
         // commit the proposals
         for proposal in proposals {
             proposal.commit().await.unwrap();
         }
 
         // get the last committed revision
-        let committed = db
-            .revision(db.root_hash().await.unwrap().unwrap())
-            .await
-            .unwrap();
+        let last_root_hash = db.root_hash().await.unwrap().unwrap();
+        let committed = db.revision(last_root_hash.clone()).await.unwrap();
+
+        // the last root hash should be the same as the last proposal root hash
+        assert_eq!(last_root_hash, last_proposal_root_hash);
 
         // check that all the keys and values are still present
         for (k, v) in keys.iter().zip(vals.iter()) {


### PR DESCRIPTION
Changed to test with 2 keys and values and 100 proposals, which seems like it exercises more of the code with less data.

Fixes #1102