### PR TITLE
feat(ffi-iterator): Batching support for Iterator (3/4)

### DIFF
--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -341,6 +341,11 @@ typedef struct OwnedSlice_OwnedKeyValuePair {
 } OwnedSlice_OwnedKeyValuePair;
 
 /**
+ * A type alias for a rust-owned byte slice.
+ */
+typedef struct OwnedSlice_OwnedKeyValuePair OwnedKeyValueBatch;
+
+/**
  * A result type returned from iterator FFI functions
  */
 typedef enum KeyValueBatchResult_Tag {
@@ -375,7 +380,7 @@ typedef struct KeyValueBatchResult {
       struct HashKey revision_not_found;
     };
     struct {
-      struct OwnedSlice_OwnedKeyValuePair some;
+      OwnedKeyValueBatch some;
     };
     struct {
       OwnedBytes err;

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -223,6 +223,30 @@ typedef struct VoidResult {
 } VoidResult;
 
 /**
+ * Owned version of `KeyValuePair`, returned to the FFI.
+ */
+typedef struct OwnedKeyValuePair {
+  OwnedBytes key;
+  OwnedBytes value;
+} OwnedKeyValuePair;
+
+/**
+ * A Rust-owned vector of bytes that can be passed to C code.
+ *
+ * C callers must free this memory using the respective FFI function for the
+ * concrete type (but not using the `free` function from the C standard library).
+ */
+typedef struct OwnedSlice_OwnedKeyValuePair {
+  struct OwnedKeyValuePair *ptr;
+  size_t len;
+} OwnedSlice_OwnedKeyValuePair;
+
+/**
+ * A type alias for a rust-owned byte slice.
+ */
+typedef struct OwnedSlice_OwnedKeyValuePair OwnedKeyValueBatch;
+
+/**
  * A result type returned from FFI functions that retrieve a single value.
  */
 typedef enum ValueResult_Tag {
@@ -275,14 +299,6 @@ typedef struct ValueResult {
 } ValueResult;
 
 /**
- * Owned version of `KeyValuePair`, returned to the FFI.
- */
-typedef struct OwnedKeyValuePair {
-  OwnedBytes key;
-  OwnedBytes value;
-} OwnedKeyValuePair;
-
-/**
  * A result type returned from iterator FFI functions
  */
 typedef enum KeyValueResult_Tag {
@@ -328,22 +344,6 @@ typedef struct KeyValueResult {
     };
   };
 } KeyValueResult;
-
-/**
- * A Rust-owned vector of bytes that can be passed to C code.
- *
- * C callers must free this memory using the respective FFI function for the
- * concrete type (but not using the `free` function from the C standard library).
- */
-typedef struct OwnedSlice_OwnedKeyValuePair {
-  struct OwnedKeyValuePair *ptr;
-  size_t len;
-} OwnedSlice_OwnedKeyValuePair;
-
-/**
- * A type alias for a rust-owned byte slice.
- */
-typedef struct OwnedSlice_OwnedKeyValuePair OwnedKeyValueBatch;
 
 /**
  * A result type returned from iterator FFI functions
@@ -717,6 +717,27 @@ struct VoidResult fwd_free_iterator(struct IteratorHandle *iterator);
  * this function does nothing.
  */
 struct VoidResult fwd_free_owned_bytes(OwnedBytes bytes);
+
+/**
+ * Consumes the [`OwnedKeyValueBatch`] and frees the memory associated with it.
+ *
+ * # Arguments
+ *
+ * * `batch` - The [`OwnedKeyValueBatch`] struct to free, previously returned from any
+ *   function from this library.
+ *
+ * # Returns
+ *
+ * - [`VoidResult::Ok`] if the memory was successfully freed.
+ * - [`VoidResult::Err`] if the process panics while freeing the memory.
+ *
+ * # Safety
+ *
+ * The caller must ensure that the `batch` struct is valid and that the memory
+ * it points to is uniquely owned by this object. However, if `batch.ptr` is null,
+ * this function does nothing.
+ */
+struct VoidResult fwd_free_owned_key_value_batch(OwnedKeyValueBatch batch);
 
 /**
  * Consumes the [`ProposalHandle`], cancels the proposal, and frees the memory.

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -330,6 +330,60 @@ typedef struct KeyValueResult {
 } KeyValueResult;
 
 /**
+ * A Rust-owned vector of bytes that can be passed to C code.
+ *
+ * C callers must free this memory using the respective FFI function for the
+ * concrete type (but not using the `free` function from the C standard library).
+ */
+typedef struct OwnedSlice_OwnedKeyValuePair {
+  struct OwnedKeyValuePair *ptr;
+  size_t len;
+} OwnedSlice_OwnedKeyValuePair;
+
+/**
+ * A result type returned from iterator FFI functions
+ */
+typedef enum KeyValueBatchResult_Tag {
+  /**
+   * The caller provided a null pointer to an iterator handle.
+   */
+  KeyValueBatchResult_NullHandlePointer,
+  /**
+   * The provided root was not found in the database.
+   */
+  KeyValueBatchResult_RevisionNotFound,
+  /**
+   * The next batch of items on iterator are returned.
+   */
+  KeyValueBatchResult_Some,
+  /**
+   * An error occurred and the message is returned as an [`OwnedBytes`]. If
+   * value is guaranteed to contain only valid UTF-8.
+   *
+   * The caller must call [`fwd_free_owned_bytes`] to free the memory
+   * associated with this error.
+   *
+   * [`fwd_free_owned_bytes`]: crate::fwd_free_owned_bytes
+   */
+  KeyValueBatchResult_Err,
+} KeyValueBatchResult_Tag;
+
+typedef struct KeyValueBatchResult {
+  KeyValueBatchResult_Tag tag;
+  union {
+    struct {
+      struct HashKey revision_not_found;
+    };
+    struct {
+      struct OwnedSlice_OwnedKeyValuePair some;
+    };
+    struct {
+      OwnedBytes err;
+    };
+  };
+} KeyValueBatchResult;
+
+/**
  * A result type returned from FFI functions that create an iterator
  */
 typedef enum IteratorResult_Tag {
@@ -814,6 +868,32 @@ struct ValueResult fwd_get_latest(const struct DatabaseHandle *db, BorrowedBytes
  *
  */
 struct KeyValueResult fwd_iter_next(struct IteratorHandle *handle);
+
+/**
+ * Retrieves the next batch of items from the iterator
+ *
+ * # Arguments
+ *
+ * * `handle` - The iterator handle returned by [`fwd_iter_on_root`] or
+ *   [`fwd_iter_on_proposal`].
+ *
+ * # Returns
+ *
+ * - [`KeyValueResult::NullHandlePointer`] if the provided iterator handle is null.
+ * - [`KeyValueResult::None`] if the iterator doesn't have any remaining values/exhausted.
+ * - [`KeyValueResult::Some`] if the next item on iterator was retrieved, with the associated
+ *   key value pair.
+ * - [`KeyValueResult::Err`] if an error occurred while retrieving the next item on iterator.
+ *
+ * # Safety
+ *
+ * The caller must:
+ * * ensure that `handle` is a valid pointer to a [`IteratorHandle`].
+ * * call [`fwd_free_owned_bytes`] on [`OwnedKeyValuePair::key`] and [`OwnedKeyValuePair::value`]
+ *   to free the memory associated with the returned error or value.
+ *
+ */
+struct KeyValueBatchResult fwd_iter_next_n(struct IteratorHandle *handle, size_t n);
 
 /**
  * Return an iterator on proposal optionally starting from a key

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -5,13 +5,14 @@ package ffi
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -268,8 +269,8 @@ func sortKV(keys, vals [][]byte) error {
 	for i := range ord {
 		ord[i] = i
 	}
-	sort.Slice(ord, func(i, j int) bool {
-		return bytes.Compare(keys[ord[i]], keys[ord[j]]) < 0
+	slices.SortFunc(ord, func(i, j int) int {
+		return bytes.Compare(keys[i], keys[j])
 	})
 	perm := make([]int, n)
 	for dest, orig := range ord {

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -1174,15 +1174,15 @@ func TestIter(t *testing.T) {
 			}
 		}
 	}
-	runForAllModes(t, "Latest", func(t *testing.T, fn func(it *Iterator) kvIter) {
+	runForAllModes(t, "Latest", func(t *testing.T, configureIterator func(it *Iterator) kvIter) {
 		r := require.New(t)
 		it, err := db.IterLatest(nil)
 		r.NoError(err)
 
-		assertIteratorYields(r, fn(it), keys, vals)
+		assertIteratorYields(r, configureIterator(it), keys, vals)
 	})
 
-	runForAllModes(t, "OnRoot", func(t *testing.T, fn func(it *Iterator) kvIter) {
+	runForAllModes(t, "OnRoot", func(t *testing.T, configureIterator func(it *Iterator) kvIter) {
 		r := require.New(t)
 		h1, err := db.IterOnRoot(firstRoot, nil)
 		r.NoError(err)
@@ -1191,12 +1191,12 @@ func TestIter(t *testing.T) {
 		h3, err := db.IterOnRoot(thirdRoot, nil)
 		r.NoError(err)
 
-		assertIteratorYields(r, fn(h1), keys[:80], vals[:80])
-		assertIteratorYields(r, fn(h2), keys[:160], vals[:160])
-		assertIteratorYields(r, fn(h3), keys, vals)
+		assertIteratorYields(r, configureIterator(h1), keys[:80], vals[:80])
+		assertIteratorYields(r, configureIterator(h2), keys[:160], vals[:160])
+		assertIteratorYields(r, configureIterator(h3), keys, vals)
 	})
 
-	runForAllModes(t, "OnProposal", func(t *testing.T, fn func(it *Iterator) kvIter) {
+	runForAllModes(t, "OnProposal", func(t *testing.T, configureIterator func(it *Iterator) kvIter) {
 		r := require.New(t)
 		updatedValues := make([][]byte, len(vals))
 		copy(updatedValues, vals)
@@ -1214,6 +1214,6 @@ func TestIter(t *testing.T) {
 		it, err := p.Iter(nil)
 		r.NoError(err)
 
-		assertIteratorYields(r, fn(it), keys, updatedValues)
+		assertIteratorYields(r, configureIterator(it), keys, updatedValues)
 	})
 }

--- a/ffi/iterator.go
+++ b/ffi/iterator.go
@@ -19,18 +19,23 @@ type Iterator struct {
 	// It is not safe to call these methods with a nil handle.
 	handle *C.IteratorHandle
 
-	// batchSize is the number of items that are loaded at once from ffi
+	// batchSize is the number of items that are loaded at once
 	// to reduce ffi call overheads
 	batchSize int
+
 	// loadedPairs is the latest loaded key value pairs retrieved
 	// from the iterator, not yet consumed by user
 	loadedPairs []*ownedKeyValue
+
 	// currentPair is the current pair retrieved from the iterator
 	currentPair *ownedKeyValue
+
 	// currentKey is the current pair retrieved from the iterator
 	currentKey []byte
+
 	// currentValue is the current pair retrieved from the iterator
 	currentValue []byte
+
 	// err is the error from the iterator, if any
 	err error
 }
@@ -65,10 +70,14 @@ func (it *Iterator) nextInternal() error {
 	return nil
 }
 
+// SetBatchSize sets the max number of pairs to be retrieved in one ffi call.
 func (it *Iterator) SetBatchSize(batchSize int) {
 	it.batchSize = batchSize
 }
 
+// Next proceeds to the next item on the iterator, and returns true
+// if succeeded and there is a pair available.
+// The new pair could be retrieved with Key and Value methods.
 func (it *Iterator) Next() bool {
 	it.err = it.nextInternal()
 	if it.currentPair == nil || it.err != nil {
@@ -81,6 +90,7 @@ func (it *Iterator) Next() bool {
 	return e == nil
 }
 
+// Key returns the key of the current pair
 func (it *Iterator) Key() []byte {
 	if it.currentPair == nil || it.err != nil {
 		return nil
@@ -88,6 +98,7 @@ func (it *Iterator) Key() []byte {
 	return it.currentKey
 }
 
+// Value returns the value of the current pair
 func (it *Iterator) Value() []byte {
 	if it.currentPair == nil || it.err != nil {
 		return nil
@@ -95,6 +106,7 @@ func (it *Iterator) Value() []byte {
 	return it.currentValue
 }
 
+// Err returns the error if Next failed
 func (it *Iterator) Err() error {
 	return it.err
 }

--- a/ffi/iterator.go
+++ b/ffi/iterator.go
@@ -48,7 +48,7 @@ func (it *Iterator) nextInternal() error {
 		}
 	}
 	if len(it.loadedPairs) == 0 {
-		if it.batchSize < 1 {
+		if it.batchSize <= 1 {
 			kv, e := getKeyValueFromKeyValueResult(C.fwd_iter_next(it.handle))
 			if e != nil {
 				return e

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -379,7 +379,12 @@ func (b *ownedKeyValueBatch) Free() error {
 		return nil
 	}
 
-	// TODO
+	if err := getErrorFromVoidResult(C.fwd_free_owned_key_value_batch(b.owned)); err != nil {
+		return fmt.Errorf("%w: %w", errFreeingValue, err)
+	}
+
+	b.owned = C.OwnedKeyValueBatch{}
+
 	return nil
 }
 
@@ -398,14 +403,10 @@ type ownedKeyValue struct {
 	value *ownedBytes
 }
 
-func (kv *ownedKeyValue) Consume() ([]byte, []byte, error) {
+func (kv *ownedKeyValue) Copy() ([]byte, []byte) {
 	key := kv.key.CopiedBytes()
 	value := kv.value.CopiedBytes()
-	e := kv.Free()
-	if e != nil {
-		return nil, nil, e
-	}
-	return key, value, nil
+	return key, value
 }
 
 func (kv *ownedKeyValue) Free() error {

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -400,14 +400,24 @@ type ownedKeyValue struct {
 
 func (kv *ownedKeyValue) Consume() ([]byte, []byte, error) {
 	key := kv.key.CopiedBytes()
-	if err := kv.key.Free(); err != nil {
-		return nil, nil, fmt.Errorf("%w: %w", errFreeingValue, err)
-	}
 	value := kv.value.CopiedBytes()
-	if err := kv.value.Free(); err != nil {
-		return nil, nil, fmt.Errorf("%w: %w", errFreeingValue, err)
+	e := kv.Free()
+	if e != nil {
+		return nil, nil, e
 	}
 	return key, value, nil
+}
+
+func (kv *ownedKeyValue) Free() error {
+	err := kv.key.Free()
+	if err != nil {
+		return fmt.Errorf("%w: %w", errFreeingValue, err)
+	}
+	err = kv.value.Free()
+	if err != nil {
+		return fmt.Errorf("%w: %w", errFreeingValue, err)
+	}
+	return nil
 }
 
 // newOwnedKeyValue creates a ownedKeyValue from a C.OwnedKeyValuePair.

--- a/ffi/src/iterator.rs
+++ b/ffi/src/iterator.rs
@@ -2,8 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 use firewood::merkle;
-use std::fmt::{Debug, Formatter};
 use firewood::v2::api;
+use std::fmt::{Debug, Formatter};
 
 type KeyValueItem = (merkle::Key, merkle::Value);
 
@@ -18,6 +18,7 @@ impl Debug for IteratorHandle<'_> {
     }
 }
 
+#[expect(clippy::missing_errors_doc)]
 impl IteratorHandle<'_> {
     pub fn iter_next(&mut self) -> Option<Result<KeyValueItem, api::Error>> {
         self.iterator.next()

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -639,3 +639,26 @@ pub unsafe extern "C" fn fwd_close_db(db: Option<Box<DatabaseHandle>>) -> VoidRe
 pub unsafe extern "C" fn fwd_free_owned_bytes(bytes: OwnedBytes) -> VoidResult {
     invoke(move || drop(bytes))
 }
+
+
+/// Consumes the [`OwnedKeyValueBatch`] and frees the memory associated with it.
+///
+/// # Arguments
+///
+/// * `batch` - The [`OwnedKeyValueBatch`] struct to free, previously returned from any
+///   function from this library.
+///
+/// # Returns
+///
+/// - [`VoidResult::Ok`] if the memory was successfully freed.
+/// - [`VoidResult::Err`] if the process panics while freeing the memory.
+///
+/// # Safety
+///
+/// The caller must ensure that the `batch` struct is valid and that the memory
+/// it points to is uniquely owned by this object. However, if `batch.ptr` is null,
+/// this function does nothing.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_free_owned_key_value_batch(batch: OwnedKeyValueBatch) -> VoidResult {
+    invoke(move || drop(batch))
+}

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -198,6 +198,33 @@ pub unsafe extern "C" fn fwd_iter_next(handle: Option<&mut IteratorHandle<'_>>) 
     invoke_with_handle(handle, IteratorHandle::iter_next)
 }
 
+/// Retrieves the next batch of items from the iterator
+///
+/// # Arguments
+///
+/// * `handle` - The iterator handle returned by [`fwd_iter_on_root`] or
+///   [`fwd_iter_on_proposal`].
+///
+/// # Returns
+///
+/// - [`KeyValueResult::NullHandlePointer`] if the provided iterator handle is null.
+/// - [`KeyValueResult::None`] if the iterator doesn't have any remaining values/exhausted.
+/// - [`KeyValueResult::Some`] if the next item on iterator was retrieved, with the associated
+///   key value pair.
+/// - [`KeyValueResult::Err`] if an error occurred while retrieving the next item on iterator.
+///
+/// # Safety
+///
+/// The caller must:
+/// * ensure that `handle` is a valid pointer to a [`IteratorHandle`].
+/// * call [`fwd_free_owned_bytes`] on [`OwnedKeyValuePair::key`] and [`OwnedKeyValuePair::value`]
+///   to free the memory associated with the returned error or value.
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_iter_next_n(handle: Option<&mut IteratorHandle<'_>>, n: usize) -> KeyValueBatchResult {
+    invoke_with_handle(handle, |it| it.iter_next_n(n))
+}
+
 /// Consumes the [`IteratorHandle`], destroys the iterator, and frees the memory.
 ///
 /// # Arguments

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -221,7 +221,10 @@ pub unsafe extern "C" fn fwd_iter_next(handle: Option<&mut IteratorHandle<'_>>) 
 ///   to free the memory associated with the returned error or value.
 ///
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn fwd_iter_next_n(handle: Option<&mut IteratorHandle<'_>>, n: usize) -> KeyValueBatchResult {
+pub unsafe extern "C" fn fwd_iter_next_n(
+    handle: Option<&mut IteratorHandle<'_>>,
+    n: usize,
+) -> KeyValueBatchResult {
     invoke_with_handle(handle, |it| it.iter_next_n(n))
 }
 
@@ -639,7 +642,6 @@ pub unsafe extern "C" fn fwd_close_db(db: Option<Box<DatabaseHandle>>) -> VoidRe
 pub unsafe extern "C" fn fwd_free_owned_bytes(bytes: OwnedBytes) -> VoidResult {
     invoke(move || drop(bytes))
 }
-
 
 /// Consumes the [`OwnedKeyValueBatch`] and frees the memory associated with it.
 ///

--- a/ffi/src/value.rs
+++ b/ffi/src/value.rs
@@ -11,7 +11,7 @@ mod results;
 pub use self::borrowed::{BorrowedBytes, BorrowedKeyValuePairs, BorrowedSlice};
 use self::display_hex::DisplayHex;
 pub use self::hash_key::HashKey;
-pub use self::kvp::{KeyValuePair, OwnedKeyValuePair};
+pub use self::kvp::{KeyValuePair, OwnedKeyValuePair, OwnedKeyValueBatch};
 pub use self::owned::{OwnedBytes, OwnedSlice};
 pub(crate) use self::results::{CResult, NullHandleResult};
 pub use self::results::{

--- a/ffi/src/value.rs
+++ b/ffi/src/value.rs
@@ -15,6 +15,6 @@ pub use self::kvp::{KeyValuePair, OwnedKeyValuePair};
 pub use self::owned::{OwnedBytes, OwnedSlice};
 pub(crate) use self::results::{CResult, NullHandleResult};
 pub use self::results::{
-    HandleResult, HashResult, IteratorResult, KeyValueResult, ProposalResult, ValueResult,
+    HandleResult, HashResult, IteratorResult, KeyValueResult, KeyValueBatchResult, ProposalResult, ValueResult,
     VoidResult,
 };

--- a/ffi/src/value.rs
+++ b/ffi/src/value.rs
@@ -11,10 +11,10 @@ mod results;
 pub use self::borrowed::{BorrowedBytes, BorrowedKeyValuePairs, BorrowedSlice};
 use self::display_hex::DisplayHex;
 pub use self::hash_key::HashKey;
-pub use self::kvp::{KeyValuePair, OwnedKeyValuePair, OwnedKeyValueBatch};
+pub use self::kvp::{KeyValuePair, OwnedKeyValueBatch, OwnedKeyValuePair};
 pub use self::owned::{OwnedBytes, OwnedSlice};
 pub(crate) use self::results::{CResult, NullHandleResult};
 pub use self::results::{
-    HandleResult, HashResult, IteratorResult, KeyValueResult, KeyValueBatchResult, ProposalResult, ValueResult,
-    VoidResult,
+    HandleResult, HashResult, IteratorResult, KeyValueBatchResult, KeyValueResult, ProposalResult,
+    ValueResult, VoidResult,
 };

--- a/ffi/src/value/kvp.rs
+++ b/ffi/src/value/kvp.rs
@@ -3,9 +3,12 @@
 
 use std::fmt;
 
-use crate::OwnedBytes;
+use crate::{OwnedBytes, OwnedSlice};
 use crate::value::BorrowedBytes;
 use firewood::v2::api;
+
+/// A type alias for a rust-owned byte slice.
+pub type OwnedKeyValueBatch = OwnedSlice<OwnedKeyValuePair>;
 
 /// A `KeyValue` represents a key-value pair, passed to the FFI.
 #[repr(C)]

--- a/ffi/src/value/kvp.rs
+++ b/ffi/src/value/kvp.rs
@@ -3,8 +3,8 @@
 
 use std::fmt;
 
-use crate::{OwnedBytes, OwnedSlice};
 use crate::value::BorrowedBytes;
+use crate::{OwnedBytes, OwnedSlice};
 use firewood::v2::api;
 
 /// A type alias for a rust-owned byte slice.

--- a/ffi/src/value/results.rs
+++ b/ffi/src/value/results.rs
@@ -6,8 +6,8 @@ use firewood::v2::api;
 use std::fmt;
 
 use crate::iterator::{CreateIteratorResult, IteratorHandle};
-use crate::value::kvp::OwnedKeyValuePair;
-use crate::{CreateProposalResult, HashKey, OwnedBytes, OwnedSlice, ProposalHandle};
+use crate::value::kvp::{OwnedKeyValueBatch, OwnedKeyValuePair};
+use crate::{CreateProposalResult, HashKey, OwnedBytes, ProposalHandle};
 
 /// The result type returned from an FFI function that returns no value but may
 /// return an error.
@@ -271,7 +271,7 @@ pub enum KeyValueBatchResult {
     /// The provided root was not found in the database.
     RevisionNotFound(HashKey),
     /// The next batch of items on iterator are returned.
-    Some(OwnedSlice<OwnedKeyValuePair>),
+    Some(OwnedKeyValueBatch),
     /// An error occurred and the message is returned as an [`OwnedBytes`]. If
     /// value is guaranteed to contain only valid UTF-8.
     ///

--- a/ffi/src/value/results.rs
+++ b/ffi/src/value/results.rs
@@ -261,7 +261,6 @@ impl From<Option<Result<(merkle::Key, merkle::Value), api::Error>>> for KeyValue
     }
 }
 
-
 /// A result type returned from iterator FFI functions
 #[derive(Debug)]
 #[repr(C)]
@@ -285,14 +284,22 @@ pub enum KeyValueBatchResult {
 impl From<Result<Vec<(merkle::Key, merkle::Value)>, api::Error>> for KeyValueBatchResult {
     fn from(value: Result<Vec<(merkle::Key, merkle::Value)>, api::Error>) -> Self {
         match value {
-                Ok(pairs) => {
-                    let values: Vec<_> = pairs.into_iter().map(|(k, v)| OwnedKeyValuePair {key:k.into(), value:v.into()}).collect();
-                    KeyValueBatchResult::Some(values.into())
-                },
-                Err(api::Error::RevisionNotFound { provided }) => KeyValueBatchResult::RevisionNotFound(
-                    HashKey::from(provided.unwrap_or_else(api::HashKey::empty)),
-                ),
-                Err(err) => KeyValueBatchResult::Err(err.to_string().into_bytes().into()),
+            Ok(pairs) => {
+                let values: Vec<_> = pairs
+                    .into_iter()
+                    .map(|(k, v)| OwnedKeyValuePair {
+                        key: k.into(),
+                        value: v.into(),
+                    })
+                    .collect();
+                KeyValueBatchResult::Some(values.into())
+            }
+            Err(api::Error::RevisionNotFound { provided }) => {
+                KeyValueBatchResult::RevisionNotFound(HashKey::from(
+                    provided.unwrap_or_else(api::HashKey::empty),
+                ))
+            }
+            Err(err) => KeyValueBatchResult::Err(err.to_string().into_bytes().into()),
         }
     }
 }


### PR DESCRIPTION
This PR introduces batched retrieval from iterator, to reduce overheads introduced from too many calls to FFI.

Depends On: #1256 