### PR TITLE
chore: deny `undocumented-unsafe-blocks`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ indexing_slicing = "warn"
 explicit_deref_methods = "warn"
 missing_const_for_fn = "warn"
 arithmetic_side_effects = "warn"
+undocumented_unsafe_blocks = "deny"
 # lower the priority of pedantic to allow overriding the lints it includes
 pedantic = { level = "warn", priority = -1 }
 # These lints are from pedantic but allowed. They are a bit too pedantic and

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -6,6 +6,10 @@
     unsafe_code,
     reason = "This is an FFI library, so unsafe code is expected."
 )]
+#![expect(
+    clippy::undocumented_unsafe_blocks,
+    reason = "https://github.com/ava-labs/firewood/pull/1158 will remove"
+)]
 #![cfg_attr(
     not(target_pointer_width = "64"),
     forbid(

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -166,8 +166,10 @@ pub fn area_size_to_index(n: u64) -> Result<AreaIndex, Error> {
 pub struct LinearAddress(NonZeroU64);
 
 #[expect(unsafe_code)]
+// SAFETY: `LinearAddress` is a wrapper around `NonZeroU64` which is also `ZeroableInOption`.
 unsafe impl bytemuck::ZeroableInOption for LinearAddress {}
 #[expect(unsafe_code)]
+// SAFETY: `LinearAddress` is a wrapper around `NonZeroU64` which is also `PodInOption`.
 unsafe impl bytemuck::PodInOption for LinearAddress {}
 
 impl LinearAddress {

--- a/storage/src/nodestore/header.rs
+++ b/storage/src/nodestore/header.rs
@@ -24,7 +24,7 @@
 //! - Uses C-compatible representation for cross-language access
 //!
 
-use bytemuck_derive::{AnyBitPattern, NoUninit};
+use bytemuck_derive::{Pod, Zeroable};
 use std::io::{Error, ErrorKind};
 
 use super::alloc::{FreeLists, LinearAddress, area_size_hash};
@@ -32,7 +32,7 @@ use crate::logger::{debug, trace};
 
 /// Can be used by filesystem tooling such as "file" to identify
 /// the version of firewood used to create this `NodeStore` file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, NoUninit, AnyBitPattern)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Zeroable, Pod)]
 #[repr(transparent)]
 pub struct Version {
     bytes: [u8; 16],
@@ -148,7 +148,7 @@ impl Version {
 
 /// Persisted metadata for a `NodeStore`.
 /// The [`NodeStoreHeader`] is at the start of the `ReadableStorage`.
-#[derive(Copy, Debug, PartialEq, Eq, Clone)]
+#[derive(Copy, Debug, PartialEq, Eq, Clone, Zeroable, Pod)]
 #[repr(C)]
 pub struct NodeStoreHeader {
     /// Identifies the version of firewood used to create this `NodeStore`.
@@ -302,11 +302,6 @@ impl NodeStoreHeader {
         }
     }
 }
-
-#[expect(unsafe_code)]
-unsafe impl bytemuck::Zeroable for NodeStoreHeader {}
-#[expect(unsafe_code)]
-unsafe impl bytemuck::Pod for NodeStoreHeader {}
 
 #[cfg(test)]
 #[expect(clippy::unwrap_used)]

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -419,10 +419,10 @@ impl NodeStore<Committed, FileBacked> {
                         .build()
                         .user_data(pos as u64);
 
+                    #[expect(unsafe_code)]
                     // SAFETY: the submission_queue_entry's found buffer must not move or go out of scope
                     // until the operation has been completed. This is ensured by having a Some(offset)
                     // and not marking it None until the kernel has said it's done below.
-                    #[expect(unsafe_code)]
                     while unsafe { ring.submission().push(&submission_queue_entry) }.is_err() {
                         ring.submitter().squeue_wait().map_err(|e| {
                             self.storage.file_io_error(


### PR DESCRIPTION
Except `ffi`, temporarily.

---

NOTE: This PR is in a stack and most are dependent on an earlier PR:

1. #1169
2. #1170
3. #1171
4. #1172
5. #1173
6. #1174
7. #1158
