### PR TITLE
chore(release): prepare for v0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.12] - 2025-08-26
+
+### 🚀 Features
+
+- *(async-removal)* Phase 3 - make `Db` trait sync ([#1213](https://github.com/ava-labs/firewood/pull/1213))
+- *(checker)* Fix error with free area that is not head of a free list ([#1231](https://github.com/ava-labs/firewood/pull/1231))
+- *(async-removal)* Phase 4 - Make `DbView` synchronous ([#1219](https://github.com/ava-labs/firewood/pull/1219))
+- *(ffi-refactor)* Refactor cached view (1/8) ([#1222](https://github.com/ava-labs/firewood/pull/1222))
+- *(ffi-refactor)* Add OwnedSlice and OwnedBytes (2/8) ([#1223](https://github.com/ava-labs/firewood/pull/1223))
+- *(ffi-refactor)* Introduce VoidResult and panic handlers (3/8) ([#1224](https://github.com/ava-labs/firewood/pull/1224))
+- *(ffi-refactor)* Refactor Db opening to use new Result structure (4/8) ([#1225](https://github.com/ava-labs/firewood/pull/1225))
+- *(ffi-refactor)* Refactor how hash values are returned (5/8) ([#1226](https://github.com/ava-labs/firewood/pull/1226))
+- *(ffi-refactor)* Refactor revision to use database handle (6/8) ([#1227](https://github.com/ava-labs/firewood/pull/1227))
+- *(ffi-refactor)* Add `ValueResult` type (7/8) ([#1228](https://github.com/ava-labs/firewood/pull/1228))
+
+### ⚙️ Miscellaneous Tasks
+
+- Only allocate the area needed ([#1217](https://github.com/ava-labs/firewood/pull/1217))
+- Synchronize .golangci.yaml ([#1234](https://github.com/ava-labs/firewood/pull/1234))
+- *(metrics-check)* Re-use previous comment instead of spamming new ones ([#1232](https://github.com/ava-labs/firewood/pull/1232))
+- Nuke grpc-testtool ([#1220](https://github.com/ava-labs/firewood/pull/1220))
+
 ## [0.0.11] - 2025-08-20
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.11"
+version = "0.0.12"
 edition = "2024"
 license-file = "LICENSE.md"
 homepage = "https://avalabs.org"
@@ -53,11 +53,11 @@ cast_possible_truncation = "allow"
 
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.0.11" }
-firewood-macros = { path = "firewood-macros", version = "0.0.11" }
-firewood-storage = { path = "storage", version = "0.0.11" }
-firewood-ffi = { path = "ffi", version = "0.0.11" }
-firewood-triehash = { path = "triehash", version = "0.0.11" }
+firewood = { path = "firewood", version = "0.0.12" }
+firewood-macros = { path = "firewood-macros", version = "0.0.12" }
+firewood-storage = { path = "storage", version = "0.0.12" }
+firewood-ffi = { path = "ffi", version = "0.0.12" }
+firewood-triehash = { path = "triehash", version = "0.0.12" }
 
 # common dependencies
 aquamarine = "0.6.0"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,9 +12,9 @@ Start off by crating a new branch:
 
 ```console
 $ git fetch
-$ git switch -c release/v0.0.12 origin/main
-branch 'release/v0.0.12' set up to track 'origin/main'.
-Switched to a new branch 'release/v0.0.12'
+$ git switch -c release/v0.0.13 origin/main
+branch 'release/v0.0.13' set up to track 'origin/main'.
+Switched to a new branch 'release/v0.0.13'
 ```
 
 ## Package Version
@@ -26,7 +26,7 @@ table to define the version for all subpackages.
 
 ```toml
 [workspace.package]
-version = "0.0.12"
+version = "0.0.13"
 ```
 
 Each package inherits this version by setting `package.version.workspace = true`.
@@ -49,7 +49,7 @@ table. E.g.,:
 ```toml
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.0.12" }
+firewood = { path = "firewood", version = "0.0.13" }
 ```
 
 This allows packages within the workspace to inherit the dependency,
@@ -78,7 +78,7 @@ To build the changelog, see git-cliff.org. Short version:
 
 ```sh
 cargo install --locked git-cliff
-git cliff --tag v0.0.12 > CHANGELOG.md
+git cliff --tag v0.0.13 > CHANGELOG.md
 ```
 
 ## Review
@@ -92,11 +92,11 @@ git cliff --tag v0.0.12 > CHANGELOG.md
 To trigger a release, push a tag to the main branch matching the new version,
 
 ```sh
-git tag -S v0.0.12
-git push origin v0.0.12
+git tag -s -a v0.0.13 -m 'Release v0.0.13'
+git push origin v0.0.13
 ```
 
-for `v0.0.12` for the merged version change. The CI will automatically publish a
+for `v0.0.13` for the merged version change. The CI will automatically publish a
 draft release which consists of release notes and changes (see
 [.github/workflows/release.yaml](.github/workflows/release.yaml)).
 


### PR DESCRIPTION
This release is out of cycle to expedite publishing the fix for #1128 which was fixed as part of #1224.
