### PR TITLE
feat(checker): do not return physical size to accomodate raw disks

### DIFF
--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -75,8 +75,8 @@ fn print_checker_report(report: CheckerReport) {
     println!(
         "\tStorage Space Utilization: {} / {} = {:.2}%",
         report.trie_stats.trie_bytes,
-        report.physical_bytes,
-        (report.trie_stats.trie_bytes as f64 / report.physical_bytes as f64) * 100.0
+        report.high_watermark,
+        (report.trie_stats.trie_bytes as f64 / report.high_watermark as f64) * 100.0
     );
     println!(
         "\tInternal Fragmentation: {} / {total_trie_area_bytes} = {:.2}%",

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -284,7 +284,7 @@ pub enum CheckerError {
         /// The error
         error: FileIoError,
         /// parent of the area
-        parent: Option<StoredAreaParent>,
+        parent: StoredAreaParent,
     },
 }
 

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -755,7 +755,7 @@ impl<T, S: ReadableStorage> NodeStore<T, S> {
             .offset()
             .checked_sub(offset_before)
             .ok_or_else(|| {
-                self.file_io_error(
+                self.storage.file_io_error(
                     Error::other("Reader offset went backwards"),
                     actual_addr,
                     Some("read_node_with_num_bytes_from_disk".to_string()),
@@ -775,20 +775,6 @@ impl<T, S: ReadableStorage> NodeStore<T, S> {
         addr: LinearAddress,
     ) -> Result<(AreaIndex, u64), FileIoError> {
         area_index_and_size(self.storage.as_ref(), addr)
-    }
-
-    pub(crate) fn physical_size(&self) -> Result<u64, FileIoError> {
-        self.storage.size()
-    }
-
-    #[cold]
-    pub(crate) fn file_io_error(
-        &self,
-        error: Error,
-        addr: u64,
-        context: Option<String>,
-    ) -> FileIoError {
-        self.storage.file_io_error(error, addr, context)
     }
 }
 


### PR DESCRIPTION
Currently checker also obtains the actual file size from the filesystem for statistics, which is not reliable on raw disks. Using high watermark instead. 