### PR TITLE
feat(async-removal): Phase 1 - lint on `clippy::unused_async`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ pedantic = { level = "warn", priority = -1 }
 # These lints are from pedantic but allowed. They are a bit too pedantic and
 # encourage making backwards incompatible changes.
 needless_pass_by_value = "allow"
-unused_async = "allow"
 unnecessary_wraps = "allow"
 unused_self = "allow"
 # Ignore interger casts. This is to avoid unnecessary `try_into` calls for usize

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -257,9 +257,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .manager(mgrcfg)
         .build();
 
-    let db = Db::new(args.global_opts.dbname.clone(), cfg)
-        .await
-        .expect("db initiation should succeed");
+    let db = Db::new(args.global_opts.dbname.clone(), cfg).expect("db initiation should succeed");
 
     match args.test_name {
         TestName::Create => {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -889,7 +889,7 @@ unsafe fn open_db(args: &CreateOrOpenArgs) -> Result<Db, String> {
         .path
         .as_str()
         .map_err(|e| format!("Invalid database path: {e}"))?;
-    Db::new_sync(path, cfg).map_err(|e| e.to_string())
+    Db::new(path, cfg).map_err(|e| e.to_string())
 }
 
 /// Arguments for logging

--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -119,7 +119,6 @@ fn bench_db<const N: usize>(criterion: &mut Criterion) {
                         let cfg = DbConfig::builder();
 
                         let db = firewood::db::Db::new(db_path, cfg.clone().truncate(true).build())
-                            .await
                             .unwrap();
 
                         db.propose(batch_ops).await.unwrap().commit().await.unwrap();

--- a/firewood/examples/insert.rs
+++ b/firewood/examples/insert.rs
@@ -63,9 +63,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .manager(mgrcfg)
         .build();
 
-    let db = Db::new("rev_db", cfg)
-        .await
-        .expect("db initiation should succeed");
+    let db = Db::new("rev_db", cfg).expect("db initiation should succeed");
 
     let keys = args.batch_size;
     let start = Instant::now();

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -28,7 +28,7 @@ pub struct Options {
     pub hash_check: bool,
 }
 
-pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
+pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let db_path = PathBuf::from(&opts.database.dbpath);
     let node_cache_size = nonzero!(1usize);
     let free_list_cache_size = nonzero!(1usize);

--- a/fwdctl/src/create.rs
+++ b/fwdctl/src/create.rs
@@ -49,11 +49,11 @@ pub(super) fn new(opts: &Options) -> DbConfig {
     DbConfig::builder().truncate(opts.truncate).build()
 }
 
-pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
+pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let db_config = new(opts);
     log::debug!("database configuration parameters: \n{db_config:?}\n");
 
-    Db::new(opts.database.dbpath.clone(), db_config).await?;
+    Db::new(opts.database.dbpath.clone(), db_config)?;
     println!(
         "created firewood database in {}",
         opts.database.dbpath.display()

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -21,7 +21,7 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("deleting key {opts:?}");
     let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
 
     let batch: Vec<BatchOp<String, String>> = vec![BatchOp::Delete {
         key: opts.key.clone(),

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -143,7 +143,7 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     }
 
     let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
     let latest_hash = db.root_hash().await?;
     let Some(latest_hash) = latest_hash else {
         println!("Database is empty");
@@ -178,7 +178,7 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
                 if (stop_key.as_ref().is_some_and(|stop_key| key >= *stop_key))
                     || key_count_exceeded(opts.max_key_count, key_count)
                 {
-                    handle_next_key(stream.next().await).await;
+                    handle_next_key(stream.next().await);
                     break;
                 }
             }
@@ -223,7 +223,7 @@ fn key_value_to_string(key: &[u8], value: &[u8], hex: bool) -> (String, String) 
     (key_str, value_str)
 }
 
-async fn handle_next_key(next_key: KeyFromStream) {
+fn handle_next_key(next_key: KeyFromStream) {
     match next_key {
         Some(Ok((key, _))) => {
             println!(
@@ -343,7 +343,7 @@ fn create_output_handler(
             let file = File::create(file_name)?;
             let mut writer = BufWriter::new(file);
             // For dot format, we generate the output immediately since it doesn't use streaming
-            db.dump_sync(&mut writer)?;
+            db.dump(&mut writer)?;
             Ok(None)
         }
     }

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -22,7 +22,7 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("get key value pair {opts:?}");
     let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
 
     let hash = db.root_hash().await?;
 

--- a/fwdctl/src/graph.rs
+++ b/fwdctl/src/graph.rs
@@ -14,11 +14,11 @@ pub struct Options {
     pub database: DatabasePath,
 }
 
-pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
+pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("dump database {opts:?}");
     let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
-    db.dump(&mut stdout()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
+    db.dump(&mut stdout())?;
     Ok(())
 }

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -25,7 +25,7 @@ pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("inserting key value pair {opts:?}");
     let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
 
     let batch: Vec<BatchOp<Vec<u8>, Vec<u8>>> = vec![BatchOp::Put {
         key: opts.key.clone().into(),

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -81,14 +81,14 @@ async fn main() -> Result<(), api::Error> {
     );
 
     match &cli.command {
-        Commands::Create(opts) => create::run(opts).await,
+        Commands::Create(opts) => create::run(opts),
         Commands::Insert(opts) => insert::run(opts).await,
         Commands::Get(opts) => get::run(opts).await,
         Commands::Delete(opts) => delete::run(opts).await,
         Commands::Root(opts) => root::run(opts).await,
         Commands::Dump(opts) => dump::run(opts).await,
-        Commands::Graph(opts) => graph::run(opts).await,
-        Commands::Check(opts) => check::run(opts).await,
+        Commands::Graph(opts) => graph::run(opts),
+        Commands::Check(opts) => check::run(opts),
     }
 }
 

--- a/fwdctl/src/root.rs
+++ b/fwdctl/src/root.rs
@@ -17,7 +17,7 @@ pub struct Options {
 pub(super) async fn run(opts: &Options) -> Result<(), api::Error> {
     let cfg = DbConfig::builder().create_if_missing(false).truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build()).await?;
+    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
 
     let hash = db.root_hash().await?;
 


### PR DESCRIPTION
Phase 1 of async removal is to add the lint for `clippy::unused_async` back into the mix to stop unnecessarily making functions async.