### PR TITLE
fix(range-proofs): serialize range proof key consistently

### DIFF
--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -166,8 +166,11 @@ impl<T: TrieReader> Merkle<T> {
             };
 
             proof.push(ProofNode {
+                // key is expected to be in nibbles
                 key: root.partial_path().iter().copied().collect(),
-                partial_len: root.partial_path().0.len(),
+                // partial len is the number of nibbles in the path leading to this node,
+                // which is always zero for the root node.
+                partial_len: 0,
                 value_digest: root
                     .value()
                     .map(|value| ValueDigest::Value(value.to_vec().into_boxed_slice())),

--- a/firewood/src/merkle.rs
+++ b/firewood/src/merkle.rs
@@ -166,7 +166,7 @@ impl<T: TrieReader> Merkle<T> {
             };
 
             proof.push(ProofNode {
-                key: root.partial_path().bytes(),
+                key: root.partial_path().iter().copied().collect(),
                 #[cfg(feature = "ethhash")]
                 partial_len: root.partial_path().0.len(),
                 value_digest: root

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -138,12 +138,6 @@ impl Path {
             nibbles_iter: self.iter(),
         }
     }
-
-    /// Create a boxed set of bytes from the Path
-    #[must_use]
-    pub fn bytes(&self) -> Box<[u8]> {
-        self.bytes_iter().collect()
-    }
 }
 
 /// Returns the nibbles in `nibbles_iter` as compressed bytes.


### PR DESCRIPTION
Every other range proof is created by collecting the nibbles
<https://github.com/ava-labs/firewood/blob/fe53dd444b2d84b84024d32d812bbaee4823cc77/firewood/src/proof.rs#L80-L81>

The field is even documented to only be nibbles. However, when the exclusion proof is before the left-most key, we are serializing the proof node incorrectly.