### PR TITLE
fix(#1324): correct replacement hints in clippy.toml

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -10,10 +10,10 @@ doc-valid-idents = [
 ]
 
 disallowed-methods = [
-  { path = "rand::rng", replacement = "firewood_storage::StdRng::from_env_or_random", reason = "use a prng with a user-defined seed instead", allow-invalid = true },
+  { path = "rand::rng", replacement = "firewood_storage::SeededRng::from_env_or_random", reason = "use a prng with a user-defined seed instead", allow-invalid = true },
 ]
 
 disallowed-types = [
-  { path = "rand::SeedableRng", replacement = "firewood_storage::StdRng", reason = "use a prng with a user-defined seed instead", allow-invalid = true },
-  { path = "rand::rngs::StdRng", replacement = "firewood_storage::StdRng", reason = "use a prng with a user-defined seed instead", allow-invalid = true },
+  { path = "rand::SeedableRng", replacement = "firewood_storage::SeededRng", reason = "use a prng with a user-defined seed instead", allow-invalid = true },
+  { path = "rand::rngs::StdRng", replacement = "firewood_storage::SeededRng", reason = "use a prng with a user-defined seed instead", allow-invalid = true },
 ]


### PR DESCRIPTION
As was pointed out, `firewood_storage::StdRng` doesn't exist. It is instead named `SeededRng`.

Closes: #1324 