### PR TITLE
fix(fwdctl)!: db path consistency + no auto-create

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -14,7 +14,7 @@ use crate::v2::api::{
     OptionalHashKeyExt,
 };
 
-use crate::manager::{RevisionManager, RevisionManagerConfig};
+use crate::manager::{ConfigManager, RevisionManager, RevisionManagerConfig};
 use async_trait::async_trait;
 use firewood_storage::{
     CheckOpt, CheckerReport, Committed, FileBacked, FileIoError, HashedNodeReader,
@@ -143,6 +143,9 @@ impl api::DbView for HistoricalRev {
 /// Database configuration.
 #[derive(Clone, TypedBuilder, Debug)]
 pub struct DbConfig {
+    /// Whether to create the DB if it doesn't exist.
+    #[builder(default = true)]
+    pub create_if_missing: bool,
     /// Whether to truncate the DB when opening it. If set, the DB will be reset and all its
     /// existing contents will be lost.
     #[builder(default = false)]
@@ -230,8 +233,12 @@ impl Db {
             proposals: counter!("firewood.proposals"),
         });
         describe_counter!("firewood.proposals", "Number of proposals created");
-        let manager =
-            RevisionManager::new(db_path.as_ref().to_path_buf(), cfg.truncate, cfg.manager)?;
+        let config_manager = ConfigManager::builder()
+            .create(cfg.create_if_missing)
+            .truncate(cfg.truncate)
+            .manager(cfg.manager)
+            .build();
+        let manager = RevisionManager::new(db_path.as_ref().to_path_buf(), config_manager)?;
         let db = Self { metrics, manager };
         Ok(db)
     }
@@ -242,8 +249,12 @@ impl Db {
             proposals: counter!("firewood.proposals"),
         });
         describe_counter!("firewood.proposals", "Number of proposals created");
-        let manager =
-            RevisionManager::new(db_path.as_ref().to_path_buf(), cfg.truncate, cfg.manager)?;
+        let config_manager = ConfigManager::builder()
+            .create(cfg.create_if_missing)
+            .truncate(cfg.truncate)
+            .manager(cfg.manager)
+            .build();
+        let manager = RevisionManager::new(db_path.as_ref().to_path_buf(), config_manager)?;
         let db = Self { metrics, manager };
         Ok(db)
     }

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Workspace dependencies
-clap = { workspace = true, features = ["cargo"] }
+clap = { workspace = true, features = ["cargo", "string"] }
 env_logger.workspace = true
 firewood.workspace = true
 firewood-storage.workspace = true

--- a/fwdctl/README.md
+++ b/fwdctl/README.md
@@ -30,10 +30,8 @@ To use
 ```sh
 # Check available options when creating a database, including the defaults.
 $ fwdctl create -h
-# Create a new, blank instance of firewood using the default name "firewood".
-$ fwdctl create firewood
-# Look inside, there are several folders representing different components of firewood, including the WAL.
-$ ls firewood
+# Create a new, blank instance of firewood using the default name "firewood.db".
+$ fwdctl create firewood.db
 ```
 
 * fwdctl get KEY

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -10,18 +10,13 @@ use firewood_storage::{CacheReadStrategy, CheckOpt, CheckerReport, FileBacked, N
 use indicatif::{ProgressBar, ProgressFinish, ProgressStyle};
 use nonzero_ext::nonzero;
 
+use crate::DatabasePath;
+
 // TODO: (optionally) add a fix option
 #[derive(Args)]
 pub struct Options {
-    /// The database path (if no path is provided, return an error). Defaults to firewood.
-    #[arg(
-        long,
-        required = false,
-        value_name = "DB_NAME",
-        default_value_t = String::from("firewood"),
-        help = "Name of the database"
-    )]
-    pub db: String,
+    #[command(flatten)]
+    pub database: DatabasePath,
 
     /// Whether to perform hash check
     #[arg(
@@ -34,7 +29,7 @@ pub struct Options {
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
-    let db_path = PathBuf::from(&opts.db);
+    let db_path = PathBuf::from(&opts.database.dbpath);
     let node_cache_size = nonzero!(1usize);
     let free_list_cache_size = nonzero!(1usize);
 
@@ -43,6 +38,7 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
         node_cache_size,
         free_list_cache_size,
         false,
+        false,                         // don't create if missing
         CacheReadStrategy::WritesOnly, // we scan the database once - no need to cache anything
     )?;
     let storage = Arc::new(fb);

