### PR TITLE
feat(ffi): refactor FFI layer for improved modularity and consistency

### DIFF
--- a/benchmark/Grafana-dashboard.json
+++ b/benchmark/Grafana-dashboard.json
@@ -952,6 +952,375 @@
       ],
       "title": "Unwritten Nodes (In Memory)",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 14,
+      "panels": [],
+      "title": "FFI",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(firewood_ffi_batch[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "Batch",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(firewood_ffi_propose[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "Propose",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(firewood_ffi_commit[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "Commit",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "FFI Operation Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(firewood_ffi_batch_ms[$__rate_interval]) / rate(firewood_ffi_batch[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "Batch",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(firewood_ffi_propose_ms[$__rate_interval]) / rate(firewood_ffi_propose[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "Propose",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(firewood_ffi_commit_ms[$__rate_interval]) / rate(firewood_ffi_commit[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "Commit",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "FFI Operation Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum(increase(firewood_ffi_cached_view_hit[$__rate_interval])) / (sum(increase(firewood_ffi_cached_view_hit[$__rate_interval])) + sum(increase(firewood_ffi_cached_view_miss[$__rate_interval])))",
+          "instant": false,
+          "legendFormat": "Cache Hit Rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "FFI Cached View Hit Rate",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -23,7 +23,6 @@ crate-type = ["staticlib"]
 # Workspace dependencies
 coarsetime.workspace = true
 firewood.workspace = true
-log.workspace = true
 metrics.workspace = true
 metrics-util.workspace = true
 # Regular dependencies

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -183,10 +183,6 @@ func (db *Database) GetFromRoot(root, key []byte) ([]byte, error) {
 		return nil, nil // Empty root is treated as no data
 	}
 
-	if len(root) != RootLength {
-		return nil, errInvalidRootLength
-	}
-
 	rootKey, err := NewHashKey(root)
 	if err != nil {
 		return nil, fmt.Errorf("invalid root hash: %w", err)

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -226,8 +226,7 @@ func TestClosedDatabase(t *testing.T) {
 	r.Empty(root)
 	r.ErrorIs(err, errDBClosed)
 
-	err = db.Close()
-	r.ErrorIs(err, errDBClosed)
+	r.NoError(db.Close())
 }
 
 func keyForTest(i int) []byte {
@@ -514,21 +513,7 @@ func TestDropProposal(t *testing.T) {
 	_, err = proposal.Get([]byte("non-existent"))
 	r.ErrorIs(err, errDroppedProposal)
 	_, err = proposal.Root()
-	r.ErrorIs(err, errDroppedProposal)
-
-	// Attempt to "emulate" the proposal to ensure it isn't internally available still.
-	proposal = &Proposal{
-		handle: db.handle,
-		id:     1,
-	}
-
-	// Check all operations on the fake proposal.
-	_, err = proposal.Get([]byte("non-existent"))
-	r.Contains(err.Error(), "proposal not found", "Get(fake proposal)")
-	_, err = proposal.Propose([][]byte{[]byte("key")}, [][]byte{[]byte("value")})
-	r.Contains(err.Error(), "proposal not found", "Propose(fake proposal)")
-	err = proposal.Commit()
-	r.Contains(err.Error(), "proposal not found", "Commit(fake proposal)")
+	r.NoError(err, "Root of dropped proposal should still be accessible")
 }
 
 // Create a proposal with 10 key-value pairs.

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -6,7 +6,6 @@
 // [Firewood]: https://github.com/ava-labs/firewood
 package ffi
 
-// // Note that -lm is required on Linux but not on Mac.
 // #include <stdlib.h>
 // #include "firewood.h"
 import "C"
@@ -14,18 +13,41 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"log"
 	"runtime"
 	"unsafe"
 )
 
-var (
-	errNilStruct = errors.New("nil struct pointer cannot be freed")
-	errBadValue  = errors.New("value from cgo formatted incorrectly")
-)
+var errUnknown = errors.New("unknown error")
 
 type Pinner interface {
 	Pin(ptr any)
 	Unpin()
+}
+
+type ownedBytesAsError RustOwnedBytes
+
+func (e *ownedBytesAsError) Error() string {
+	if e == nil {
+		return errUnknown.Error()
+	}
+
+	return (*RustOwnedBytes)(e).string()
+}
+
+type HashKey [32]byte
+
+func NewHashKey(b []byte) (HashKey, error) {
+	if len(b) != 32 {
+		return HashKey{}, fmt.Errorf("hash key must be 32 bytes, got %d", len(b))
+	}
+	var key HashKey
+	copy(key[:], b)
+	return key, nil
+}
+
+func (h HashKey) toC() C.HashKey {
+	return *(*C.HashKey)(unsafe.Pointer(&h))
 }
 
 // newBorrowedBytes creates a new BorrowedBytes from a Go byte slice.
@@ -102,135 +124,314 @@ func newKeyValuePairs(keys, vals [][]byte, pinner Pinner) (C.BorrowedKeyValuePai
 	return newBorrowedKeyValuePairs(pairs, pinner), nil
 }
 
-// hashAndIDFromValue converts the cgo `Value` payload into:
+// free releases the memory associated with the Database.
 //
-//	case | data    | len   | meaning
+// This is not safe to call while there are any outstanding Proposals. All proposals
+// must be freed or committed before calling this.
 //
-// 1.    | nil     | 0     | invalid
-// 2.    | nil     | non-0 | proposal deleted everything
-// 3.    | non-nil | 0     | error string
-// 4.    | non-nil | non-0 | hash and id
+// This is safe to call if the pointer is nil, in which case it does nothing. The
+// pointer will be set to nil after freeing to prevent double free.
 //
-// The value should never be nil.
-func hashAndIDFromValue(v *C.struct_Value) ([]byte, uint32, error) {
-	// Pin the returned value to prevent it from being garbage collected.
-	defer runtime.KeepAlive(v)
-
-	if v == nil {
-		return nil, 0, errNilStruct
-	}
-
-	if v.data == nil {
-		// Case 2
-		if v.len != 0 {
-			return nil, uint32(v.len), nil
-		}
-
-		// Case 1
-		return nil, 0, errBadValue
-	}
-
-	// Case 3
-	if v.len == 0 {
-		errStr := C.GoString((*C.char)(unsafe.Pointer(v.data)))
-		C.fwd_free_value(v)
-		return nil, 0, errors.New(errStr)
-	}
-
-	// Case 4
-	id := uint32(v.len)
-	buf := C.GoBytes(unsafe.Pointer(v.data), RootLength)
-	v.len = C.size_t(RootLength) // set the length to free
-	C.fwd_free_value(v)
-	return buf, id, nil
-}
-
-// errorFromValue converts the cgo `Value` payload into:
+// clearFinalizer indicates whether to clear the finalizer to prevent double finalization.
 //
-//	case | data    | len   | meaning
-//
-// 1.    | nil     | 0     | empty
-// 2.    | nil     | non-0 | invalid
-// 3.    | non-nil | 0     | error string
-// 4.    | non-nil | non-0 | invalid
-//
-// The value should never be nil.
-func errorFromValue(v *C.struct_Value) error {
-	// Pin the returned value to prevent it from being garbage collected.
-	defer runtime.KeepAlive(v)
-
-	if v == nil {
-		return errNilStruct
-	}
-
-	// Case 1
-	if v.data == nil && v.len == 0 {
+// This should be false when called by the finalizer itself but true when called
+// from other code that explicitly frees the memory.
+func (db *Database) free(clearFinalizer bool) error {
+	if db == nil {
 		return nil
 	}
 
-	// Case 3
-	if v.len == 0 {
-		errStr := C.GoString((*C.char)(unsafe.Pointer(v.data)))
-		C.fwd_free_value(v)
-		return errors.New(errStr)
+	if clearFinalizer {
+		runtime.SetFinalizer(db, nil) // Prevent double finalization
 	}
 
-	// Case 2 and 4
-	C.fwd_free_value(v)
-	return errBadValue
+	ptr := db.handle
+	if ptr == nil {
+		return nil
+	}
+
+	// Set before freeing in case we panic or race with the finalizer
+	db.handle = nil
+
+	if err := fromVoidResult(C.fwd_close_db(ptr)); err != nil {
+		return fmt.Errorf("unexpected error when closing database: %w", err)
+	}
+
+	return nil
 }
 
-// bytesFromValue converts the cgo `Value` payload to:
+// free releases the memory associated with the Proposal.
 //
-//	case | data    | len   | meaning
+// This is safe to call if the pointer is nil, in which case it does nothing.
 //
-// 1.    | nil     | 0     | empty
-// 2.    | nil     | non-0 | invalid
-// 3.    | non-nil | 0     | error string
-// 4.    | non-nil | non-0 | bytes (most common)
-//
-// The value should never be nil.
-func bytesFromValue(v *C.struct_Value) ([]byte, error) {
-	// Pin the returned value to prevent it from being garbage collected.
-	defer runtime.KeepAlive(v)
-
-	if v == nil {
-		return nil, errNilStruct
+// The pointer will be set to nil after freeing to prevent double free.
+func (p *Proposal) free(clearFinalizer bool) error {
+	if p == nil {
+		return nil
 	}
 
-	// Case 4
-	if v.len != 0 && v.data != nil {
-		buf := C.GoBytes(unsafe.Pointer(v.data), C.int(v.len))
-		C.fwd_free_value(v)
-		return buf, nil
+	if clearFinalizer {
+		runtime.SetFinalizer(p, nil) // Prevent double finalization
 	}
 
-	// Case 1
-	if v.len == 0 && v.data == nil {
+	ptr := p.handle
+	if ptr == nil {
+		return nil
+	}
+
+	// Set before freeing in case we panic or race with the finalizer
+	p.handle = nil
+
+	if err := fromVoidResult(C.fwd_free_proposal(ptr)); err != nil {
+		return fmt.Errorf("unexpected error when freeing proposal: %w", err)
+	}
+
+	return nil
+}
+
+// RustOwnedBytes is a wrapper around C.OwnedBytes that provides a Go interface
+// for Rust-owned byte slices.
+type RustOwnedBytes struct {
+	owned C.OwnedBytes
+}
+
+// Free releases the memory associated with the RustOwnedBytes.
+//
+// It is safe to call this method multiple times, and it will do nothing if the
+// RustOwnedBytes is nil or has already been freed.
+func (b *RustOwnedBytes) Free() error {
+	return b.free(true)
+}
+
+func (b *RustOwnedBytes) free(clearFinalizer bool) error {
+	if b == nil {
+		return nil
+	}
+
+	if clearFinalizer {
+		runtime.SetFinalizer(b, nil) // Prevent double finalization
+	}
+
+	this := *b               // copy so we can reset before freeing,
+	b.owned = C.OwnedBytes{} // reset to clear the pointer
+
+	if this.owned.ptr == nil {
+		return nil
+	}
+
+	if err := fromVoidResult(C.fwd_free_owned_bytes(this.owned)); err != nil {
+		return fmt.Errorf("unexpected error when freeing owned bytes: %w", err)
+	}
+
+	return nil
+}
+
+// BorrowedBytes returns the underlying byte slice. It may return nil if the
+// data has already been freed was never set.
+//
+// The returned slice is valid only as long as the RustOwnedBytes is valid.
+//
+// It does not copy the data; however, the slice is valid only as long as the
+// RustOwnedBytes is valid. If the RustOwnedBytes is freed, the slice will
+// become invalid.
+func (b *RustOwnedBytes) BorrowedBytes() []byte {
+	if b == nil {
+		return nil
+	}
+
+	if b.owned.ptr == nil {
+		return nil
+	}
+
+	return unsafe.Slice((*byte)(b.owned.ptr), b.owned.len)
+}
+
+func (b *RustOwnedBytes) CopiedBytes() []byte {
+	if b == nil {
+		return nil
+	}
+
+	if b.owned.ptr == nil {
+		return nil
+	}
+
+	return C.GoBytes(unsafe.Pointer(b.owned.ptr), C.int(b.owned.len))
+}
+
+// string returns the string representation of the RustOwnedBytes.
+//
+// It is not exported because it should not be used except by types that are certain
+// that the RustOwnedBytes is of a utf-8 encoded string.
+func (b *RustOwnedBytes) string() string {
+	if b == nil {
+		return ""
+	}
+
+	if b.owned.ptr == nil {
+		return ""
+	}
+
+	return unsafe.String((*byte)(b.owned.ptr), b.owned.len)
+}
+
+// fromOwnedBytes creates a RustOwnedBytes from a C.OwnedBytes.
+//
+// It sets a finalizer to free the memory when the RustOwnedBytes is no longer
+// referenced. If the C.OwnedBytes is nil, it returns nil.
+func fromOwnedBytes(owned C.OwnedBytes) *RustOwnedBytes {
+	if owned.ptr == nil {
+		return nil
+	}
+
+	rustBytes := &RustOwnedBytes{owned: owned}
+	runtime.SetFinalizer(rustBytes, func(b *RustOwnedBytes) {
+		if err := b.free(false); err != nil {
+			log.Panicf("failed to free RustOwnedBytes: %v", err)
+		}
+	})
+
+	return rustBytes
+}
+
+// fromHashResult creates a byte slice or error from a C.HashResult.
+//
+// It returns nil, nil if the result is None.
+// It returns nil, err if the result is an error.
+// It returns a byte slice, nil if the result is Some.
+func fromHashResult(result C.HashResult) ([]byte, error) {
+	switch result.tag {
+	case C.HashResult_NullHandlePointer:
+		return nil, errDBClosed
+	case C.HashResult_None:
 		return nil, nil
+	case C.HashResult_Some:
+		// copy the bytes from the C.HashResult to a fixed-size array
+		hashKey := fromHashKey((*C.HashKey)(unsafe.Pointer(&result.anon0)))
+		return hashKey, nil
+	case C.HashResult_Err:
+		ownedBytes := fromOwnedBytes(*(*C.OwnedBytes)(unsafe.Pointer(&result.anon0)))
+		// the finalizer will free the memory when the pointer goes out of scope
+		return nil, (*ownedBytesAsError)(ownedBytes)
+	default:
+		return nil, fmt.Errorf("unknown C.HashResult tag: %d", result.tag)
 	}
-
-	// Case 3
-	if v.len == 0 {
-		errStr := C.GoString((*C.char)(unsafe.Pointer(v.data)))
-		C.fwd_free_value(v)
-		return nil, errors.New(errStr)
-	}
-
-	// Case 2
-	return nil, errBadValue
 }
 
-func databaseFromResult(result *C.struct_DatabaseCreationResult) (*C.DatabaseHandle, error) {
-	if result == nil {
-		return nil, errNilStruct
+// fromVoidResult converts a C.VoidResult to an error.
+//
+// It return nil if the result is Ok, otherwise it return an error.
+func fromVoidResult(result C.VoidResult) error {
+	switch result.tag {
+	case C.VoidResult_NullHandlePointer:
+		return errDBClosed
+	case C.VoidResult_Ok:
+		return nil
+	case C.VoidResult_Err:
+		ownedBytes := fromOwnedBytes(*(*C.OwnedBytes)(unsafe.Pointer(&result.anon0)))
+		// the finalizer will free the memory when the pointer goes out of scope
+		return (*ownedBytesAsError)(ownedBytes)
+	default:
+		return fmt.Errorf("unknown C.VoidResult tag: %d", result.tag)
 	}
+}
 
-	if result.error_str != nil {
-		errStr := C.GoString((*C.char)(unsafe.Pointer(result.error_str)))
-		C.fwd_free_database_error_result(result)
-		runtime.KeepAlive(result)
-		return nil, errors.New(errStr)
+// fromValueResult converts a C.ValueResult to a byte slice or error.
+//
+// It returns nil, nil if the result is None.
+// It returns nil, errRevisionNotFound if the result is RevisionNotFound.
+// It returns a byte slice, nil if the result is Some.
+// It returns an error if the result is an error.
+func fromValueResult(result C.ValueResult) ([]byte, error) {
+	switch result.tag {
+	case C.ValueResult_NullHandlePointer:
+		return nil, errDBClosed
+	case C.ValueResult_RevisionNotFound:
+		// NOTE: the result value contains the provided root hash, we could use
+		// it in the error message if needed.
+		return nil, errRevisionNotFound
+	case C.ValueResult_None:
+		return nil, nil
+	case C.ValueResult_Some:
+		ownedBytes := fromOwnedBytes(*(*C.OwnedBytes)(unsafe.Pointer(&result.anon0)))
+		bytes := ownedBytes.CopiedBytes()
+		if err := ownedBytes.Free(); err != nil {
+			return nil, fmt.Errorf("failed to free owned bytes: %w", err)
+		}
+		return bytes, nil
+	case C.ValueResult_Err:
+		ownedBytes := fromOwnedBytes(*(*C.OwnedBytes)(unsafe.Pointer(&result.anon0)))
+		// the finalizer will free the memory when the pointer goes out of scope
+		return nil, (*ownedBytesAsError)(ownedBytes)
+	default:
+		return nil, fmt.Errorf("unknown C.ValueResult tag: %d", result.tag)
 	}
-	return result.db, nil
+}
+
+// fromHandleResult converts a C.HandleResult to a Database or error.
+//
+// It sets a finalizer to free the memory when the Database is no longer
+// referenced.
+//
+// If the C.HandleResult is an error, it returns an error instead of a Database.
+func fromHandleResult(result C.HandleResult) (*Database, error) {
+	switch result.tag {
+	case C.HandleResult_Ok:
+		ptr := *(**C.DatabaseHandle)(unsafe.Pointer(&result.anon0))
+		db := &Database{
+			handle: ptr,
+		}
+		runtime.SetFinalizer(db, func(db *Database) {
+			if err := db.free(false); err != nil {
+				log.Panicf("failed to free Database: %v", err)
+			}
+		})
+		return db, nil
+	case C.HandleResult_Err:
+		ownedBytes := fromOwnedBytes(*(*C.OwnedBytes)(unsafe.Pointer(&result.anon0)))
+		// the finalizer will free the memory when the pointer goes out of scope
+		return nil, (*ownedBytesAsError)(ownedBytes)
+	default:
+		return nil, fmt.Errorf("unknown C.HandleResult tag: %d", result.tag)
+	}
+}
+
+// fromProposalResult converts a C.ProposalResult to a Proposal or error.
+//
+// It sets a finalizer to free the memory when the Proposal is no longer
+// referenced. However, there is no guarantee that the Proposal will be free
+// before the Database is closed, so it is recommended to call Commit() or Free()
+// on the Proposal before closing the Database.
+func fromProposalResult(result C.ProposalResult, db *Database) (*Proposal, error) {
+	switch result.tag {
+	case C.ProposalResult_NullHandlePointer:
+		return nil, errDBClosed
+	case C.ProposalResult_Ok:
+		body := (*C.ProposalResult_Ok_Body)(unsafe.Pointer(&result.anon0))
+		proposal := &Proposal{
+			db:     db,
+			handle: body.handle,
+			root:   fromHashKey(&body.root_hash),
+		}
+		runtime.SetFinalizer(proposal, func(p *Proposal) {
+			if err := p.free(false); err != nil {
+				log.Panicf("failed to free Proposal: %v", err)
+			}
+		})
+		return proposal, nil
+	case C.ProposalResult_Err:
+		ownedBytes := fromOwnedBytes(*(*C.OwnedBytes)(unsafe.Pointer(&result.anon0)))
+		// the finalizer will free the memory when the pointer goes out of scope
+		return nil, (*ownedBytesAsError)(ownedBytes)
+	default:
+		return nil, fmt.Errorf("unknown C.ProposalResult tag: %d", result.tag)
+	}
+}
+
+func fromHashKey(key *C.HashKey) []byte {
+	if key == nil {
+		return nil
+	}
+	hashKey := make([]byte, 32)
+	copy(hashKey, unsafe.Slice((*byte)(unsafe.Pointer(key)), 32))
+	return hashKey
 }

--- a/ffi/metrics_test.go
+++ b/ffi/metrics_test.go
@@ -40,7 +40,7 @@ func TestMetrics(t *testing.T) {
 
 	var logsDisabled bool
 	if err := StartLogs(logConfig); err != nil {
-		r.Contains(err.Error(), "logger feature is disabled")
+		r.Contains(err.Error(), "Logging is not available")
 		logsDisabled = true
 	}
 

--- a/ffi/proposal.go
+++ b/ffi/proposal.go
@@ -18,58 +18,28 @@ import (
 var errDroppedProposal = errors.New("proposal already dropped")
 
 type Proposal struct {
-	// handle is returned and accepted by cgo functions. It MUST be treated as
-	// an opaque value without special meaning.
-	// https://en.wikipedia.org/wiki/Blinkenlights
-	handle *C.DatabaseHandle
+	// The database this proposal is associated with. We hold onto this to ensure
+	// the database handle outlives the proposal handle, which is required for
+	// the proposal to be valid.
+	db *Database
 
-	// The proposal ID.
-	// id = 0 is reserved for a dropped proposal.
-	id uint32
+	// handle is an opaque pointer to the proposal within Firewood. It should be
+	// passed to the C FFI functions that operate on proposals
+	//
+	// It is not safe to call these methods with a nil handle.
+	//
+	// Calls to `C.fwd_commit_proposal` and `C.fwd_free_proposal` will invalidate
+	// this handle, so it should not be used after those calls.
+	handle *C.ProposalHandle
 
 	// The proposal root hash.
 	root []byte
-}
-
-// newProposal creates a new Proposal from the given DatabaseHandle and Value.
-// The Value must be returned from a Firewood FFI function.
-// An error can only occur from parsing the Value.
-func newProposal(handle *C.DatabaseHandle, val *C.struct_Value) (*Proposal, error) {
-	bytes, id, err := hashAndIDFromValue(val)
-	if err != nil {
-		return nil, err
-	}
-
-	// If the proposal root is nil, it means the proposal is empty.
-	if bytes == nil {
-		bytes = make([]byte, RootLength)
-	}
-
-	return &Proposal{
-		handle: handle,
-		id:     id,
-		root:   bytes,
-	}, nil
 }
 
 // Root retrieves the root hash of the proposal.
 // If the proposal is empty (i.e. no keys in database),
 // it returns nil, nil.
 func (p *Proposal) Root() ([]byte, error) {
-	if p.handle == nil {
-		return nil, errDBClosed
-	}
-
-	if p.id == 0 {
-		return nil, errDroppedProposal
-	}
-
-	// If the hash is empty, return the empty root hash.
-	if p.root == nil {
-		return make([]byte, RootLength), nil
-	}
-
-	// Get the root hash of the proposal.
 	return p.root, nil
 }
 
@@ -77,29 +47,21 @@ func (p *Proposal) Root() ([]byte, error) {
 // If the key does not exist, it returns (nil, nil).
 func (p *Proposal) Get(key []byte) ([]byte, error) {
 	if p.handle == nil {
-		return nil, errDBClosed
-	}
-
-	if p.id == 0 {
 		return nil, errDroppedProposal
 	}
 
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
 
-	// Get the value for the given key.
-	val := C.fwd_get_from_proposal(p.handle, C.uint32_t(p.id), newBorrowedBytes(key, &pinner))
-	return bytesFromValue(&val)
+	borrowed := newBorrowedBytes(key, &pinner)
+
+	return fromValueResult(C.fwd_get_from_proposal(p.handle, borrowed))
 }
 
 // Propose creates a new proposal with the given keys and values.
 // The proposal is not committed until Commit is called.
 func (p *Proposal) Propose(keys, vals [][]byte) (*Proposal, error) {
 	if p.handle == nil {
-		return nil, errDBClosed
-	}
-
-	if p.id == 0 {
 		return nil, errDroppedProposal
 	}
 
@@ -111,48 +73,29 @@ func (p *Proposal) Propose(keys, vals [][]byte) (*Proposal, error) {
 		return nil, err
 	}
 
-	// Propose the keys and values.
-	val := C.fwd_propose_on_proposal(p.handle, C.uint32_t(p.id), kvp)
-
-	return newProposal(p.handle, &val)
+	return fromProposalResult(C.fwd_propose_on_proposal(p.handle, kvp), p.db)
 }
 
 // Commit commits the proposal and returns any errors.
-// If an error occurs, the proposal is dropped and no longer valid.
+//
+// The proposal handle is no longer valid after this call, but the root
+// hash can still be retrieved using Root().
 func (p *Proposal) Commit() error {
 	if p.handle == nil {
-		return errDBClosed
-	}
-
-	if p.id == 0 {
 		return errDroppedProposal
 	}
 
-	// Commit the proposal and return the hash.
-	errVal := C.fwd_commit(p.handle, C.uint32_t(p.id))
-	err := errorFromValue(&errVal)
+	_, err := fromHashResult(C.fwd_commit_proposal(p.handle))
+	p.handle = nil // we no longer own the proposal handle
+
 	if err != nil {
-		// this is unrecoverable due to Rust's ownership model
-		// The underlying proposal is no longer valid.
-		p.id = 0
+		return err
 	}
-	return err
+
+	return nil
 }
 
 // Drop removes the proposal from memory in Firewood.
-// In the case of an error, the proposal can assumed to be dropped.
-// An error is returned if the proposal was already dropped.
 func (p *Proposal) Drop() error {
-	if p.handle == nil {
-		return errDBClosed
-	}
-
-	if p.id == 0 {
-		return errDroppedProposal
-	}
-
-	// Drop the proposal.
-	val := C.fwd_drop_proposal(p.handle, C.uint32_t(p.id))
-	p.id = 0
-	return errorFromValue(&val)
+	return p.free(true)
 }

--- a/ffi/src/arc_cache.rs
+++ b/ffi/src/arc_cache.rs
@@ -1,0 +1,91 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+//! A simple single-item cache for database views.
+//!
+//! This module provides [`ArcCache`], a thread-safe cache that holds at most one
+//! key-value pair. It's specifically designed to cache database views in the FFI
+//! layer to improve performance by avoiding repeated view creation for the same
+//! root hash during database operations.
+
+use std::sync::{Arc, Mutex};
+
+/// A thread-safe single-item cache that stores key-value pairs as `Arc<V>`.
+///
+/// This cache is optimized for scenarios where you frequently access the same
+/// item and want to avoid expensive recomputation. It holds at most one cached
+/// entry and replaces it when a different key is requested.
+///
+/// The cache is thread-safe and uses a mutex to protect concurrent access.
+/// Values are stored as `Arc<V>` to allow cheap cloning and sharing across
+/// threads.
+#[derive(Debug)]
+pub struct ArcCache<K, V: ?Sized> {
+    cache: Mutex<Option<(K, Arc<V>)>>,
+}
+
+impl<K: PartialEq, V: ?Sized> ArcCache<K, V> {
+    pub const fn new() -> Self {
+        ArcCache {
+            cache: Mutex::new(None),
+        }
+    }
+
+    /// Gets the cached value for the given key, or creates and caches a new value.
+    ///
+    /// If the cache contains an entry with a key equal to the provided key,
+    /// returns a clone of the cached `Arc<V>`. Otherwise, calls the factory
+    /// function to create a new value, caches it, and returns it.
+    ///
+    /// # Cache Behavior
+    ///
+    /// - Cache hit: Returns the cached value immediately
+    /// - Cache miss: Clears any existing cache entry, calls factory, caches the result
+    /// - Factory error: Cache is cleared and the error is propagated
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to look up or cache
+    /// * `factory` - A function that creates the value if not cached. It receives
+    ///   a reference to the key as an argument.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error produced by the factory function.
+    pub fn get_or_try_insert_with<E>(
+        &self,
+        key: K,
+        factory: impl FnOnce(&K) -> Result<Arc<V>, E>,
+    ) -> Result<Arc<V>, E> {
+        let mut cache = self
+            .cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some((cached_key, value)) = cache.as_ref() {
+            if *cached_key == key {
+                return Ok(Arc::clone(value));
+            }
+        }
+
+        // clear the cache before running the factory in case it fails
+        *cache = None;
+
+        let value = factory(&key)?;
+        *cache = Some((key, Arc::clone(&value)));
+
+        Ok(value)
+    }
+
+    pub fn clear(&self) {
+        self.cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+    }
+}
+
+impl<K: PartialEq, T: ?Sized> Default for ArcCache<K, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -1,0 +1,303 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use std::{num::NonZeroUsize, sync::Arc};
+
+use firewood::{
+    db::{Db, DbConfig, DbViewSyncBytes},
+    manager::RevisionManagerConfig,
+    v2::api::{self, HashKey, HashKeyExt, KeyValuePairIter},
+};
+
+use crate::{BorrowedBytes, CView, CreateProposalResult, KeyValuePair, arc_cache::ArcCache};
+
+use metrics::counter;
+
+const DEFAULT_CACHE_SIZE: NonZeroUsize = const { NonZeroUsize::new(1_500_000).unwrap() };
+const DEFAULT_FREE_LIST_CACHE_SIZE: NonZeroUsize = const { NonZeroUsize::new(40_000).unwrap() };
+const DEFAULT_REVISIONS: usize = 128;
+
+/// The cache read strategy to use for the database.
+///
+/// This controls what types of database operations are cached to improve
+/// performance by avoiding redundant disk reads and computations.
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum CacheReadStrategy {
+    /// Only cache write operations. This is the most conservative strategy
+    /// that minimizes memory usage but may result in more disk reads.
+    WritesOnly = 0,
+
+    /// Cache both write operations and branch node reads. This provides
+    /// better performance for tree traversal operations while keeping
+    /// memory usage moderate.
+    BranchReads = 1,
+
+    /// Cache all read and write operations. This provides the best performance
+    /// but uses the most memory as it caches leaf nodes and values in addition
+    /// to branch nodes.
+    All = 2,
+}
+
+impl From<CacheReadStrategy> for firewood::manager::CacheReadStrategy {
+    fn from(strategy: CacheReadStrategy) -> Self {
+        match strategy {
+            CacheReadStrategy::WritesOnly => firewood::manager::CacheReadStrategy::WritesOnly,
+            CacheReadStrategy::BranchReads => firewood::manager::CacheReadStrategy::BranchReads,
+            CacheReadStrategy::All => firewood::manager::CacheReadStrategy::All,
+        }
+    }
+}
+
+impl From<firewood::manager::CacheReadStrategy> for CacheReadStrategy {
+    fn from(strategy: firewood::manager::CacheReadStrategy) -> Self {
+        match strategy {
+            firewood::manager::CacheReadStrategy::WritesOnly => CacheReadStrategy::WritesOnly,
+            firewood::manager::CacheReadStrategy::BranchReads => CacheReadStrategy::BranchReads,
+            firewood::manager::CacheReadStrategy::All => CacheReadStrategy::All,
+        }
+    }
+}
+
+/// Arguments for creating or opening a database. These are passed to [`fwd_open_db`]
+///
+/// [`fwd_open_db`]: crate::fwd_open_db
+#[repr(C)]
+#[derive(Debug)]
+pub struct DatabaseHandleArgs<'a> {
+    /// The path to the database file.
+    ///
+    /// This must be a valid UTF-8 string, even on Windows.
+    ///
+    /// If this is empty, an error will be returned.
+    pub path: BorrowedBytes<'a>,
+
+    /// The size of the node cache. If zero, the default size of 1,500,000 nodes
+    /// will be used.
+    pub cache_size: usize,
+
+    /// The size of the free list cache. If zero, the default size of 40,000 nodes
+    /// will be used.
+    pub free_list_cache_size: usize,
+
+    /// The maximum number of revisions to keep. If zero, the default of 128
+    /// revisions will be used.
+    ///
+    /// If this is less than 2, an error will be returned.
+    pub revisions: usize,
+
+    /// The cache read strategy to use.
+    pub strategy: CacheReadStrategy,
+
+    /// Whether to truncate the database file if it exists.
+    pub truncate: bool,
+}
+
+impl DatabaseHandleArgs<'_> {
+    const fn cache_size(&self) -> NonZeroUsize {
+        match NonZeroUsize::new(self.cache_size) {
+            Some(size) => size,
+            None => DEFAULT_CACHE_SIZE,
+        }
+    }
+
+    const fn free_list_cache_size(&self) -> NonZeroUsize {
+        match NonZeroUsize::new(self.free_list_cache_size) {
+            Some(size) => size,
+            None => DEFAULT_FREE_LIST_CACHE_SIZE,
+        }
+    }
+
+    const fn revisions(&self) -> usize {
+        if self.revisions == 0 {
+            DEFAULT_REVISIONS
+        } else {
+            // if 1, building the revision manager will fail, but that's on the caller
+            self.revisions
+        }
+    }
+
+    fn as_rev_manager_config(&self) -> RevisionManagerConfig {
+        RevisionManagerConfig::builder()
+            .node_cache_size(self.cache_size())
+            .free_list_cache_size(self.free_list_cache_size())
+            .max_revisions(self.revisions())
+            .cache_read_strategy(self.strategy.into())
+            .build()
+    }
+}
+
+/// A handle to the database, returned by `fwd_open_db`.
+///
+/// These handles are passed to the other FFI functions.
+///
+#[derive(Debug)]
+#[repr(C)]
+pub struct DatabaseHandle {
+    /// A single cached view to improve performance of reads while committing
+    cached_view: ArcCache<HashKey, dyn DbViewSyncBytes>,
+
+    /// The database
+    db: Db,
+}
+
+impl DatabaseHandle {
+    /// Creates a new database handle from the given arguments.
+    ///
+    /// # Errors
+    ///
+    /// If the path is empty, or if the configuration is invalid, this will return an error.
+    pub fn new(args: DatabaseHandleArgs<'_>) -> Result<Self, api::Error> {
+        let cfg = DbConfig::builder()
+            .truncate(args.truncate)
+            .manager(args.as_rev_manager_config())
+            .build();
+
+        let path = args
+            .path
+            .as_str()
+            .map_err(|err| invalid_data(format!("database path contains invalid utf-8: {err}")))?;
+
+        if path.is_empty() {
+            return Err(invalid_data("database path cannot be empty"));
+        }
+
+        Db::new_sync(path, cfg).map(Self::from)
+    }
+
+    /// Returns the current root hash of the database.
+    ///
+    /// # Errors
+    ///
+    /// An error is returned if there was an i/o error while reading the root hash.
+    pub fn current_root_hash(&self) -> Result<Option<HashKey>, api::Error> {
+        self.db.root_hash_sync()
+    }
+
+    /// Returns a value from the database for the given key from the latest root hash.
+    ///
+    /// # Errors
+    ///
+    /// An error is returned if there was an i/o error while reading the value.
+    pub fn get_latest(&self, key: impl AsRef<[u8]>) -> Result<Option<Box<[u8]>>, api::Error> {
+        let Some(root) = self.current_root_hash()? else {
+            return Err(api::Error::RevisionNotFound {
+                provided: HashKey::default_root_hash(),
+            });
+        };
+
+        self.db
+            .revision_sync(root)?
+            .val_sync_bytes(key.as_ref())
+            .map_err(api::Error::from)
+    }
+
+    /// Returns a value from the database for the given key from the specified root hash.
+    ///
+    /// # Errors
+    ///
+    /// An error is returned if the root hash is invalid or if there was an i/o error
+    /// while reading the value.
+    pub fn get_from_root(
+        &self,
+        root: HashKey,
+        key: impl AsRef<[u8]>,
+    ) -> Result<Option<Box<[u8]>>, api::Error> {
+        self.get_root(root)?
+            .val_sync_bytes(key.as_ref())
+            .map_err(api::Error::from)
+    }
+
+    /// Creates a proposal with the given values and returns the proposal and the start time.
+    ///
+    /// # Errors
+    ///
+    /// An error is returned if the proposal could not be created.
+    pub fn create_batch<'kvp>(
+        &self,
+        values: (impl AsRef<[KeyValuePair<'kvp>]> + 'kvp),
+    ) -> Result<Option<HashKey>, api::Error> {
+        let CreateProposalResult { handle, start_time } =
+            self.create_proposal_handle(values.as_ref())?;
+
+        let root_hash = handle.commit_proposal(|commit_time| {
+            counter!("firewood.ffi.commit_ms").increment(commit_time.as_millis());
+        })?;
+
+        counter!("firewood.ffi.batch_ms").increment(start_time.elapsed().as_millis());
+        counter!("firewood.ffi.batch").increment(1);
+
+        Ok(root_hash)
+    }
+
+    pub(crate) fn get_root(&self, root: HashKey) -> Result<Arc<dyn DbViewSyncBytes>, api::Error> {
+        // construct outside of the closure so that when the closure is dropped
+        // without executing, it triggers the hit counter
+        let token = CachedViewHitOnDrop;
+        self.cached_view.get_or_try_insert_with(root, move |key| {
+            token.miss();
+            self.db.view_sync(HashKey::clone(key)).map(Arc::from)
+        })
+    }
+
+    pub(crate) fn clear_cached_view(&self) {
+        self.cached_view.clear();
+    }
+}
+
+impl From<Db> for DatabaseHandle {
+    fn from(db: Db) -> Self {
+        Self {
+            db,
+            cached_view: ArcCache::new(),
+        }
+    }
+}
+
+/// A RAII metrics helper that tracks cache hits and misses for database views.
+///
+/// This type uses the drop pattern to automatically record cache metrics:
+/// - By default, dropping this type records a cache hit
+/// - Calling [`Self::miss`] before dropping records a cache miss instead
+///
+/// This ensures that every cache lookup is properly tracked in metrics without
+/// requiring manual instrumentation at each call site.
+///
+/// # Metrics Recorded
+///
+/// - `firewood.ffi.cached_view.hit` - Incremented when the cache lookup succeeds
+/// - `firewood.ffi.cached_view.miss` - Incremented when the cache lookup fails
+struct CachedViewHitOnDrop;
+
+impl Drop for CachedViewHitOnDrop {
+    fn drop(&mut self) {
+        counter!("firewood.ffi.cached_view.hit").increment(1);
+    }
+}
+
+impl CachedViewHitOnDrop {
+    fn miss(self) {
+        std::mem::forget(self);
+        counter!("firewood.ffi.cached_view.miss").increment(1);
+    }
+}
+
+impl<'db> CView<'db> for &'db crate::DatabaseHandle {
+    fn handle(&self) -> &'db crate::DatabaseHandle {
+        self
+    }
+
+    fn create_proposal<'kvp>(
+        self,
+        values: (impl AsRef<[KeyValuePair<'kvp>]> + 'kvp),
+    ) -> Result<firewood::db::Proposal<'db>, api::Error> {
+        self.db
+            .propose_sync(values.as_ref().iter().map_into_batch())
+    }
+}
+
+type BoxErr = Box<dyn std::error::Error + Send + Sync>;
+
+fn invalid_data(error: impl Into<BoxErr>) -> api::Error {
+    api::Error::IO(std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -14,10 +14,6 @@
     unsafe_code,
     reason = "This is an FFI library, so unsafe code is expected."
 )]
-#![expect(
-    clippy::undocumented_unsafe_blocks,
-    reason = "https://github.com/ava-labs/firewood/pull/1158 will remove"
-)]
 #![cfg_attr(
     not(target_pointer_width = "64"),
     forbid(
@@ -26,22 +22,18 @@
     )
 )]
 
+mod arc_cache;
+mod handle;
+mod logging;
 mod metrics_setup;
+mod proposal;
 mod value;
 
-use std::collections::HashMap;
-use std::ffi::{CStr, CString, c_char};
-use std::fmt::{self, Display, Formatter};
-use std::ops::Deref;
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Mutex, RwLock};
+use firewood::db::DbViewSync;
 
-use firewood::db::{Db, DbConfig, DbViewSync as _, DbViewSyncBytes, Proposal};
-use firewood::manager::{CacheReadStrategy, RevisionManagerConfig};
-
-use firewood::v2::api::{HashKey, KeyValuePairIter};
-use metrics::counter;
-
+pub use crate::handle::*;
+pub use crate::logging::*;
+pub use crate::proposal::*;
 pub use crate::value::*;
 
 #[cfg(unix)]
@@ -49,165 +41,114 @@ pub use crate::value::*;
 #[doc(hidden)]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-type ProposalId = u32;
-
-#[doc(hidden)]
-static ID_COUNTER: AtomicU32 = AtomicU32::new(1);
-
-/// Atomically retrieves the next proposal ID.
-#[doc(hidden)]
-fn next_id() -> ProposalId {
-    ID_COUNTER.fetch_add(1, Ordering::Relaxed)
-}
-
-/// A handle to the database, returned by `fwd_create_db` and `fwd_open_db`.
+/// Invokes a closure and returns the result as a [`CResult`].
 ///
-/// These handles are passed to the other FFI functions.
+/// If the closure panics, it will return [`CResult::from_panic`] with the panic
+/// information.
+#[inline]
+fn invoke<T: CResult, V: Into<T>>(once: impl FnOnce() -> V) -> T {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(once)) {
+        Ok(result) => result.into(),
+        Err(panic) => T::from_panic(panic),
+    }
+}
+
+/// Invokes a closure that requires a handle and returns the result as a [`NullHandleResult`].
 ///
-#[derive(Debug)]
-pub struct DatabaseHandle<'p> {
-    /// List of oustanding proposals, by ID
-    // Keep proposals first, as they must be dropped before the database handle is dropped due to lifetime
-    // issues.
-    proposals: RwLock<HashMap<ProposalId, Proposal<'p>>>,
-
-    /// A single cached view to improve performance of reads while committing
-    cached_view: Mutex<Option<(HashKey, Box<dyn DbViewSyncBytes>)>>,
-
-    /// The database
-    db: Db,
-}
-
-impl From<Db> for DatabaseHandle<'_> {
-    fn from(db: Db) -> Self {
-        Self {
-            db,
-            proposals: RwLock::new(HashMap::new()),
-            cached_view: Mutex::new(None),
-        }
+/// If the provided handle is [`None`], the function will return early with the
+/// [`NullHandleResult::null_handle_pointer_error`] result.
+///
+/// Otherwise, the closure is invoked with the handle. If the closure panics,
+/// it will be caught and returned as a [`CResult::from_panic`].
+#[inline]
+fn invoke_with_handle<H, T: NullHandleResult, V: Into<T>>(
+    handle: Option<H>,
+    once: impl FnOnce(H) -> V,
+) -> T {
+    match handle {
+        Some(handle) => invoke(move || once(handle)),
+        None => T::null_handle_pointer_error(),
     }
 }
 
-impl DatabaseHandle<'_> {
-    fn clear_cached_view(&self) {
-        self.cached_view
-            .lock()
-            .expect("cached_view lock is poisoned")
-            .take();
-    }
-}
-
-impl Deref for DatabaseHandle<'_> {
-    type Target = Db;
-
-    fn deref(&self) -> &Self::Target {
-        &self.db
-    }
-}
-
-/// Gets the value associated with the given key from the database.
+/// Open a database with the given arguments.
 ///
 /// # Arguments
 ///
-/// * `db` - The database handle returned by `open_db`
-/// * `key` - The key to look up, in `BorrowedBytes` form
+/// See [`DatabaseHandleArgs`].
 ///
 /// # Returns
 ///
-/// A `Value` containing the requested value.
-/// A `Value` containing {0, "error message"} if the get failed.
-/// There is one error case that may be expected to be null by the caller,
-/// but should be handled externally: The database has no entries - "IO error: Root hash not found"
-/// This is expected behavior if the database is empty.
+/// - [`HandleResult::Ok`] with the database handle if successful.
+/// - [`HandleResult::Err`] if an error occurs while opening the database.
 ///
 /// # Safety
 ///
 /// The caller must:
-///  * ensure that `db` is a valid pointer returned by `open_db`
-///  * ensure that `key` is a valid pointer to a `Value` struct
-///  * call `free_value` to free the memory associated with the returned `Value`
+/// - ensure that the database is freed with [`fwd_close_db`] when no longer needed.
+/// - ensure that the database handle is freed only after freeing or committing
+///   all proposals created on it.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_open_db(args: DatabaseHandleArgs) -> HandleResult {
+    invoke(move || DatabaseHandle::new(args))
+}
+
+/// Get the root hash of the latest version of the database
 ///
+/// # Argument
+///
+/// * `db` - The database handle returned by [`fwd_open_db`]
+///
+/// # Returns
+///
+/// - [`HashResult::NullHandlePointer`] if the provided database handle is null.
+/// - [`HashResult::None`] if the database is empty.
+/// - [`HashResult::Some`] with the root hash of the database.
+/// - [`HashResult::Err`] if an error occurred while looking up the root hash.
+///
+/// # Safety
+///
+/// * ensure that `db` is a valid pointer to a [`DatabaseHandle`]
+/// * call [`fwd_free_owned_bytes`] to free the memory associated with the
+///   returned error ([`HashKey`] does not need to be freed as it is returned
+///   by value).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_root_hash(db: Option<&DatabaseHandle>) -> HashResult {
+    invoke_with_handle(db, DatabaseHandle::current_root_hash)
+}
+
+/// Gets the value associated with the given key from the database for the
+/// latest revision.
+///
+/// # Arguments
+///
+/// * `db` - The database handle returned by [`fwd_open_db`]
+/// * `key` - The key to look up as a [`BorrowedBytes`]
+///
+/// # Returns
+///
+/// - [`ValueResult::NullHandlePointer`] if the provided database handle is null.
+/// - [`ValueResult::RevisionNotFound`] if no revision was found for the root
+///   (i.e., there is no current root).
+/// - [`ValueResult::None`] if the key was not found.
+/// - [`ValueResult::Some`] if the key was found with the associated value.
+/// - [`ValueResult::Err`] if an error occurred while retrieving the value.
+///
+/// # Safety
+///
+/// The caller must:
+/// * ensure that `db` is a valid pointer to a [`DatabaseHandle`].
+/// * ensure that `key` is valid for [`BorrowedBytes`]
+/// * call [`fwd_free_owned_bytes`] to free the memory associated with the
+///   returned error or value.
+///
+/// [`BorrowedBytes`]: crate::value::BorrowedBytes
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fwd_get_latest(
-    db: Option<&DatabaseHandle<'_>>,
-    key: BorrowedBytes<'_>,
-) -> Value {
-    get_latest(db, &key).unwrap_or_else(Into::into)
-}
-
-/// This function is not exposed to the C API.
-/// Internal call for `fwd_get_latest` to remove error handling from the C API
-#[doc(hidden)]
-fn get_latest(db: Option<&DatabaseHandle<'_>>, key: &[u8]) -> Result<Value, String> {
-    let db = db.ok_or("db should be non-null")?;
-    // Find root hash.
-    // Matches `hash` function but we use the TrieHash type here
-    let Some(root) = db.root_hash_sync().map_err(|e| e.to_string())? else {
-        return Ok(Value::default());
-    };
-
-    // Find revision assoicated with root.
-    let rev = db.revision_sync(root).map_err(|e| e.to_string())?;
-
-    // Get value associated with key.
-    let value = rev
-        .val_sync_bytes(key)
-        .map_err(|e| e.to_string())?
-        .ok_or("")?;
-    Ok(value.into())
-}
-
-/// Gets the value associated with the given key from the proposal provided.
-///
-/// # Arguments
-///
-/// * `db` - The database handle returned by `open_db`
-/// * `id` - The ID of the proposal to get the value from
-/// * `key` - The key to look up, in `BorrowedBytes` form
-///
-/// # Returns
-///
-/// A `Value` containing the requested value.
-/// A `Value` containing {0, "error message"} if the get failed.
-///
-/// # Safety
-///
-/// The caller must:
-///  * ensure that `db` is a valid pointer returned by `open_db`
-///  * ensure that `key` is a valid pointer to a `Value` struct
-///  * call `free_value` to free the memory associated with the returned `Value`
-///
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_get_from_proposal(
-    db: Option<&DatabaseHandle<'_>>,
-    id: ProposalId,
-    key: BorrowedBytes<'_>,
-) -> Value {
-    get_from_proposal(db, id, &key).unwrap_or_else(Into::into)
-}
-
-/// This function is not exposed to the C API.
-/// Internal call for `fwd_get_from_proposal` to remove error handling from the C API
-#[doc(hidden)]
-fn get_from_proposal(
-    db: Option<&DatabaseHandle<'_>>,
-    id: ProposalId,
-    key: &[u8],
-) -> Result<Value, String> {
-    let db = db.ok_or("db should be non-null")?;
-    // Get proposal from ID.
-    let proposals = db
-        .proposals
-        .read()
-        .map_err(|_| "proposal lock is poisoned")?;
-    let proposal = proposals.get(&id).ok_or("proposal not found")?;
-
-    // Get value associated with key.
-    let value = proposal
-        .val_sync(key)
-        .map_err(|e| e.to_string())?
-        .ok_or("")?;
-    Ok(value.into())
+    db: Option<&DatabaseHandle>,
+    key: BorrowedBytes,
+) -> ValueResult {
+    invoke_with_handle(db, move |db| db.get_latest(key))
 }
 
 /// Gets a value assoicated with the given root hash and key.
@@ -216,860 +157,339 @@ fn get_from_proposal(
 ///
 /// # Arguments
 ///
-/// * `db` - The database handle returned by `open_db`
-/// * `root` - The root hash to look up, in `BorrowedBytes` form
-/// * `key` - The key to look up, in `BorrowedBytes` form
+/// * `db` - The database handle returned by [`fwd_open_db`]
+/// * `root` - The root hash to look up as a [`HashKey`]
+/// * `key` - The key to look up as a [`BorrowedBytes`]
 ///
 /// # Returns
 ///
-/// A `Value` containing the requested value.
-/// A `Value` containing {0, "error message"} if the get failed.
+/// - [`ValueResult::NullHandlePointer`] if the provided database handle is null.
+/// - [`ValueResult::RevisionNotFound`] if no revision was found for the specified root.
+/// - [`ValueResult::None`] if the key was not found.
+/// - [`ValueResult::Some`] if the key was found with the associated value.
+/// - [`ValueResult::Err`] if an error occurred while retrieving the value.
 ///
 /// # Safety
 ///
 /// The caller must:
-/// * ensure that `db` is a valid pointer returned by `open_db`
-/// * ensure that `key` is a valid pointer to a `Value` struct
-/// * ensure that `root` is a valid pointer to a `Value` struct
-/// * call `free_value` to free the memory associated with the returned `Value`
-///
+/// * ensure that `db` is a valid pointer to a [`DatabaseHandle`]
+/// * ensure that `key` is a valid for [`BorrowedBytes`]
+/// * call [`fwd_free_owned_bytes`] to free the memory associated [`OwnedBytes`]
+///   returned in the result.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fwd_get_from_root(
-    db: Option<&DatabaseHandle<'_>>,
-    root: BorrowedBytes<'_>,
-    key: BorrowedBytes<'_>,
-) -> Value {
-    get_from_root(db, &root, &key).unwrap_or_else(Into::into)
-}
-
-/// Internal call for `fwd_get_from_root` to remove error handling from the C API
-#[doc(hidden)]
-fn get_from_root(
-    db: Option<&DatabaseHandle<'_>>,
-    root: &[u8],
-    key: &[u8],
-) -> Result<Value, String> {
-    let db = db.ok_or("db should be non-null")?;
-    let requested_root = HashKey::try_from(root).map_err(|e| e.to_string())?;
-    let mut cached_view = db.cached_view.lock().expect("cached_view lock is poisoned");
-    let value = match cached_view.as_ref() {
-        // found the cached view, use it
-        Some((root_hash, view)) if root_hash == &requested_root => {
-            counter!("firewood.ffi.cached_view.hit").increment(1);
-            view.val_sync_bytes(key)
-        }
-        // If what was there didn't match the requested root, we need a new view, so we
-        // update the cache
-        _ => {
-            counter!("firewood.ffi.cached_view.miss").increment(1);
-            let rev = view_sync_from_root(db, root)?;
-            let result = rev.val_sync_bytes(key);
-            *cached_view = Some((requested_root.clone(), rev));
-            result
-        }
-    }
-    .map_err(|e| e.to_string())?
-    .ok_or("")?;
-
-    Ok(value.into())
-}
-fn view_sync_from_root(
-    db: &DatabaseHandle<'_>,
-    root: &[u8],
-) -> Result<Box<dyn DbViewSyncBytes>, String> {
-    let rev = db
-        .view_sync(HashKey::try_from(root).map_err(|e| e.to_string())?)
-        .map_err(|e| e.to_string())?;
-    Ok(rev)
+    db: Option<&DatabaseHandle>,
+    root: HashKey,
+    key: BorrowedBytes,
+) -> ValueResult {
+    invoke_with_handle(db, move |db| db.get_from_root(root.into(), key))
 }
 
 /// Puts the given key-value pairs into the database.
 ///
 /// # Arguments
 ///
-/// * `db` - The database handle returned by `open_db`
-/// * `values` - A `BorrowedKeyValuePairs` struct containing the key-value pairs to put.
+/// * `db` - The database handle returned by [`fwd_open_db`]
+/// * `values` - A [`BorrowedKeyValuePairs`] containing the key-value pairs to put.
 ///
 /// # Returns
 ///
-/// The new root hash of the database, in Value form.
-/// A `Value` containing {0, "error message"} if the commit failed.
-///
-/// # Errors
-///
-/// * `"key-value pair is null"` - A `KeyValue` struct is null
-/// * `"db should be non-null"` - The database handle is null
-/// * `"couldn't get key-value pair"` - A `KeyValue` struct is null
-/// * `"proposed revision is empty"` - The proposed revision is empty
+/// - [`HashResult::NullHandlePointer`] if the provided database handle is null.
+/// - [`HashResult::None`] if the commit resulted in an empty database.
+/// - [`HashResult::Some`] if the commit was successful, containing the new root hash.
+/// - [`HashResult::Err`] if an error occurred while committing the batch.
 ///
 /// # Safety
 ///
-/// This function is unsafe because it dereferences raw pointers.
 /// The caller must:
-///  * ensure that `db` is a valid pointer returned by `open_db`
-///  * ensure that `values` is a valid pointer and that it points to an array of `KeyValue` structs of length `nkeys`.
-///  * ensure that the `Value` fields of the `KeyValue` structs are valid pointers.
-///
+/// * ensure that `db` is a valid pointer to a [`DatabaseHandle`]
+/// * ensure that `values` is valid for [`BorrowedKeyValuePairs`]
+/// * call [`fwd_free_owned_bytes`] to free the memory associated with the
+///   returned error ([`HashKey`] does not need to be freed as it is returned by
+///   value).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn fwd_batch(
-    db: Option<&DatabaseHandle<'_>>,
-    values: BorrowedKeyValuePairs,
-) -> Value {
-    batch(db, &values).unwrap_or_else(Into::into)
-}
-
-/// Internal call for `fwd_batch` to remove error handling from the C API
-#[doc(hidden)]
-fn batch(db: Option<&DatabaseHandle<'_>>, values: &[KeyValuePair<'_>]) -> Result<Value, String> {
-    let db = db.ok_or("db should be non-null")?;
-    let start = coarsetime::Instant::now();
-
-    // Create a batch of operations to perform.
-    let batch = values.iter().map_into_batch();
-
-    // Propose the batch of operations.
-    let proposal = db.propose_sync(batch).map_err(|e| e.to_string())?;
-    let propose_time = start.elapsed().as_millis();
-    counter!("firewood.ffi.propose_ms").increment(propose_time);
-
-    let hash_val = proposal
-        .root_hash_sync()
-        .map_err(|e| e.to_string())?
-        .ok_or("Proposed revision is empty")?
-        .as_slice()
-        .into();
-
-    // Commit the proposal.
-    proposal.commit_sync().map_err(|e| e.to_string())?;
-
-    // Get the root hash of the database post-commit.
-    let propose_plus_commit_time = start.elapsed().as_millis();
-    counter!("firewood.ffi.batch_ms").increment(propose_plus_commit_time);
-    counter!("firewood.ffi.commit_ms")
-        .increment(propose_plus_commit_time.saturating_sub(propose_time));
-    counter!("firewood.ffi.batch").increment(1);
-    Ok(hash_val)
+    db: Option<&DatabaseHandle>,
+    values: BorrowedKeyValuePairs<'_>,
+) -> HashResult {
+    invoke_with_handle(db, move |db| db.create_batch(values))
 }
 
 /// Proposes a batch of operations to the database.
 ///
 /// # Arguments
 ///
-/// * `db` - The database handle returned by `open_db`
-/// * `values` - A `BorrowedKeyValuePairs` struct containing the key-value pairs to put.
+/// * `db` - The database handle returned by [`fwd_open_db`]
+/// * `values` - A [`BorrowedKeyValuePairs`] containing the key-value pairs to put.
 ///
 /// # Returns
 ///
-/// On success, a `Value` containing {len=id, data=hash}. In this case, the
-/// hash will always be 32 bytes, and the id will be non-zero.
-/// On failure, a `Value` containing {0, "error message"}.
+/// - [`ProposalResult::NullHandlePointer`] if the provided database handle is null.
+/// - [`ProposalResult::Ok`] if the proposal was created, with the proposal handle
+///   and calculated root hash.
+/// - [`ProposalResult::Err`] if an error occurred while creating the proposal.
 ///
 /// # Safety
 ///
-/// This function is unsafe because it dereferences raw pointers.
 /// The caller must:
-///  * ensure that `db` is a valid pointer returned by `open_db`
-///  * ensure that `values` is a valid pointer and that it points to an array of `KeyValue` structs of length `nkeys`.
-///  * ensure that the `Value` fields of the `KeyValue` structs are valid pointers.
-///
+/// * ensure that `db` is a valid pointer to a [`DatabaseHandle`]
+/// * ensure that `values` is valid for [`BorrowedKeyValuePairs`]
+/// * call [`fwd_commit_proposal`] or [`fwd_free_proposal`] to free the memory
+///   associated with the proposal. And, the caller must ensure this is done
+///   before calling [`fwd_close_db`] to avoid memory leaks or undefined behavior.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_propose_on_db<'p>(
-    db: Option<&'p DatabaseHandle<'p>>,
+pub unsafe extern "C" fn fwd_propose_on_db<'db>(
+    db: Option<&'db DatabaseHandle>,
     values: BorrowedKeyValuePairs<'_>,
-) -> Value {
-    // Note: the id is guaranteed to be non-zero
-    // because we use an atomic counter that starts at 1.
-    propose_on_db(db, &values).unwrap_or_else(Into::into)
+) -> ProposalResult<'db> {
+    invoke_with_handle(db, move |db| db.create_proposal_handle(values))
 }
 
-/// Internal call for `fwd_propose_on_db` to remove error handling from the C API
-#[doc(hidden)]
-fn propose_on_db<'p>(
-    db: Option<&'p DatabaseHandle<'p>>,
-    values: &[KeyValuePair<'_>],
-) -> Result<Value, String> {
-    let db = db.ok_or("db should be non-null")?;
-    // Create a batch of operations to perform.
-    let batch = values.iter().map_into_batch();
-
-    // Propose the batch of operations.
-    let proposal = db.propose_sync(batch).map_err(|e| e.to_string())?;
-
-    // Get the root hash of the new proposal.
-    let mut root_hash: Value = match proposal.root_hash_sync().map_err(|e| e.to_string())? {
-        Some(root) => Value::from(root.as_slice()),
-        None => String::new().into(),
-    };
-
-    // Store the proposal in the map. We need the write lock instead.
-    let new_id = next_id(); // Guaranteed to be non-zero
-    db.proposals
-        .write()
-        .map_err(|_| "proposal lock is poisoned")?
-        .insert(new_id, proposal);
-    root_hash.len = new_id as usize; // Set the length to the proposal ID
-    Ok(root_hash)
+/// Gets the value associated with the given key from the proposal provided.
+///
+/// # Arguments
+///
+/// * `handle` - The proposal handle returned by [`fwd_propose_on_db`] or
+///   [`fwd_propose_on_proposal`].
+/// * `key` - The key to look up, as a [`BorrowedBytes`].
+///
+/// # Returns
+///
+/// - [`ValueResult::NullHandlePointer`] if the provided database handle is null.
+/// - [`ValueResult::None`] if the key was not found.
+/// - [`ValueResult::Some`] if the key was found with the associated value.
+/// - [`ValueResult::Err`] if an error occurred while retrieving the value.
+///
+/// # Safety
+///
+/// The caller must:
+/// * ensure that `handle` is a valid pointer to a [`ProposalHandle`]
+/// * ensure that `key` is valid for [`BorrowedBytes`]
+/// * call [`fwd_free_owned_bytes`] to free the memory associated [`OwnedBytes`]
+///   returned in the result.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_get_from_proposal(
+    handle: Option<&ProposalHandle<'_>>,
+    key: BorrowedBytes,
+) -> ValueResult {
+    invoke_with_handle(handle, move |handle| handle.val_sync(key))
 }
 
 /// Proposes a batch of operations to the database on top of an existing proposal.
 ///
 /// # Arguments
 ///
-/// * `db` - The database handle returned by `open_db`
-/// * `proposal_id` - The ID of the proposal to propose on
-/// * `values` - A `BorrowedKeyValuePairs` struct containing the key-value pairs to put.
+/// * `handle` - The proposal handle returned by [`fwd_propose_on_db`] or
+///   [`fwd_propose_on_proposal`].
+/// * `values` - A [`BorrowedKeyValuePairs`] containing the key-value pairs to put.
 ///
 /// # Returns
 ///
-/// On success, a `Value` containing {len=id, data=hash}. In this case, the
-/// hash will always be 32 bytes, and the id will be non-zero.
-/// On failure, a `Value` containing {0, "error message"}.
+/// - [`ProposalResult::NullHandlePointer`] if the provided database handle is null.
+/// - [`ProposalResult::Ok`] if the proposal was created, with the proposal handle
+///   and calculated root hash.
+/// - [`ProposalResult::Err`] if an error occurred while creating the proposal.
 ///
 /// # Safety
 ///
-/// This function is unsafe because it dereferences raw pointers.
 /// The caller must:
-///  * ensure that `db` is a valid pointer returned by `open_db`
-///  * ensure that `values` is a valid pointer and that it points to an array of `KeyValue` structs of length `nkeys`.
-///  * ensure that the `Value` fields of the `KeyValue` structs are valid pointers.
-///
+/// * ensure that `handle` is a valid pointer to a [`ProposalHandle`]
+/// * ensure that `values` is valid for [`BorrowedKeyValuePairs`]
+/// * call [`fwd_commit_proposal`] or [`fwd_free_proposal`] to free the memory
+///   associated with the proposal. And, the caller must ensure this is done
+///   before calling [`fwd_close_db`] to avoid memory leaks or undefined behavior.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_propose_on_proposal(
-    db: Option<&DatabaseHandle<'_>>,
-    proposal_id: ProposalId,
+pub unsafe extern "C" fn fwd_propose_on_proposal<'db>(
+    handle: Option<&ProposalHandle<'db>>,
     values: BorrowedKeyValuePairs<'_>,
-) -> Value {
-    // Note: the id is guaranteed to be non-zero
-    // because we use an atomic counter that starts at 1.
-    propose_on_proposal(db, proposal_id, &values).unwrap_or_else(Into::into)
-}
-
-/// Internal call for `fwd_propose_on_proposal` to remove error handling from the C API
-#[doc(hidden)]
-fn propose_on_proposal(
-    db: Option<&DatabaseHandle<'_>>,
-    proposal_id: ProposalId,
-    values: &[KeyValuePair<'_>],
-) -> Result<Value, String> {
-    let db = db.ok_or("db should be non-null")?;
-    // Create a batch of operations to perform.
-    let batch = values.iter().map_into_batch();
-
-    // Get proposal from ID.
-    // We need write access to add the proposal after we create it.
-    let guard = db
-        .proposals
-        .write()
-        .expect("failed to acquire write lock on proposals");
-    let proposal = guard.get(&proposal_id).ok_or("proposal not found")?;
-    let new_proposal = proposal.propose_sync(batch).map_err(|e| e.to_string())?;
-    drop(guard); // Drop the read lock before we get the write lock.
-
-    // Get the root hash of the new proposal.
-    let mut root_hash: Value = match new_proposal.root_hash_sync().map_err(|e| e.to_string())? {
-        Some(root) => Value::from(root.as_slice()),
-        None => String::new().into(),
-    };
-
-    // Store the proposal in the map. We need the write lock instead.
-    let new_id = next_id(); // Guaranteed to be non-zero
-    db.proposals
-        .write()
-        .map_err(|_| "proposal lock is poisoned")?
-        .insert(new_id, new_proposal);
-    root_hash.len = new_id as usize; // Set the length to the proposal ID
-    Ok(root_hash)
+) -> ProposalResult<'db> {
+    invoke_with_handle(handle, move |p| p.create_proposal_handle(values))
 }
 
 /// Commits a proposal to the database.
 ///
