### PR TITLE
chore: Add support for enormous disk

### DIFF
--- a/benchmark/bootstrap/aws-launch.sh
+++ b/benchmark/bootstrap/aws-launch.sh
@@ -26,6 +26,7 @@ declare -A VALID_INSTANCES=(
     ["r6id.2xlarge"]="amd64"
     ["x2gd.2xlarge"]="arm64"
     ["z1d.2xlarge"]="amd64"
+    ["i8ge.12xlarge"]="arm64"
 )
 
 # Maximum spot prices for each instance type (from the pricing table)
@@ -42,6 +43,7 @@ declare -A MAX_SPOT_PRICES=(
     ["r6id.2xlarge"]="0.6048"
     ["x2gd.2xlarge"]="0.6680"
     ["z1d.2xlarge"]="0.7440"
+    ["i8ge.12xlarge"]="5.6952"
 )
 
 # Valid nblocks values
@@ -77,6 +79,7 @@ show_usage() {
     echo "  r6id.2xlarge   amd64 474  8    64 GiB   \$0.6048 Intel Xeon Scalable"
     echo "  x2gd.2xlarge   arm64 475  8    128 GiB  \$0.6680 Graviton2 memory-optimized"
     echo "  z1d.2xlarge    amd64 300  8    64 GiB   \$0.7440 High-frequency Intel Xeon CPUs"
+    echo "  i8ge.12xlarge  arm64 11250 48  384 GiB  \$5.5952 Careful, very expensive"
     echo ""
     echo "Valid nblocks values: ${VALID_NBLOCKS[*]}"
 }

--- a/benchmark/bootstrap/aws-launch.sh
+++ b/benchmark/bootstrap/aws-launch.sh
@@ -353,7 +353,7 @@ runcmd:
   - >
     sudo -u ubuntu -D /mnt/nvme/ubuntu/avalanchego --login
     time task reexecute-cchain-range CURRENT_STATE_DIR=/mnt/nvme/ubuntu/exec-data/current-state BLOCK_DIR=/mnt/nvme/ubuntu/exec-data/blocks START_BLOCK=1 END_BLOCK=__END_BLOCK__ CONFIG=firewood METRICS_ENABLED=false
-    > bootstrap.log 2>&1
+    > /var/log/bootstrap.log 2>&1
 END_HEREDOC
 )
 

--- a/benchmark/bootstrap/aws-launch.sh
+++ b/benchmark/bootstrap/aws-launch.sh
@@ -47,7 +47,7 @@ declare -A MAX_SPOT_PRICES=(
 )
 
 # Valid nblocks values
-VALID_NBLOCKS=("1m" "10m" "20m" "30m" "40m" "50m")
+VALID_NBLOCKS=("1m" "10m" "50m")
 
 # Function to show usage
 show_usage() {
@@ -361,9 +361,6 @@ END_HEREDOC
 case $NBLOCKS in
     "1m")   END_BLOCK="1000000" ;;
     "10m")  END_BLOCK="10000000" ;;
-    "20m")  END_BLOCK="20000000" ;;
-    "30m")  END_BLOCK="30000000" ;;
-    "40m")  END_BLOCK="40000000" ;;
     "50m")  END_BLOCK="50000000" ;;
     *)      END_BLOCK="1000000" ;;  # Default fallback
 esac

--- a/benchmark/setup-scripts/build-environment.sh
+++ b/benchmark/setup-scripts/build-environment.sh
@@ -10,7 +10,7 @@ fi
 apt upgrade -y
 
 # install the build dependency packages
-pkgs=(git protobuf-compiler build-essential apt-transport-https net-tools zfsutils-linux)
+pkgs=(git protobuf-compiler build-essential apt-transport-https net-tools zfsutils-linux mdadm)
 install_pkgs=()
 for pkg in "${pkgs[@]}"; do
   if ! dpkg -s "$pkg" > /dev/null 2>&1; then
@@ -21,15 +21,52 @@ if [ "${#install_pkgs[@]}" -gt 0 ]; then
   apt-get install -y "${install_pkgs[@]}"
 fi
   