--- a/fwdctl/src/create.rs
+++ b/fwdctl/src/create.rs
@@ -5,15 +5,12 @@ use clap::{Args, value_parser};
 use firewood::db::{Db, DbConfig};
 use firewood::v2::api;
 
+use crate::DatabasePath;
+
 #[derive(Args)]
 pub struct Options {
-    /// DB Options
-    #[arg(
-        required = true,
-        value_name = "NAME",
-        help = "A name for the database. A good default name is firewood."
-    )]
-    pub name: String,
+    #[command(flatten)]
+    pub database: DatabasePath,
 
     #[arg(
         long,
@@ -56,7 +53,10 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     let db_config = new(opts);
     log::debug!("database configuration parameters: \n{db_config:?}\n");
 
-    Db::new(opts.name.clone(), db_config).await?;
-    println!("created firewood database in {:?}", opts.name);
+    Db::new(opts.database.dbpath.clone(), db_config).await?;
+    println!(
+        "created firewood database in {}",
+        opts.database.dbpath.display()
+    );
     Ok(())
 }

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -5,28 +5,23 @@ use clap::Args;
 use firewood::db::{BatchOp, Db, DbConfig};
 use firewood::v2::api::{self, Db as _, Proposal as _};
 
+use crate::DatabasePath;
+
 #[derive(Debug, Args)]
 pub struct Options {
+    #[command(flatten)]
+    pub database: DatabasePath,
+
     /// The key to delete
     #[arg(required = true, value_name = "KEY", help = "Key to delete")]
     pub key: String,
-
-    /// The database path (if no path is provided, return an error). Defaults to firewood.
-    #[arg(
-        long,
-        required = false,
-        value_name = "DB_NAME",
-        default_value_t = String::from("firewood"),
-        help = "Name of the database"
-    )]
-    pub db: String,
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("deleting key {opts:?}");
-    let cfg = DbConfig::builder().truncate(false);
+    let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
 