+/// This function will consume the proposal regardless of whether the commit
+/// is successful.
+///
 /// # Arguments
 ///
-/// * `db` - The database handle returned by `open_db`
-/// * `proposal_id` - The ID of the proposal to commit
+/// * `handle` - The proposal handle returned by [`fwd_propose_on_db`] or
+///   [`fwd_propose_on_proposal`].
 ///
 /// # Returns
 ///
-/// A `Value` containing {0, null} if the commit was successful.
-/// A `Value` containing {0, "error message"} if the commit failed.
-///
-/// # Safety
-///
-/// This function is unsafe because it dereferences raw pointers.
-/// The caller must ensure that `db` is a valid pointer returned by `open_db`
-///
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_commit(db: Option<&DatabaseHandle<'_>>, proposal_id: u32) -> Value {
-    commit(db, proposal_id).map_or_else(Into::into, Into::into)
-}
-
-/// Internal call for `fwd_commit` to remove error handling from the C API
-#[doc(hidden)]
-fn commit(db: Option<&DatabaseHandle<'_>>, proposal_id: u32) -> Result<(), String> {
-    let db = db.ok_or("db should be non-null")?;
-    let proposal = db
-        .proposals
-        .write()
-        .map_err(|_| "proposal lock is poisoned")?
-        .remove(&proposal_id)
-        .ok_or("proposal not found")?;
-
-    // Get the proposal hash and cache the view. We never cache an empty proposal.
-    let proposal_hash = proposal.root_hash_sync();
-
-    if let Ok(Some(proposal_hash)) = proposal_hash {
-        let mut guard = db.cached_view.lock().expect("cached_view lock is poisoned");
-        match db.view_sync(proposal_hash.clone()) {
-            Ok(view) => *guard = Some((proposal_hash, view)),
-            Err(_) => *guard = None, // Clear cache on error
-        }
-        drop(guard);
-    }
-
-    // Commit the proposal
-    let result = proposal.commit_sync().map_err(|e| e.to_string());
-
-    // Clear the cache, which will force readers after this point to find the committed root hash
-    db.clear_cached_view();
-
-    result
-}
-
-/// Drops a proposal from the database.
-/// The propopsal's data is now inaccessible, and can be freed by the `RevisionManager`.
-///
-/// # Arguments
-///
-/// * `db` - The database handle returned by `open_db`
-/// * `proposal_id` - The ID of the proposal to drop
-///
-/// # Safety
-///
-/// This function is unsafe because it dereferences raw pointers.
-/// The caller must ensure that `db` is a valid pointer returned by `open_db`
-///
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_drop_proposal(
-    db: Option<&DatabaseHandle<'_>>,
-    proposal_id: u32,
-) -> Value {
-    drop_proposal(db, proposal_id).map_or_else(Into::into, Into::into)
-}
-
-/// Internal call for `fwd_drop_proposal` to remove error handling from the C API
-#[doc(hidden)]
-fn drop_proposal(db: Option<&DatabaseHandle<'_>>, proposal_id: u32) -> Result<(), String> {
-    let db = db.ok_or("db should be non-null")?;
-    let mut proposals = db
-        .proposals
-        .write()
-        .map_err(|_| "proposal lock is poisoned")?;
-    proposals.remove(&proposal_id).ok_or("proposal not found")?;
-    Ok(())
-}
-
-/// Get the root hash of the latest version of the database
-///
-/// # Argument
-///
-/// * `db` - The database handle returned by `open_db`
-///
 /// # Returns
 ///
