### PR TITLE
chore: only allocate the area needed

### DIFF
--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -228,11 +228,13 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
                 .file_io_error(e, 0, Some("allocate_from_freed".to_string()))
         })?;
 
-        if let Some(free_stored_area_addr) = self.header.free_lists_mut().get_mut(index.as_usize())
-        {
-            let address = free_stored_area_addr
-                .take()
-                .expect("impossible due to find earlier");
+        let free_stored_area_addr = self
+            .header
+            .free_lists_mut()
+            .get_mut(index.as_usize())
+            .expect("index is less than AreaIndex::NUM_AREA_SIZES");
+        if let Some(address) = free_stored_area_addr {
+            let address = *address;
             // Get the first free block of sufficient size.
             if let Some(free_head) = self.storage.free_list_cache(address) {
                 trace!("free_head@{address}(cached): {free_head:?} size:{index}");


### PR DESCRIPTION
As shown from statistics, Firewood currently has a lot of internal fragmentations because it will allocate any large enough free area from the free list, often times in which the allocated area is several times bigger than the area needed. We have found 3 possible mitigations:
1. When allocating, only allocate the area needed to store the node but not larger areas (this PR)
2. Since allocation happens in batches, we can allocate areas in the order of area sizes - so that large areas have priority and it may avoid allocating large areas from file end in a lot of cases. 
3. If only large areas are available, split the area and only allocate one. Because Merkle Trie contains dominantly small trie nodes, this design should lead to low external fragmentation. 

We need to run more experiments to see if these approaches actually work well. 