### PR TITLE
chore: cargo +nightly clippy --fix

### DIFF
--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -147,7 +147,7 @@ impl DatabaseHandle<'_> {
     /// An error is returned if the proposal could not be created.
     pub fn create_batch<'kvp>(
         &self,
-        values: (impl AsRef<[KeyValuePair<'kvp>]> + 'kvp),
+        values: impl AsRef<[KeyValuePair<'kvp>]> + 'kvp,
     ) -> Result<Option<HashKey>, api::Error> {
         let start = coarsetime::Instant::now();
 

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -76,7 +76,7 @@ fn main() -> Result<(), api::Error> {
 
     env_logger::init_from_env(
         env_logger::Env::default()
-            .filter_or(env_logger::DEFAULT_FILTER_ENV, cli.log_level.to_string()),
+            .filter_or(env_logger::DEFAULT_FILTER_ENV, cli.log_level.clone()),
     );
 
     match &cli.command {

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -75,8 +75,7 @@ fn main() -> Result<(), api::Error> {
     let cli = Cli::parse();
 
     env_logger::init_from_env(
-        env_logger::Env::default()
-            .filter_or(env_logger::DEFAULT_FILTER_ENV, cli.log_level.clone()),
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, cli.log_level.clone()),
     );
 
     match &cli.command {

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -47,7 +47,7 @@ fn is_valid_key(key: &Path) -> bool {
 
 #[cfg(not(feature = "ethhash"))]
 fn is_valid_key(key: &Path) -> bool {
-    key.0.len() % 2 == 0
+    key.0.len().is_multiple_of(2)
 }
 
 /// Options for the checker

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -211,7 +211,7 @@ impl Iterator for NibblesIterator<'_> {
         if self.is_empty() {
             return None;
         }
-        let result = if self.head % 2 == 0 {
+        let result = if self.head.is_multiple_of(2) {
             #[expect(clippy::indexing_slicing)]
             NIBBLES[(self.data[self.head / 2] >> 4) as usize]
         } else {
@@ -262,7 +262,7 @@ impl DoubleEndedIterator for NibblesIterator<'_> {
             return None;
         }
 
-        let result = if self.tail % 2 == 0 {
+        let result = if self.tail.is_multiple_of(2) {
             #[expect(clippy::indexing_slicing)]
             NIBBLES[(self.data[self.tail / 2 - 1] & 0xf) as usize]
         } else {

--- a/storage/src/nodestore/primitives.rs
+++ b/storage/src/nodestore/primitives.rs
@@ -274,7 +274,7 @@ impl LinearAddress {
     #[inline]
     #[must_use]
     pub const fn is_aligned(self) -> bool {
-        self.0.get() % (Self::MIN_AREA_SIZE) == 0
+        self.0.get().is_multiple_of(Self::MIN_AREA_SIZE)
     }
 
     /// The maximum area size available for allocation.


### PR DESCRIPTION
```
➜  firewood git:(main) cargo +nightly clippy
    Checking firewood-storage v0.0.12 (/Users/rkuris/open-source/firewood/storage)
   Compiling firewood-macros v0.0.12 (/Users/rkuris/open-source/firewood/firewood-macros)
   Compiling firewood-ffi v0.0.12 (/Users/rkuris/open-source/firewood/ffi)
   Compiling firewood-fwdctl v0.0.12 (/Users/rkuris/open-source/firewood/fwdctl)
    Checking firewood-triehash v0.0.12 (/Users/rkuris/open-source/firewood/triehash)
warning: manual implementation of `.is_multiple_of()`
  --> storage/src/checker/mod.rs:50:5
   |
50 |     key.0.len() % 2 == 0
   |     ^^^^^^^^^^^^^^^^^^^^ help: replace with: `key.0.len().is_multiple_of(2)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of
   = note: `#[warn(clippy::manual_is_multiple_of)]` on by default

warning: manual implementation of `.is_multiple_of()`
   --> storage/src/node/path.rs:214:25
    |
214 |         let result = if self.head % 2 == 0 {
    |                         ^^^^^^^^^^^^^^^^^^ help: replace with: `self.head.is_multiple_of(2)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of

warning: manual implementation of `.is_multiple_of()`
   --> storage/src/node/path.rs:265:25
    |
265 |         let result = if self.tail % 2 == 0 {
    |                         ^^^^^^^^^^^^^^^^^^ help: replace with: `self.tail.is_multiple_of(2)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of

warning: manual implementation of `.is_multiple_of()`
   --> storage/src/nodestore/primitives.rs:277:9
    |
277 |         self.0.get() % (Self::MIN_AREA_SIZE) == 0
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `self.0.get().is_multiple_of((Self::MIN_AREA_SIZE))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of

warning: `firewood-storage` (lib) generated 4 warnings (run `cargo clippy --fix --lib -p firewood-storage` to apply 4 suggestions)
    Checking firewood v0.0.12 (/Users/rkuris/open-source/firewood/firewood)
    Checking firewood-benchmark v0.0.12 (/Users/rkuris/open-source/firewood/benchmark)
warning: implicitly cloning a `String` by calling `to_string` on its dereferenced type
  --> fwdctl/src/main.rs:79:56
   |
79 |             .filter_or(env_logger::DEFAULT_FILTER_ENV, cli.log_level.to_string()),
   |                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `cli.log_level.clone()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#implicit_clone
   = note: `-W clippy::implicit-clone` implied by `-W clippy::pedantic`
   = help: to override `-W clippy::pedantic` add `#[allow(clippy::implicit_clone)]`

warning: `firewood-fwdctl` (bin "fwdctl") generated 1 warning (run `cargo clippy --fix --bin "fwdctl"` to apply 1 suggestion)
warning: unnecessary parentheses around type
   --> ffi/src/handle.rs:150:17
    |
150 |         values: (impl AsRef<[KeyValuePair<'kvp>]> + 'kvp),
    |                 ^                                       ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
150 -         values: (impl AsRef<[KeyValuePair<'kvp>]> + 'kvp),
150 +         values: impl AsRef<[KeyValuePair<'kvp>]> + 'kvp,
    |

warning: `firewood-ffi` (lib) generated 1 warning (run `cargo clippy --fix --lib -p firewood-ffi` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.37s
```