### PR TITLE
feat: remove `Batch` type alias

### DIFF
--- a/benchmark/src/create.rs
+++ b/benchmark/src/create.rs
@@ -31,7 +31,7 @@ impl TestRunner for Create {
             let root = Span::root(func_path!(), SpanContext::random());
             let _guard = root.set_local_parent();
 
-            let batch = Self::generate_inserts(key * keys, args.global_opts.batch_size).collect();
+            let batch = Self::generate_inserts(key * keys, args.global_opts.batch_size);
 
             let proposal = db.propose(batch).await.expect("proposal should succeed");
             proposal.commit().await?;

--- a/benchmark/src/single.rs
+++ b/benchmark/src/single.rs
@@ -31,13 +31,10 @@ impl TestRunner for Single {
         let mut batch_id = 0;
 
         while start.elapsed().as_secs() / 60 < args.global_opts.duration_minutes {
-            let batch = inner_keys
-                .iter()
-                .map(|key| BatchOp::Put {
-                    key,
-                    value: vec![batch_id as u8],
-                })
-                .collect();
+            let batch = inner_keys.iter().map(|key| BatchOp::Put {
+                key,
+                value: vec![batch_id as u8],
+            });
             let proposal = db.propose(batch).await.expect("proposal should succeed");
             proposal.commit().await?;
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -8,10 +8,11 @@
 
 use crate::merkle::{Merkle, Value};
 use crate::stream::MerkleKeyValueStream;
+pub use crate::v2::api::BatchOp;
 use crate::v2::api::{
-    self, FrozenProof, FrozenRangeProof, HashKey, KeyType, OptionalHashKeyExt, ValueType,
+    self, FrozenProof, FrozenRangeProof, HashKey, KeyType, KeyValuePair, KeyValuePairIter,
+    OptionalHashKeyExt,
 };
-pub use crate::v2::api::{Batch, BatchOp};
 
 use crate::manager::{RevisionManager, RevisionManagerConfig};
 use async_trait::async_trait;
@@ -181,15 +182,15 @@ impl api::Db for Db {
     }
 
     #[fastrace::trace(short_name = true)]
-    async fn propose<'db, K: KeyType, V: ValueType>(
+    async fn propose<'db>(
         &'db self,
-        batch: api::Batch<K, V>,
+        batch: (impl IntoIterator<IntoIter: KeyValuePairIter> + Send),
     ) -> Result<Self::Proposal<'db>, api::Error> {
         let parent = self.manager.current_revision();
         let proposal = NodeStore::new(&parent)?;
         let mut merkle = Merkle::from(proposal);
         let span = fastrace::Span::enter_with_local_parent("merkleops");
-        for op in batch {
+        for op in batch.into_iter().map_into_batch() {
             match op {
                 BatchOp::Put { key, value } => {
                     merkle.insert(key.as_ref(), value.as_ref().into())?;
@@ -265,15 +266,15 @@ impl Db {
     }
 
     /// propose a new batch synchronously
-    pub fn propose_sync<K: KeyType, V: ValueType>(
+    pub fn propose_sync(
         &self,
-        batch: Batch<K, V>,
+        batch: impl IntoIterator<IntoIter: KeyValuePairIter>,
     ) -> Result<Proposal<'_>, api::Error> {
         let parent = self.manager.current_revision();
         let proposal = NodeStore::new(&parent)?;
         let mut merkle = Merkle::from(proposal);
         for op in batch {
-            match op {
+            match op.into_batch() {
                 BatchOp::Put { key, value } => {
                     merkle.insert(key.as_ref(), value.as_ref().into())?;
                 }
@@ -385,9 +386,9 @@ impl<'db> api::Proposal for Proposal<'db> {
     type Proposal = Proposal<'db>;
 
     #[fastrace::trace(short_name = true)]
-    async fn propose<K: KeyType, V: ValueType>(
+    async fn propose(
         &self,
-        batch: api::Batch<K, V>,
+        batch: (impl IntoIterator<IntoIter: KeyValuePairIter> + Send),
     ) -> Result<Self::Proposal, api::Error> {
         self.create_proposal(batch)
     }
@@ -404,23 +405,23 @@ impl Proposal<'_> {
     }
 
     /// Create a new proposal from the current one synchronously
-    pub fn propose_sync<K: KeyType, V: ValueType>(
+    pub fn propose_sync(
         &self,
-        batch: api::Batch<K, V>,
+        batch: impl IntoIterator<IntoIter: KeyValuePairIter>,
     ) -> Result<Self, api::Error> {
         self.create_proposal(batch)
     }
 
     #[crate::metrics("firewood.proposal.create", "database proposal creation")]
-    fn create_proposal<K: KeyType, V: ValueType>(
+    fn create_proposal(
         &self,
-        batch: api::Batch<K, V>,
+        batch: impl IntoIterator<IntoIter: KeyValuePairIter>,
     ) -> Result<Self, api::Error> {
         let parent = self.nodestore.clone();
         let proposal = NodeStore::new(&parent)?;
         let mut merkle = Merkle::from(proposal);
         for op in batch {
-            match op {
+            match op.into_batch() {
                 BatchOp::Put { key, value } => {
                     merkle.insert(key.as_ref(), value.as_ref().into())?;
                 }
@@ -454,8 +455,8 @@ mod test {
     use firewood_storage::{CheckOpt, CheckerError};
     use rand::rng;
 
-    use crate::db::Db;
-    use crate::v2::api::{Db as _, DbView as _, Proposal as _};
+    use crate::db::{Db, Proposal};
+    use crate::v2::api::{Db as _, DbView as _, KeyValuePairIter, Proposal as _};
 
     use super::{BatchOp, DbConfig};
 
@@ -680,16 +681,11 @@ mod test {
             .unzip();
 
         // create two batches, one with the first half of keys and values, and one with the last half keys and values
-        let mut kviter = keys
-            .iter()
-            .zip(vals.iter())
-            .map(|(k, v)| BatchOp::Put { key: k, value: v });
-        let batch1 = kviter.by_ref().take(N / 2).collect();
-        let batch2 = kviter.collect();
+        let mut kviter = keys.iter().zip(vals.iter()).map_into_batch();
 
         // create two proposals, second one has a base of the first one
-        let proposal1 = db.propose(batch1).await.unwrap();
-        let proposal2 = proposal1.propose(batch2).await.unwrap();
+        let proposal1 = db.propose(kviter.by_ref().take(N / 2)).await.unwrap();
+        let proposal2 = proposal1.propose(kviter).await.unwrap();
 
         // iterate over the keys and values again, checking that the values are in the correct proposal
         let mut kviter = keys.iter().zip(vals.iter());
@@ -789,6 +785,53 @@ mod test {
         }
     }
 
+    struct Fuse<I>(Option<I>);
+
+    impl<I: Iterator> Iterator for Fuse<I> {
+        type Item = I::Item;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            match &mut self.0 {
+                Some(iter) => {
+                    let opt = iter.next();
+                    if opt.is_none() {
+                        self.0 = None; // consume the iterator
+                    }
+                    opt
+                }
+                None => None,
+            }
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            match &self.0 {
+                Some(iter) => iter.size_hint(),
+                None => (0, Some(0)),
+            }
+        }
+    }
+
+    trait IterExt: Iterator {
+        async fn chunk_fold<B, F>(self, chunk_size: usize, init: B, mut f: F) -> B
+        where
+            Self: Sized,
+            F: for<'a, 'b> AsyncFnMut(B, &'b mut core::iter::Take<&'a mut Fuse<Self>>) -> B,
+        {
+            let mut iter = Fuse(Some(self));
+            let mut acc = init;
+            while iter.0.is_some() {
+                let mut chunk = iter.by_ref().take(chunk_size);
+                acc = f(acc, chunk.by_ref()).await;
+                for _ in chunk {
+                    // consume the chunk
+                }
+            }
+            acc
+        }
+    }
+
+    impl<T: Iterator> IterExt for T {}
+
     #[tokio::test]
     async fn test_deep_propose() {
         const NUM_KEYS: usize = 2;
@@ -796,47 +839,28 @@ mod test {
 
         let db = testdb().await;
 
-        // create NUM_KEYS * NUM_PROPOSALS keys and values
-        let (keys, vals): (Vec<_>, Vec<_>) = (0..NUM_KEYS * NUM_PROPOSALS)
-            .map(|i| {
-                (
-                    format!("key{i}").into_bytes(),
-                    Box::from(format!("value{i}").as_bytes()),
-                )
-            })
-            .unzip();
+        let ops = (0..(NUM_KEYS * NUM_PROPOSALS))
+            .map(|i| (format!("key{i}"), format!("value{i}")))
+            .collect::<Vec<_>>();
 
-        // create batches of NUM_KEYS keys and values
-        let batches: Vec<_> = keys
-            .chunks(NUM_KEYS)
-            .zip(vals.chunks(NUM_KEYS))
-            .map(|(k, v)| {
-                k.iter()
-                    .zip(v.iter())
-                    .map(|(k, v)| BatchOp::Put { key: k, value: v })
-                    .collect()
-            })
-            .collect();
+        let proposals = ops
+            .iter()
+            .chunk_fold(
+                NUM_KEYS,
+                Vec::<Proposal<'_>>::with_capacity(NUM_PROPOSALS),
+                async |mut proposals, ops| {
+                    let proposal = if let Some(parent) = proposals.last() {
+                        parent.propose(ops).await.unwrap()
+                    } else {
+                        db.propose(ops).await.unwrap()
+                    };
 
-        // better be correct
-        assert_eq!(batches.len(), NUM_PROPOSALS);
+                    proposals.push(proposal);
+                    proposals
+                },
+            )
+            .await;
 
-        // create proposals from the batches. The first one is created from the db, the others are
-        // children
-        let mut batches_iter = batches.into_iter();
-        let mut proposals = vec![db.propose(batches_iter.next().unwrap()).await.unwrap()];
-
-        for batch in batches_iter {
-            let proposal = proposals.last().unwrap().propose(batch).await.unwrap();
-            proposals.push(proposal);
-        }
-
-        // check that each value is present in the final proposal
-        for (k, v) in keys.iter().zip(vals.iter()) {
-            assert_eq!(&proposals.last().unwrap().val(k).await.unwrap().unwrap(), v);
-        }
-
-        // save the last proposal root hash for comparison with the final database root hash
         let last_proposal_root_hash = proposals
             .last()
             .unwrap()
@@ -858,8 +882,12 @@ mod test {
         assert_eq!(last_root_hash, last_proposal_root_hash);
 
         // check that all the keys and values are still present
-        for (k, v) in keys.iter().zip(vals.iter()) {
-            assert_eq!(&committed.val(k).await.unwrap().unwrap(), v);
+        for (k, v) in &ops {
+            assert_eq!(
+                committed.val(k).await.unwrap().as_deref(),
+                Some(v.as_bytes()),
+                "Value for key {k:?} should be {v:?}",
+            );
         }
     }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -883,10 +883,11 @@ mod test {
 
         // check that all the keys and values are still present
         for (k, v) in &ops {
+            let found = committed.val(k).await.unwrap();
             assert_eq!(
-                committed.val(k).await.unwrap().as_deref(),
+                found.as_deref(),
                 Some(v.as_bytes()),
-                "Value for key {k:?} should be {v:?}",
+                "Value for key {k:?} should be {v:?} but was {found:?}",
             );
         }
     }

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -4,13 +4,15 @@
 use crate::manager::RevisionManagerError;
 use crate::merkle::{Key, Value};
 use crate::proof::{Proof, ProofError, ProofNode};
-pub use crate::range_proof::RangeProof;
 use async_trait::async_trait;
 use firewood_storage::{FileIoError, TrieHash};
 use futures::Stream;
 use std::fmt::Debug;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+
+pub use crate::range_proof::RangeProof;
+pub use crate::v2::batch_op::{BatchOp, KeyValuePair, KeyValuePairIter, MapIntoBatch};
 
 /// A `KeyType` is something that can be xcast to a u8 reference,
 /// and can be sent and shared across threads. References with
@@ -86,45 +88,6 @@ pub type FrozenRangeProof = RangeProof<Key, Value, Box<[ProofNode]>>;
 /// A frozen proof uses an immutable collection of proof nodes.
 pub type FrozenProof = Proof<Box<[ProofNode]>>;
 
-/// A key/value pair operation. Only put (upsert) and delete are
-/// supported
-#[derive(Debug)]
-pub enum BatchOp<K: KeyType, V: ValueType> {
-    /// Upsert a key/value pair
-    Put {
-        /// the key
-        key: K,
-        /// the value
-        value: V,
-    },
-
-    /// Delete a key
-    Delete {
-        /// The key
-        key: K,
-    },
-
-    /// Delete a range of keys by prefix
-    DeleteRange {
-        /// The prefix of the keys to delete
-        prefix: K,
-    },
-}
-
-/// A list of operations to consist of a batch that
-/// can be proposed
-pub type Batch<K, V> = Vec<BatchOp<K, V>>;
-
-/// A convenience implementation to convert a vector of key/value
-/// pairs into a batch of insert operations
-#[must_use]
-pub fn vec_into_batch<K: KeyType, V: ValueType>(value: Vec<(K, V)>) -> Batch<K, V> {
-    value
-        .into_iter()
-        .map(|(key, value)| BatchOp::Put { key, value })
-        .collect()
-}
-
 /// Errors returned through the API
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
@@ -170,7 +133,7 @@ pub enum Error {
 
     /// Internal error
     #[error("Internal error")]
-    InternalError(Box<dyn std::error::Error + Send>),
+    InternalError(Box<dyn std::error::Error + Send + Sync>),
 
     /// Range too small
     #[error("Range too small")]
@@ -260,9 +223,9 @@ pub trait Db {
     /// * `data` - A batch consisting of [BatchOp::Put] and
     ///            [BatchOp::Delete] operations to apply
     ///
-    async fn propose<'db, K: KeyType, V: ValueType>(
+    async fn propose<'db>(
         &'db self,
-        data: Batch<K, V>,
+        data: (impl IntoIterator<IntoIter: KeyValuePairIter> + Send),
     ) -> Result<Self::Proposal<'db>, Error>
     where
         Self: 'db;
@@ -369,9 +332,9 @@ pub trait Proposal: DbView + Send + Sync {
     ///
     /// A new proposal
     ///
-    async fn propose<K: KeyType, V: ValueType>(
+    async fn propose(
         &self,
-        data: Batch<K, V>,
+        data: (impl IntoIterator<IntoIter: KeyValuePairIter> + Send),
     ) -> Result<Self::Proposal, Error>;
 }
 

--- a/firewood/src/v2/batch_op.rs
+++ b/firewood/src/v2/batch_op.rs
@@ -1,0 +1,211 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use crate::v2::api::{KeyType, ValueType};
+
+/// A key/value pair operation. Only put (upsert) and delete are
+/// supported
+#[derive(Debug, Clone, Copy)]
+pub enum BatchOp<K: KeyType, V: ValueType> {
+    /// Upsert a key/value pair
+    Put {
+        /// the key
+        key: K,
+        /// the value
+        value: V,
+    },
+
+    /// Delete a key
+    Delete {
+        /// The key
+        key: K,
+    },
+
+    /// Delete a range of keys by prefix
+    DeleteRange {
+        /// The prefix of the keys to delete
+        prefix: K,
+    },
+}
+
+impl<K: KeyType, V: ValueType> BatchOp<K, V> {
+    /// Get the key of this operation
+    #[must_use]
+    pub const fn key(&self) -> &K {
+        match self {
+            BatchOp::Put { key, .. }
+            | BatchOp::Delete { key }
+            | BatchOp::DeleteRange { prefix: key } => key,
+        }
+    }
+
+    /// Get the value of this operation
+    #[must_use]
+    pub const fn value(&self) -> Option<&V> {
+        match self {
+            BatchOp::Put { value, .. } => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Convert this operation into a borrowed version, where the key and value
+    /// are references to the original data.
+    #[must_use]
+    pub const fn borrowed(&self) -> BatchOp<&K, &V> {
+        match self {
+            BatchOp::Put { key, value } => BatchOp::Put { key, value },
+            BatchOp::Delete { key } => BatchOp::Delete { key },
+            BatchOp::DeleteRange { prefix } => BatchOp::DeleteRange { prefix },
+        }
+    }
+
+    /// Erases the key and value types, returning a [`BatchOp`] with the key
+    /// and value dereferenced to `&[u8]`.
+    #[inline]
+    #[must_use]
+    pub fn as_ref(&self) -> BatchOp<&[u8], &[u8]> {
+        match self {
+            BatchOp::Put { key, value } => BatchOp::Put {
+                key: key.as_ref(),
+                value: value.as_ref(),
+            },
+            BatchOp::Delete { key } => BatchOp::Delete { key: key.as_ref() },
+            BatchOp::DeleteRange { prefix } => BatchOp::DeleteRange {
+                prefix: prefix.as_ref(),
+            },
+        }
+    }
+}
+
+impl BatchOp<&[u8], &[u8]> {
+    fn eq_impl(self, other: Self) -> bool {
+        std::mem::discriminant(&self) == std::mem::discriminant(&other)
+            && self.key() == other.key()
+            && self.value() == other.value()
+    }
+
+    fn hash_impl<H: std::hash::Hasher>(self, state: &mut H) {
+        use std::hash::Hash;
+        std::mem::discriminant(&self).hash(state);
+        self.key().hash(state);
+        if let Some(value) = self.value() {
+            value.hash(state);
+        }
+    }
+}
+
+impl<K1, V1, K2, V2> PartialEq<BatchOp<K2, V2>> for BatchOp<K1, V1>
+where
+    K1: KeyType,
+    K2: KeyType,
+    V1: ValueType,
+    V2: ValueType,
+{
+    fn eq(&self, other: &BatchOp<K2, V2>) -> bool {
+        BatchOp::eq_impl(self.as_ref(), other.as_ref())
+    }
+}
+
+impl<K: KeyType, V: ValueType> Eq for BatchOp<K, V> {}
+
+impl<K: KeyType, V: ValueType> std::hash::Hash for BatchOp<K, V> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        BatchOp::hash_impl(self.as_ref(), state);
+    }
+}
+
+/// A key/value pair that can be used in a batch.
+pub trait KeyValuePair {
+    /// The key type
+    type Key: KeyType;
+
+    /// The value type
+    type Value: ValueType;
+
+    /// Convert this key-value pair into a [`BatchOp`].
+    #[must_use]
+    fn into_batch(self) -> BatchOp<Self::Key, Self::Value>;
+}
+
+impl<'a, K: KeyType, V: ValueType> KeyValuePair for &'a (K, V) {
+    type Key = &'a K;
+    type Value = &'a V;
+
+    #[inline]
+    fn into_batch(self) -> BatchOp<Self::Key, Self::Value> {
+        // this converting `&'a (K, V)` into `(&'a K, &'a V)`
+        let (key, value) = self;
+        (key, value).into_batch()
+    }
+}
+
+impl<K: KeyType, V: ValueType> KeyValuePair for (K, V) {
+    type Key = K;
+    type Value = V;
+
+    #[inline]
+    fn into_batch(self) -> BatchOp<Self::Key, Self::Value> {
+        let (key, value) = self;
+        if value.as_ref().is_empty() {
+            BatchOp::DeleteRange { prefix: key }
+        } else {
+            BatchOp::Put { key, value }
+        }
+    }
+}
+
+impl<K: KeyType, V: ValueType> KeyValuePair for BatchOp<K, V> {
+    type Key = K;
+    type Value = V;
+
+    fn into_batch(self) -> BatchOp<Self::Key, Self::Value> {
+        self
+    }
+}
+
+impl<'a, K: KeyType, V: ValueType> KeyValuePair for &'a BatchOp<K, V> {
+    type Key = &'a K;
+    type Value = &'a V;
+
+    fn into_batch(self) -> BatchOp<Self::Key, Self::Value> {
+        self.borrowed()
+    }
+}
+
+/// An extension trait for iterators that yield [`KeyValuePair`]s.
+pub trait KeyValuePairIter:
+    Iterator<Item: KeyValuePair<Key = Self::Key, Value = Self::Value>>
+{
+    /// An associated type for the iterator item's key type. This is a convenience
+    /// requirement to avoid needing to build up nested generic associated types.
+    /// E.g., `<<Self as Iterator>::Item as KeyValuePair>::Key`
+    type Key: KeyType;
+
+    /// An associated type for the iterator item's value type. This is a convenience
+    /// requirement to avoid needing to build up nested generic associated types.
+    /// E.g., `<<Self as Iterator>::Item as KeyValuePair>::Value`
+    type Value: ValueType;
+
+    /// Maps the items of this iterator into [`BatchOp`]s.
+    #[inline]
+    fn map_into_batch(self) -> MapIntoBatch<Self>
+    where
+        Self: Sized,
+        Self::Item: KeyValuePair,
+    {
+        self.map(KeyValuePair::into_batch)
+    }
+}
+
+impl<I: Iterator<Item: KeyValuePair>> KeyValuePairIter for I {
+    type Key = <I::Item as KeyValuePair>::Key;
+    type Value = <I::Item as KeyValuePair>::Value;
+}
+
+/// An iterator that maps a [`KeyValuePair`] into a [`BatchOp`] on yielded items.
+pub type MapIntoBatch<I> = std::iter::Map<
+    I,
+    fn(
+        <I as Iterator>::Item,
+    ) -> BatchOp<<I as KeyValuePairIter>::Key, <I as KeyValuePairIter>::Value>,
+>;

--- a/firewood/src/v2/mod.rs
+++ b/firewood/src/v2/mod.rs
@@ -3,3 +3,6 @@
 
 /// The public API
 pub mod api;
+
+/// A batch operation and associated types
+mod batch_op;


### PR DESCRIPTION
The `Batch<K, V>` type alias has been removed in favor of using `IntoIterator<Item = BatchOp<K, V>>` in its place. The functions were already generic over `K` and `V`. Therefore, making them generic over the iterator type makes sense as well.

This also prevents unecessary allocations as we are no longer forced to collect into a vector unecessarily. Being able to iteratively build batch operations allow other range related improvements to be embedded in the iterator passed into `propose...`.

`BatchOp<K, V>` is constructed from `KeyValuePair` implementations and a default implementation is provided for `(K, V)` tuples. The behavior of using `DeleteRange` when the value is empty is preserved from FFI.

Also included is a refactor of the benchmarks to use the preferred batch iterator style. This is also used later on to benchmark future changes in range operations.

---

NOTE: This PR is in a stack and most are dependent on an earlier PR:

1. #1169
2. #1170
3. #1171
4. #1172
5. #1173
6. #1174
7. #1158
