### PR TITLE
feat: refactor value types to use the type alias

### DIFF
--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -11,6 +11,7 @@
 )]
 
 use crate::manager::RevisionManagerError;
+use crate::merkle::{Key, Value};
 use crate::proof::{Proof, ProofError, ProofNode};
 pub use crate::range_proof::RangeProof;
 use async_trait::async_trait;
@@ -45,7 +46,7 @@ impl<T> ValueType for T where T: AsRef<[u8]> + Send + Sync + Debug {}
 pub type HashKey = firewood_storage::TrieHash;
 
 /// A frozen proof is a proof that is stored in immutable memory.
-pub type FrozenRangeProof = RangeProof<Box<[u8]>, Box<[u8]>, Box<[ProofNode]>>;
+pub type FrozenRangeProof = RangeProof<Key, Value, Box<[ProofNode]>>;
 
 /// A frozen proof uses an immutable collection of proof nodes.
 pub type FrozenProof = Proof<Box<[ProofNode]>>;
@@ -113,9 +114,9 @@ pub enum Error {
     #[error("Invalid range: {start_key:?} > {end_key:?}")]
     InvalidRange {
         /// The provided starting key
-        start_key: Box<[u8]>,
+        start_key: Key,
         /// The provided ending key
-        end_key: Box<[u8]>,
+        end_key: Key,
     },
 
     #[error("IO error: {0}")]
@@ -234,7 +235,7 @@ pub trait Db {
 #[async_trait]
 pub trait DbView {
     /// The type of a stream of key/value pairs
-    type Stream<'a>: Stream<Item = Result<(Box<[u8]>, Vec<u8>), Error>>
+    type Stream<'a>: Stream<Item = Result<(Key, Value), Error>>
     where
         Self: 'a;
 
@@ -247,7 +248,7 @@ pub trait DbView {
     async fn root_hash(&self) -> Result<Option<HashKey>, Error>;
 
     /// Get the value of a specific key
-    async fn val<K: KeyType>(&self, key: K) -> Result<Option<Box<[u8]>>, Error>;
+    async fn val<K: KeyType>(&self, key: K) -> Result<Option<Value>, Error>;
 
     /// Obtain a proof for a single key
     async fn single_key_proof<K: KeyType>(&self, key: K) -> Result<FrozenProof, Error>;
@@ -282,7 +283,7 @@ pub trait DbView {
 
     /// Obtain a stream over the keys/values of this view, starting from the beginning
     fn iter(&self) -> Result<Self::Stream<'_>, Error> {
-        self.iter_option(Option::<Box<[u8]>>::None)
+        self.iter_option(Option::<Key>::None)
     }
 
     /// Obtain a stream over the key/values, starting at a specific key

--- a/firewood/src/v2/emptydb.rs
+++ b/firewood/src/v2/emptydb.rs
@@ -3,6 +3,7 @@
 
 use super::api::{Batch, Db, DbView, Error, HashKey, KeyType, ValueType};
 use super::propose::{Proposal, ProposalBase};
+use crate::merkle::{Key, Value};
 use crate::v2::api::{FrozenProof, FrozenRangeProof};
 use async_trait::async_trait;
 use futures::Stream;
@@ -60,7 +61,7 @@ impl DbView for HistoricalImpl {
         Ok(None)
     }
 
-    async fn val<K: KeyType>(&self, _key: K) -> Result<Option<Box<[u8]>>, Error> {
+    async fn val<K: KeyType>(&self, _key: K) -> Result<Option<Value>, Error> {
         Ok(None)
     }
 
@@ -87,7 +88,7 @@ impl DbView for HistoricalImpl {
 pub struct EmptyStreamer;
 
 impl Stream for EmptyStreamer {
-    type Item = Result<(Box<[u8]>, Vec<u8>), Error>;
+    type Item = Result<(Key, Value), Error>;
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -8,7 +8,7 @@
 
 use clap::Args;
 use firewood::db::{Db, DbConfig};
-use firewood::merkle::Key;
+use firewood::merkle::{Key, Value};
 use firewood::stream::MerkleKeyValueStream;
 use firewood::v2::api::{self, Db as _};
 use futures_util::StreamExt;
@@ -18,7 +18,7 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 
-type KeyFromStream = Option<Result<(Key, Vec<u8>), api::Error>>;
+type KeyFromStream = Option<Result<(Key, Value), api::Error>>;
 
 #[derive(Debug, Args)]
 pub struct Options {


### PR DESCRIPTION
Also, switch to using boxed slices everywhere. I found a couple places where we do a lot of copies, more than just in serialization and more than I first though when I opened #1058.