### PR TITLE
feat(checker): annotate IO error with parent pointer in checker errors

### DIFF
--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -932,10 +932,7 @@ mod test {
             start: free_list1_area2,
             size: area_size1,
             intersection: vec![intersection_start..intersection_end],
-            parent: StoredAreaParent::FreeList(FreeListParent::PrevFreeArea(
-                free_list1_area1,
-                area_index1,
-            )),
+            parent: StoredAreaParent::FreeList(FreeListParent::PrevFreeArea(free_list1_area1)),
         }];
         let expected_free_lists_stats = FreeListsStats {
             area_counts: HashMap::from([(area_size1, 1), (area_size2, 2)]),

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -932,7 +932,10 @@ mod test {
             start: free_list1_area2,
             size: area_size1,
             intersection: vec![intersection_start..intersection_end],
-            parent: StoredAreaParent::FreeList(FreeListParent::PrevFreeArea(free_list1_area1)),
+            parent: StoredAreaParent::FreeList(FreeListParent::PrevFreeArea(
+                free_list1_area1,
+                area_index1,
+            )),
         }];
         let expected_free_lists_stats = FreeListsStats {
             area_counts: HashMap::from([(area_size1, 1), (area_size2, 2)]),

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -278,18 +278,17 @@ pub enum CheckerError {
     /// IO error
     #[error("IO error")]
     #[derive_where(skip_inner)]
-    IO(#[from] FileIoError),
+    IO {
+        /// The error
+        error: FileIoError,
+        /// parent of the area
+        parent: Option<StoredAreaParent>,
+    },
 }
 
 impl From<CheckerError> for Vec<CheckerError> {
     fn from(error: CheckerError) -> Self {
         vec![error]
-    }
-}
-
-impl From<FileIoError> for Vec<CheckerError> {
-    fn from(error: FileIoError) -> Self {
-        vec![CheckerError::IO(error)]
     }
 }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -107,7 +107,7 @@ pub enum FreeListParent {
     /// The stored area is the head of the free list, so the header points to it
     FreeListHead(AreaIndex),
     /// The stored area is not the head of the free list, so a previous free area points to it
-    PrevFreeArea(LinearAddress),
+    PrevFreeArea(LinearAddress, AreaIndex),
 }
 
 impl LowerHex for StoredAreaParent {
@@ -136,8 +136,8 @@ impl LowerHex for FreeListParent {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             FreeListParent::FreeListHead(index) => f.write_fmt(format_args!("FreeLists[{index}]")),
-            FreeListParent::PrevFreeArea(addr) => {
-                f.write_str("FreeArea@")?;
+            FreeListParent::PrevFreeArea(addr, area_index) => {
+                f.write_fmt(format_args!("FreeArea({area_index})@"))?;
                 LowerHex::fmt(addr, f)
             }
         }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -107,7 +107,7 @@ pub enum FreeListParent {
     /// The stored area is the head of the free list, so the header points to it
     FreeListHead(AreaIndex),
     /// The stored area is not the head of the free list, so a previous free area points to it
-    PrevFreeArea(LinearAddress, AreaIndex),
+    PrevFreeArea(LinearAddress),
 }
 
 impl LowerHex for StoredAreaParent {
@@ -136,8 +136,8 @@ impl LowerHex for FreeListParent {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
             FreeListParent::FreeListHead(index) => f.write_fmt(format_args!("FreeLists[{index}]")),
-            FreeListParent::PrevFreeArea(addr, area_index) => {
-                f.write_fmt(format_args!("FreeArea({area_index})@"))?;
+            FreeListParent::PrevFreeArea(addr) => {
+                f.write_str("FreeArea@")?;
                 LowerHex::fmt(addr, f)
             }
         }

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -641,10 +641,13 @@ impl<'a, S: ReadableStorage> FreeListIterator<'a, S> {
     )]
     fn next_with_parent(
         &mut self,
-    ) -> Option<Result<((LinearAddress, AreaIndex), FreeListParent), FileIoError>> {
+    ) -> Option<(
+        Result<(LinearAddress, AreaIndex), FileIoError>,
+        FreeListParent,
+    )> {
         let parent = self.parent;
         let next_addr = self.next()?;
-        Some(next_addr.map(|free_area| (free_area, parent)))
+        Some((next_addr, parent))
     }
 }
 
@@ -678,7 +681,6 @@ pub(crate) struct FreeAreaWithMetadata {
     pub addr: LinearAddress,
     pub area_index: AreaIndex,
     pub free_list_id: AreaIndex,
-    pub parent: FreeListParent,
 }
 
 pub(crate) struct FreeListsIterator<'a, S: ReadableStorage> {
@@ -719,15 +721,17 @@ impl<'a, S: ReadableStorage> FreeListsIterator<'a, S> {
 
     pub(crate) fn next_with_metadata(
         &mut self,
-    ) -> Option<Result<FreeAreaWithMetadata, FileIoError>> {
+    ) -> Option<(Result<FreeAreaWithMetadata, FileIoError>, FreeListParent)> {
         self.next_inner(FreeListIterator::next_with_parent)
-            .map(|next_with_parent| {
-                next_with_parent.map(|((addr, area_index), parent)| FreeAreaWithMetadata {
-                    addr,
-                    area_index,
-                    free_list_id: self.current_free_list_id,
+            .map(|(next, parent)| {
+                (
+                    next.map(|(addr, area_index)| FreeAreaWithMetadata {
+                        addr,
+                        area_index,
+                        free_list_id: self.current_free_list_id,
+                    }),
                     parent,
-                })
+                )
             })
     }
 
@@ -1015,33 +1019,41 @@ mod tests {
 
         // expected
         let expected_free_list1 = vec![
-            FreeAreaWithMetadata {
-                addr: free_list1_area1,
-                area_index: area_index1,
-                free_list_id: area_index1,
-                parent: FreeListParent::FreeListHead(area_index1),
-            },
-            FreeAreaWithMetadata {
-                addr: free_list1_area2,
-                area_index: area_index1,
-                free_list_id: area_index1,
-                parent: FreeListParent::PrevFreeArea(free_list1_area1),
-            },
+            (
+                FreeAreaWithMetadata {
+                    addr: free_list1_area1,
+                    area_index: area_index1,
+                    free_list_id: area_index1,
+                },
+                FreeListParent::FreeListHead(area_index1),
+            ),
+            (
+                FreeAreaWithMetadata {
+                    addr: free_list1_area2,
+                    area_index: area_index1,
+                    free_list_id: area_index1,
+                },
+                FreeListParent::PrevFreeArea(free_list1_area1),
+            ),
         ];
 
         let expected_free_list2 = vec![
-            FreeAreaWithMetadata {
-                addr: free_list2_area1,
-                area_index: area_index2,
-                free_list_id: area_index2,
-                parent: FreeListParent::FreeListHead(area_index2),
-            },
-            FreeAreaWithMetadata {
-                addr: free_list2_area2,
-                area_index: area_index2,
-                free_list_id: area_index2,
-                parent: FreeListParent::PrevFreeArea(free_list2_area1),
-            },
+            (
+                FreeAreaWithMetadata {
+                    addr: free_list2_area1,
+                    area_index: area_index2,
+                    free_list_id: area_index2,
+                },
+                FreeListParent::FreeListHead(area_index2),
+            ),
+            (
+                FreeAreaWithMetadata {
+                    addr: free_list2_area2,
+                    area_index: area_index2,
+                    free_list_id: area_index2,
+                },
+                FreeListParent::PrevFreeArea(free_list2_area1),
+            ),
         ];
 
         let mut expected_iterator = if area_index1 < area_index2 {
@@ -1052,14 +1064,14 @@ mod tests {
 
         loop {
             let next = free_list_iter.next_with_metadata();
-            let expected = expected_iterator.next();
-
-            if expected.is_none() {
+            let Some((expected, expected_parent)) = expected_iterator.next() else {
                 assert!(next.is_none());
                 break;
-            }
+            };
 
-            assert_eq!(next.unwrap().unwrap(), expected.unwrap());
+            let (next, next_parent) = next.unwrap();
+            assert_eq!(next.unwrap(), expected);
+            assert_eq!(next_parent, expected_parent);
         }
     }
 
@@ -1114,29 +1126,31 @@ mod tests {
 
         // start at the first free list
         assert_eq!(free_list_iter.current_free_list_id, 0);
+        let (next, next_parent) = free_list_iter.next_with_metadata().unwrap();
         assert_eq!(
-            free_list_iter.next_with_metadata().unwrap().unwrap(),
+            next.unwrap(),
             FreeAreaWithMetadata {
                 addr: free_list1_area1,
                 area_index: area_index1,
                 free_list_id: area_index1,
-                parent: FreeListParent::FreeListHead(area_index1),
             },
         );
+        assert_eq!(next_parent, FreeListParent::FreeListHead(area_index1));
         // `next_with_metadata` moves the iterator to the first free list that is not empty
         assert_eq!(free_list_iter.current_free_list_id, area_index1);
         free_list_iter.move_to_next_free_list();
         // `move_to_next_free_list` moves the iterator to the next free list
         assert_eq!(free_list_iter.current_free_list_id, area_index1 + 1);
+        let (next, next_parent) = free_list_iter.next_with_metadata().unwrap();
         assert_eq!(
-            free_list_iter.next_with_metadata().unwrap().unwrap(),
+            next.unwrap(),
             FreeAreaWithMetadata {
                 addr: free_list2_area1,
                 area_index: area_index2,
                 free_list_id: area_index2,
-                parent: FreeListParent::FreeListHead(area_index2),
             },
         );
+        assert_eq!(next_parent, FreeListParent::FreeListHead(area_index2));
         // `next_with_metadata` moves the iterator to the first free list that is not empty
         assert_eq!(free_list_iter.current_free_list_id, area_index2);
         free_list_iter.move_to_next_free_list();

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -668,7 +668,7 @@ impl<S: ReadableStorage> Iterator for FreeListIterator<'_, S> {
         };
 
         // update the next address to the next free block
-        self.parent = FreeListParent::PrevFreeArea(next_addr, stored_area_index);
+        self.parent = FreeListParent::PrevFreeArea(next_addr);
         self.next_addr = free_area.next_free_block();
         Some(Ok((next_addr, stored_area_index)))
     }
@@ -1033,7 +1033,7 @@ mod tests {
                     area_index: area_index1,
                     free_list_id: area_index1,
                 },
-                FreeListParent::PrevFreeArea(free_list1_area1, area_index1),
+                FreeListParent::PrevFreeArea(free_list1_area1),
             ),
         ];
 
@@ -1052,7 +1052,7 @@ mod tests {
                     area_index: area_index2,
                     free_list_id: area_index2,
                 },
-                FreeListParent::PrevFreeArea(free_list2_area1, area_index2),
+                FreeListParent::PrevFreeArea(free_list2_area1),
             ),
         ];
 

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -668,7 +668,7 @@ impl<S: ReadableStorage> Iterator for FreeListIterator<'_, S> {
         };
 
         // update the next address to the next free block
-        self.parent = FreeListParent::PrevFreeArea(next_addr);
+        self.parent = FreeListParent::PrevFreeArea(next_addr, stored_area_index);
         self.next_addr = free_area.next_free_block();
         Some(Ok((next_addr, stored_area_index)))
     }
@@ -1033,7 +1033,7 @@ mod tests {
                     area_index: area_index1,
                     free_list_id: area_index1,
                 },
-                FreeListParent::PrevFreeArea(free_list1_area1),
+                FreeListParent::PrevFreeArea(free_list1_area1, area_index1),
             ),
         ];
 
@@ -1052,7 +1052,7 @@ mod tests {
                     area_index: area_index2,
                     free_list_id: area_index2,
                 },
-                FreeListParent::PrevFreeArea(free_list2_area1),
+                FreeListParent::PrevFreeArea(free_list2_area1, area_index2),
             ),
         ];
 


### PR DESCRIPTION
This is the initial diff to fix freelist. Some IO errors are fixable by truncating the free list, so annotate IO error with enough information to fix it at the end of traversal. 