### PR TITLE
feat(ffi-refactor): refactor cached view

### DIFF
--- a/ffi/src/arc_cache.rs
+++ b/ffi/src/arc_cache.rs
@@ -1,0 +1,91 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+//! A simple single-item cache for database views.
+//!
+//! This module provides [`ArcCache`], a thread-safe cache that holds at most one
+//! key-value pair. It's specifically designed to cache database views in the FFI
+//! layer to improve performance by avoiding repeated view creation for the same
+//! root hash during database operations.
+
+use std::sync::{Arc, Mutex};
+
+/// A thread-safe single-item cache that stores key-value pairs as `Arc<V>`.
+///
+/// This cache is optimized for scenarios where you frequently access the same
+/// item and want to avoid expensive recomputation. It holds at most one cached
+/// entry and replaces it when a different key is requested.
+///
+/// The cache is thread-safe and uses a mutex to protect concurrent access.
+/// Values are stored as `Arc<V>` to allow cheap cloning and sharing across
+/// threads.
+#[derive(Debug)]
+pub struct ArcCache<K, V: ?Sized> {
+    cache: Mutex<Option<(K, Arc<V>)>>,
+}
+
+impl<K: PartialEq, V: ?Sized> ArcCache<K, V> {
+    pub const fn new() -> Self {
+        ArcCache {
+            cache: Mutex::new(None),
+        }
+    }
+
+    /// Gets the cached value for the given key, or creates and caches a new value.
+    ///
+    /// If the cache contains an entry with a key equal to the provided key,
+    /// returns a clone of the cached `Arc<V>`. Otherwise, calls the factory
+    /// function to create a new value, caches it, and returns it.
+    ///
+    /// # Cache Behavior
+    ///
+    /// - Cache hit: Returns the cached value immediately
+    /// - Cache miss: Clears any existing cache entry, calls factory, caches the result
+    /// - Factory error: Cache is cleared and the error is propagated
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key to look up or cache
+    /// * `factory` - A function that creates the value if not cached. It receives
+    ///   a reference to the key as an argument.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error produced by the factory function.
+    pub fn get_or_try_insert_with<E>(
+        &self,
+        key: K,
+        factory: impl FnOnce(&K) -> Result<Arc<V>, E>,
+    ) -> Result<Arc<V>, E> {
+        let mut cache = self
+            .cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some((cached_key, value)) = cache.as_ref() {
+            if *cached_key == key {
+                return Ok(Arc::clone(value));
+            }
+        }
+
+        // clear the cache before running the factory in case it fails
+        *cache = None;
+
+        let value = factory(&key)?;
+        *cache = Some((key, Arc::clone(&value)));
+
+        Ok(value)
+    }
+
+    pub fn clear(&self) {
+        self.cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+    }
+}
+
+impl<K: PartialEq, T: ?Sized> Default for ArcCache<K, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -1,0 +1,44 @@
+use firewood::v2::api::{self, ArcDynDbView, HashKey};
+use metrics::counter;
+
+use crate::DatabaseHandle;
+
+impl DatabaseHandle<'_> {
+    pub(crate) fn get_root(&self, root: HashKey) -> Result<ArcDynDbView, api::Error> {
+        // construct outside of the closure so that when the closure is dropped
+        // without executing, it triggers the hit counter
+        let token = CachedViewHitOnDrop;
+        self.cached_view.get_or_try_insert_with(root, move |key| {
+            token.miss();
+            self.db.view(HashKey::clone(key))
+        })
+    }
+}
+
+/// A RAII metrics helper that tracks cache hits and misses for database views.
+///
+/// This type uses the drop pattern to automatically record cache metrics:
+/// - By default, dropping this type records a cache hit
+/// - Calling [`Self::miss`] before dropping records a cache miss instead
+///
+/// This ensures that every cache lookup is properly tracked in metrics without
+/// requiring manual instrumentation at each call site.
+///
+/// # Metrics Recorded
+///
+/// - `firewood.ffi.cached_view.hit` - Incremented when the cache lookup succeeds
+/// - `firewood.ffi.cached_view.miss` - Incremented when the cache lookup fails
+pub(crate) struct CachedViewHitOnDrop;
+
+impl Drop for CachedViewHitOnDrop {
+    fn drop(&mut self) {
+        counter!("firewood.ffi.cached_view.hit").increment(1);
+    }
+}
+
+impl CachedViewHitOnDrop {
+    pub fn miss(self) {
+        std::mem::forget(self);
+        counter!("firewood.ffi.cached_view.miss").increment(1);
+    }
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -26,6 +26,8 @@
     )
 )]
 
