### PR TITLE
feat!: rename `Hashable::key`

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -167,7 +167,6 @@ impl<T: TrieReader> Merkle<T> {
 
             proof.push(ProofNode {
                 key: root.partial_path().bytes(),
-                #[cfg(feature = "ethhash")]
                 partial_len: root.partial_path().0.len(),
                 value_digest: root
                     .value()

--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -90,12 +90,14 @@ pub struct ProofNode {
 
 impl std::fmt::Debug for ProofNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Filter the missing children and only show the present ones with their indices
         let child_hashes = self
             .child_hashes
             .iter()
             .enumerate()
             .filter_map(|(i, h)| h.as_ref().map(|h| (i, h)))
             .collect::<Vec<_>>();
+        // Compute the hash and render it as well
         let hash = firewood_storage::Preimage::to_hash(self);
 
         f.debug_struct("ProofNode")

--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -90,13 +90,19 @@ pub struct ProofNode {
 
 impl std::fmt::Debug for ProofNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let child_hashes = self
+            .child_hashes
+            .iter()
+            .enumerate()
+            .filter_map(|(i, h)| h.as_ref().map(|h| (i, h)))
+            .collect::<Vec<_>>();
         let hash = firewood_storage::Preimage::to_hash(self);
 
         f.debug_struct("ProofNode")
             .field("key", &self.key)
             .field("partial_len", &self.partial_len)
             .field("value_digest", &self.value_digest)
-            .field("child_hashes", &self.child_hashes)
+            .field("child_hashes", &child_hashes)
             .field("hash", &hash)
             .finish()
     }

--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -80,7 +80,6 @@ pub struct ProofNode {
     /// The key this node is at. Each byte is a nibble.
     pub key: Key,
     /// The length of the key prefix that is shared with the previous node.
-    #[cfg(feature = "ethhash")]
     pub partial_len: usize,
     /// None if the node does not have a value.
     /// Otherwise, the node's value or the hash of its value.
@@ -91,39 +90,29 @@ pub struct ProofNode {
 
 impl std::fmt::Debug for ProofNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let key: Vec<u8> = self.key().collect();
-        let children: Vec<(usize, &HashType)> = self
-            .child_hashes
-            .iter()
-            .enumerate()
-            .filter_map(|(i, c)| c.as_ref().map(|h| (i, h)))
-            .collect();
-        let value_digest = self.value_digest();
-
-        let mut ds = f.debug_struct("ProofNode");
-        ds.field("key", &key)
-            .field("value_digest", &value_digest)
-            .field("child_hashes", &children);
-
-        #[cfg(feature = "ethhash")]
-        ds.field("partial_len", &self.partial_len);
-
-        // Compute the hash and render it as well
         let hash = firewood_storage::Preimage::to_hash(self);
-        ds.field("hash", &hash);
 
-        ds.finish()
+        f.debug_struct("ProofNode")
+            .field("key", &self.key)
+            .field("partial_len", &self.partial_len)
+            .field("value_digest", &self.value_digest)
+            .field("child_hashes", &self.child_hashes)
+            .field("hash", &hash)
+            .finish()
     }
 }
 
 impl Hashable for ProofNode {
-    fn key(&self) -> impl Iterator<Item = u8> + Clone {
-        self.key.as_ref().iter().copied()
+    fn parent_prefix_path(&self) -> impl Iterator<Item = u8> + Clone {
+        self.full_path().take(self.partial_len)
     }
 
-    #[cfg(feature = "ethhash")]
     fn partial_path(&self) -> impl Iterator<Item = u8> + Clone {
-        self.key.as_ref().iter().skip(self.partial_len).copied()
+        self.full_path().skip(self.partial_len)
+    }
+
+    fn full_path(&self) -> impl Iterator<Item = u8> + Clone {
+        self.key.as_ref().iter().copied()
     }
 
     fn value_digest(&self) -> Option<ValueDigest<&[u8]>> {
@@ -147,15 +136,13 @@ impl From<PathIterItem> for ProofNode {
             BranchNode::empty_children()
         };
 
-        #[cfg(feature = "ethhash")]
         let partial_len = item
             .key_nibbles
             .len()
-            .saturating_sub(item.node.partial_path().0.len());
+            .saturating_sub(item.node.partial_path().len());
 
         Self {
             key: item.key_nibbles,
-            #[cfg(feature = "ethhash")]
             partial_len,
             value_digest: item
                 .node
@@ -207,19 +194,19 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
             // Assert that only nodes whose keys are an even number of nibbles
             // have a `value_digest`.
             #[cfg(not(feature = "branch_factor_256"))]
-            if node.key().count() % 2 != 0 && node.value_digest().is_some() {
+            if node.full_path().count() % 2 != 0 && node.value_digest().is_some() {
                 return Err(ProofError::ValueAtOddNibbleLength);
             }
 
             if let Some(next_node) = iter.peek() {
                 // Assert that every node's key is a prefix of `key`, except for the last node,
                 // whose key can be equal to or a suffix of `key` in an exclusion proof.
-                if next_nibble(node.key(), key.iter().copied()).is_none() {
+                if next_nibble(node.full_path(), key.iter().copied()).is_none() {
                     return Err(ProofError::ShouldBePrefixOfProvenKey);
                 }
 
                 // Assert that every node's key is a prefix of the next node's key.
-                let next_node_index = next_nibble(node.key(), next_node.key());
+                let next_node_index = next_nibble(node.full_path(), next_node.full_path());
 
                 let Some(next_nibble) = next_node_index else {
                     return Err(ProofError::ShouldBePrefixOfNextKey);
@@ -235,7 +222,7 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
             }
         }
 
-        if last_node.key().count() == key.len() {
+        if last_node.full_path().count() == key.len() {
             return Ok(last_node.value_digest());
         }
 

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -131,9 +131,9 @@ impl<T: AsRef<[u8]>> ValueDigest<T> {
 
 /// A node in the trie that can be hashed.
 pub trait Hashable: std::fmt::Debug {
-    /// The full key of the node where each byte is a nibble.
+    /// The full path of this node's parent where each byte is a nibble.
     fn parent_prefix_path(&self) -> impl Iterator<Item = u8> + Clone;
-    /// The partial path of this node omitting the parent's prefix.
+    /// The partial path of this node where each byte is a nibble.
     fn partial_path(&self) -> impl Iterator<Item = u8> + Clone;
     /// The node's value or hash.
     fn value_digest(&self) -> Option<ValueDigest<&[u8]>>;
@@ -141,7 +141,7 @@ pub trait Hashable: std::fmt::Debug {
     /// Yields 0 elements if the node is a leaf.
     fn children(&self) -> Children<HashType>;
 
-    /// The full path of this node including the parent's prefix.
+    /// The full path of this node including the parent's prefix where each byte is a nibble.
     fn full_path(&self) -> impl Iterator<Item = u8> + Clone {
         self.parent_prefix_path().chain(self.partial_path())
     }

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -131,16 +131,20 @@ impl<T: AsRef<[u8]>> ValueDigest<T> {
 
 /// A node in the trie that can be hashed.
 pub trait Hashable: std::fmt::Debug {
-    /// The key of the node where each byte is a nibble.
-    fn key(&self) -> impl Iterator<Item = u8> + Clone;
-    /// The partial path of this node
-    #[cfg(feature = "ethhash")]
+    /// The full key of the node where each byte is a nibble.
+    fn parent_prefix_path(&self) -> impl Iterator<Item = u8> + Clone;
+    /// The partial path of this node omitting the parent's prefix.
     fn partial_path(&self) -> impl Iterator<Item = u8> + Clone;
     /// The node's value or hash.
     fn value_digest(&self) -> Option<ValueDigest<&[u8]>>;
     /// Each element is a child's index and hash.
     /// Yields 0 elements if the node is a leaf.
     fn children(&self) -> Children<HashType>;
+
+    /// The full path of this node including the parent's prefix.
+    fn full_path(&self) -> impl Iterator<Item = u8> + Clone {
+        self.parent_prefix_path().chain(self.partial_path())
+    }
 }
 
 /// A preimage of a hash.
@@ -198,15 +202,10 @@ impl<'a, N: HashableNode> From<NodeAndPrefix<'a, N>> for HashType {
 }
 
 impl<'a, N: HashableNode> Hashable for NodeAndPrefix<'a, N> {
-    fn key(&self) -> impl Iterator<Item = u8> + Clone {
-        self.prefix
-            .0
-            .iter()
-            .copied()
-            .chain(self.node.partial_path())
+    fn parent_prefix_path(&self) -> impl Iterator<Item = u8> + Clone {
+        self.prefix.0.iter().copied()
     }
 
-    #[cfg(feature = "ethhash")]
     fn partial_path(&self) -> impl Iterator<Item = u8> + Clone {
         self.node.partial_path()
     }

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -90,7 +90,7 @@ impl<T: Hashable> Preimage for T {
 
         trace!(
             "SIZE WAS {} {}",
-            self.key().count(),
+            self.full_path().count(),
             hex::encode(&collector),
         );
 
@@ -102,7 +102,7 @@ impl<T: Hashable> Preimage for T {
     }
 
     fn write(&self, buf: &mut impl HasUpdate) {
-        let is_account = self.key().count() == 64;
+        let is_account = self.full_path().count() == 64;
         trace!("is_account: {is_account}");
 
         let child_hashes = self.children();
@@ -224,7 +224,7 @@ impl<T: Hashable> Preimage for T {
                     // treat like non-account since it didn't have a value
                     warn!(
                         "Account node {:x?} without value",
-                        self.key().collect::<Vec<_>>()
+                        self.full_path().collect::<Vec<_>>()
                     );
                     bytes.as_ref().into()
                 }

--- a/storage/src/hashers/merkledb.rs
+++ b/storage/src/hashers/merkledb.rs
@@ -50,7 +50,7 @@ impl<T: Hashable> Preimage for T {
         add_value_digest_to_buf(buf, self.value_digest());
 
         // Add key length (in bits) to hash pre-image
-        let mut key = self.key();
+        let mut key = self.full_path();
         // let mut key = key.as_ref().iter();
         let key_bit_len = BITS_PER_NIBBLE * key.clone().count() as u64;
         add_varint_to_buf(buf, key_bit_len);


### PR DESCRIPTION
This renames `Hashable::key` to `Hashable::full_path`. I also included `parent_prefix_path` and `partial_path` unconditionally as they are useful to me during serialization.

I had already done this in prep for serialization but comments on #1268 prompted me to pull it out and publish separately.