### PR TITLE
feat: Add lock to the deleted vector in MutableProposal

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -627,7 +627,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
     /// Each element of `key` is 1 nibble.
     /// Returns the new root of the subtrie.
     pub fn insert_helper(
-        &mut self,
+        &self,
         mut node: Node,
         key: &[u8],
         value: Value,
@@ -793,7 +793,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
     /// Each element of `key` is 1 nibble.
     #[expect(clippy::too_many_lines)]
     fn remove_helper(
-        &mut self,
+        &self,
         mut node: Node,
         key: &[u8],
     ) -> Result<(Option<Node>, Option<Value>), FileIoError> {
@@ -1019,7 +1019,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
     }
 
     fn remove_prefix_helper(
-        &mut self,
+        &self,
         mut node: Node,
         key: &[u8],
         deleted: &mut usize,
@@ -1154,7 +1154,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
 
     /// Recursively deletes all children of a branch node.
     fn delete_children(
-        &mut self,
+        &self,
         branch: &mut BranchNode,
         deleted: &mut usize,
     ) -> Result<(), FileIoError> {

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -240,13 +240,14 @@ impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
     }
 
     /// Marks the node at `addr` as deleted in this proposal.
-    /// 
+    ///
     /// # Panics
     ///
     /// Will panic if deleted is None
     pub fn delete_node(&self, node: MaybePersistedNode) {
         trace!("Pending delete at {node:?}");
-        self.kind.deleted
+        self.kind
+            .deleted
             .lock()
             .expect("failed lock acquire")
             .as_mut()
@@ -522,16 +523,16 @@ impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
             storage,
         } = val;
 
-        let deleted = kind
-            .deleted
-            .lock()
-            .expect("lock acquire failed")
-            .take()
-            .expect("none option");
         let mut nodestore = NodeStore {
             header,
             kind: Arc::new(ImmutableProposal {
-                deleted: deleted.into(),
+                deleted: kind
+                    .deleted
+                    .lock()
+                    .expect("lock acquire failed")
+                    .take()
+                    .expect("none option")
+                    .into(),
                 parent: Arc::new(ArcSwap::new(Arc::new(kind.parent))),
                 root_hash: None,
                 root: None,

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -243,7 +243,7 @@ impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
     /// 
     /// # Panics
     ///
-    /// Will panic if the deleted array is None
+    /// Will panic if deleted is None
     pub fn delete_node(&self, node: MaybePersistedNode) {
         trace!("Pending delete at {node:?}");
         self.kind.deleted

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -249,7 +249,7 @@ impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
         self.kind
             .deleted
             .lock()
-            .expect("failed lock acquire")
+            .expect("lock acquire failed")
             .as_mut()
             .expect("none option")
             .push(node);


### PR DESCRIPTION
This PR adds a lock to the deleted vector in MutableProsposal. This allows read_for_update in MutableProposal to take a &self instead of a &mut self, which in turn allows insert_helper, remove_helper, and remove_prefix_helper to take a &self instead of a &mut self.

The purpose of this change is to allow other threads (worker threads) to call insert_helper concurrently in certain cases. That change will be implemented in a later PR.

In a discussion with Ron, we considered two options for allowing concurrent access to the Merkle trie. The first is to create Merkle tries for each child node from the root, and the second was to allow concurrent updates to the MutableProposal. There are some potential performance advantages to the first option, but the second one (as implemented in this PR) will likely require fewer interface changes to implement.