### PR TITLE
chore: Add missing debug traits

### DIFF
--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -127,7 +127,7 @@ impl<T: AsRef<[u8]>> ValueDigest<T> {
 }
 
 /// A node in the trie that can be hashed.
-pub trait Hashable {
+pub trait Hashable: std::fmt::Debug {
     /// The key of the node where each byte is a nibble.
     fn key(&self) -> impl Iterator<Item = u8> + Clone;
     /// The partial path of this node
@@ -148,7 +148,7 @@ pub trait Preimage {
     fn write(&self, buf: &mut impl HasUpdate);
 }
 
-trait HashableNode {
+trait HashableNode: std::fmt::Debug {
     fn partial_path(&self) -> impl Iterator<Item = u8> + Clone;
     fn value(&self) -> Option<&[u8]>;
     fn child_hashes(&self) -> Children<HashType>;
@@ -182,6 +182,7 @@ impl HashableNode for LeafNode {
     }
 }
 
+#[derive(Debug)]
 struct NodeAndPrefix<'a, N: HashableNode> {
     node: &'a N,
     prefix: &'a Path,

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -141,7 +141,7 @@ pub trait Hashable: std::fmt::Debug {
 }
 
 /// A preimage of a hash.
-pub trait Preimage {
+pub trait Preimage: std::fmt::Debug {
     /// Returns the hash of this preimage.
     fn to_hash(&self) -> HashType;
     /// Write this hash preimage to `buf`.


### PR DESCRIPTION
Debugging range proofs is easier when things are printable.