-/// A `Value` containing the root hash of the database.
-/// A `Value` containing {0, "error message"} if the root hash could not be retrieved.
-/// One expected error is "IO error: Root hash not found" if the database is empty.
-/// This should be handled by the caller.
+/// - [`HashResult::NullHandlePointer`] if the provided database handle is null.
+/// - [`HashResult::None`] if the commit resulted in an empty database.
+/// - [`HashResult::Some`] if the commit was successful, containing the new root hash.
+/// - [`HashResult::Err`] if an error occurred while committing the batch.
 ///
 /// # Safety
 ///
-/// This function is unsafe because it dereferences raw pointers.
-/// The caller must ensure that `db` is a valid pointer returned by `open_db`
-///
+/// The caller must:
+/// * ensure that `handle` is a valid pointer to a [`ProposalHandle`]
+/// * ensure that `handle` is not used again after this function is called.
+/// * call [`fwd_free_owned_bytes`] to free the memory associated with the
+///   returned error ([`HashKey`] does not need to be freed as it is returned
+///   by value).
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_root_hash(db: Option<&DatabaseHandle<'_>>) -> Value {
-    root_hash(db).unwrap_or_else(Into::into)
-}
-
-/// This function is not exposed to the C API.
-/// Internal call for `fwd_root_hash` to remove error handling from the C API
-#[doc(hidden)]
-fn root_hash(db: Option<&DatabaseHandle<'_>>) -> Result<Value, String> {
-    let db = db.ok_or("db should be non-null")?;
-    db.root_hash_sync()
-        .map_err(|e| e.to_string())?
-        .map(|root| Value::from(root.as_slice()))
-        .map_or_else(|| Ok(Value::default()), Ok)
-}
-
-/// A value returned by the FFI.
-///
-/// This is used in several different ways, including:
-/// * An C-style string.
-/// * An ID for a proposal.
-/// * A byte slice containing data.
-///
-/// For more details on how the data may be stored, refer to the function signature
-/// that returned it or the `From` implementations.
-///
-/// The data stored in this struct (if `data` is not null) must be manually freed
-/// by the caller using `fwd_free_value`.
-///
-#[derive(Debug, Default)]
-#[repr(C)]
-pub struct Value {
-    pub len: usize,
-    pub data: Option<std::ptr::NonNull<u8>>,
-}
-
-impl Display for Value {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match (self.len, self.data) {
-            (0, None) => write!(f, "[not found]"),
-            (0, Some(data)) => write!(f, "[error] {}", unsafe {
-                CStr::from_ptr(data.as_ptr() as *const c_char).to_string_lossy()
-            }),
-            (len, None) => write!(f, "[id] {len}"),
-            (_, Some(_)) => write!(f, "[data] {:?}", self.as_slice()),
-        }
-    }
-}
-
-impl Value {
-    #[must_use]
-    pub const fn as_slice(&self) -> &[u8] {
-        if let Some(data) = self.data {
-            // SAFETY: We must assume that if non-null, the C caller provided valid pointer
-            // and length, otherwise caller assumes responsibility for undefined behavior.
-            unsafe { std::slice::from_raw_parts(data.as_ptr(), self.len) }
-        } else {
-            &[]
-        }
-    }
-}
-
-impl From<&[u8]> for Value {
-    fn from(data: &[u8]) -> Self {
-        let boxed: Box<[u8]> = data.into();
-        boxed.into()
-    }
-}
-
-impl From<Box<[u8]>> for Value {
-    fn from(data: Box<[u8]>) -> Self {
-        let len = data.len();
-        let leaked_ptr = Box::leak(data).as_mut_ptr();
-        let data = std::ptr::NonNull::new(leaked_ptr);
-        Value { len, data }
-    }
-}
-
-impl From<String> for Value {
-    fn from(s: String) -> Self {
-        if s.is_empty() {
-            Self::default()
-        } else {
-            let cstr = CString::new(s).unwrap_or_default().into_raw();
-            Value {
-                len: 0,
-                data: std::ptr::NonNull::new(cstr.cast::<u8>()),
-            }
-        }
-    }
-}
-
-impl From<u32> for Value {
-    fn from(v: u32) -> Self {
-        // WARNING: This should only be called with values >= 1.
-        // In much of the Go code, v.len == 0 is used to indicate a null-terminated string.
-        // This may cause a panic or memory corruption if used incorrectly.
-        assert_ne!(v, 0);
-        Self {
-            len: v as usize,
-            data: None,
-        }
-    }
-}
-
-impl From<()> for Value {
-    fn from((): ()) -> Self {
-        Self::default()
-    }
-}
-
-/// Frees the memory associated with a `Value`.
-///
-/// # Arguments
-///
-/// * `value` - The `Value` to free, previously returned from any Rust function.
-///
-/// # Safety
-///
-/// This function is unsafe because it dereferences raw pointers.
-/// The caller must ensure that `value` is a valid pointer.
-///
-/// # Panics
-///
-/// This function panics if `value` is `null`.
-///
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_free_value(value: Option<&mut Value>) {
-    let value = value.expect("value should be non-null");
-    if let Some(data) = value.data {
-        let data_ptr = data.as_ptr();
-        // We assume that if the length is 0, then the data is a null-terminated string.
-        if value.len > 0 {
-            let recreated_box =
-                unsafe { Box::from_raw(std::slice::from_raw_parts_mut(data_ptr, value.len)) };
-            drop(recreated_box);
-        } else {
-            let raw_str = data_ptr.cast::<c_char>();
-            let cstr = unsafe { CString::from_raw(raw_str) };
-            drop(cstr);
-        }
-    }
-}
-
-/// Struct returned by `fwd_create_db` and `fwd_open_db`
-#[derive(Debug)]
-#[repr(C)]
-pub struct DatabaseCreationResult {
-    pub db: Option<Box<DatabaseHandle<'static>>>,
-    pub error_str: Option<std::ptr::NonNull<u8>>,
-}
-
-impl From<Result<Db, String>> for DatabaseCreationResult {
-    fn from(result: Result<Db, String>) -> Self {
-        match result {
-            Ok(db) => DatabaseCreationResult {
-                db: Some(Box::new(db.into())),
-                error_str: None,
-            },
-            Err(error_msg) => {
-                let error_cstring = CString::new(error_msg).unwrap_or_default().into_raw();
-                DatabaseCreationResult {
-                    db: None,
-                    error_str: std::ptr::NonNull::new(error_cstring.cast::<u8>()),
-                }
-            }
-        }
-    }
-}
-
-/// Frees the memory associated with a `DatabaseCreationResult`.
-/// This only needs to be called if the `error_str` field is non-null.
-///
-/// # Arguments
-///
-/// * `result` - The `DatabaseCreationResult` to free, previously returned from `fwd_create_db` or `fwd_open_db`.
-///
-/// # Safety
-///
-/// This function is unsafe because it dereferences raw pointers.
-/// The caller must ensure that `result` is a valid pointer.
-///
-/// # Panics
-///
-/// This function panics if `result` is `null`.
-///
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_free_database_error_result(
-    result: Option<&mut DatabaseCreationResult>,
-) {
-    let result = result.expect("result should be non-null");
-    // Free the error string if it exists
-    if let Some(nonnull) = result.error_str {
-        let raw_str = nonnull.cast::<c_char>().as_ptr();
-        let cstr = unsafe { CString::from_raw(raw_str) };
-        drop(cstr);
-    }
-    // Note: we don't free the db pointer as it's managed by the caller
+pub unsafe extern "C" fn fwd_commit_proposal(
+    proposal: Option<Box<ProposalHandle<'_>>>,
+) -> HashResult {
+    invoke_with_handle(proposal, move |proposal| {
+        proposal.commit_proposal(|commit_time| {
+            metrics::counter!("firewood.ffi.commit_ms").increment(commit_time.as_millis());
+            metrics::counter!("firewood.ffi.commit").increment(1);
+        })
+    })
 }
 
 /// Start metrics recorder for this process.
 ///
 /// # Returns
 ///
-/// A `Value` containing {0, null} if the metrics recorder was initialized.
-/// A `Value` containing {0, "error message"} if an error occurs.
+/// - [`VoidResult::Ok`] if the recorder was initialized.
+/// - [`VoidResult::Err`] if an error occurs during initialization.
 #[unsafe(no_mangle)]
-pub extern "C" fn fwd_start_metrics() -> Value {
-    metrics_setup::setup_metrics()
-        .map_err(|e| e.to_string())
-        .map_or_else(Into::into, Into::into)
+pub extern "C" fn fwd_start_metrics() -> VoidResult {
+    invoke(metrics_setup::setup_metrics)
 }
 
 /// Start metrics recorder and exporter for this process.
+///
+/// # Arguments
 ///
 /// * `metrics_port` - the port where metrics will be exposed at
 ///
 /// # Returns
 ///
-/// A `Value` containing {0, null} if the metrics recorder was initialized and
-/// the exporter was started.
-/// A `Value` containing {0, "error message"} if an error occurs.
+/// - [`VoidResult::Ok`] if the recorder was initialized.
+/// - [`VoidResult::Err`] if an error occurs during initialization.
+///
+/// # Safety
+///
+/// The caller must:
+/// * call [`fwd_free_owned_bytes`] to free the memory associated with the
+///   returned error (if any).
 #[unsafe(no_mangle)]
-pub extern "C" fn fwd_start_metrics_with_exporter(metrics_port: u16) -> Value {
-    metrics_setup::setup_metrics_with_exporter(metrics_port)
-        .map_err(|e| e.to_string())
-        .map_or_else(Into::into, Into::into)
+pub extern "C" fn fwd_start_metrics_with_exporter(metrics_port: u16) -> VoidResult {
+    invoke(move || metrics_setup::setup_metrics_with_exporter(metrics_port))
 }
 
 /// Gather latest metrics for this process.
 ///
 /// # Returns
 ///
-/// A `Value` containing {len, bytes} representing the latest metrics for this process.
-/// A `Value` containing {0, "error message"} if unable to get the latest metrics.
-#[unsafe(no_mangle)]
-pub extern "C" fn fwd_gather() -> Value {
-    metrics_setup::gather_metrics().map_or_else(Into::into, |s| s.as_bytes().into())
-}
-
-/// Common arguments, accepted by both `fwd_create_db()` and `fwd_open_db()`.
-///
-/// * `path` - The path to the database file, which will be truncated if passed to `fwd_create_db()`
-///   otherwise should exist if passed to `fwd_open_db()`.
-/// * `cache_size` - The size of the node cache, returns an error if <= 0
-/// * `free_list_cache_size` - The size of the free list cache, returns an error if <= 0
-/// * `revisions` - The maximum number of revisions to keep; firewood currently requires this to be at least 2.
-/// * `strategy` - The cache read strategy to use, 0 for writes only,
-///   1 for branch reads, and 2 for all reads.
-/// * `truncate` - Whether to truncate the database file if it exists.
-///   Returns an error if the value is not 0, 1, or 2.
-#[repr(C)]
-pub struct CreateOrOpenArgs<'a> {
-    path: BorrowedBytes<'a>,
-    cache_size: usize,
-    free_list_cache_size: usize,
-    revisions: usize,
-    strategy: u8,
-    truncate: bool,
-}
-
-/// Open a database with the given cache size and maximum number of revisions
-///
-/// # Arguments
-///
-/// See `CreateOrOpenArgs`.
-///
-/// # Returns
-///
-/// A database handle, or panics if it cannot be created
+/// - [`ValueResult::None`] if the gathered metrics resulted in an empty string.
+/// - [`ValueResult::Some`] the gathered metrics as an [`OwnedBytes`] (with
+///   guaranteed to be utf-8 data, not null terminated).
+/// - [`ValueResult::Err`] if an error occurred while retrieving the value.
 ///
 /// # Safety
 ///
-/// This function uses raw pointers so it is unsafe.
-/// It is the caller's responsibility to ensure that path is a valid pointer to a null-terminated string.
-/// The caller must also ensure that the cache size is greater than 0 and that the number of revisions is at least 2.
-/// The caller must call `close` to free the memory associated with the returned database handle.
-///
+/// The caller must:
+/// * call [`fwd_free_owned_bytes`] to free the memory associated with the
+///   returned error or value.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_open_db(args: CreateOrOpenArgs) -> DatabaseCreationResult {
-    unsafe { open_db(&args) }.into()
-}
-
-/// Internal call for `fwd_open_db` to remove error handling from the C API
-#[doc(hidden)]
-unsafe fn open_db(args: &CreateOrOpenArgs) -> Result<Db, String> {
-    let cfg = DbConfig::builder()
-        .truncate(args.truncate)
-        .manager(manager_config(
-            args.cache_size,
-            args.free_list_cache_size,
-            args.revisions,
-            args.strategy,
-        )?)
-        .build();
-
-    if args.path.is_empty() {
-        return Err("path should not be empty".to_string());
-    }
-    let path = args
-        .path
-        .as_str()
-        .map_err(|e| format!("Invalid database path: {e}"))?;
-    Db::new_sync(path, cfg).map_err(|e| e.to_string())
-}
-
-/// Arguments for logging
-///
-/// * `path` - The file path where logs for this process are stored. By
-///   default, this is set to /tmp/firewood-log.txt
-/// * `filter_level` - The filter level for logs. By default, this is set to info.
-#[repr(C)]
-pub struct LogArgs<'a> {
-    path: BorrowedBytes<'a>,
-    filter_level: BorrowedBytes<'a>,
+pub extern "C" fn fwd_gather() -> ValueResult {
+    invoke(metrics_setup::gather_metrics)
 }
 
 /// Start logs for this process.
 ///
 /// # Arguments
 ///
-/// See `LogArgs`.
+/// See [`LogArgs`].
 ///
 /// # Returns
 ///
-/// A `Value` containing {0, null} if the global logger was initialized.
-/// A `Value` containing {0, "error message"} if an error occurs.
+/// - [`VoidResult::Ok`] if the recorder was initialized.
+/// - [`VoidResult::Err`] if an error occurs during initialization.
+///
+/// # Safety
+///
+/// The caller must:
+/// * call [`fwd_free_owned_bytes`] to free the memory associated with the
+///   returned error (if any).
 #[unsafe(no_mangle)]
-pub extern "C" fn fwd_start_logs(args: LogArgs<'_>) -> Value {
-    start_logs(&args).map_or_else(Into::into, Into::into)
-}
-
-#[cfg(feature = "logger")]
-#[doc(hidden)]
-fn start_logs(log_args: &LogArgs) -> Result<(), String> {
-    use env_logger::Target::Pipe;
-    use std::fs::OpenOptions;
-    use std::path::Path;
-
-    let log_path = log_args
-        .path
-        .as_str()
-        .map_err(|e| format!("Invalid log path: {e}"))?;
-    let log_path = if log_path.is_empty() {
-        std::borrow::Cow::Owned(std::env::temp_dir().join("firewood-log.txt"))
-    } else {
-        std::borrow::Cow::Borrowed(std::path::Path::new(log_path))
-    };
-
-    let log_dir = log_path.parent().unwrap_or_else(|| Path::new("."));
-    std::fs::create_dir_all(log_dir).map_err(|e| e.to_string())?;
-
-    let level = if log_args.filter_level.is_empty() {
-        "info"
-    } else {
-        log_args
-            .filter_level
-            .as_str()
-            .map_err(|e| format!("Invalid log level: {e}"))?
-    }
-    .parse::<log::LevelFilter>()
-    .map_err(|e| format!("failed to parse log level: {e}"))?;
-
-    let file = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(false)
-        .open(log_path)
-        .map_err(|e| e.to_string())?;
-
-    env_logger::Builder::new()
-        .filter_level(level)
-        .target(Pipe(Box::new(file)))
-        .try_init()
-        .map_err(|e| e.to_string())?;
-
-    Ok(())
-}
-
-#[cfg(not(feature = "logger"))]
-#[doc(hidden)]
-fn start_logs(_log_args: &LogArgs) -> Result<(), String> {
-    Err(String::from("logger feature is disabled"))
-}
-
-#[doc(hidden)]
-fn manager_config(
-    cache_size: usize,
-    free_list_cache_size: usize,
-    revisions: usize,
-    strategy: u8,
-) -> Result<RevisionManagerConfig, String> {
-    let cache_read_strategy = match strategy {
-        0 => CacheReadStrategy::WritesOnly,
-        1 => CacheReadStrategy::BranchReads,
-        2 => CacheReadStrategy::All,
-        _ => return Err("invalid cache strategy".to_string()),
-    };
-    let config = RevisionManagerConfig::builder()
-        .node_cache_size(
-            cache_size
-                .try_into()
-                .map_err(|_| "cache size should be non-zero")?,
-        )
-        .max_revisions(revisions)
-        .cache_read_strategy(cache_read_strategy)
-        .free_list_cache_size(
-            free_list_cache_size
-                .try_into()
-                .map_err(|_| "free list cache size should be non-zero")?,
-        )
-        .build();
-    Ok(config)
+pub extern "C" fn fwd_start_logs(args: LogArgs) -> VoidResult {
+    invoke(move || args.start_logging())
 }
 
 /// Close and free the memory for a database handle
 ///
+/// # Arguments
+///
+/// * `db` - The database handle to close, previously returned from a call to [`fwd_open_db`].
+///
+/// # Returns
+///
+/// - [`VoidResult::NullHandlePointer`] if the provided database handle is null.
+/// - [`VoidResult::Ok`] if the database handle was successfully closed and freed.
+/// - [`VoidResult::Err`] if the process panics while closing the database handle.
+///
 /// # Safety
 ///
-/// This function uses raw pointers so it is unsafe.
-/// It is the caller's responsibility to ensure that the database handle is valid.
-/// Using the db after calling this function is undefined behavior
+/// Callers must ensure that:
+///
+/// - `db` is a valid pointer to a [`DatabaseHandle`] returned by [`fwd_open_db`].
+/// - There are no handles to any open proposals. If so, they must be freed first
+///   using [`fwd_free_proposal`].
+/// - The database handle is not used after this function is called.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_close_db(db: Option<Box<DatabaseHandle>>) -> VoidResult {
+    invoke_with_handle(db, drop)
+}
+
+/// Consumes the [`OwnedBytes`] and frees the memory associated with it.
 ///
 /// # Arguments
 ///
-/// * `db` - The database handle to close, previously returned from a call to `open_db()`
+/// * `bytes` - The [`OwnedBytes`] struct to free, previously returned from any
+///   function from this library.
 ///
-/// # Panics
+/// # Returns
 ///
-/// This function panics if:
-/// * `db` is `None` (null pointer)
-/// * A lock is poisoned
+/// - [`VoidResult::Ok`] if the memory was successfully freed.
+/// - [`VoidResult::Err`] if the process panics while freeing the memory.
+///
+/// # Safety
+///
+/// The caller must ensure that the `bytes` struct is valid and that the memory
+/// it points to is uniquely owned by this object. However, if `bytes.ptr` is null,
+/// this function does nothing.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_close_db(db: Option<&mut DatabaseHandle>) {
-    let db_handle = db.expect("db should be non-null");
-
-    // Explicitly clear the downstream items. Drop will do these in order, so this
-    // code is defensive in case someone reorders the struct memebers of DatabaseHandle.
-    db_handle
-        .proposals
-        .write()
-        .expect("proposals lock is poisoned")
-        .clear();
-    db_handle.clear_cached_view();
-
-    // The database handle will be dropped automatically when db_handle goes out of scope
+pub unsafe extern "C" fn fwd_free_owned_bytes(bytes: OwnedBytes) -> VoidResult {
+    invoke(move || {
+        drop(bytes);
+        VoidResult::Ok
+    })
 }
 
-#[cfg(test)]
-mod tests {
-    #![expect(clippy::unwrap_used)]
-
-    use super::*;
-
-    #[test]
-    fn test_invalid_value_display() {
-        let value = Value::default();
-        assert_eq!(format!("{value}"), "[not found]");
-    }
-
-    #[test]
-    fn test_value_display_with_error_string() {
-        let cstr = CString::new("test").unwrap();
-        let value = Value {
-            len: 0,
-            data: std::ptr::NonNull::new(cstr.as_ptr().cast::<u8>().cast_mut()),
-        };
-        assert_eq!(format!("{value}"), "[error] test");
-    }
-
-    #[test]
-    fn test_value_display_with_data() {
-        let value = Value {
-            len: 4,
-            data: std::ptr::NonNull::new(
-                Box::leak(b"test".to_vec().into_boxed_slice()).as_mut_ptr(),
-            ),
-        };
-        assert_eq!(format!("{value}"), "[data] [116, 101, 115, 116]");
-    }
-
-    #[test]
-    fn test_value_display_with_id() {
-        let value = Value { len: 4, data: None };
-        assert_eq!(format!("{value}"), "[id] 4");
-    }
+/// Consumes the [`ProposalHandle`], cancels the proposal, and frees the memory.
+///
+/// # Arguments
+///
+/// * `proposal` - A pointer to a [`ProposalHandle`] previously returned from a
+///   function from this library.
+///
+/// # Returns
+///
+/// - [`VoidResult::NullHandlePointer`] if the provided proposal handle is null.
+/// - [`VoidResult::Ok`] if the proposal was successfully cancelled and freed.
+/// - [`VoidResult::Err`] if the process panics while freeing the memory.
+///
+/// # Safety
+///
+/// The caller must ensure that the `proposal` is not null and that it points to
+/// a valid [`ProposalHandle`] previously returned by a function from this library.
+///
+/// The caller must ensure that the proposal was not committed. [`fwd_commit_proposal`]
+/// will consume the proposal automatically.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_free_proposal(
+    proposal: Option<Box<ProposalHandle<'_>>>,
+) -> VoidResult {
+    invoke_with_handle(proposal, drop)
 }

--- a/ffi/src/logging.rs
+++ b/ffi/src/logging.rs
@@ -1,0 +1,123 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use crate::BorrowedBytes;
+
+/// Arguments for initializing logging for the Firewood FFI.
+#[repr(C)]
+pub struct LogArgs<'a> {
+    /// The file path where logs for this process are stored.
+    ///
+    /// If empty, this is set to `${TMPDIR}/firewood-log.txt`.
+    ///
+    /// This is required to be a valid UTF-8 string.
+    pub path: BorrowedBytes<'a>,
+
+    /// The filter level for logs.
+    ///
+    /// If empty, this is set to `info`.
+    ///
+    /// This is required to be a valid UTF-8 string.
+    pub filter_level: BorrowedBytes<'a>,
+}
+
+#[cfg(feature = "logger")]
+impl LogArgs<'_> {
+    fn path(&self) -> std::io::Result<std::borrow::Cow<'_, std::path::Path>> {
+        let path = self.path.as_str().map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("log path contains invalid utf-8: {err}"),
+            )
+        })?;
+        if path.is_empty() {
+            Ok(std::borrow::Cow::Owned(
+                std::env::temp_dir().join("firewood-log.txt"),
+            ))
+        } else {
+            Ok(std::borrow::Cow::Borrowed(std::path::Path::new(path)))
+        }
+    }
+
+    fn log_level(&self) -> std::io::Result<&str> {
+        let level = self.filter_level.as_str().map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("log level contains invalid utf-8: {err}"),
+            )
+        })?;
+        if level.is_empty() {
+            Ok("info")
+        } else {
+            Ok(level)
+        }
+    }
+
+    /// Starts logging to the specified file path with the given filter level.
+    ///
+    /// # Errors
+    ///
+    /// If the log file cannot be created or opened, or if the log level is invalid,
+    /// this will return an error.
+    pub fn start_logging(&self) -> std::io::Result<()> {
+        use env_logger::Target::Pipe;
+        use std::fs::OpenOptions;
+
+        let log_path = self.path()?;
+
+        if let Some(log_dir) = log_path.parent() {
+            std::fs::create_dir_all(log_dir).map_err(|e| {
+                std::io::Error::new(
+                    e.kind(),
+                    format!(
+                        "failed to create log directory `{}`: {e}",
+                        log_dir.display()
+                    ),
+                )
+            })?;
+        }
+
+        let level = self.log_level()?;
+        let level = level.parse().map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid log level `{level}`: {e}"),
+            )
+        })?;
+
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(&log_path)
+            .map_err(|e| {
+                std::io::Error::new(
+                    e.kind(),
+                    format!("failed to open log file `{}`: {e}", log_path.display()),
+                )
+            })?;
+
+        env_logger::Builder::new()
+            .filter_level(level)
+            .target(Pipe(Box::new(file)))
+            .try_init()
+            .map_err(|e| std::io::Error::other(format!("failed to initialize logger: {e}")))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "logger"))]
+impl LogArgs<'_> {
+    /// Starts logging to the specified file path with the given filter level.
+    ///
+    /// # Errors
+    ///
+    /// This method will always return an error because the `logger` feature is not enabled.
+    pub fn start_logging(&self) -> std::io::Result<()> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "firewood-ffi was compiled without the `logger` feature. Logging is not available.",
+        ))
+    }
+}

