### PR TITLE
refactor: unify root storage using Child enum

### DIFF
--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -223,7 +223,7 @@ mod ethhash {
             self
         }
 
-        pub(crate) fn into_triehash(self) -> TrieHash {
+        pub fn into_triehash(self) -> TrieHash {
             self.into()
         }
     }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -89,7 +89,9 @@ use std::sync::Arc;
 use crate::hashednode::hash_node;
 use crate::node::Node;
 use crate::node::persist::MaybePersistedNode;
-use crate::{CacheReadStrategy, Child, FileIoError, HashType, Path, ReadableStorage, SharedNode, TrieHash};
+use crate::{
+    CacheReadStrategy, Child, FileIoError, HashType, Path, ReadableStorage, SharedNode, TrieHash,
+};
 
 use super::linear::WritableStorage;
 

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -89,7 +89,7 @@ use std::sync::Arc;
 use crate::hashednode::hash_node;
 use crate::node::Node;
 use crate::node::persist::MaybePersistedNode;
-use crate::{CacheReadStrategy, FileIoError, Path, ReadableStorage, SharedNode, TrieHash};
+use crate::{CacheReadStrategy, Child, FileIoError, HashType, Path, ReadableStorage, SharedNode, TrieHash};
 
 use super::linear::WritableStorage;
 
@@ -121,16 +121,15 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
             header,
             kind: Committed {
                 deleted: Box::default(),
-                root_hash: None,
-                root: header.root_address().map(Into::into),
+                root: None,
             },
             storage,
         };
 
-        if let Some(root_address) = nodestore.header.root_address() {
+        if let Some(root_address) = header.root_address() {
             let node = nodestore.read_node_from_disk(root_address, "open");
             let root_hash = node.map(|n| hash_node(&n, &Path(SmallVec::default())))?;
-            nodestore.kind.root_hash = Some(root_hash.into_triehash());
+            nodestore.kind.root = Some(Child::AddressWithHash(root_address, root_hash));
         }
 
         Ok(nodestore)
@@ -150,7 +149,6 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
             storage,
             kind: Committed {
                 deleted: Box::default(),
-                root_hash: None,
                 root: None,
             },
         })
@@ -177,10 +175,12 @@ impl Parentable for Arc<ImmutableProposal> {
         NodeStoreParent::Proposed(Arc::clone(self))
     }
     fn root_hash(&self) -> Option<TrieHash> {
-        self.root_hash.clone()
+        self.root
+            .as_ref()
+            .and_then(|root| root.hash().cloned().map(HashType::into_triehash))
     }
     fn root(&self) -> Option<MaybePersistedNode> {
-        self.root.clone()
+        self.root.as_ref().map(Child::as_maybe_persisted_node)
     }
 }
 
@@ -204,13 +204,19 @@ impl<S> NodeStore<Arc<ImmutableProposal>, S> {
 
 impl Parentable for Committed {
     fn as_nodestore_parent(&self) -> NodeStoreParent {
-        NodeStoreParent::Committed(self.root_hash.clone())
+        NodeStoreParent::Committed(
+            self.root
+                .as_ref()
+                .and_then(|root| root.hash().cloned().map(HashType::into_triehash)),
+        )
     }
     fn root_hash(&self) -> Option<TrieHash> {
-        self.root_hash.clone()
+        self.root
+            .as_ref()
+            .and_then(|root| root.hash().cloned().map(HashType::into_triehash))
     }
     fn root(&self) -> Option<MaybePersistedNode> {
-        self.root.clone()
+        self.root.as_ref().map(Child::as_maybe_persisted_node)
     }
 }
 
@@ -353,21 +359,10 @@ pub trait RootReader {
 }
 
 /// A committed revision of a merkle trie.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Committed {
     deleted: Box<[MaybePersistedNode]>,
-    root_hash: Option<TrieHash>,
-    root: Option<MaybePersistedNode>,
-}
-
-impl Clone for Committed {
-    fn clone(&self) -> Self {
-        Self {
-            deleted: self.deleted.clone(),
-            root_hash: self.root_hash.clone(),
-            root: self.root.clone(),
-        }
-    }
+    root: Option<Child>,
 }
 
 #[derive(Clone, Debug)]
