### PR TITLE
feat: make NodeStore more generic

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -159,7 +159,7 @@ impl RevisionManager {
             return Err(RevisionManagerError::NotLatest);
         }
 
-        let mut committed = proposal.as_committed(current_revision);
+        let mut committed = proposal.as_committed(&current_revision);
 
         // 2. Persist delete list for this committed revision to disk for recovery
 

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -1186,7 +1186,7 @@ mod tests {
         let immutable_merkle: Merkle<NodeStore<Arc<ImmutableProposal>, _>> =
             merkle.try_into().unwrap();
         println!("{}", immutable_merkle.dump().unwrap());
-        merkle = Merkle::from(NodeStore::new(&Arc::new(immutable_merkle.into_inner())).unwrap());
+        merkle = immutable_merkle.fork().unwrap();
 
         let mut stream = merkle.key_value_iter();
 


### PR DESCRIPTION
This commit enhances the `NodeStore` structure to be more generic, allowing it to work with different storage backends. In a future change, I have tests that execute a write-commit-read loop using `MemStore`. However, this does not work without this change as `NodeStore` currently has many methods that are specific to the `FileStore` implementation.

Passing in an `Arc` is not required as we're not cloning the arc. This makes it easier to use the `NodeStore` without needing to wrap it in an `Arc` every time.

A `fork` method is also added to `NodeStore` for easier cloning of the store into a new mutable instance.