--- a/ffi/src/metrics_setup.rs
+++ b/ffi/src/metrics_setup.rs
@@ -81,12 +81,28 @@ pub fn gather_metrics() -> Result<String, String> {
     Ok(recorder.stats())
 }
 
+/// Internal data structure for the [`TextRecorder`] containing the metrics registry and help text.
+///
+/// This structure holds:
+/// - A metrics registry that stores all counter and gauge values with atomic storage
+/// - A mutex-protected map of help text for each metric name
+///
+/// The atomic storage ensures thread-safe updates to metric values, while the mutex
+/// protects the help text map during concurrent access.
 #[derive(Debug)]
 struct TextRecorderInner {
     registry: Registry<Key, AtomicStorage>,
     help: Mutex<HashMap<String, String>>,
 }
 
+/// A metrics recorder that outputs metrics in Prometheus text exposition format.
+///
+/// This recorder implements the [`metrics::Recorder`] trait and formats all
+/// collected metrics as text in the format expected by Prometheus. It supports
+/// counters and gauges, but not histograms.
+///
+/// The recorder is thread-safe and can be shared across multiple threads.
+/// All metrics are stored in memory and can be retrieved via [`Self::stats`].
 #[derive(Debug, Clone)]
 struct TextRecorder {
     inner: Arc<TextRecorderInner>,

--- a/ffi/src/proposal.rs
+++ b/ffi/src/proposal.rs
@@ -1,0 +1,159 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use firewood::v2::api::{self, HashKey, KeyValuePairIter};
+
+use crate::value::KeyValuePair;
+
+use metrics::counter;
+
+/// An opaque wrapper around a Proposal that also retains a reference to the
+/// database handle it was created from.
+#[derive(Debug)]
+pub struct ProposalHandle<'db> {
+    hash_key: Option<HashKey>,
+    proposal: firewood::db::Proposal<'db>,
+    handle: &'db crate::DatabaseHandle,
+}
+
+impl ProposalHandle<'_> {
+    /// Returns the root hash of the proposal.
+    #[must_use]
+    pub fn hash_key(&self) -> Option<crate::HashKey> {
+        self.hash_key.clone().map(Into::into)
+    }
+
+    /// Consume and commit a proposal.
+    ///
+    /// # Arguments
+    ///
+    /// - `token`: An callback function that will be called with the duration
+    ///   of the commit operation. This will be dropped without being called if
+    ///   the commit fails.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if committing the proposal fails or if the
+    /// proposal is empty.
+    pub fn commit_proposal(
+        self,
+        token: impl FnOnce(coarsetime::Duration),
+    ) -> Result<Option<HashKey>, api::Error> {
+        let ProposalHandle {
+            hash_key,
+            proposal,
+            handle,
+        } = self;
+
+        // promote the proposal to the handle's cached view so that it can be used
+        // for future reads while the proposal is being committed
+        if let Some(ref hash_key) = hash_key {
+            _ = handle.get_root(hash_key.clone());
+        }
+
+        let start_time = coarsetime::Instant::now();
+        proposal.commit_sync()?;
+        let commit_time = start_time.elapsed();
+
+        // clear the cached view so that it does not hold onto the proposal view
+        handle.clear_cached_view();
+
+        token(commit_time);
+
+        Ok(hash_key)
+    }
+}
+
+impl firewood::db::DbViewSyncBytes for ProposalHandle<'_> {
+    fn val_sync_bytes(
+        &self,
+        key: &[u8],
+    ) -> Result<Option<firewood::merkle::Value>, firewood::db::DbError> {
+        self.proposal.val_sync_bytes(key)
+    }
+}
+
+#[derive(Debug)]
+pub struct CreateProposalResult<'db> {
+    pub handle: ProposalHandle<'db>,
+    pub start_time: coarsetime::Instant,
+}
+
+/// A trait that abstracts over database handles and proposal handles for creating proposals.
+///
+/// This trait allows functions to work with both [`DatabaseHandle`] and [`ProposalHandle`]
+/// uniformly when creating new proposals. It provides a common interface for:
+/// - Getting the underlying database handle
+/// - Creating proposals from key-value pairs
+/// - Creating proposal handles with timing information
+///
+/// This abstraction enables proposal chaining (creating proposals on top of other proposals)
+/// while maintaining a consistent API.
+///
+/// [`DatabaseHandle`]: crate::DatabaseHandle
+pub trait CView<'db> {
+    /// Returns a reference to the database handle that is ultimately used to
+    /// create the proposal. For the database handle, this returns itself. For,
+    /// a proposal handle, this returns the handle that was used to create the
+    /// proposal.
+    fn handle(&self) -> &'db crate::DatabaseHandle;
+
+    /// Create a [`firewood::db::Proposal`] with the provided key-value pairs.
+    ///
+    /// # Errors
+    ///
+    /// This function will return a database error if the proposal could not be
+    /// created.
+    fn create_proposal<'kvp>(
+        self,
+        values: (impl AsRef<[KeyValuePair<'kvp>]> + 'kvp),
+    ) -> Result<firewood::db::Proposal<'db>, api::Error>;
+
+    /// Create a [`ProposalHandle`] from the values and return it with timing
+    /// information.
+    ///
+    /// # Errors
+    ///
+    /// This function will return a database error if the proposal could not be
+    /// created or if the proposal is empty.
+    fn create_proposal_handle<'kvp>(
+        self,
+        values: (impl AsRef<[KeyValuePair<'kvp>]> + 'kvp),
+    ) -> Result<CreateProposalResult<'db>, api::Error>
+    where
+        Self: Sized,
+    {
+        let handle = self.handle();
+
+        let start_time = coarsetime::Instant::now();
+        let proposal = self.create_proposal(values)?;
+        let propose_time = start_time.elapsed();
+        counter!("firewood.ffi.propose_ms").increment(propose_time.as_millis());
+        counter!("firewood.ffi.propose").increment(1);
+
+        let hash_key = proposal.root_hash_sync()?;
+
+        Ok(CreateProposalResult {
+            handle: ProposalHandle {
+                hash_key,
+                proposal,
+                handle,
+            },
+            start_time,
+        })
+    }
+}
+
+impl<'db> CView<'db> for &ProposalHandle<'db> {
+    fn handle(&self) -> &'db crate::DatabaseHandle {
+        self.handle
+    }
+
+    fn create_proposal<'kvp>(
+        self,
+        values: (impl AsRef<[KeyValuePair<'kvp>]> + 'kvp),
+    ) -> Result<firewood::db::Proposal<'db>, api::Error> {
+        self.proposal
+            .propose_sync(values.as_ref().iter().map_into_batch())
+    }
+}

