### PR TITLE
chore(release): prepare for v0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.0.12] - 2025-08-26
+## [0.0.13] - 2025-09-26
 
 ### 🚀 Features
 
@@ -16,6 +16,43 @@ All notable changes to this project will be documented in this file.
 - *(ffi-refactor)* Refactor how hash values are returned (5/8) ([#1226](https://github.com/ava-labs/firewood/pull/1226))
 - *(ffi-refactor)* Refactor revision to use database handle (6/8) ([#1227](https://github.com/ava-labs/firewood/pull/1227))
 - *(ffi-refactor)* Add `ValueResult` type (7/8) ([#1228](https://github.com/ava-labs/firewood/pull/1228))
+- *(checker)* Print report using template for better readability ([#1237](https://github.com/ava-labs/firewood/pull/1237))
+- *(checker)* Fix free lists when the erroneous area is the head ([#1240](https://github.com/ava-labs/firewood/pull/1240))
+- *(ffi-proofs)* Stub interfaces for FFI to interact with proofs. ([#1253](https://github.com/ava-labs/firewood/pull/1253))
+- Explicit impl of PartialEq/Eq on HashOrRlp ([#1260](https://github.com/ava-labs/firewood/pull/1260))
+- *(proofs)* [**breaking**] Disable `ValueDigest::Hash` for ethhash ([#1269](https://github.com/ava-labs/firewood/pull/1269))
+- [**breaking**] Rename `Hashable::key` ([#1270](https://github.com/ava-labs/firewood/pull/1270))
+- *(range-proofs)* KeyValuePairIter (1/2) ([#1282](https://github.com/ava-labs/firewood/pull/1282))
+- *(proofs)* [**breaking**] Add v0 serialization for RangeProofs ([#1271](https://github.com/ava-labs/firewood/pull/1271))
+- *(ffi-refactor)* Replace sequence id with pointer to proposals (8/8) ([#1221](https://github.com/ava-labs/firewood/pull/1221))
+
+### 🐛 Bug Fixes
+
+- Add an advisory lock ([#1244](https://github.com/ava-labs/firewood/pull/1244))
+- Path iterator returned wrong node ([#1259](https://github.com/ava-labs/firewood/pull/1259))
+- Use `count` instead of `size_hint` ([#1268](https://github.com/ava-labs/firewood/pull/1268))
+- Correct typo in README.md ([#1276](https://github.com/ava-labs/firewood/pull/1276))
+- Resolve build failures by pinning opentelemetry to 0.30 ([#1281](https://github.com/ava-labs/firewood/pull/1281))
+- *(range-proofs)* Serialize range proof key consistently ([#1278](https://github.com/ava-labs/firewood/pull/1278))
+- *(range-proofs)* Fix verify of exclusion proofs ([#1279](https://github.com/ava-labs/firewood/pull/1279))
+- *(ffi)* GetFromRoot typo ([#1298](https://github.com/ava-labs/firewood/pull/1298))
+- Incorrect gauge metrics ([#1300](https://github.com/ava-labs/firewood/pull/1300))
+- M6id is a amd64 machine ([#1305](https://github.com/ava-labs/firewood/pull/1305))
+- Revert #1116 ([#1313](https://github.com/ava-labs/firewood/pull/1313))
+
+### 💼 Other
+
+- *(deps)* Update typed-builder requirement from 0.21.0 to 0.22.0 ([#1275](https://github.com/ava-labs/firewood/pull/1275))
+
+### 📚 Documentation
+
+- README implies commit == persist ([#1283](https://github.com/ava-labs/firewood/pull/1283))
+
+### 🧪 Testing
+
+- Mark new_empty_proposal as test only ([#1249](https://github.com/ava-labs/firewood/pull/1249))
+- *(firewood)* Use ctor section to init logger for all tests ([#1277](https://github.com/ava-labs/firewood/pull/1277))
+- *(bootstrap)* Bootstrap testing scripts ([#1287](https://github.com/ava-labs/firewood/pull/1287))
 
 ### ⚙️ Miscellaneous Tasks
 
@@ -23,6 +60,24 @@ All notable changes to this project will be documented in this file.
 - Synchronize .golangci.yaml ([#1234](https://github.com/ava-labs/firewood/pull/1234))
 - *(metrics-check)* Re-use previous comment instead of spamming new ones ([#1232](https://github.com/ava-labs/firewood/pull/1232))
 - Nuke grpc-testtool ([#1220](https://github.com/ava-labs/firewood/pull/1220))
+- Rename FuzzTree ([#1239](https://github.com/ava-labs/firewood/pull/1239))
+- Upgrade to rust 1.89 ([#1242](https://github.com/ava-labs/firewood/pull/1242))
+- Rename mut_root to root_mut ([#1248](https://github.com/ava-labs/firewood/pull/1248))
+- Add missing debug traits ([#1254](https://github.com/ava-labs/firewood/pull/1254))
+- These tests actually work now ([#1262](https://github.com/ava-labs/firewood/pull/1262))
+- Cargo +nightly clippy --fix ([#1265](https://github.com/ava-labs/firewood/pull/1265))
+- Update .golangci.yaml ([#1274](https://github.com/ava-labs/firewood/pull/1274))
+- Various script improvements ([#1288](https://github.com/ava-labs/firewood/pull/1288))
+- *(bootstrap)* Add keys for brandon ([#1289](https://github.com/ava-labs/firewood/pull/1289))
+- *(bootstrap)* Add keys for Bernard and Amin ([#1291](https://github.com/ava-labs/firewood/pull/1291))
+- [**breaking**] Decorate enums and structs with `#[non_exhaustive]` ([#1292](https://github.com/ava-labs/firewood/pull/1292))
+- Add spot instance support ([#1294](https://github.com/ava-labs/firewood/pull/1294))
+- Upgrade go ([#1296](https://github.com/ava-labs/firewood/pull/1296))
+- Ask for clippy and rustfmt ([#1306](https://github.com/ava-labs/firewood/pull/1306))
+- Add support for enormous disk ([#1308](https://github.com/ava-labs/firewood/pull/1308))
+- Disable non-security dependabot version bumps ([#1315](https://github.com/ava-labs/firewood/pull/1315))
+- Upgrade dependencies ([#1314](https://github.com/ava-labs/firewood/pull/1314))
+- *(benchmark)* Add ssh key ([#1316](https://github.com/ava-labs/firewood/pull/1316))
 
 ## [0.0.11] - 2025-08-20
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.12"
+version = "0.0.13"
 edition = "2024"
 license-file = "LICENSE.md"
 homepage = "https://avalabs.org"
@@ -54,11 +54,11 @@ cast_possible_truncation = "allow"
 
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.0.12" }
-firewood-macros = { path = "firewood-macros", version = "0.0.12" }
-firewood-storage = { path = "storage", version = "0.0.12" }
-firewood-ffi = { path = "ffi", version = "0.0.12" }
-firewood-triehash = { path = "triehash", version = "0.0.12" }
+firewood = { path = "firewood", version = "0.0.13" }
+firewood-macros = { path = "firewood-macros", version = "0.0.13" }
+firewood-storage = { path = "storage", version = "0.0.13" }
+firewood-ffi = { path = "ffi", version = "0.0.13" }
+firewood-triehash = { path = "triehash", version = "0.0.13" }
 
 # common dependencies
 aquamarine = "0.6.0"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,9 +12,9 @@ Start off by crating a new branch:
 
 ```console
 $ git fetch
-$ git switch -c release/v0.0.13 origin/main
-branch 'release/v0.0.13' set up to track 'origin/main'.
-Switched to a new branch 'release/v0.0.13'
+$ git switch -c release/v0.0.14 origin/main
+branch 'release/v0.0.14' set up to track 'origin/main'.
+Switched to a new branch 'release/v0.0.14'
 ```
 
 ## Package Version
@@ -26,7 +26,7 @@ table to define the version for all subpackages.
 
 ```toml
 [workspace.package]
-version = "0.0.13"
+version = "0.0.14"
 ```
 
 Each package inherits this version by setting `package.version.workspace = true`.
@@ -41,15 +41,16 @@ Therefore, updating only the version defined in the root config is needed.
 
 ## Dependency Version
 
-The next step is to bump the dependency declarations to the new version. Packages
-within the workspace that are used as libraries are also defined within the
-[`[workspace.dependencies]`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table)
+`cargo publish` for each package requires that each dependency specify _a_ version;
+therefore, the next step is to bump the dependency declarations to the new version.
+Packages within the workspace that are used as libraries are also defined within
+the [`[workspace.dependencies]`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table)
 table. E.g.,:
 
 ```toml
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.0.13" }
+firewood = { path = "firewood", version = "0.0.14" }
 ```
 
 This allows packages within the workspace to inherit the dependency,
@@ -78,7 +79,7 @@ To build the changelog, see git-cliff.org. Short version:
 
 ```sh
 cargo install --locked git-cliff
-git cliff --tag v0.0.13 > CHANGELOG.md
+git cliff --tag v0.0.14 -o CHANGELOG.md
 ```
 
 ## Review
@@ -92,11 +93,14 @@ git cliff --tag v0.0.13 > CHANGELOG.md
 To trigger a release, push a tag to the main branch matching the new version,
 
 ```sh
-git tag -s -a v0.0.13 -m 'Release v0.0.13'
-git push origin v0.0.13
+# be sure to switch back to the main branch before tagging
+git checkout main
+git pull --prune
+git tag -s -a v0.0.14 -m 'Release v0.0.14'
+git push origin v0.0.14
 ```
 
-for `v0.0.13` for the merged version change. The CI will automatically publish a
+for `v0.0.14` for the merged version change. The CI will automatically publish a
 draft release which consists of release notes and changes (see
 [.github/workflows/release.yaml](.github/workflows/release.yaml)).
 


### PR DESCRIPTION
The changelog is a little messed up because when I tagged `v0.0.12`, I accidentally did it from the branch and not the commit that was squashed and merged into main. When git-cliff walks the history, it fails to find the tag thus 0.0.12 technically didn't happen. Correcting this in order to correct the changelog would require re-tagging and that would be very disruptive. It's unfortunately better to pretend 0.0.12 didn't happen. This is also why I amended the release doc.
