### PR TITLE
feat(checker): checker returns all errors found in the report

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -331,10 +331,7 @@ impl Db {
     }
 
     /// Check the database for consistency
-    pub async fn check(
-        &self,
-        opt: CheckOpt,
-    ) -> Result<CheckerReport, firewood_storage::CheckerError> {
+    pub async fn check(&self, opt: CheckOpt) -> CheckerReport {
         let latest_rev_nodestore = self.manager.current_revision();
         latest_rev_nodestore.check(opt)
     }
@@ -799,15 +796,15 @@ mod test {
 
             // check the database for consistency, sometimes checking the hashes
             let hash_check = rng.borrow_mut().random();
-            if let Err(e) = db
+            let report = db
                 .check(CheckOpt {
                     hash_check,
                     progress_bar: None,
                 })
-                .await
-            {
+                .await;
+            if !report.errors.is_empty() {
                 db.dump(&mut std::io::stdout()).await.unwrap();
-                panic!("error: {e}");
+                panic!("error: {:?}", report.errors);
             }
         }
     }

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -55,12 +55,10 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
         )
         .with_finish(ProgressFinish::WithMessage("Check Completed!".into()));
 
-    let report = NodeStore::open(storage)?
-        .check(CheckOpt {
-            hash_check: opts.hash_check,
-            progress_bar: Some(progress_bar),
-        })
-        .map_err(|e| api::Error::InternalError(Box::new(e)))?;
+    let report = NodeStore::open(storage)?.check(CheckOpt {
+        hash_check: opts.hash_check,
+        progress_bar: Some(progress_bar),
+    });
 
     print_checker_report(report);
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -285,6 +285,18 @@ pub enum CheckerError {
     IO(#[from] FileIoError),
 }
 
+impl From<CheckerError> for Vec<CheckerError> {
+    fn from(error: CheckerError) -> Self {
+        vec![error]
+    }
+}
+
+impl From<FileIoError> for Vec<CheckerError> {
+    fn from(error: FileIoError) -> Self {
+        vec![CheckerError::IO(error)]
+    }
+}
+
 #[cfg(test)]
 mod test_utils {
     use rand::rngs::StdRng;


### PR DESCRIPTION
Beforehand, checker returns an error whenever it encounters a problem. With this PR, it will return all errors it can find:

1. If a node in the trie is problematic, it will not traverse any deeper from this node, but checker will return multiple errors with nodes that do not have ancestry relationships. 
2. If a free area is problematic, it will continue traversing and the iterator controls when to stop. 
3. No error will ever be reported when visiting leaked areas. 