--- a/ffi/src/value.rs
+++ b/ffi/src/value.rs
@@ -3,8 +3,15 @@
 
 mod borrowed;
 mod display_hex;
+mod hash_key;
 mod kvp;
+mod owned;
+mod results;
 
 pub use self::borrowed::{BorrowedBytes, BorrowedKeyValuePairs, BorrowedSlice};
 use self::display_hex::DisplayHex;
+pub use self::hash_key::HashKey;
 pub use self::kvp::KeyValuePair;
+pub use self::owned::{OwnedBytes, OwnedSlice};
+pub(crate) use self::results::{CResult, NullHandleResult};
+pub use self::results::{HandleResult, HashResult, ProposalResult, ValueResult, VoidResult};

--- a/ffi/src/value/hash_key.rs
+++ b/ffi/src/value/hash_key.rs
@@ -1,0 +1,38 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use std::fmt;
+
+/// A root database hash key, used in FFI functions that provide or return
+/// a root hash. This type requires no allocation and can be copied freely
+/// and droppped without any additional overhead.
+///
+/// This is useful because it is the same size as 4 words which is equivalent
+/// to 2 heap-allocated slices (pointer + length each), or 1.5 vectors (which
+/// uses an extra word for allocation capacity) and it can be passed around
+/// without needing to allocate or deallocate memory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+// Must use `repr(C)` instead of `repr(transparent)` to ensure it is a struct
+// with one field instead of a type alias of an array of 32 element, which is
+// necessary for FFI compatibility so that `HashKey` can be passed by value;
+// otherwise, it would look like a pointer to an array of 32 bytes.
+#[repr(C)]
+pub struct HashKey([u8; 32]);
+
+impl fmt::Display for HashKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        super::DisplayHex(&self.0).fmt(f)
+    }
+}
+
+impl From<firewood::v2::api::HashKey> for HashKey {
+    fn from(value: firewood::v2::api::HashKey) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<HashKey> for firewood::v2::api::HashKey {
+    fn from(value: HashKey) -> Self {
+        value.0.into()
+    }
+}

--- a/ffi/src/value/owned.rs
+++ b/ffi/src/value/owned.rs
@@ -1,0 +1,161 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use std::{fmt, ptr::NonNull};
+
+/// A type alias for a rust-owned byte slice.
+pub type OwnedBytes = OwnedSlice<u8>;
+
+/// A Rust-owned vector of bytes that can be passed to C code.
+///
+/// C callers must free this memory using the respective FFI function for the
+/// concrete type (but not using the `free` function from the C standard library).
+#[derive(Debug)]
+#[repr(C)]
+pub struct OwnedSlice<T> {
+    ptr: Option<NonNull<T>>,
+    len: usize,
+}
+
+impl<T> OwnedSlice<T> {
+    /// Dereferences the pointer to the owned slice, returning a slice of the contained type.
+    #[must_use]
+    pub const fn as_slice(&self) -> &[T] {
+        match self.ptr {
+            // SAFETY: if the pointer is not null, we are assuming the caller has not changed
+            // it from when we originally created the `OwnedSlice`.
+            Some(ptr) => unsafe { std::slice::from_raw_parts(ptr.as_ptr(), self.len) },
+            None => &[],
+        }
+    }
+
+    /// Returns a mutable slice of the owned slice, allowing modification of the contained type.
+    #[must_use]
+    pub const fn as_mut_slice(&mut self) -> &mut [T] {
+        match self.ptr {
+            // SAFETY: if the pointer is not null, we are assuming the caller has not changed
+            // it from when we originally created the `OwnedSlice`.
+            Some(ptr) => unsafe { std::slice::from_raw_parts_mut(ptr.as_ptr(), self.len) },
+            None => &mut [],
+        }
+    }
+
+    /// Transforms the owned slice into a boxed slice, consuming the original.
+    #[must_use]
+    pub fn into_boxed_slice(self) -> Box<[T]> {
+        self.into()
+    }
+
+    fn take_box(&mut self) -> Box<[T]> {
+        match self.ptr.take() {
+            // SAFETY: if the pointer is not null, we are assuming the caller has not changed
+            // it from when we originally created the `OwnedSlice`. The owned slice was created
+            // from a `Box::leak`, so we can safely convert it back using `Box::from_raw`.
+            Some(ptr) => unsafe {
+                Box::from_raw(std::slice::from_raw_parts_mut(ptr.as_ptr(), self.len))
+            },
+            None => Box::new([]),
+        }
+    }
+}
+
+impl<T: Clone> Clone for OwnedSlice<T> {
+    fn clone(&self) -> Self {
+        self.as_slice().to_vec().into()
+    }
+}
+
+impl<T> AsRef<[T]> for OwnedSlice<T> {
+    fn as_ref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> AsMut<[T]> for OwnedSlice<T> {
+    fn as_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T> std::borrow::Borrow<[T]> for OwnedSlice<T> {
+    fn borrow(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> std::borrow::BorrowMut<[T]> for OwnedSlice<T> {
+    fn borrow_mut(&mut self) -> &mut [T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T: std::hash::Hash> std::hash::Hash for OwnedSlice<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_slice().hash(state);
+    }
+}
+
+impl<T: PartialEq> PartialEq for OwnedSlice<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<T: Eq> Eq for OwnedSlice<T> {}
+
+impl<T: PartialOrd> PartialOrd for OwnedSlice<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.as_slice().partial_cmp(other.as_slice())
+    }
+}
+
+impl<T: Ord> Ord for OwnedSlice<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_slice().cmp(other.as_slice())
+    }
+}
+
+impl<T> From<Box<[T]>> for OwnedSlice<T> {
+    fn from(data: Box<[T]>) -> Self {
+        let len = data.len();
+        let ptr = NonNull::from(Box::leak(data)).cast::<T>();
+        Self {
+            ptr: Some(ptr),
+            len,
+        }
+    }
+}
+
+impl<T> From<Vec<T>> for OwnedSlice<T> {
+    fn from(data: Vec<T>) -> Self {
+        data.into_boxed_slice().into()
+    }
+}
+
+impl<T> From<OwnedSlice<T>> for Box<[T]> {
+    fn from(mut owned: OwnedSlice<T>) -> Self {
+        owned.take_box()
+    }
+}
+
+impl<T> Drop for OwnedSlice<T> {
+    fn drop(&mut self) {
+        drop(self.take_box());
+    }
+}
+
+impl fmt::Display for OwnedBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        super::DisplayHex(self.as_slice()).fmt(f)
+    }
+}
+
+// send/sync rules for owned values apply here: if the value is send, the pointer
+// is send. if the value is sync, the pointer is sync. This is because we own the
+// value and whether or not the pointer can traverse threads is determined by
+// the value itself.
+
+// SAFETY: described above
+unsafe impl<T: Send> Send for OwnedSlice<T> {}
+// SAFETY: described above
+unsafe impl<T: Sync> Sync for OwnedSlice<T> {}