+mod arc_cache;
+mod handle;
 mod metrics_setup;
 mod value;
 
@@ -33,15 +35,16 @@ use std::collections::HashMap;
 use std::ffi::{CStr, CString, c_char};
 use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
+use std::sync::RwLock;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Mutex, RwLock};
 
 use firewood::db::{Db, DbConfig, Proposal};
 use firewood::manager::{CacheReadStrategy, RevisionManagerConfig};
 
-use firewood::v2::api::{ArcDynDbView, Db as _, DbView, HashKey, KeyValuePairIter, Proposal as _};
+use firewood::v2::api::{self, Db as _, DbView, HashKey, KeyValuePairIter, Proposal as _};
 use metrics::counter;
 
+use crate::arc_cache::ArcCache;
 pub use crate::value::*;
 
 #[cfg(unix)]
@@ -72,7 +75,7 @@ pub struct DatabaseHandle<'p> {
     proposals: RwLock<HashMap<ProposalId, Proposal<'p>>>,
 
     /// A single cached view to improve performance of reads while committing
-    cached_view: Mutex<Option<(HashKey, ArcDynDbView)>>,
+    cached_view: ArcCache<HashKey, dyn api::DynDbView + Send + Sync + 'static>,
 
     /// The database
     db: Db,
@@ -83,17 +86,14 @@ impl From<Db> for DatabaseHandle<'_> {
         Self {
             db,
             proposals: RwLock::new(HashMap::new()),
-            cached_view: Mutex::new(None),
+            cached_view: ArcCache::new(),
         }
     }
 }
 
 impl DatabaseHandle<'_> {
     fn clear_cached_view(&self) {
-        self.cached_view
-            .lock()
-            .expect("cached_view lock is poisoned")
-            .take();
+        self.cached_view.clear();
     }
 }
 
@@ -245,33 +245,9 @@ fn get_from_root(
 ) -> Result<Value, String> {
     let db = db.ok_or("db should be non-null")?;
     let requested_root = HashKey::try_from(root).map_err(|e| e.to_string())?;
-    let mut cached_view = db.cached_view.lock().expect("cached_view lock is poisoned");
-    let value = match cached_view.as_ref() {
-        // found the cached view, use it
-        Some((root_hash, view)) if root_hash == &requested_root => {
-            counter!("firewood.ffi.cached_view.hit").increment(1);
-            view.val(key)
-        }
-        // If what was there didn't match the requested root, we need a new view, so we
-        // update the cache
-        _ => {
-            counter!("firewood.ffi.cached_view.miss").increment(1);
-            let rev = view_sync_from_root(db, root)?;
-            let result = rev.val(key);
-            *cached_view = Some((requested_root.clone(), rev));
-            result
-        }
-    }
-    .map_err(|e| e.to_string())?
-    .ok_or("")?;
-
+    let cached_view = db.get_root(requested_root).map_err(|e| e.to_string())?;
+    let value = cached_view.val(key).map_err(|e| e.to_string())?.ok_or("")?;
     Ok(value.into())
-}
-fn view_sync_from_root(db: &DatabaseHandle<'_>, root: &[u8]) -> Result<ArcDynDbView, String> {
-    let rev = db
-        .view(HashKey::try_from(root).map_err(|e| e.to_string())?)
-        .map_err(|e| e.to_string())?;
-    Ok(rev)
 }
 
 /// Puts the given key-value pairs into the database.
@@ -508,13 +484,8 @@ fn commit(db: Option<&DatabaseHandle<'_>>, proposal_id: u32) -> Result<(), Strin
     // Get the proposal hash and cache the view. We never cache an empty proposal.
     let proposal_hash = proposal.root_hash();
 
-    if let Ok(Some(proposal_hash)) = proposal_hash {
-        let mut guard = db.cached_view.lock().expect("cached_view lock is poisoned");
-        match db.view(proposal_hash.clone()) {
-            Ok(view) => *guard = Some((proposal_hash, view)),
-            Err(_) => *guard = None, // Clear cache on error
-        }
-        drop(guard);
+    if let Ok(Some(ref hash_key)) = proposal_hash {
+        _ = db.get_root(hash_key.clone());
     }
 
     // Commit the proposal


### PR DESCRIPTION
Because of earlier PRs, we can take advantage of the arc and eagerly drop the lock on the cache afer loading it.