### PR TITLE
ci: add a job to invoke ingored tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -143,6 +143,34 @@ jobs:
       - name: Run tests with features enabled
         run: cargo test --verbose ${{ matrix.profile-args }}
 
+  test-ignored:
+    needs: build
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        include:
+          - profile-key: debug-no-default-features
+            profile-args: "--no-default-features"
+          - profile-key: debug-no-features
+            profile-args: ""
+          - profile-key: debug-ethhash-logger
+            profile-args: "--features ethhash,logger"
+          - profile-key: maxperf-ethhash-logger
+            profile-args: "--profile maxperf --features ethhash,logger"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: "false"
+          shared-key: ${{ matrix.profile-key }}
+      - name: Run ignored tests with features enabled
+        run: cargo test --verbose ${{ matrix.profile-args }} -- --include-ignored
+
   examples:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
It's understandable that this might be a controversial change. However, I believe that having a job to invoke the ignored tests is beneficial so that we can still run them and ensure they are still broken. In the future, we may even want to ensure this job fails so that we can detect when a test is no longer broken and can be removed from the ignore list.

Currently, this will run on every pull request and merge to main, but we can adjust this as needed.