### PR TITLE
feat(checker): checker truncate erroneous free lists

### DIFF
--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -195,6 +195,10 @@ pub enum Error {
     /// An invalid root hash was provided
     #[error(transparent)]
     InvalidRootHash(#[from] firewood_storage::InvalidTrieHashLength),
+
+    /// Checker Failed to Run
+    #[error("checker failed to run")]
+    CheckerFailedToRun,
 }
 
 impl From<RevisionManagerError> for Error {

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -31,6 +31,15 @@ pub struct Options {
         help = "Should perform hash check"
     )]
     pub hash_check: bool,
+
+    /// Whether to fix observed inconsistencies
+    #[arg(
+        long,
+        required = false,
+        default_value_t = false,
+        help = "Should fix observed inconsistencies"
+    )]
+    pub fix: bool,
 }
 
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
@@ -58,6 +67,7 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     let report = NodeStore::open(storage)?.check(CheckOpt {
         hash_check: opts.hash_check,
         progress_bar: Some(progress_bar),
+        fix: opts.fix,
     });
 
     print_checker_report(report);

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -278,18 +278,17 @@ pub enum CheckerError {
     /// IO error
     #[error("IO error")]
     #[derive_where(skip_inner)]
-    IO(#[from] FileIoError),
+    IO {
+        /// The error
+        error: FileIoError,
+        /// parent of the area
+        parent: Option<StoredAreaParent>,
+    },
 }
 
 impl From<CheckerError> for Vec<CheckerError> {
     fn from(error: CheckerError) -> Self {
         vec![error]
-    }
-}
-
-impl From<FileIoError> for Vec<CheckerError> {
-    fn from(error: FileIoError) -> Self {
-        vec![CheckerError::IO(error)]
     }
 }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -292,6 +292,32 @@ impl From<CheckerError> for Vec<CheckerError> {
     }
 }
 
