### PR TITLE
feat: Parallel hashing of Merkle trie

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -778,7 +778,13 @@ mod test {
                 }
                 batch
             });
-            let proposal = db.propose(batch).unwrap();
+
+            // randomly uses either propose or propose_parallel
+            let proposal = if rng.random() {
+                db.propose(batch).unwrap()
+            } else {
+                db.propose_parallel(batch).unwrap()
+            };
             proposal.commit().unwrap();
 
             // check the database for consistency, sometimes checking the hashes

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -281,7 +281,7 @@ impl ParallelMerkle {
                     // Adding deleted nodes (from calling read_for_update) from the child's nodestore.
                     proposal.delete_nodes(deleted_nodes.as_slice());
 
-                    // Set the child at index to child_root.
+                    // Set the child at index to child_root which is the root of the child's subtrie.
                     *root_branch
                         .children
                         .get_mut(index as usize)

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -36,7 +36,7 @@ enum Request {
 
 #[derive(Debug)]
 enum Response {
-    // returns both the new root of the subtrie at the given nibble and the deleted nodes.
+    // return both the new root of the subtrie at the given nibble and the deleted nodes.
     Root(u8, Option<Child>, Vec<MaybePersistedNode>),
     Error(FileIoError),
 }

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -36,7 +36,7 @@ enum Request {
 
 #[derive(Debug)]
 enum Response {
-    // returns the new root of the subtrie at the given nibble and the deleted nodes.
+    // returns both the new root of the subtrie at the given nibble and the deleted nodes.
     Root(u8, Option<Child>, Vec<MaybePersistedNode>),
     Error(FileIoError),
 }

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -227,12 +227,15 @@ impl ParallelMerkle {
                     }
                     // Sent from the coordinator to the workers to signal that the batch is done.
                     Request::Done => {
-                        let root = merkle.nodestore.root_mut();
-                        let hashed_result = std::mem::take(root)
-                            .map(|root_node| {
-                                let (root_node, root_hash, _unwritten_count) =
+                        // Hash this subtrie and return the root as a Child::MaybePersisted.
+                        let hashed_result = merkle
+                            .nodestore
+                            .root_mut()
+                            .take()
+                            .map(|root| {
+                                let (root_node, root_hash, _) =
                                     NodeStore::<MutableProposal, FileBacked>::hash_helper_index(
-                                        root_node,
+                                        root,
                                         first_nibble,
                                     )?;
                                 Ok(Child::MaybePersisted(root_node, root_hash))

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -233,23 +233,21 @@ impl ParallelMerkle {
                             .root_mut()
                             .take()
                             .map(|root| {
-                                let (root_node, root_hash, _) =
-                                    NodeStore::<MutableProposal, FileBacked>::hash_helper_index(
-                                        root,
-                                        first_nibble,
-                                    )?;
+                                let (root_node, root_hash, _) = NodeStore::<
+                                    MutableProposal,
+                                    FileBacked,
+                                >::hash_subtrie_with_index(
+                                    root, first_nibble
+                                )?;
                                 Ok(Child::MaybePersisted(root_node, root_hash))
                             })
                             .transpose();
-
-                        //let a = merkle.nodestore.deleted_as_slice();
-                        //let a= merkle.nodestore.deleted_as_slice().to_vec();
 
                         let response = match hashed_result {
                             Ok(hashed_root) => Response::Root(
                                 first_nibble,
                                 hashed_root,
-                                merkle.nodestore.deleted_as_slice().to_vec(),
+                                merkle.nodestore.take_deleted_nodes(),
                             ),
                             Err(err) => Response::Error(err),
                         };

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -115,7 +115,9 @@ where
 
     /// Hashes the given `node` and the subtree rooted at it.
     /// Returns the hashed node and its hash.
-    pub(super) fn hash_helper(
+    //pub(super) fn hash_helper(
+    #[allow(clippy::missing_errors_doc)]
+    pub fn hash_helper(    
         #[cfg(feature = "ethhash")] &self,
         node: Node,
     ) -> Result<(MaybePersistedNode, HashType, usize), FileIoError> {

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -114,21 +114,18 @@ where
         )
     }
 
-    /// TODO
-    #[allow(clippy::missing_errors_doc)]
-    pub fn hash_helper_index(
+    /// Hashes the given `node` and its subtree with `child_index` added to the root path.
+    /// Returns the hashed node and its hash.
+    ///
+    /// # Errors
+    ///
+    /// Can return a `FileIoError` if it is unable to read a node that it is hashing.
+    pub fn hash_subtrie_with_index(
         #[cfg(feature = "ethhash")] &self,
         node: Node,
         child_index: u8,
     ) -> Result<(MaybePersistedNode, HashType, usize), FileIoError> {
-        let mut root_path = Path::from_nibbles_iterator(
-                    once(child_index));
-
-        //let mut root_path = Path::new();
-        //let mut root_path = node.partial_path();
-        //root_path.
-        //let mut root_path = Path::clone(node.partial_path());
-        //root_path.copy_from_slice(node.partial_path());
+        let mut root_path = Path::from_nibbles_iterator(once(child_index));
         #[cfg(not(feature = "ethhash"))]
         let res = Self::hash_helper_inner(node, PathGuard::from_path(&mut root_path))?;
         #[cfg(feature = "ethhash")]
@@ -138,17 +135,11 @@ where
 
     /// Hashes the given `node` and the subtree rooted at it.
     /// Returns the hashed node and its hash.
-    //pub(super) fn hash_helper(
-    #[allow(clippy::missing_errors_doc)]
-    pub fn hash_helper(    
+    pub(super) fn hash_helper(
         #[cfg(feature = "ethhash")] &self,
         node: Node,
     ) -> Result<(MaybePersistedNode, HashType, usize), FileIoError> {
         let mut root_path = Path::new();
-        //let mut root_path = node.partial_path();
-        //root_path.
-        //let mut root_path = Path::clone(node.partial_path());
-        //root_path.copy_from_slice(node.partial_path());
         #[cfg(not(feature = "ethhash"))]
         let res = Self::hash_helper_inner(node, PathGuard::from_path(&mut root_path))?;
         #[cfg(feature = "ethhash")]

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -159,7 +159,6 @@ where
     ) -> Result<(MaybePersistedNode, HashType, usize), FileIoError> {
         // If this is a branch, find all unhashed children and recursively hash them.
         trace!("hashing {node:?} at {path_prefix:?}");
-        println!("hashing {node:?} at {path_prefix:?}");
         let mut nodes_processed = 1usize; // Count this node
         if let Node::Branch(ref mut b) = node {
             // special case code for ethereum hashes at the account level
@@ -250,8 +249,7 @@ where
 
                 nodes_processed = nodes_processed.saturating_add(child_count);
                 *child = Some(Child::MaybePersisted(child_node, child_hash));
-                //trace!("child now {child:?}");
-                println!("child now {child:?}");
+                trace!("child now {child:?}");
             }
         }
         // At this point, we either have a leaf or a branch with all children hashed.

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -588,6 +588,9 @@ impl<S: WritableStorage> NodeStore<Arc<ImmutableProposal>, S> {
     }
 }
 
+// TODO (Bernard): Add a Hash function here to hash mutable proposal.
+
+
 impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
     for NodeStore<Arc<ImmutableProposal>, S>
 {

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -588,9 +588,6 @@ impl<S: WritableStorage> NodeStore<Arc<ImmutableProposal>, S> {
     }
 }
 
-// TODO (Bernard): Add a Hash function here to hash mutable proposal.
-
-
 impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
     for NodeStore<Arc<ImmutableProposal>, S>
 {
@@ -627,6 +624,8 @@ impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
         #[cfg(not(feature = "ethhash"))]
         let (root, root_hash, unwritten_count) =
             NodeStore::<MutableProposal, S>::hash_helper(root)?;
+
+        println!("****** root: {root:?} and root_hash: {root_hash:?}");
 
         let immutable_proposal =
             Arc::into_inner(nodestore.kind).expect("no other references to the proposal");

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -251,10 +251,9 @@ impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
         self.kind.deleted.push(node);
     }
 
-    /// Return nodes that have been maked as deleted in this proposal as a slice.
-    #[must_use]
-    pub const fn deleted_as_slice(&self) -> &[MaybePersistedNode] {
-        self.kind.deleted.as_slice()
+    /// Take the nodes that have been maked as deleted in this proposal.
+    pub fn take_deleted_nodes(&mut self) -> Vec<MaybePersistedNode> {
+        std::mem::take(&mut self.kind.deleted)
     }
 
     /// Adds to the nodes deleted in this proposal.
@@ -624,8 +623,6 @@ impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
         #[cfg(not(feature = "ethhash"))]
         let (root, root_hash, unwritten_count) =
             NodeStore::<MutableProposal, S>::hash_helper(root)?;
-
-        println!("****** root: {root:?} and root_hash: {root_hash:?}");
 
         let immutable_proposal =
             Arc::into_inner(nodestore.kind).expect("no other references to the proposal");

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -251,7 +251,7 @@ impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
         self.kind.deleted.push(node);
     }
 
-    /// Take the nodes that have been maked as deleted in this proposal.
+    /// Take the nodes that have been marked as deleted in this proposal.
     pub fn take_deleted_nodes(&mut self) -> Vec<MaybePersistedNode> {
         std::mem::take(&mut self.kind.deleted)
     }


### PR DESCRIPTION
This PR builds on https://github.com/ava-labs/firewood/pull/1258 to support parallel hashing. The workers performing parallel inserts will now perform hashing on their subtrie when they receive the Done message from the main thread. This is safe even if the trie is modified after post-processing because there is only one case in which any of the subtries is modified during post-processing (the root only has one child and no value). For this case, the updated root will be rehashed.

The public function hash_subtrie_with_index has been added in nodestore/hash.rs to allow the workers to correctly hash their subtrie by accounting for their child index.

The test fuzz_checker has been modified to randomly use either propose or propose_parallel to check the correctness of both hashing approaches (serial and parallel).