### PR TITLE
feat(checker): add EthKeySize error

### DIFF
--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -19,6 +19,8 @@ use std::ops::Range;
 
 use indicatif::ProgressBar;
 
+const VALID_ETH_KEY_SIZES: [usize; 2] = [64, 128]; // in number of nibbles - two nibbles make a byte
+
 /// Options for the checker
 #[derive(Debug)]
 pub struct CheckOpt {
@@ -153,10 +155,7 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
         let mut current_node_path = path_prefix.clone();
         current_node_path.0.extend_from_slice(node.partial_path());
         #[cfg(feature = "ethhash")]
-        if node.value().is_some()
-            && current_node_path.0.len() != 32
-            && current_node_path.0.len() != 64
-        {
+        if node.value().is_some() && !VALID_ETH_KEY_SIZES.contains(&current_node_path.0.len()) {
             return Err(CheckerError::EthKeySize {
                 key: current_node_path,
                 address: subtrie_root_address,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -261,6 +261,20 @@ pub enum CheckerError {
     #[error("The checker can only check persisted nodestores")]
     UnpersistedRoot,
 
+    #[cfg(feature = "ethhash")]
+    #[error(
+        "The node {key:?} at {address:#x} (parent: {parent:#x}) has a value but its path is not 32 or 64 bytes long"
+    )]
+    /// With ethhash, a value corresponds to a key that is not 32 or 64 bytes long
+    EthKeySize {
+        /// The key found, or equivalently the path of the node that stores the value
+        key: Path,
+        /// Address of the node
+        address: LinearAddress,
+        /// Parent of the node
+        parent: TrieNodeParent,
+    },
+
     /// IO error
     #[error("IO error")]
     #[derive_where(skip_inner)]


### PR DESCRIPTION
With ethhash, all values should correspond to a key with 32 or 64 bytes (64 or 128 nibbles). 