+impl CheckerError {
+    #[must_use]
+    const fn free_list_parent(&self) -> Option<&FreeListParent> {
+        match self {
+            CheckerError::AreaIntersects {
+                parent: StoredAreaParent::FreeList(parent),
+                ..
+            }
+            | CheckerError::AreaOutOfBounds {
+                parent: StoredAreaParent::FreeList(parent),
+                ..
+            }
+            | CheckerError::FreelistAreaSizeMismatch { parent, .. }
+            | CheckerError::AreaMisaligned {
+                parent: StoredAreaParent::FreeList(parent),
+                ..
+            }
+            | CheckerError::IO {
+                parent: Some(StoredAreaParent::FreeList(parent)),
+                ..
+            } => Some(parent),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_utils {
     use rand::rngs::StdRng;

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -641,10 +641,13 @@ impl<'a, S: ReadableStorage> FreeListIterator<'a, S> {
     )]
     fn next_with_parent(
         &mut self,
-    ) -> Option<Result<((LinearAddress, AreaIndex), FreeListParent), FileIoError>> {
+    ) -> Option<(
+        Result<(LinearAddress, AreaIndex), FileIoError>,
+        FreeListParent,
+    )> {
         let parent = self.parent;
         let next_addr = self.next()?;
-        Some(next_addr.map(|free_area| (free_area, parent)))
+        Some((next_addr, parent))
     }
 }
 
@@ -678,7 +681,6 @@ pub(crate) struct FreeAreaWithMetadata {
     pub addr: LinearAddress,
     pub area_index: AreaIndex,
     pub free_list_id: AreaIndex,
-    pub parent: FreeListParent,
 }
 
 pub(crate) struct FreeListsIterator<'a, S: ReadableStorage> {
@@ -719,15 +721,17 @@ impl<'a, S: ReadableStorage> FreeListsIterator<'a, S> {
 
     pub(crate) fn next_with_metadata(
         &mut self,
-    ) -> Option<Result<FreeAreaWithMetadata, FileIoError>> {
+    ) -> Option<(Result<FreeAreaWithMetadata, FileIoError>, FreeListParent)> {
         self.next_inner(FreeListIterator::next_with_parent)
-            .map(|next_with_parent| {
-                next_with_parent.map(|((addr, area_index), parent)| FreeAreaWithMetadata {
-                    addr,
-                    area_index,
-                    free_list_id: self.current_free_list_id,
+            .map(|(next, parent)| {
+                (
+                    next.map(|(addr, area_index)| FreeAreaWithMetadata {
+                        addr,
+                        area_index,
+                        free_list_id: self.current_free_list_id,
+                    }),
                     parent,
-                })
+                )
             })
     }
 
@@ -1015,33 +1019,41 @@ mod tests {
 
         // expected
         let expected_free_list1 = vec![
-            FreeAreaWithMetadata {
-                addr: free_list1_area1,
-                area_index: area_index1,
-                free_list_id: area_index1,
-                parent: FreeListParent::FreeListHead(area_index1),
-            },
-            FreeAreaWithMetadata {
-                addr: free_list1_area2,
-                area_index: area_index1,
-                free_list_id: area_index1,
-                parent: FreeListParent::PrevFreeArea(free_list1_area1),
-            },
+            (
+                FreeAreaWithMetadata {
+                    addr: free_list1_area1,
+                    area_index: area_index1,
+                    free_list_id: area_index1,
+                },
+                FreeListParent::FreeListHead(area_index1),
+            ),
+            (
+                FreeAreaWithMetadata {
+                    addr: free_list1_area2,
+                    area_index: area_index1,
+                    free_list_id: area_index1,
+                },
+                FreeListParent::PrevFreeArea(free_list1_area1),
+            ),
         ];
 
         let expected_free_list2 = vec![
-            FreeAreaWithMetadata {
-                addr: free_list2_area1,
-                area_index: area_index2,
-                free_list_id: area_index2,
-                parent: FreeListParent::FreeListHead(area_index2),
-            },
-            FreeAreaWithMetadata {
-                addr: free_list2_area2,
-                area_index: area_index2,
-                free_list_id: area_index2,
-                parent: FreeListParent::PrevFreeArea(free_list2_area1),
-            },
+            (
+                FreeAreaWithMetadata {
+                    addr: free_list2_area1,
+                    area_index: area_index2,
+                    free_list_id: area_index2,
+                },
+                FreeListParent::FreeListHead(area_index2),
+            ),
+            (
+                FreeAreaWithMetadata {
+                    addr: free_list2_area2,
+                    area_index: area_index2,
+                    free_list_id: area_index2,
+                },
+                FreeListParent::PrevFreeArea(free_list2_area1),
+            ),
         ];
 
         let mut expected_iterator = if area_index1 < area_index2 {
@@ -1052,14 +1064,14 @@ mod tests {
 
         loop {
             let next = free_list_iter.next_with_metadata();
-            let expected = expected_iterator.next();
-
-            if expected.is_none() {
+            let Some((expected, expected_parent)) = expected_iterator.next() else {
                 assert!(next.is_none());
                 break;
-            }
+            };
 
-            assert_eq!(next.unwrap().unwrap(), expected.unwrap());
+            let (next, next_parent) = next.unwrap();
+            assert_eq!(next.unwrap(), expected);
+            assert_eq!(next_parent, expected_parent);
         }
     }
 
@@ -1114,29 +1126,31 @@ mod tests {
 
         // start at the first free list
         assert_eq!(free_list_iter.current_free_list_id, 0);
+        let (next, next_parent) = free_list_iter.next_with_metadata().unwrap();
         assert_eq!(
-            free_list_iter.next_with_metadata().unwrap().unwrap(),
+            next.unwrap(),
             FreeAreaWithMetadata {
                 addr: free_list1_area1,
                 area_index: area_index1,
                 free_list_id: area_index1,
-                parent: FreeListParent::FreeListHead(area_index1),
             },
         );
+        assert_eq!(next_parent, FreeListParent::FreeListHead(area_index1));
         // `next_with_metadata` moves the iterator to the first free list that is not empty
         assert_eq!(free_list_iter.current_free_list_id, area_index1);
         free_list_iter.move_to_next_free_list();
         // `move_to_next_free_list` moves the iterator to the next free list
         assert_eq!(free_list_iter.current_free_list_id, area_index1 + 1);
+        let (next, next_parent) = free_list_iter.next_with_metadata().unwrap();
         assert_eq!(
-            free_list_iter.next_with_metadata().unwrap().unwrap(),
+            next.unwrap(),
             FreeAreaWithMetadata {
                 addr: free_list2_area1,
                 area_index: area_index2,
                 free_list_id: area_index2,
-                parent: FreeListParent::FreeListHead(area_index2),
             },
         );
+        assert_eq!(next_parent, FreeListParent::FreeListHead(area_index2));
         // `next_with_metadata` moves the iterator to the first free list that is not empty
         assert_eq!(free_list_iter.current_free_list_id, area_index2);
         free_list_iter.move_to_next_free_list();


### PR DESCRIPTION
This is the second PR for the checker to fix the DB image. This PR does two things:

1. The checker now takes a `&mut self` instead of `&self`. This is required to update the header freelists. 
2. For each error with a valid parent reference, the checker will truncate the free list, effectively truncate the erroneous free area from the list. 