### PR TITLE
feat: Update RangeProof structure

### DIFF
--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -139,6 +139,7 @@ pub mod proof;
 // Re-export the proc macro from firewood-macros
 pub use firewood_macros::metrics;
 
+/// Range proof module
 pub mod range_proof;
 
 /// Stream module, for both node and key-value streams

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -330,6 +330,8 @@ impl<T: TrieReader> Merkle<T> {
     ///   - If `Some(n)`, at most n key-value pairs will be included
     ///   - If `None`, all key-value pairs in the range will be included
     ///   - Useful for paginating through large ranges
+    ///   - **NOTE**: avalanchego's limit is based on the entire packet size and not the
+    ///     number of key-value pairs. Currently, we only limit by the number of pairs.
     ///
     /// # Returns
     ///

--- a/firewood/src/range_proof.rs
+++ b/firewood/src/range_proof.rs
@@ -1,45 +1,6 @@
 // Copyright (C) 2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-//! Range proof implementation for Merkle tries.
-//!
-//! This module provides the [`RangeProof`] type, which enables efficient cryptographic
-//! proofs for contiguous ranges of key-value pairs within a Merkle trie. Range proofs
-//! are essential for blockchain state synchronization, allowing nodes to verify that
-//! they have received a complete and authentic subset of the trie without downloading
-//! the entire data structure.
-//!
-//! # Overview
-//!
-//! A range proof consists of three components:
-//! 1. **Start proof**: Proves the lower boundary of the range
-//! 2. **End proof**: Proves the upper boundary of the range
-//! 3. **Key-value pairs**: The actual data within the proven range
-//!
-//! Together, these components allow a verifier to confirm that:
-//! - The provided key-value pairs are authentic members of the trie
-//! - No keys have been omitted from within the specified range
-//! - The trie has the expected root hash
-//!
-//! # Use Cases
-//!
-//! Range proofs are particularly valuable for:
-//! - **State sync**: Nodes can download and verify portions of the state trie incrementally
-//! - **Light clients**: Can verify specific account ranges without full trie access
-//! - **Auditing**: Prove the contents of a specific key range at a given block height
-//! - **Sharding**: Verify state partitions across different shards
-//!
-//! # Example
-//!
-//! ```ignore
-//! // Create a range proof for keys from "alice" to "charlie"
-//! let range_proof = RangeProof::new(
-//!     start_proof,  // Proof for "alice" or nearest key before
-//!     end_proof,    // Proof for "charlie" or nearest key after
-//!     key_values,   // Vec of (key, value) pairs in the range
-//! );
-//! ```
-
 use crate::proof::{Proof, ProofCollection};
 
 /// A range proof is a cryptographic proof that demonstrates a contiguous set of key-value pairs
@@ -95,12 +56,6 @@ where
     ///   established by the start and end proofs. The keys should be in lexicographic
     ///   order as they appear in the trie. May be empty if proving the absence of keys
     ///   in a range.
-    ///
-    /// # Example Use Cases
-    ///
-    /// - Proving keys "alice" through "charlie" exist with their values
-    /// - Proving no keys exist between "aardvark" and "apple"
-    /// - Proving all keys starting with a specific prefix
     #[must_use]
     pub const fn new(
         start_proof: Proof<H>,


### PR DESCRIPTION
While implementing the range proof verification, I realized that having an Option over a byte range is not ideal to work with. This meant that I needed to do `proof.is_none_or(|p| p.is_empty())` every time I wanted to use say a proof was empty. It was easier to use `proof.is_empty()` everywhere. The inverse was also true where when I wanted to use a proof, I first needed to destructure it and then check if it was empty. 

```rust
let proof = match proof { Some(proof) if !proof.is_empty() => Some(proof), None };
```

Was in many places in my code.

Also updated is the method signature and documentation for `verify_range_proof` to match how it will be used in the future.