### PR TITLE
perf: optimize hashing by avoiding unnecessary clone operations

### DIFF
--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -137,7 +137,7 @@ pub trait Hashable {
     fn value_digest(&self) -> Option<ValueDigest<&[u8]>>;
     /// Each element is a child's index and hash.
     /// Yields 0 elements if the node is a leaf.
-    fn children(&self) -> Children<HashType>;
+    fn children(&self) -> Children<&HashType>;
 }
 
 /// A preimage of a hash.
@@ -151,7 +151,7 @@ pub trait Preimage {
 trait HashableNode {
     fn partial_path(&self) -> impl Iterator<Item = u8> + Clone;
     fn value(&self) -> Option<&[u8]>;
-    fn child_hashes(&self) -> Children<HashType>;
+    fn child_hashes(&self) -> Children<&HashType>;
 }
 
 impl HashableNode for BranchNode {
@@ -163,7 +163,7 @@ impl HashableNode for BranchNode {
         self.value.as_deref()
     }
 
-    fn child_hashes(&self) -> Children<HashType> {
+    fn child_hashes(&self) -> Children<&HashType> {
         self.children_hashes()
     }
 }
@@ -177,7 +177,7 @@ impl HashableNode for LeafNode {
         Some(&self.value)
     }
 
-    fn child_hashes(&self) -> Children<HashType> {
+    fn child_hashes(&self) -> Children<&HashType> {
         BranchNode::empty_children()
     }
 }
@@ -211,7 +211,7 @@ impl<'a, N: HashableNode> Hashable for NodeAndPrefix<'a, N> {
         self.node.value().map(ValueDigest::Value)
     }
 
-    fn children(&self) -> Children<HashType> {
+    fn children(&self) -> Children<&HashType> {
         self.node.child_hashes()
     }
 }

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -19,6 +19,7 @@
 )]
 
 use crate::logger::warn;
+use crate::node::branch::ChildrenExt;
 use crate::{
     BranchNode, HashType, Hashable, Preimage, TrieHash, ValueDigest, hashednode::HasUpdate,
     logger::trace,
@@ -119,7 +120,7 @@ impl<T: Hashable> Preimage for T {
 
         let child_hashes = self.children();
 
-        let children = child_hashes.iter().filter(|c| c.is_some()).count();
+        let children = child_hashes.count_some();
 
         if children == 0 {
             // since there are no children, this must be a leaf

--- a/storage/src/hashers/merkledb.rs
+++ b/storage/src/hashers/merkledb.rs
@@ -10,6 +10,7 @@
 )]
 
 use crate::hashednode::{HasUpdate, Hashable, Preimage};
+use crate::node::branch::ChildrenExt;
 use crate::{TrieHash, ValueDigest};
 /// Merkledb compatible hashing algorithm.
 use integer_encoding::VarInt;
@@ -35,7 +36,7 @@ impl<T: Hashable> Preimage for T {
     fn write(&self, buf: &mut impl HasUpdate) {
         let children = self.children();
 
-        let num_children = children.iter().filter(|c| c.is_some()).count() as u64;
+        let num_children = children.count_some() as u64;
 
         add_varint_to_buf(buf, num_children);
 


### PR DESCRIPTION
I did not notice this the first time when I touched this, but, we were unecessarily cloning the data to be hashed. This change avoid that.