-# If there is an NVMe device, format it and mount it to /mnt/nvme/ubuntu/firewood
-# this happens on amazon ec2 instances
-NVME_DEV="$(realpath /dev/disk/by-id/nvme-Amazon_EC2_NVMe_Instance_Storage_* | uniq)"
-if [ -n "$NVME_DEV" ]; then
-  mkfs.ext4 -E nodiscard -i 6291456 "$NVME_DEV"
+# If there are NVMe devices, set up RAID if multiple, or use single device
+mapfile -t NVME_DEVS < <(realpath /dev/disk/by-id/nvme-Amazon_EC2_NVMe_Instance_Storage_* 2>/dev/null | sort | uniq)
+if [ "${#NVME_DEVS[@]}" -gt 0 ]; then
+  DEVICE_TO_USE=""
+
+  if [ "${#NVME_DEVS[@]}" -eq 1 ]; then
+    # Single device, use it directly
+    DEVICE_TO_USE="${NVME_DEVS[0]}"
+    echo "Using single NVMe device: $DEVICE_TO_USE"
+  elif [ "${#NVME_DEVS[@]}" -eq 2 ]; then
+    # Two devices, create RAID1
+    echo "Creating RAID1 array with 2 devices: ${NVME_DEVS[*]}"
+    mdadm --create /dev/md0 --level=1 --raid-devices=2 "${NVME_DEVS[@]}"
+    DEVICE_TO_USE="/dev/md0"
+  elif [ "${#NVME_DEVS[@]}" -eq 3 ]; then
+    # Three devices, create RAID5
+    echo "Creating RAID5 array with 3 devices: ${NVME_DEVS[*]}"
+    mdadm --create /dev/md0 --level=5 --raid-devices=3 "${NVME_DEVS[@]}"
+    DEVICE_TO_USE="/dev/md0"
+  elif [ "${#NVME_DEVS[@]}" -eq 4 ]; then
+    # Four devices, create RAID10
+    echo "Creating RAID10 array with 4 devices: ${NVME_DEVS[*]}"
+    mdadm --create /dev/md0 --level=10 --raid-devices=4 "${NVME_DEVS[@]}"
+    DEVICE_TO_USE="/dev/md0"
+  else
+    echo "Unsupported number of NVMe devices: ${#NVME_DEVS[@]}. Using first device only."
+    DEVICE_TO_USE="${NVME_DEVS[0]}"
+  fi
+
+  # Wait for RAID array to be ready (if created)
+  if [[ "$DEVICE_TO_USE" == "/dev/md0" ]]; then
+    echo "Waiting for RAID array to be ready..."
+    while [ ! -e "$DEVICE_TO_USE" ]; do
+      sleep 1
+    done
+    # Save RAID configuration
+    mdadm --detail --scan >> /etc/mdadm/mdadm.conf
+    update-initramfs -u
+  fi
+
+  # Format and mount the device
+  mkfs.ext4 -E nodiscard -i 6291456 "$DEVICE_TO_USE"
   NVME_MOUNT=/mnt/nvme
   mkdir -p "$NVME_MOUNT"
-  mount -o noatime "$NVME_DEV" "$NVME_MOUNT"
-  echo "$NVME_DEV $NVME_MOUNT ext4 noatime 0 0" >> /etc/fstab
+  mount -o noatime "$DEVICE_TO_USE" "$NVME_MOUNT"
+  echo "$DEVICE_TO_USE $NVME_MOUNT ext4 noatime 0 0" >> /etc/fstab
   mkdir -p "$NVME_MOUNT/ubuntu/firewood"
   chown ubuntu:ubuntu "$NVME_MOUNT/ubuntu" "$NVME_MOUNT/ubuntu/firewood"
   ln -s "$NVME_MOUNT/ubuntu/firewood" /home/ubuntu/firewood


### PR DESCRIPTION
I need to test firewood boostrapping when we don't delete anything so I added support for an instance with ~13T of disk space.