-    let db = Db::new(opts.db.clone(), cfg.build()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
 
     let batch: Vec<BatchOp<String, String>> = vec![BatchOp::Delete {
         key: opts.key.clone(),

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -2,33 +2,27 @@
 // See the file LICENSE.md for licensing terms.
 
 use clap::Args;
-use std::str;
 
 use firewood::db::{Db, DbConfig};
 use firewood::v2::api::{self, Db as _, DbView as _};
 
+use crate::DatabasePath;
+
 #[derive(Debug, Args)]
 pub struct Options {
+    #[command(flatten)]
+    pub database: DatabasePath,
+
     /// The key to get the value for
     #[arg(required = true, value_name = "KEY", help = "Key to get")]
     pub key: String,
-
-    /// The database path (if no path is provided, return an error). Defaults to firewood.
-    #[arg(
-        long,
-        required = false,
-        value_name = "DB_NAME",
-        default_value_t = String::from("firewood"),
-        help = "Name of the database"
-    )]
-    pub db: String,
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("get key value pair {opts:?}");
-    let cfg = DbConfig::builder().truncate(false);
+    let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
 
-    let db = Db::new(opts.db.clone(), cfg.build()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
 
     let hash = db.root_hash().await?;
 

--- a/fwdctl/src/graph.rs
+++ b/fwdctl/src/graph.rs
@@ -6,22 +6,19 @@ use firewood::db::{Db, DbConfig};
 use firewood::v2::api;
 use std::io::stdout;
 
+use crate::DatabasePath;
+
 #[derive(Debug, Args)]
 pub struct Options {
-    /// The database path (if no path is provided, return an error). Defaults to firewood.
-    #[arg(
-        value_name = "DB_NAME",
-        default_value_t = String::from("firewood"),
-        help = "Name of the database"
-    )]
-    pub db: String,
+    #[command(flatten)]
+    pub database: DatabasePath,
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("dump database {opts:?}");
-    let cfg = DbConfig::builder().truncate(false);
+    let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
 
-    let db = Db::new(opts.db.clone(), cfg.build()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
     db.dump(&mut stdout()).await?;
     Ok(())
 }

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -5,8 +5,13 @@ use clap::Args;
 use firewood::db::{BatchOp, Db, DbConfig};
 use firewood::v2::api::{self, Db as _, Proposal as _};
 
+use crate::DatabasePath;
+
 #[derive(Debug, Args)]
 pub struct Options {
+    #[command(flatten)]
+    pub database: DatabasePath,
+
     /// The key to insert
     #[arg(required = true, value_name = "KEY", help = "Key to insert")]
     pub key: String,
@@ -14,23 +19,13 @@ pub struct Options {
     /// The value to insert
     #[arg(required = true, value_name = "VALUE", help = "Value to insert")]
     pub value: String,
-
-    /// The database path (if no path is provided, return an error). Defaults to firewood.
-    #[arg(
-        long,
-        required = false,
-        value_name = "DB_NAME",
-        default_value_t = String::from("firewood"),
-        help = "Name of the database"
-    )]
-    pub db: String,
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("inserting key value pair {opts:?}");
-    let cfg = DbConfig::builder().truncate(false);
+    let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
 
-    let db = Db::new(opts.db.clone(), cfg.build()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
 
     let batch: Vec<BatchOp<Vec<u8>, Vec<u8>>> = vec![BatchOp::Put {
         key: opts.key.clone().into(),

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -3,6 +3,8 @@
 
 #![doc = include_str!("../README.md")]
 
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 use firewood::v2::api;
 
@@ -14,6 +16,20 @@ pub mod get;
 pub mod graph;
 pub mod insert;
 pub mod root;
+
+#[derive(Clone, Debug, Parser)]
+pub struct DatabasePath {
+    /// The database path. Defaults to firewood.db
+    #[arg(
+        long = "db",
+        short = 'd',
+        required = false,
+        value_name = "DB_NAME",
+        default_value = default_db_path().into_os_string(),
+        help = "Name of the database"
+    )]
+    pub dbpath: PathBuf,
+}
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -74,4 +90,8 @@ async fn main() -> Result<(), api::Error> {
         Commands::Graph(opts) => graph::run(opts).await,
         Commands::Check(opts) => check::run(opts).await,
     }
+}
+
+fn default_db_path() -> PathBuf {
+    PathBuf::from("firewood.db")
 }

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -25,7 +25,7 @@ pub struct DatabasePath {
         short = 'd',
         required = false,
         value_name = "DB_NAME",
-        default_missing_value_os = default_db_path(),
+        default_value_os_t = default_db_path(),
         help = "Name of the database"
     )]
     pub dbpath: PathBuf,

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -25,7 +25,7 @@ pub struct DatabasePath {
         short = 'd',
         required = false,
         value_name = "DB_NAME",
-        default_value = default_db_path().into_os_string(),
+        default_missing_value_os = default_db_path(),
         help = "Name of the database"
     )]
     pub dbpath: PathBuf,

--- a/fwdctl/src/root.rs
+++ b/fwdctl/src/root.rs
@@ -2,28 +2,22 @@
 // See the file LICENSE.md for licensing terms.
 
 use clap::Args;
-use std::str;
 
 use firewood::db::{Db, DbConfig};
 use firewood::v2::api::{self, Db as _};
 
+use crate::DatabasePath;
+
 #[derive(Debug, Args)]
 pub struct Options {
-    /// The database path (if no path is provided, return an error). Defaults to firewood.
-    #[arg(
-        long,
-        required = false,
-        value_name = "DB_NAME",
-        default_value_t = String::from("firewood"),
-        help = "Name of the database"
-    )]
-    pub db: String,
+    #[command(flatten)]
+    pub database: DatabasePath,
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
-    let cfg = DbConfig::builder().truncate(false);
+    let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
 
