### PR TITLE
feat(fwdctl): Add support for dump formats

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -325,9 +325,7 @@ impl Db {
     pub fn dump_sync(&self, w: &mut dyn Write) -> Result<(), std::io::Error> {
         let latest_rev_nodestore = self.manager.current_revision();
         let merkle = Merkle::from(latest_rev_nodestore);
-        merkle
-            .dump(w)
-            .map_err(std::io::Error::other)
+        merkle.dump(w).map_err(std::io::Error::other)
     }
 
     /// Get a copy of the database metrics

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -325,9 +325,9 @@ impl Db {
     pub fn dump_sync(&self, w: &mut dyn Write) -> Result<(), std::io::Error> {
         let latest_rev_nodestore = self.manager.current_revision();
         let merkle = Merkle::from(latest_rev_nodestore);
-        // TODO: This should be a stream
-        let output = merkle.dump()?;
-        write!(w, "{output}")
+        merkle
+            .dump(w)
+            .map_err(std::io::Error::other)
     }
 
     /// Get a copy of the database metrics

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -234,7 +234,12 @@ impl RevisionManager {
 
         if crate::logger::trace_enabled() {
             let merkle = Merkle::from(committed);
-            trace!("{}", merkle.dump().expect("failed to dump merkle"));
+            let mut buffer = Vec::new();
+            if let Ok(()) = merkle.dump(&mut buffer) {
+                if let Ok(s) = String::from_utf8(buffer) {
+                    trace!("{s}");
+                }
+            }
         }
 
         Ok(())

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -234,11 +234,8 @@ impl RevisionManager {
 
         if crate::logger::trace_enabled() {
             let merkle = Merkle::from(committed);
-            let mut buffer = Vec::new();
-            if let Ok(()) = merkle.dump(&mut buffer) {
-                if let Ok(s) = String::from_utf8(buffer) {
-                    trace!("{s}");
-                }
+            if let Ok(s) = merkle.dump_to_string() {
+                trace!("{s}");
             }
         }
 

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -16,7 +16,7 @@ use firewood_storage::{
 use futures::{StreamExt, TryStreamExt};
 use metrics::counter;
 use std::collections::HashSet;
-use std::fmt::{Debug, Write};
+use std::fmt::Debug;
 use std::future::ready;
 use std::io::Error;
 use std::iter::once;
@@ -31,6 +31,8 @@ pub type Value = Box<[u8]>;
 
 // convert a set of nibbles into a printable string
 // panics if there is a non-nibble byte in the set
+// TODO: This is more efficient than the LowerHex implementation for Path
+// so combine them.
 #[cfg(not(feature = "branch_factor_256"))]
 fn nibbles_formatter<X: IntoIterator<Item = u8>>(nib: X) -> String {
     nib.into_iter()
@@ -51,27 +53,27 @@ fn nibbles_formatter<X: IntoIterator<Item = u8>>(nib: X) -> String {
 macro_rules! write_attributes {
     ($writer:ident, $node:expr, $value:expr) => {
         if !$node.partial_path.0.is_empty() {
-            write!(
-                $writer,
-                " pp={}",
-                nibbles_formatter($node.partial_path.0.clone())
-            )
-            .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
+            let pp_str = format!(" pp={}", nibbles_formatter($node.partial_path.0.clone()));
+            $writer
+                .write_all(pp_str.as_bytes())
+                .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
         }
         if !$value.is_empty() {
             match std::str::from_utf8($value) {
                 Ok(string) if string.chars().all(char::is_alphanumeric) => {
-                    write!($writer, " val={}", string)
+                    let val_str = format!(" val={}", string);
+                    $writer
+                        .write_all(val_str.as_bytes())
                         .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
                 }
                 _ => {
                     let hex = hex::encode($value);
+                    let val_str = format!(" val={:.6}", hex);
+                    $writer
+                        .write_all(val_str.as_bytes())
+                        .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
                     if hex.len() > 6 {
-                        write!($writer, " val={:.6}...", hex).map_err(|e| {
-                            FileIoError::from_generic_no_file(e, "write attributes")
-                        })?;
-                    } else {
-                        write!($writer, " val={}", hex).map_err(|e| {
+                        $writer.write_all(b"...").map_err(|e| {
                             FileIoError::from_generic_no_file(e, "write attributes")
                         })?;
                     }
@@ -478,12 +480,12 @@ impl<T: TrieReader> Merkle<T> {
 
 impl<T: HashedNodeReader> Merkle<T> {
     /// Dump a node, recursively, to a dot file
-    pub(crate) fn dump_node(
+    pub(crate) fn dump_node<W: std::io::Write + ?Sized>(
         &self,
         node: &MaybePersistedNode,
         hash: Option<&HashType>,
         seen: &mut HashSet<String>,
-        writer: &mut dyn Write,
+        writer: &mut W,
     ) -> Result<(), FileIoError> {
         writeln!(writer, "  {node}[label=\"{node}")
             .map_err(Error::other)
@@ -536,31 +538,29 @@ impl<T: HashedNodeReader> Merkle<T> {
     ///
     /// Dot files can be rendered using `dot -Tpng -o output.png input.dot`
     /// or online at <https://dreampuf.github.io/GraphvizOnline>
-    pub(crate) fn dump(&self) -> Result<String, Error> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing to the output writer fails.
+    pub(crate) fn dump<W: std::io::Write + ?Sized>(&self, writer: &mut W) -> Result<(), Error> {
         let root = self.nodestore.root_as_maybe_persisted_node();
 
-        let mut result = String::new();
-        writeln!(result, "digraph Merkle {{\n  rankdir=LR;").map_err(Error::other)?;
+        writeln!(writer, "digraph Merkle {{\n  rankdir=LR;").map_err(Error::other)?;
         if let (Some(root), Some(root_hash)) = (root, self.nodestore.root_hash()) {
-            writeln!(result, " root -> {root}")
+            writeln!(writer, " root -> {root}")
                 .map_err(Error::other)
                 .map_err(|e| FileIoError::new(e, None, 0, None))
                 .map_err(Error::other)?;
             let mut seen = HashSet::new();
-            self.dump_node(
-                &root,
-                Some(&root_hash.into_hash_type()),
-                &mut seen,
-                &mut result,
-            )
-            .map_err(Error::other)?;
+            self.dump_node(&root, Some(&root_hash.into_hash_type()), &mut seen, writer)
+                .map_err(Error::other)?;
         }
-        write!(result, "}}")
+        writeln!(writer, "}}")
             .map_err(Error::other)
             .map_err(|e| FileIoError::new(e, None, 0, None))
             .map_err(Error::other)?;
 
-        Ok(result)
+        Ok(())
     }
 }
 

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -562,6 +562,20 @@ impl<T: HashedNodeReader> Merkle<T> {
 
         Ok(())
     }
+
+    /// Dump the trie to a string (for testing purposes).
+    ///
+    /// This is a convenience function for tests that need the dot output as a string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing to the string fails.
+    #[cfg(test)]
+    pub(crate) fn dump_to_string(&self) -> Result<String, Error> {
+        let mut buffer = Vec::new();
+        self.dump(&mut buffer)?;
+        String::from_utf8(buffer).map_err(Error::other)
+    }
 }
 
 impl<F: Parentable, S: ReadableStorage> Merkle<NodeStore<F, S>> {

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -11,6 +11,7 @@ mod triehash;
 mod unvalidated;
 
 use std::collections::HashMap;
+use std::fmt::Write;
 
 use super::*;
 use firewood_storage::{Committed, MemStore, MutableProposal, NodeStore, RootReader, TrieHash};
@@ -637,7 +638,7 @@ fn test_root_hash_simple_insertions() -> Result<(), Error> {
         ("horse", "stallion"),
         ("ddd", "ok"),
     ])
-    .dump()
+    .dump_to_string()
     .unwrap();
     Ok(())
 }
@@ -773,7 +774,7 @@ fn test_root_hash_reversed_deletions() -> Result<(), FileIoError> {
         let (new_hashes, _) = items.iter().rev().fold(
             (vec![], complete_immutable_merkle),
             |(mut new_hashes, immutable_merkle_before_removal), (k, _)| {
-                let before = immutable_merkle_before_removal.dump().unwrap();
+                let before = immutable_merkle_before_removal.dump_to_string().unwrap();
                 let mut merkle = Merkle::from(
                     NodeStore::new(immutable_merkle_before_removal.nodestore()).unwrap(),
                 );
@@ -784,7 +785,7 @@ fn test_root_hash_reversed_deletions() -> Result<(), FileIoError> {
                     immutable_merkle_after_removal.nodestore.root_hash(),
                     k,
                     before,
-                    immutable_merkle_after_removal.dump().unwrap(),
+                    immutable_merkle_after_removal.dump_to_string().unwrap(),
                 ));
                 (new_hashes, immutable_merkle_after_removal)
             },

--- a/firewood/src/stream.rs
+++ b/firewood/src/stream.rs
@@ -1185,7 +1185,7 @@ mod tests {
 
         let immutable_merkle: Merkle<NodeStore<Arc<ImmutableProposal>, _>> =
             merkle.try_into().unwrap();
-        println!("{}", immutable_merkle.dump().unwrap());
+        println!("{}", immutable_merkle.dump_to_string().unwrap());
         merkle = immutable_merkle.fork().unwrap();
 
         let mut stream = merkle.key_value_iter();

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -123,6 +123,28 @@ pub struct Options {
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("dump database {opts:?}");
 
+    // Check if dot format is used with unsupported options
+    if opts.output_format == "dot" {
+        if opts.start_key.is_some() || opts.start_key_hex.is_some() {
+            return Err(api::Error::InternalError(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Dot format does not support --start-key or --start-key-hex options",
+            ))));
+        }
+        if opts.stop_key.is_some() || opts.stop_key_hex.is_some() {
+            return Err(api::Error::InternalError(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Dot format does not support --stop-key or --stop-key-hex options",
+            ))));
+        }
+        if opts.max_key_count.is_some() {
+            return Err(api::Error::InternalError(Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Dot format does not support --max-key-count option",
+            ))));
+        }
+    }
+
     let cfg = DbConfig::builder().truncate(false);
     let db = Db::new(opts.db.clone(), cfg.build()).await?;
     let latest_hash = db.root_hash().await?;


### PR DESCRIPTION
Found myself needing to dump dot graphs during debugging. This was too hard, since the API for generating these wasn't exposed to fwdctl. Added it to fwdctl, as well as refactoring the dump methods to use writers instead of returning a string.