### PR TITLE
feat(ffi-iterator): Initial Implementation of FFI iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ compose-dev.yaml
 # ignore test databases
 *_db
 
+# ignore env and local
+.env
+.local_ws
+
 #### Below sections are auto-generated ####
 
 # Created by https://www.toptal.com/developers/gitignore/api/rust,visualstudiocode,vim,macos

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -14,6 +14,14 @@
 typedef struct DatabaseHandle DatabaseHandle;
 
 /**
+ * A handle to the iterator, returned and used by `fwd_iter_*`.
+ *
+ * These handles are passed to the other FFI functions.
+ *
+ */
+typedef struct IteratorHandle IteratorHandle;
+
+/**
  * A value returned by the FFI.
  *
  * This is used in several different ways, including:
@@ -48,6 +56,14 @@ typedef struct DatabaseCreationResult {
   struct DatabaseHandle *db;
   uint8_t *error_str;
 } DatabaseCreationResult;
+
+/**
+ * Struct returned by `fwd_iter_*`
+ */
+typedef struct IteratorCreationResult {
+  struct IteratorHandle *iterator;
+  uint8_t *error_str;
+} IteratorCreationResult;
 
 typedef uint32_t ProposalId;
 
@@ -199,6 +215,26 @@ struct Value fwd_drop_proposal(const struct DatabaseHandle *db, uint32_t proposa
 void fwd_free_database_error_result(struct DatabaseCreationResult *result);
 
 /**
+ * Frees the memory associated with a `IteratorCreationResult`.
+ * This only needs to be called if the `error_str` field is non-null.
+ *
+ * # Arguments
+ *
+ * * `result` - The `IteratorCreationResult` to free, previously returned from `fwd_iter_*`.
+ *
+ * # Safety
+ *
+ * This function is unsafe because it dereferences raw pointers.
+ * The caller must ensure that `result` is a valid pointer.
+ *
+ * # Panics
+ *
+ * This function panics if `result` is `null`.
+ *
+ */
+void fwd_free_iterator_error_result(struct IteratorCreationResult *result);
+
+/**
  * Frees the memory associated with a `Value`.
  *
  * # Arguments
@@ -307,6 +343,51 @@ struct Value fwd_get_from_root(const struct DatabaseHandle *db,
  *
  */
 struct Value fwd_get_latest(const struct DatabaseHandle *db, struct Value key);
+
+/**
+ * Return an iterator optionally starting from a key in database
+ *
+ * # Arguments
+ *
+ * * `db` - The database handle returned by `open_db`
+ * * `key` - The key to start from, in `Value` form
+ *
+ * # Returns
+ *
+ * An iterator handle, or an error
+ *
+ * # Safety
+ *
+ * The caller must:
+ *  * ensure that `db` is a valid pointer returned by `open_db`
+ *  * ensure that `key` is a valid pointer to a `Value` struct
+ *  * TODO: Handle freeing the iterator handle
+ *
+ */
+struct IteratorCreationResult fwd_iter_latest(const struct DatabaseHandle *db, struct Value key);
+
+/**
+ * Retreives the next item from the iterator
+ *
+ * # Arguments
+ *
+ * * `db` - The database handle returned by `open_db`
+ * * `it` - The database handle returned by `fwd_iter_*`
+ *
+ * # Returns
+ *
+ * A `KeyValue` containing the next pair of (key, value) on the iterator.
+ * A `KeyValue` containing with key {0, ""}, and value with an error message if failed.
+ *
+ * # Safety
+ *
+ * The caller must:
+ *  * ensure that `db` is a valid pointer returned by `open_db`
+ *  * ensure that `it` is a valid pointer returned by `fwd_iter_*`
+ *  * call `free_key_value` to free the memory associated with the returned `KeyValue`
+ *
+ */
+struct KeyValue fwd_iter_next(const struct DatabaseHandle *db, const struct IteratorHandle *it);
 
 /**
  * Open a database with the given cache size and maximum number of revisions

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -995,13 +995,10 @@ func TestIterBasic(t *testing.T) {
 	handle, err := db.Iter(keys[3])
 	r.NoError(err)
 
-	kv, err := handle.Next()
-	r.NoError(err)
-	r.Equal(keys[3], kv.Key)
-	r.Equal(vals[3], kv.Value)
-
-	kv, err = handle.Next()
-	r.NoError(err)
-	r.Equal(keys[4], kv.Key)
-	r.Equal(vals[4], kv.Value)
+	for i := 3; handle.Next(); i += 1 {
+		t.Logf("%s => %s", string(handle.Key()), string(handle.Value()))
+		r.Equal(keys[i], handle.Key())
+		r.Equal(vals[i], handle.Value())
+	}
+	r.NoError(handle.Err())
 }

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -981,3 +981,27 @@ func TestGetFromRoot(t *testing.T) {
 	_, err = db.GetFromRoot(nonExistentRoot, []byte("key"))
 	r.Error(err, "GetFromRoot with non-existent root should return error")
 }
+
+// Tests that basic iterator functionality works
+func TestIterBasic(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	// Commit 10 key-value pairs.
+	keys, vals := kvForTest(20)
+	_, err := db.Update(keys[:10], vals[:10])
+	r.NoError(err)
+
+	handle, err := db.Iter(keys[3])
+	r.NoError(err)
+
+	kv, err := handle.Next()
+	r.NoError(err)
+	r.Equal(keys[3], kv.Key)
+	r.Equal(vals[3], kv.Value)
+
+	kv, err = handle.Next()
+	r.NoError(err)
+	r.Equal(keys[4], kv.Key)
+	r.Equal(vals[4], kv.Value)
+}

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -162,9 +162,13 @@ func kvFromKeyValue(v *C.struct_KeyValue) (*KeyValue, error) {
 		return nil, e
 	}
 
+	if kb == nil && vb == nil {
+		return nil, nil
+	}
+
 	if kb == nil {
 		// TODO: free
-		//C.fwd_free_value(v)
+		// C.fwd_free_value(v)
 		return nil, errors.New(string(vb))
 	}
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -188,7 +188,9 @@ fn iter_latest(db: Option<&DatabaseHandle<'_>>, key: &Value) -> Result<IteratorH
     // Find root hash.
     // Matches `hash` function but we use the TrieHash type here
     let Some(root) = db.root_hash_sync().map_err(|e| e.to_string())? else {
-        return Ok(IteratorHandle{ state: Mutex::new(Box::new(None)) });
+        return Ok(IteratorHandle {
+            state: Mutex::new(Box::new(None)),
+        });
     };
 
     // Find revision associated with root.
@@ -251,13 +253,15 @@ fn iter_next(
     let rev = db.revision_sync(root).map_err(|e| e.to_string())?;
 
     let merkle = Merkle::from(&rev);
-    let mut state = iterator_handle.state.lock().expect("iterator_handle lock is poisoned");
+    let mut state = iterator_handle
+        .state
+        .lock()
+        .expect("iterator_handle lock is poisoned");
     let inner_state = state.take();
-    let Some(inner_state) =  inner_state else {
+    let Some(inner_state) = inner_state else {
         return Ok(KeyValue::default());
     };
-    let mut stream =
-        MerkleKeyValueStream::from_internal_state(merkle.nodestore(), inner_state);
+    let mut stream = MerkleKeyValueStream::from_internal_state(merkle.nodestore(), inner_state);
     let next = stream.next_sync();
     **state = Some(stream.internal_state());
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -23,11 +23,11 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
-use firewood::db::{
-    BatchOp as DbBatchOp, Db, DbConfig, DbViewSync as _, DbViewSyncBytes, Proposal,
-};
+use firewood::db::{BatchOp as DbBatchOp, Db, DbConfig, DbViewSync, DbViewSyncBytes, Proposal};
 use firewood::manager::{CacheReadStrategy, RevisionManagerConfig};
 
+use firewood::merkle::Merkle;
+use firewood::stream::{MerkleKeyValueStream, NodeStreamState};
 use firewood::v2::api::HashKey;
 use metrics::counter;
 
@@ -66,6 +66,16 @@ pub struct DatabaseHandle<'p> {
 
     /// The database
     db: Db,
+}
+
+/// A handle to the iterator, returned and used by `fwd_iter_*`.
+///
+/// These handles are passed to the other FFI functions.
+///
+#[derive(Debug)]
+pub struct IteratorHandle {
+    /// Internal state of the iterator
+    state: Mutex<Box<Option<NodeStreamState>>>,
 }
 
 impl From<Db> for DatabaseHandle<'_> {
@@ -142,6 +152,123 @@ fn get_latest(db: Option<&DatabaseHandle<'_>>, key: &Value) -> Result<Value, Str
         .map_err(|e| e.to_string())?
         .ok_or("")?;
     Ok(value.into())
+}
+
+/// Return an iterator optionally starting from a key in database
+///
+/// # Arguments
+///
+/// * `db` - The database handle returned by `open_db`
+/// * `key` - The key to start from, in `Value` form
+///
+/// # Returns
+///
+/// An iterator handle, or an error
+///
+/// # Safety
+///
+/// The caller must:
+///  * ensure that `db` is a valid pointer returned by `open_db`
+///  * ensure that `key` is a valid pointer to a `Value` struct
+///  * TODO: Handle freeing the iterator handle
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_iter_latest(
+    db: Option<&DatabaseHandle<'_>>,
+    key: Value,
+) -> IteratorCreationResult {
+    iter_latest(db, &key).into()
+}
+
+/// Internal call for `fwd_iter_latest` to remove error handling from the C API
+#[doc(hidden)]
+fn iter_latest(db: Option<&DatabaseHandle<'_>>, key: &Value) -> Result<IteratorHandle, String> {
+    let db = db.ok_or("db should be non-null")?;
+
+    // Find root hash.
+    // Matches `hash` function but we use the TrieHash type here
+    let Some(root) = db.root_hash_sync().map_err(|e| e.to_string())? else {
+        todo!()
+    };
+
+    // Find revision associated with root.
+    let rev = db.revision_sync(root).map_err(|e| e.to_string())?;
+    let mk = Merkle::from(&rev);
+
+    let mkv = if key.len == 0 {
+        mk.key_value_iter()
+    } else {
+        mk.key_value_iter_from_key(key.as_slice())
+    };
+
+    Ok(IteratorHandle {
+        state: Mutex::new(Box::new(Some(mkv.internal_state()))),
+    })
+}
+
+/// Retreives the next item from the iterator
+///
+/// # Arguments
+///
+/// * `db` - The database handle returned by `open_db`
+/// * `it` - The database handle returned by `fwd_iter_*`
+///
+/// # Returns
+///
+/// A `KeyValue` containing the next pair of (key, value) on the iterator.
+/// A `KeyValue` containing with key {0, ""}, and value with an error message if failed.
+///
+/// # Safety
+///
+/// The caller must:
+///  * ensure that `db` is a valid pointer returned by `open_db`
+///  * ensure that `it` is a valid pointer returned by `fwd_iter_*`
+///  * call `free_key_value` to free the memory associated with the returned `KeyValue`
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_iter_next(
+    db: Option<&DatabaseHandle<'_>>,
+    it: Option<&IteratorHandle>,
+) -> KeyValue {
+    iter_next(db, it).unwrap_or_else(Into::into)
+}
+
+/// Internal call for `fwd_iter_next` to remove error handling from the C API
+#[doc(hidden)]
+fn iter_next(
+    db: Option<&DatabaseHandle<'_>>,
+    iterator_handle: Option<&IteratorHandle>,
+) -> Result<KeyValue, String> {
+    let db = db.ok_or("db should be non-null")?;
+    let iterator_handle = iterator_handle.ok_or("iterator_handle should be non-null")?;
+
+    // Find root hash.
+    // Matches `hash` function but we use the TrieHash type here
+    let Some(root) = db.root_hash_sync().map_err(|e| e.to_string())? else {
+        return Ok(KeyValue::default());
+    };
+    // Find revision associated with root.
+    let rev = db.revision_sync(root).map_err(|e| e.to_string())?;
+
+    let merkle = Merkle::from(&rev);
+    let mut state = iterator_handle.state.lock().expect("iterator_handle lock is poisoned");
+    let inner_state = state.take();
+    let Some(inner_state) =  inner_state else {
+        return Ok(KeyValue::default());
+    };
+    let mut stream =
+        MerkleKeyValueStream::from_internal_state(merkle.nodestore(), inner_state);
+    let next = stream.next_sync();
+
+    if let Some(next) = next {
+        let (k, v) = next.map_err(|e| e.to_string())?;
+        **state = Some(stream.internal_state());
+        let key: Value = k.into();
+        let value: Value = v.as_slice().into();
+        Ok(KeyValue { key, value })
+    } else {
+        Ok(KeyValue::default())
+    }
 }
 
 /// Gets the value associated with the given key from the proposal provided.
@@ -271,6 +398,7 @@ fn view_sync_from_root(
 }
 
 /// A `KeyValue` represents a key-value pair, passed to the FFI.
+#[derive(Debug, Default)]
 #[repr(C)]
 pub struct KeyValue {
     key: Value,
@@ -713,6 +841,15 @@ impl From<String> for Value {
     }
 }
 
+impl From<String> for KeyValue {
+    fn from(s: String) -> Self {
+        KeyValue {
+            key: Value::default(),
+            value: s.into(),
+        }
+    }
+}
+
 impl From<u32> for Value {
     fn from(v: u32) -> Self {
         // WARNING: This should only be called with values >= 1.
@@ -810,6 +947,62 @@ impl From<Result<Db, String>> for DatabaseCreationResult {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fwd_free_database_error_result(
     result: Option<&mut DatabaseCreationResult>,
+) {
+    let result = result.expect("result should be non-null");
+    // Free the error string if it exists
+    if let Some(nonnull) = result.error_str {
+        let raw_str = nonnull.cast::<c_char>().as_ptr();
+        let cstr = unsafe { CString::from_raw(raw_str) };
+        drop(cstr);
+    }
+    // Note: we don't free the db pointer as it's managed by the caller
+}
+
+/// Struct returned by `fwd_iter_*`
+#[derive(Debug)]
+#[repr(C)]
+pub struct IteratorCreationResult {
+    pub iterator: Option<Box<IteratorHandle>>,
+    pub error_str: Option<std::ptr::NonNull<u8>>,
+}
+
+impl From<Result<IteratorHandle, String>> for IteratorCreationResult {
+    fn from(result: Result<IteratorHandle, String>) -> Self {
+        match result {
+            Ok(handle) => IteratorCreationResult {
+                iterator: Some(Box::new(handle)),
+                error_str: None,
+            },
+            Err(error_msg) => {
+                let error_cstring = CString::new(error_msg).unwrap_or_default().into_raw();
+                IteratorCreationResult {
+                    iterator: None,
+                    error_str: std::ptr::NonNull::new(error_cstring.cast::<u8>()),
+                }
+            }
+        }
+    }
+}
+
+/// Frees the memory associated with a `IteratorCreationResult`.
+/// This only needs to be called if the `error_str` field is non-null.
+///
+/// # Arguments
+///
+/// * `result` - The `IteratorCreationResult` to free, previously returned from `fwd_iter_*`.
+///
+/// # Safety
+///
+/// This function is unsafe because it dereferences raw pointers.
+/// The caller must ensure that `result` is a valid pointer.
+///
+/// # Panics
+///
+/// This function panics if `result` is `null`.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_free_iterator_error_result(
+    result: Option<&mut IteratorCreationResult>,
 ) {
     let result = result.expect("result should be non-null");
     // Free the error string if it exists

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -269,7 +269,7 @@ fn iter_next(
     if let Some(next) = next {
         let (k, v) = next.map_err(|e| e.to_string())?;
         let key: Value = k.into();
-        let value: Value = v.as_slice().into();
+        let value: Value = v.into();
         Ok(KeyValue { key, value })
     } else {
         Ok(KeyValue::default())

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -17,7 +17,6 @@
 use crate::proof::{Proof, ProofError, ProofNode};
 #[cfg(test)]
 use crate::range_proof::RangeProof;
-#[cfg(test)]
 use crate::stream::MerkleKeyValueStream;
 use crate::stream::PathIterator;
 #[cfg(test)]
@@ -171,8 +170,8 @@ impl<T: TrieReader> Merkle<T> {
         self.nodestore.root_node()
     }
 
-    #[cfg(test)]
-    pub(crate) const fn nodestore(&self) -> &T {
+    /// retrieve the underlying nodestore
+    pub const fn nodestore(&self) -> &T {
         &self.nodestore
     }
 
@@ -237,17 +236,13 @@ impl<T: TrieReader> Merkle<T> {
     ) -> Result<PathIterator<'_, 'a, T>, FileIoError> {
         PathIterator::new(&self.nodestore, key)
     }
-
-    #[cfg(test)]
-    pub(super) fn key_value_iter(&self) -> MerkleKeyValueStream<'_, T> {
+    /// get an iterator on key values starting from beginning
+    pub fn key_value_iter(&self) -> MerkleKeyValueStream<'_, T> {
         MerkleKeyValueStream::from(&self.nodestore)
     }
 
-    #[cfg(test)]
-    pub(super) fn key_value_iter_from_key<K: AsRef<[u8]>>(
-        &self,
-        key: K,
-    ) -> MerkleKeyValueStream<'_, T> {
+    /// get an iterator on key values starting from key
+    pub fn key_value_iter_from_key<K: AsRef<[u8]>>(&self, key: K) -> MerkleKeyValueStream<'_, T> {
         // TODO danlaine: change key to &[u8]
         MerkleKeyValueStream::from_key(&self.nodestore, key.as_ref())
     }

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -401,13 +401,13 @@ impl<'a, T: TrieReader> MerkleKeyValueStream<'a, T> {
                         Some(Ok((key, node))) => match &*node {
                             Node::Branch(branch) => {
                                 if let Some(value) = branch.value.as_ref() {
-                                    return Some(Ok((key, value.to_vec())));
+                                    return Some(Ok((key, value.clone())));
                                 }
                                 // This node doesn't have a value to return.
                                 // Continue to the next node.
                             }
                             Node::Leaf(leaf) => {
-                                return Some(Ok((key, leaf.value.to_vec())));
+                                return Some(Ok((key, leaf.value.clone())));
                             }
                         },
                         Some(Err(e)) => return Some(Err(e.into())),


### PR DESCRIPTION
This draft is a step towards implementing the FFI iterator mentioned in #1009. The implementation is kept simple as possible for now without any batching and directly fetches the next item of the iterator. 

Steps on the list:
- [x] Implement a simple iterator in Go with `Next()`, `Key()`, `Value()`, and `Err()`, with proper Rust counterparts `fwd_iter_latest` and `fwd_iter_next`. 
- [ ] Implement `IterOnRoot` for creating an iterator associated with specified root, for a revision or an existing proposal.
- [ ] Explore batching for reduced overhead
- [ ] Optimize memory management for batching (avoiding large copies)
- [ ] Proper resource deallocation
- [ ] More tests