--- a/ffi/src/value/results.rs
+++ b/ffi/src/value/results.rs
@@ -1,0 +1,337 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use std::fmt;
+
+use firewood::v2::api;
+
+use crate::{CreateProposalResult, HashKey, OwnedBytes, ProposalHandle};
+
+/// The result type returned from an FFI function that returns no value but may
+/// return an error.
+#[derive(Debug)]
+#[repr(C)]
+pub enum VoidResult {
+    /// The caller provided a null pointer to the input handle.
+    NullHandlePointer,
+
+    /// The operation was successful and no error occurred.
+    Ok,
+
+    /// An error occurred and the message is returned as an [`OwnedBytes`]. Its
+    /// value is guaranteed to contain only valid UTF-8.
+    ///
+    /// The caller must call [`fwd_free_owned_bytes`] to free the memory
+    /// associated with this error.
+    ///
+    /// [`fwd_free_owned_bytes`]: crate::fwd_free_owned_bytes
+    Err(OwnedBytes),
+}
+
+impl From<()> for VoidResult {
+    fn from((): ()) -> Self {
+        VoidResult::Ok
+    }
+}
+
+impl<E: fmt::Display> From<Result<(), E>> for VoidResult {
+    fn from(value: Result<(), E>) -> Self {
+        match value {
+            Ok(()) => VoidResult::Ok,
+            Err(err) => VoidResult::Err(err.to_string().into_bytes().into()),
+        }
+    }
+}
+
+/// The result type returned from the open or create database functions.
+#[derive(Debug)]
+#[repr(C)]
+pub enum HandleResult {
+    /// The database was opened or created successfully and the handle is
+    /// returned as an opaque pointer.
+    ///
+    /// The caller must ensure that [`fwd_close_db`] is called to free resources
+    /// associated with this handle when it is no longer needed.
+    ///
+    /// [`fwd_close_db`]: crate::fwd_close_db
+    Ok(Box<crate::DatabaseHandle>),
+
+    /// An error occurred and the message is returned as an [`OwnedBytes`]. If
+    /// value is guaranteed to contain only valid UTF-8.
+    ///
+    /// The caller must call [`fwd_free_owned_bytes`] to free the memory
+    /// associated with this error.
+    ///
+    /// [`fwd_free_owned_bytes`]: crate::fwd_free_owned_bytes
+    Err(OwnedBytes),
+}
+
+impl<E: fmt::Display> From<Result<crate::DatabaseHandle, E>> for HandleResult {
+    fn from(value: Result<crate::DatabaseHandle, E>) -> Self {
+        match value {
+            Ok(handle) => HandleResult::Ok(Box::new(handle)),
+            Err(err) => HandleResult::Err(err.to_string().into_bytes().into()),
+        }
+    }
+}
+
+/// A result type returned from FFI functions that retrieve a single value.
+#[derive(Debug)]
+#[repr(C)]
+pub enum ValueResult {
+    /// The caller provided a null pointer to a database handle.
+    NullHandlePointer,
+    /// The provided root was not found in the database.
+    RevisionNotFound(HashKey),
+    /// The provided key was not found in the database or proposal.
+    None,
+    /// A value was found and is returned.
+    ///
+    /// The caller must call [`fwd_free_owned_bytes`] to free the memory
+    /// associated with this value.
+    ///
+    /// [`fwd_free_owned_bytes`]: crate::fwd_free_owned_bytes
+    Some(OwnedBytes),
+    /// An error occurred and the message is returned as an [`OwnedBytes`]. If
+    /// value is guaranteed to contain only valid UTF-8.
+    ///
+    /// The caller must call [`fwd_free_owned_bytes`] to free the memory
+    /// associated with this error.
+    ///
+    /// [`fwd_free_owned_bytes`]: crate::fwd_free_owned_bytes
+    Err(OwnedBytes),
+}
+
+impl<E: fmt::Display> From<Result<String, E>> for ValueResult {
+    fn from(value: Result<String, E>) -> Self {
+        match value {
+            Ok(data) => ValueResult::Some(data.into_bytes().into()),
+            Err(err) => ValueResult::Err(err.to_string().into_bytes().into()),
+        }
+    }
+}
+
+impl From<Result<Option<Box<[u8]>>, api::Error>> for ValueResult {
+    fn from(value: Result<Option<Box<[u8]>>, api::Error>) -> Self {
+        match value {
+            Ok(None) => ValueResult::None,
+            Err(api::Error::RevisionNotFound { provided }) => ValueResult::RevisionNotFound(
+                HashKey::from(provided.unwrap_or_else(api::HashKey::empty)),
+            ),
+            Ok(Some(data)) => ValueResult::Some(data.into()),
+            Err(err) => ValueResult::Err(err.to_string().into_bytes().into()),
+        }
+    }
+}
+
+impl From<Result<Option<Box<[u8]>>, firewood::db::DbError>> for ValueResult {
+    fn from(value: Result<Option<Box<[u8]>>, firewood::db::DbError>) -> Self {
+        value.map_err(api::Error::from).into()
+    }
+}
+
+/// A result type returned from FFI functions return the database root hash. This
+/// may or may not be after a mutation.
+#[derive(Debug)]
+#[repr(C)]
+pub enum HashResult {
+    /// The caller provided a null pointer to a database handle.
+    NullHandlePointer,
+    /// The proposal resulted in an empty database or the database currently has
+    /// no root hash.
+    None,
+    /// The mutation was successful and the root hash is returned, if this result
+    /// was from a mutation. Otherwise, this is the current root hash of the
+    /// database.
+    Some(HashKey),
+    /// An error occurred and the message is returned as an [`OwnedBytes`]. If
+    /// value is guaranteed to contain only valid UTF-8.
+    ///
+    /// The caller must call [`fwd_free_owned_bytes`] to free the memory
+    /// associated with this error.
+    ///
+    /// [`fwd_free_owned_bytes`]: crate::fwd_free_owned_bytes
+    Err(OwnedBytes),
+}
+
+impl<E: fmt::Display> From<Result<Option<api::HashKey>, E>> for HashResult {
+    fn from(value: Result<Option<api::HashKey>, E>) -> Self {
+        match value {
+            Ok(None) => HashResult::None,
+            Ok(Some(hash)) => HashResult::Some(HashKey::from(hash)),
+            Err(err) => HashResult::Err(err.to_string().into_bytes().into()),
+        }
+    }
+}
+
+/// A result type returned from FFI functions that create a proposal but do not
+/// commit it to the database.
+#[derive(Debug)]
+#[repr(C)]
+pub enum ProposalResult<'db> {
+    /// The caller provided a null pointer to a database handle.
+    NullHandlePointer,
+    /// Buulding the proposal was successful and the proposal ID and root hash
+    /// are returned.
+    Ok {
+        /// An opaque pointer to the [`ProposalHandle`] that can be use to create
+        /// an additional proposal or later commit. The caller must ensure that this
+        /// pointer is freed with [`fwd_free_proposal`] if it is not committed.
+        ///
+        /// [`fwd_free_proposal`]: crate::fwd_free_proposal
+        // note: opaque pointers mut be boxed because the FFI does not the structure definition.
+        handle: Box<ProposalHandle<'db>>,
+        /// The root hash of the proposal. Zeroed if the proposal resulted in an
+        /// empty database.
+        root_hash: HashKey,
+    },
+    /// An error occurred and the message is returned as an [`OwnedBytes`]. If
+    /// value is guaranteed to contain only valid UTF-8.
+    ///
+    /// The caller must call [`fwd_free_owned_bytes`] to free the memory
+    /// associated with this error.
+    ///
+    /// [`fwd_free_owned_bytes`]: crate::fwd_free_owned_bytes
+    Err(OwnedBytes),
+}
+
+impl<'db, E: fmt::Display> From<Result<CreateProposalResult<'db>, E>> for ProposalResult<'db> {
+    fn from(value: Result<CreateProposalResult<'db>, E>) -> Self {
+        match value {
+            Ok(CreateProposalResult { handle, .. }) => ProposalResult::Ok {
+                root_hash: handle.hash_key().unwrap_or_default(),
+                handle: Box::new(handle),
+            },
+            Err(err) => ProposalResult::Err(err.to_string().into_bytes().into()),
+        }
+    }
+}
+
+/// Helper trait to handle the different result types returned from FFI functions.
+///
+/// Once Try trait is stable, we can use that instead of this trait:
+///
+/// ```ignore
+/// impl std::ops::FromResidual<Option<std::convert::Infallible>> for VoidResult {
+///     #[inline]
+///     fn from_residual(residual: Option<std::convert::Infallible>) -> Self {
+///         match residual {
+///             None => VoidResult::NullHandlePointer,
+///             // no other branches are needed because `std::convert::Infallible` is uninhabited
+///             // this compiles without error because the compiler knows that Some(_) is impossible
+///             // see: https://github.com/rust-lang/rust/blob/3fb1b53a9dbfcdf37a4b67d35cde373316829930/library/core/src/option.rs#L2627-L2631
+///             // and: https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
+///         }
+///     }
+/// }
+/// ```
+pub(crate) trait NullHandleResult: CResult {
+    fn null_handle_pointer_error() -> Self;
+}
+
+pub(crate) trait CResult: Sized {
+    fn from_err(err: impl ToString) -> Self;
+
+    fn from_panic(panic: Box<dyn std::any::Any + Send>) -> Self
+    where
+        Self: Sized,
+    {
+        Self::from_err(Panic::from(panic))
+    }
+}
+
+impl NullHandleResult for VoidResult {
+    fn null_handle_pointer_error() -> Self {
+        Self::NullHandlePointer
+    }
+}
+
+impl CResult for VoidResult {
+    fn from_err(err: impl ToString) -> Self {
+        Self::Err(err.to_string().into_bytes().into())
+    }
+}
+
+impl CResult for HandleResult {
+    fn from_err(err: impl ToString) -> Self {
+        Self::Err(err.to_string().into_bytes().into())
+    }
+}
+
+impl NullHandleResult for ValueResult {
+    fn null_handle_pointer_error() -> Self {
+        Self::NullHandlePointer
+    }
+}
+
+impl CResult for ValueResult {
+    fn from_err(err: impl ToString) -> Self {
+        Self::Err(err.to_string().into_bytes().into())
+    }
+}
+
+impl NullHandleResult for HashResult {
+    fn null_handle_pointer_error() -> Self {
+        Self::NullHandlePointer
+    }
+}
+
+impl CResult for HashResult {
+    fn from_err(err: impl ToString) -> Self {
+        Self::Err(err.to_string().into_bytes().into())
+    }
+}
+
+impl NullHandleResult for ProposalResult<'_> {
+    fn null_handle_pointer_error() -> Self {
+        Self::NullHandlePointer
+    }
+}
+
+impl CResult for ProposalResult<'_> {
+    fn from_err(err: impl ToString) -> Self {
+        Self::Err(err.to_string().into_bytes().into())
+    }
+}
+
+enum Panic {
+    Static(&'static str),
+    Formatted(String),
+    SendSyncErr(Box<dyn std::error::Error + Send + Sync>),
+    SendErr(Box<dyn std::error::Error + Send>),
+    Unknown(#[expect(unused)] Box<dyn std::any::Any + Send>),
+    // TODO: add variant to capture backtrace with panic hook
+    // https://doc.rust-lang.org/stable/std/panic/fn.set_hook.html
+}
+
+impl From<Box<dyn std::any::Any + Send>> for Panic {
+    fn from(panic: Box<dyn std::any::Any + Send>) -> Self {
+        macro_rules! downcast {
+            ($Variant:ident($panic:ident)) => {
+                let $panic = match $panic.downcast() {
+                    Ok(panic) => return Panic::$Variant(*panic),
+                    Err(panic) => panic,
+                };
+            };
+        }
+
+        downcast!(Static(panic));
+        downcast!(Formatted(panic));
+        downcast!(SendSyncErr(panic));
+        downcast!(SendErr(panic));
+
+        Self::Unknown(panic)
+    }
+}
+
+impl fmt::Display for Panic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Panic::Static(msg) => f.pad(msg),
+            Panic::Formatted(msg) => f.pad(msg),
+            Panic::SendSyncErr(err) => err.fmt(f),
+            Panic::SendErr(err) => err.fmt(f),
+            Panic::Unknown(_) => f.pad("unknown panic type recovered"),
+        }
+    }
+}


### PR DESCRIPTION
- Split monolithic `lib.`rs into focused modules: `handle`, `proposal`, `arc_cache`, `logging`, and `value` submodules.
- Replace global proposal tracking with encapsulated `ProposalHandle` that retains database reference. This extra reference is only necessary to do the cached memory view while we are committing the view.
- Added `ArcCache` to hold the cached memory view. Maybe this goes away in the future.
- Restructure value types into separate modules (`hash_key`, `owned`, `results`)
- Add comprehensive error handling with `CResult` types and panic recovery
- Remove undocumented unsafe blocks clippy exception
- Update Go bindings to use new handle-based API
- Add Grafana dashboard configuration for metrics (to silence the CI bot)

This refactor improves code organization, type safety, and maintainability while preserving the existing FFI API surface.

I would like to break this down into smaller pieces, but at this point I don't know how much I can break it down without making it an interim mess.

---

NOTE: This PR is in a stack and most are dependent on an earlier PR:

1. #1174
2. #1158
