### PR TITLE
fix: incorrect gauge metrics

### DIFF
--- a/ffi/src/metrics_setup.rs
+++ b/ffi/src/metrics_setup.rs
@@ -161,8 +161,7 @@ impl TextRecorder {
             self.write_labels(&mut output, key.labels());
             // Load gauge value: Uses gauge.load(Ordering::Relaxed) to get the current gauge value
             let value = gauge.load(Ordering::Relaxed);
-            writeln!(output, " {} {}", f64::from_bits(value), epoch_ms)
-                .expect("write error");
+            writeln!(output, " {} {}", f64::from_bits(value), epoch_ms).expect("write error");
         }
 
         // Prometheus does not support multiple TYPE declarations for the same metric,


### PR DESCRIPTION
The metrics package is very strange in that gauges are stored as f64 but in a u64 container. Clueless as to why, but you must use from_bits to get the actual float value.

The metrics are reporting 4629700416936869888 as the max_revision count, which is actually 32:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=80c05d7b7f47eb7f459382e2f9950c10