@@ -395,10 +390,8 @@ pub struct ImmutableProposal {
     deleted: Box<[MaybePersistedNode]>,
     /// The parent of this proposal.
     parent: Arc<ArcSwap<NodeStoreParent>>,
-    /// The hash of the root node for this proposal
-    root_hash: Option<TrieHash>,
-    /// The root node, either in memory or on disk
-    root: Option<MaybePersistedNode>,
+    /// The root of the trie in this proposal.
+    root: Option<Child>,
 }
 
 impl ImmutableProposal {
@@ -482,7 +475,6 @@ impl<S: WritableStorage> From<NodeStore<ImmutableProposal, S>> for NodeStore<Com
             header: val.header,
             kind: Committed {
                 deleted: val.kind.deleted.clone(),
-                root_hash: val.kind.root_hash.clone(),
                 root: val.kind.root.clone(),
             },
             storage: val.storage,
@@ -510,7 +502,6 @@ impl<S: WritableStorage> NodeStore<Arc<ImmutableProposal>, S> {
             header: current_revision.header,
             kind: Committed {
                 deleted: self.kind.deleted.clone(),
-                root_hash: self.kind.root_hash.clone(),
                 root: self.kind.root.clone(),
             },
             storage: self.storage.clone(),
@@ -535,7 +526,6 @@ impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
             kind: Arc::new(ImmutableProposal {
                 deleted: kind.deleted.into(),
                 parent: Arc::new(ArcSwap::new(Arc::new(kind.parent))),
-                root_hash: None,
                 root: None,
             }),
             storage,
@@ -558,8 +548,7 @@ impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
         nodestore.kind = Arc::new(ImmutableProposal {
             deleted: immutable_proposal.deleted.clone(),
             parent: immutable_proposal.parent.clone(),
-            root_hash: Some(root_hash.into_triehash()),
-            root: Some(root),
+            root: Some(Child::MaybePersisted(root, root_hash)),
         });
 
         Ok(nodestore)
@@ -593,20 +582,28 @@ impl<S: ReadableStorage> RootReader for NodeStore<MutableProposal, S> {
 impl<S: ReadableStorage> RootReader for NodeStore<Committed, S> {
     fn root_node(&self) -> Option<SharedNode> {
         // TODO: If the read_node fails, we just say there is no root; this is incorrect
-        self.kind.root.as_ref()?.as_shared_node(self).ok()
+        self.kind
+            .root
+            .as_ref()
+            .map(Child::as_maybe_persisted_node)
+            .and_then(|node| node.as_shared_node(self).ok())
     }
     fn root_as_maybe_persisted_node(&self) -> Option<MaybePersistedNode> {
-        self.kind.root.clone()
+        self.kind.root.as_ref().map(Child::as_maybe_persisted_node)
     }
 }
 
 impl<S: ReadableStorage> RootReader for NodeStore<Arc<ImmutableProposal>, S> {
     fn root_node(&self) -> Option<SharedNode> {
         // Use the MaybePersistedNode's as_shared_node method to get the root
-        self.kind.root.as_ref()?.as_shared_node(self).ok()
+        self.kind
+            .root
+            .as_ref()
+            .map(Child::as_maybe_persisted_node)
+            .and_then(|node| node.as_shared_node(self).ok())
     }
     fn root_as_maybe_persisted_node(&self) -> Option<MaybePersistedNode> {
-        self.kind.root.clone()
+        self.kind.root.as_ref().map(Child::as_maybe_persisted_node)
     }
 }
 


### PR DESCRIPTION
There were two fields representing a root, the address and the hash. They were both options, which means that it is possible for one to be None and the other to be Some, which would be a logic error. This PR makes that impossible.

Thought hard about whether or not to use Child, as it's possible to use something simpler than that, but based on the fact that we're going to add deferred persistence, this is probably the right structure. The owned Node variant of Child will never be used, but this problem is systemic and perhaps worthy of another PR and is much more difficult.

Summary of changes:

- Replace separate root_hash and root fields with single Child-based root
- Update all root access methods to use Child::as_maybe_persisted_node()
- Fix test compilation errors by properly chaining method calls
- Simplify root persistence logic using Child::persisted_address()