### PR TITLE
fix: resolve build failures by pinning opentelemetry to 0.30

### DIFF
--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 readme.workspace = true
 rust-version.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["opentelemetry-proto"]
+
 [[bin]]
 name = "benchmark"
 path = "src/main.rs"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -34,9 +34,10 @@ sha2.workspace = true
 # Regular dependencies
 fastrace-opentelemetry = { version = "0.13.0" }
 metrics-exporter-prometheus = { version = "0.17.2", optional = true }
-opentelemetry = "0.30.0"
-opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic"] }
-opentelemetry_sdk = "0.30.0"
+opentelemetry = "=0.30.0"
+opentelemetry-otlp = { version = "=0.30.0", features = ["grpc-tonic"] }
+opentelemetry-proto = "=0.30.0"
+opentelemetry_sdk = "=0.30.0"
 pretty-duration = "0.1.1"
 
 [dependencies.tokio]


### PR DESCRIPTION
OpenTelemetry updated to 0.30.1 today, but not all packages were updated causing our builds to fail. This pins them to 0.30.0 until the issue is resolved.