### PR TITLE
test: mark new_empty_proposal as test only

### DIFF
--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -277,6 +277,7 @@ impl<S: WritableStorage> NodeStore<MutableProposal, S> {
     /// # Panics
     ///
     /// Panics if the header cannot be written.
+    #[cfg(any(test, feature = "test_utils"))]
     pub fn new_empty_proposal(storage: Arc<S>) -> Self {
         let header = NodeStoreHeader::new();
         let header_bytes = bytemuck::bytes_of(&header);


### PR DESCRIPTION
While reviewing #1240, I noticed that `new_empty_proposal` is only used in tests and is unsafe to use in non-test code. This change tries to make that clearer by marking it as `#[cfg(test)]` or including it only if `features="test_utils"` is enabled (for use in integration tests).