### PR TITLE
chore: synchronize .golangci.yaml

### DIFF
--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,1 +1,2 @@
 .golangci.yaml
+.golangci.yaml.orig

--- a/.github/.golangci.yaml.patch
+++ b/.github/.golangci.yaml.patch
@@ -1,5 +1,5 @@
---- .github/.golangci.yaml	2025-08-02 10:10:13
-+++ ffi/.golangci.yaml	2025-08-02 10:10:13
+--- .github/.golangci.yaml	2025-08-22 10:01:30
++++ ffi/.golangci.yaml	2025-08-22 10:01:26
 @@ -69,8 +69,6 @@
        rules:
          packages:
@@ -39,7 +39,7 @@
      revive:
        rules:
          # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
-@@ -168,17 +147,6 @@
+@@ -171,17 +150,6 @@
          # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
          - name: useless-break
            disabled: false
@@ -57,7 +57,7 @@
      tagalign:
        align: true
        sort: true
-@@ -186,16 +154,16 @@
+@@ -189,16 +157,16 @@
          - serialize
        strict: true
      testifylint:
@@ -84,7 +84,7 @@
      unused:
        # Mark all struct fields that have been written to as used.
        # Default: true
-@@ -224,7 +192,7 @@
+@@ -227,7 +195,7 @@
          - standard
          - default
          - blank

--- a/ffi/.golangci.yaml
+++ b/ffi/.golangci.yaml
@@ -98,6 +98,9 @@ linters:
         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#empty-lines
         - name: empty-lines
           disabled: false
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#redundant-import-alias
+        - name: redundant-import-alias
+          disabled: false
         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#string-format
         - name: string-format
           disabled: false


### PR DESCRIPTION
https://github.com/ava-labs/firewood/actions/runs/17160824491/job/48689403352

ran

```console
$ .github/scripts/verify_golangci_yaml_changes.sh apply
Downloading upstream .golangci.yaml from 'https://raw.githubusercontent.com/ava-labs/avalanchego/refs/heads/master/.golangci.yml'...
patching file '.github/.golangci.yaml'
Successfully applied the patch from .github/.golangci.yaml.patch to ffi/.golangci.yaml
Updated expected changes in .github/.golangci.yaml.patch

$ .github/scripts/verify_golangci_yaml_changes.sh update
Downloading upstream .golangci.yaml from 'https://raw.githubusercontent.com/ava-labs/avalanchego/refs/heads/master/.golangci.yml'...
Updated expected changes in .github/.golangci.yaml.patch
```

and then also updated the gitignore because patch generated the orig file.