-    let db = Db::new(opts.db.clone(), cfg.build()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
 
     let hash = db.root_hash().await?;
 

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -6,7 +6,7 @@ use assert_cmd::Command;
 use predicates::prelude::*;
 use serial_test::serial;
 use std::fs::{self, remove_file};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const PRG: &str = "fwdctl";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -41,6 +41,7 @@ fn fwdctl_prints_version() -> Result<()> {
 fn fwdctl_creates_database() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
@@ -54,6 +55,7 @@ fn fwdctl_insert_successful() -> Result<()> {
     // Create db
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
@@ -63,8 +65,8 @@ fn fwdctl_insert_successful() -> Result<()> {
         .arg("insert")
         .args(["year"])
         .args(["2023"])
-        .args(["--db"])
-        .args([tmpdb::path()])
+        .arg("--db")
+        .arg(tmpdb::path())
         .assert()
         .success()
         .stdout(predicate::str::contains("year"));
@@ -78,7 +80,8 @@ fn fwdctl_get_successful() -> Result<()> {
     // Create db and insert data
     Command::cargo_bin(PRG)?
         .arg("create")
-        .args([tmpdb::path()])
+        .arg("--db")
+        .arg(tmpdb::path())
         .assert()
         .success();
 
@@ -86,8 +89,8 @@ fn fwdctl_get_successful() -> Result<()> {
         .arg("insert")
         .args(["year"])
         .args(["2023"])
-        .args(["--db"])
-        .args([tmpdb::path()])
+        .arg("--db")
+        .arg(tmpdb::path())
         .assert()
         .success()
         .stdout(predicate::str::contains("year"));
@@ -96,8 +99,8 @@ fn fwdctl_get_successful() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("get")
         .args(["year"])
-        .args(["--db"])
-        .args([tmpdb::path()])
+        .arg("--db")
+        .arg(tmpdb::path())
         .assert()
         .success()
         .stdout(predicate::str::contains("2023"));
@@ -110,6 +113,7 @@ fn fwdctl_get_successful() -> Result<()> {
 fn fwdctl_delete_successful() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
@@ -118,8 +122,8 @@ fn fwdctl_delete_successful() -> Result<()> {
         .arg("insert")
         .args(["year"])
         .args(["2023"])
-        .args(["--db"])
-        .args([tmpdb::path()])
+        .arg("--db")
+        .arg(tmpdb::path())
         .assert()
         .success()
         .stdout(predicate::str::contains("year"));
@@ -128,8 +132,8 @@ fn fwdctl_delete_successful() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("delete")
         .args(["year"])
-        .args(["--db"])
-        .args([tmpdb::path()])
+        .arg("--db")
+        .arg(tmpdb::path())
         .assert()
         .success()
         .stdout(predicate::str::contains("key year deleted successfully"));
@@ -142,6 +146,7 @@ fn fwdctl_delete_successful() -> Result<()> {
 fn fwdctl_root_hash() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
@@ -150,8 +155,8 @@ fn fwdctl_root_hash() -> Result<()> {
         .arg("insert")
         .args(["year"])
         .args(["2023"])
-        .args(["--db"])
-        .args([tmpdb::path()])
+        .arg("--db")
+        .arg(tmpdb::path())
         .assert()
         .success()
         .stdout(predicate::str::contains("year"));
@@ -159,8 +164,8 @@ fn fwdctl_root_hash() -> Result<()> {
     // Get root
     Command::cargo_bin(PRG)?
         .arg("root")
-        .args(["--db"])
-        .args([tmpdb::path()])
+        .arg("--db")
+        .arg(tmpdb::path())
         .assert()
         .success()
         .stdout(predicate::str::is_empty().not());
@@ -173,6 +178,7 @@ fn fwdctl_root_hash() -> Result<()> {
 fn fwdctl_dump() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
@@ -181,8 +187,8 @@ fn fwdctl_dump() -> Result<()> {
         .arg("insert")
         .args(["year"])
         .args(["2023"])
-        .args(["--db"])
-        .args([tmpdb::path()])
+        .arg("--db")
+        .arg(tmpdb::path())
         .assert()
         .success()
         .stdout(predicate::str::contains("year"));
@@ -190,7 +196,8 @@ fn fwdctl_dump() -> Result<()> {
     // Get root
     Command::cargo_bin(PRG)?
         .arg("dump")
-        .args([tmpdb::path()])
+        .arg("--db")
+        .arg(tmpdb::path())
         .assert()
         .success()
         .stdout(predicate::str::contains("2023"));
@@ -203,36 +210,37 @@ fn fwdctl_dump() -> Result<()> {
 fn fwdctl_dump_with_start_stop_and_max() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
 
     Command::cargo_bin(PRG)?
         .arg("insert")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["a"])
         .args(["1"])
-        .args(["--db"])
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("a"));
 
     Command::cargo_bin(PRG)?
         .arg("insert")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["b"])
         .args(["2"])
-        .args(["--db"])
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("b"));
 
     Command::cargo_bin(PRG)?
         .arg("insert")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["c"])
         .args(["3"])
-        .args(["--db"])
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("c"));
@@ -240,9 +248,10 @@ fn fwdctl_dump_with_start_stop_and_max() -> Result<()> {
     // Test stop in the middle
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--stop-key"])
         .arg("b")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains(
@@ -252,9 +261,10 @@ fn fwdctl_dump_with_start_stop_and_max() -> Result<()> {
     // Test stop in the end
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--stop-key"])
         .arg("c")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains(
@@ -264,9 +274,10 @@ fn fwdctl_dump_with_start_stop_and_max() -> Result<()> {
     // Test start in the middle
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--start-key"])
         .arg("b")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::starts_with("\'b"));
@@ -274,11 +285,12 @@ fn fwdctl_dump_with_start_stop_and_max() -> Result<()> {
     // Test start and stop
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--start-key"])
         .arg("b")
         .args(["--stop-key"])
         .arg("b")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::starts_with("\'b"))
@@ -289,11 +301,12 @@ fn fwdctl_dump_with_start_stop_and_max() -> Result<()> {
     // Test start and stop
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--start-key"])
         .arg("b")
         .args(["--max-key-count"])
         .arg("1")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::starts_with("\'b"))
@@ -309,36 +322,37 @@ fn fwdctl_dump_with_start_stop_and_max() -> Result<()> {
 fn fwdctl_dump_with_csv_and_json() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
 
     Command::cargo_bin(PRG)?
         .arg("insert")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["a"])
         .args(["1"])
-        .args(["--db"])
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("a"));
 
     Command::cargo_bin(PRG)?
         .arg("insert")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["b"])
         .args(["2"])
-        .args(["--db"])
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("b"));
 
     Command::cargo_bin(PRG)?
         .arg("insert")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["c"])
         .args(["3"])
-        .args(["--db"])
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("c"));
@@ -346,9 +360,10 @@ fn fwdctl_dump_with_csv_and_json() -> Result<()> {
     // Test output csv
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--output-format"])
         .arg("csv")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("Dumping to dump.csv"));
@@ -360,9 +375,10 @@ fn fwdctl_dump_with_csv_and_json() -> Result<()> {
     // Test output json
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--output-format"])
         .arg("json")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("Dumping to dump.json"));
@@ -382,16 +398,17 @@ fn fwdctl_dump_with_csv_and_json() -> Result<()> {
 fn fwdctl_dump_with_file_name() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
 
     Command::cargo_bin(PRG)?
         .arg("insert")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["a"])
         .args(["1"])
-        .args(["--db"])
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("a"));
@@ -399,9 +416,10 @@ fn fwdctl_dump_with_file_name() -> Result<()> {
     // Test without output format
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--output-file-name"])
         .arg("test")
-        .args([tmpdb::path()])
         .assert()
         .failure()
         .stderr(predicate::str::contains("--output-format"));
@@ -409,11 +427,12 @@ fn fwdctl_dump_with_file_name() -> Result<()> {
     // Test output csv
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--output-format"])
         .arg("csv")
         .args(["--output-file-name"])
         .arg("test")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("Dumping to test.csv"));
@@ -425,11 +444,12 @@ fn fwdctl_dump_with_file_name() -> Result<()> {
     // Test output json
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--output-format"])
         .arg("json")
         .args(["--output-file-name"])
         .arg("test")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("Dumping to test.json"));
@@ -446,36 +466,37 @@ fn fwdctl_dump_with_file_name() -> Result<()> {
 fn fwdctl_dump_with_hex() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
 
     Command::cargo_bin(PRG)?
         .arg("insert")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["a"])
         .args(["1"])
-        .args(["--db"])
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("a"));
 
     Command::cargo_bin(PRG)?
         .arg("insert")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["b"])
         .args(["2"])
-        .args(["--db"])
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("b"));
 
     Command::cargo_bin(PRG)?
         .arg("insert")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["c"])
         .args(["3"])
-        .args(["--db"])
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::contains("c"));
@@ -483,11 +504,12 @@ fn fwdctl_dump_with_hex() -> Result<()> {
     // Test without output format
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--start-key"])
         .arg("a")
         .args(["--start-key-hex"])
         .arg("61")
-        .args([tmpdb::path()])
         .assert()
         .failure()
         .stderr(predicate::str::contains("--start-key"))
@@ -496,9 +518,10 @@ fn fwdctl_dump_with_hex() -> Result<()> {
     // Test start with hex value
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--start-key-hex"])
         .arg("62")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::starts_with("\'b"));
@@ -506,9 +529,10 @@ fn fwdctl_dump_with_hex() -> Result<()> {
     // Test stop with hex value
     Command::cargo_bin(PRG)?
         .arg("dump")
+        .arg("--db")
+        .arg(tmpdb::path())
         .args(["--stop-key-hex"])
         .arg("62")
-        .args([tmpdb::path()])
         .assert()
         .success()
         .stdout(predicate::str::starts_with("\'a"))
@@ -524,6 +548,7 @@ fn fwdctl_dump_with_hex() -> Result<()> {
 fn fwdctl_check_empty_db() -> Result<()> {
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
@@ -559,6 +584,7 @@ fn fwdctl_check_db_with_data() -> Result<()> {
 
     Command::cargo_bin(PRG)?
         .arg("create")
+        .arg("--db")
         .arg(tmpdb::path())
         .assert()
         .success();
@@ -569,10 +595,10 @@ fn fwdctl_check_db_with_data() -> Result<()> {
         let value = sample_iter.by_ref().take(10).collect::<String>();
         Command::cargo_bin(PRG)?
             .arg("insert")
+            .arg("--db")
+            .arg(tmpdb::path())
             .args([key])
             .args([value])
-            .args(["--db"])
-            .args([tmpdb::path()])
             .assert()
             .success();
     }
@@ -597,16 +623,22 @@ fn fwdctl_check_db_with_data() -> Result<()> {
 // of this in different directories will have different databases
 
 mod tmpdb {
+    use std::sync::OnceLock;
+
     use super::*;
 
     const FIREWOOD_TEST_DB_NAME: &str = "test_firewood";
     const TARGET_TMP_DIR: Option<&str> = option_env!("CARGO_TARGET_TMPDIR");
 
-    pub fn path() -> PathBuf {
-        TARGET_TMP_DIR
-            .map(PathBuf::from)
-            .or_else(|| std::env::var("TMPDIR").ok().map(PathBuf::from))
-            .unwrap_or(std::env::temp_dir())
-            .join(FIREWOOD_TEST_DB_NAME)
+    pub fn path() -> &'static Path {
+        static PATH: OnceLock<PathBuf> = OnceLock::new();
+        PATH.get_or_init(|| {
+            TARGET_TMP_DIR
+                .map(PathBuf::from)
+                .or_else(|| std::env::var("TMPDIR").ok().map(PathBuf::from))
+                .unwrap_or(std::env::temp_dir())
+                .join(FIREWOOD_TEST_DB_NAME)
+        })
+        .as_path()
     }
 }

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -91,13 +91,14 @@ impl FileBacked {
         node_cache_size: NonZero<usize>,
         free_list_cache_size: NonZero<usize>,
         truncate: bool,
+        create: bool,
         cache_read_strategy: CacheReadStrategy,
     ) -> Result<Self, FileIoError> {
         let fd = OpenOptions::new()
             .read(true)
             .write(true)
             .truncate(truncate)
-            .create(true)
+            .create(create)
             .open(&path)
             .map_err(|e| FileIoError {
                 inner: e,
@@ -331,6 +332,7 @@ mod test {
             nonzero!(10usize),
             nonzero!(10usize),
             false,
+            true,
             CacheReadStrategy::WritesOnly,
         )
         .unwrap();
@@ -372,6 +374,7 @@ mod test {
             nonzero!(10usize),
             nonzero!(10usize),
             false,
+            true,
             CacheReadStrategy::WritesOnly,
         )
         .unwrap();

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -788,6 +788,7 @@ mod tests {
                     nonzero!(10usize),
                     nonzero!(10usize),
                     false,
+                    true,
                     CacheReadStrategy::WritesOnly,
                 )
                 .unwrap(),


### PR DESCRIPTION
I found that a small typo in the database creates a new one. This isn't the expected behavior, and is a regression from the ffi changes that always create a database.

In addition, cleaned up the database path option so it's exactly the same across all subcommands.

- Use consistent `--db` flag across all commands instead of positional arguments
- Set `create_if_missing=false` for most commands (except `create`)
- Refactor tests to use cleaner `.arg()` syntax for single arguments
- Compute the test path one time for all tests
- Remove unnecessary string conversions