### PR TITLE
feat(checker): add error when node data is bigger than area size

### DIFF
--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -261,6 +261,16 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
         let (area_index, area_size) = self.area_index_and_size(subtrie_root_address)?;
         let (node, node_bytes) = self.read_node_with_num_bytes_from_disk(subtrie_root_address)?;
 
+        // check if the node fits in the area
+        if node_bytes > area_size {
+            return Err(vec![CheckerError::NodeLargerThanArea {
+                area_start: subtrie_root_address,
+                area_size,
+                node_bytes,
+                parent,
+            }]);
+        }
+
         // if the node has a value, check that the key is valid
         let mut current_path_prefix = path_prefix.clone();
         current_path_prefix.0.extend_from_slice(node.partial_path());

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -114,7 +114,6 @@ struct SubTrieMetadata {
 }
 
 /// [`NodeStore`] checker
-// TODO: S needs to be writeable if we ask checker to fix the issues
 #[expect(clippy::result_large_err)]
 impl<S: WritableStorage> NodeStore<Committed, S> {
     /// Go through the filebacked storage and check for any inconsistencies. It proceeds in the following steps:
@@ -124,7 +123,6 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
     /// 4. check leaked areas - what are the spaces between trie nodes and free lists we have traversed?
     /// # Errors
     /// Returns a [`CheckerError`] if the database is inconsistent.
-    // TODO: report all errors, not just the first one
     pub fn check(&self, opt: CheckOpt) -> CheckerReport {
         // 1. Check the header
         let db_size = self.size();
@@ -317,18 +315,13 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
             // collect the trie bytes
             trie_stats.trie_bytes = trie_stats.trie_bytes.saturating_add(node_bytes);
             // collect low occupancy area count
-            let smallest_area_index = area_size_to_index(node_bytes).map_err(|e| {
-                self.file_io_error(
-                    e,
-                    subtrie_root_address.get(),
-                    Some("area_size_to_index".to_string()),
-                )
-            })?;
+            let smallest_area_index = area_size_to_index(node_bytes)
+                .expect("impossible since we checked that node_bytes <= area_size");
             if smallest_area_index < area_index {
                 trie_stats.low_occupancy_area_count =
                     trie_stats.low_occupancy_area_count.saturating_add(1);
             }
-            // collect the multi-page area count
+            // collect the number of areas that requires reading an extra page due to not being aligned
             if extra_read_pages(subtrie_root_address, area_size)
                 .expect("impossible since we checked in visited.insert_area()")
                 > 0

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -207,6 +207,21 @@ pub enum CheckerError {
         parent: StoredAreaParent,
     },
 
+    /// Node is larger than the area it is stored in
+    #[error(
+        "stored area at {area_start:#x} with size {area_size} (parent: {parent:#x}) stores a node of size {node_bytes}"
+    )]
+    NodeLargerThanArea {
+        /// Address of the area
+        area_start: LinearAddress,
+        /// Size of the area
+        area_size: u64,
+        /// Size of the node
+        node_bytes: u64,
+        /// The parent of the area
+        parent: TrieNodeParent,
+    },
+
     /// Freelist area size does not match
     #[error(
         "Free area {address:#x} of size {size} (parent: {parent:#x}) is found in free list {actual_free_list} but it should be in freelist {expected_free_list}"


### PR DESCRIPTION
When reading a node from an area, we simply read from the address of the area without checking if the read will span beyond the given area. This PR fills in the gap. 