### PR TITLE
research(rootstore): implementations POC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +346,9 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -410,6 +422,16 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cast"
@@ -700,6 +722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,6 +841,15 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "doxygen-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
+dependencies = [
+ "phf",
+]
 
 [[package]]
 name = "dtor"
@@ -949,6 +989,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastant"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1091,7 @@ dependencies = [
  "firewood-storage",
  "firewood-triehash",
  "hash-db",
+ "heed",
  "hex",
  "hex-literal",
  "integer-encoding",
@@ -1047,6 +1100,8 @@ dependencies = [
  "pprof",
  "rand 0.9.2",
  "rlp",
+ "rocksdb",
+ "rusqlite",
  "sha3",
  "tempfile",
  "test-case",
@@ -1433,10 +1488,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "heed"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a56c94661ddfb51aa9cdfbf102cfcc340aa69267f95ebccc4af08d7c530d393"
+dependencies = [
+ "bitflags 2.9.4",
+ "byteorder",
+ "heed-traits",
+ "heed-types",
+ "libc",
+ "lmdb-master-sys",
+ "once_cell",
+ "page_size",
+ "serde",
+ "synchronoise",
+ "url",
+]
+
+[[package]]
+name = "heed-traits"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3130048d404c57ce5a1ac61a903696e8fcde7e8c2991e9fcfc1f27c3ef74ff"
+
+[[package]]
+name = "heed-types"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c255bdf46e07fb840d120a36dcc81f385140d7191c76a7391672675c01a55d"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "heed-traits",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1984,6 +2086,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2132,17 @@ name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
+name = "lmdb-master-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864808e0b19fb6dd3b70ba94ee671b82fce17554cf80aeb0a155c65bb08027df"
+dependencies = [
+ "cc",
+ "doxygen-rs",
+ "libc",
+]
 
 [[package]]
 name = "lock_api"
@@ -2018,6 +2167,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe949189f46fabb938b3a9a0be30fdd93fd8a09260da863399a8cf3db756ec8"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -2305,6 +2464,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,6 +2531,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,6 +2603,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain_hasher"
@@ -2881,10 +3098,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "rtrb"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8388ea1a9e0ea807e442e8263a699e7edcb320ecbcd21b4fa8ff859acce3ba"
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.9.4",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -3170,6 +3411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3283,6 +3530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synchronoise"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbc01390fc626ce8d1cffe3376ded2b72a11bb70e1c75f404a210e4daa4def2"
+dependencies = [
+ "crossbeam-queue",
 ]
 
 [[package]]
@@ -3832,6 +4088,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4377,4 +4639,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -23,6 +23,12 @@ readme.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+# Eventually, only one of these will stick around
+heed = "0.22.0"
+rusqlite = "0.37.0"
+rocksdb = "0.24.0"
+rand = "0.9.2"
+
 # Workspace dependencies
 bytemuck_derive.workspace = true
 bytemuck.workspace = true
@@ -66,6 +72,10 @@ sha3 = "0.10.8"
 
 [[bench]]
 name = "hashops"
+harness = false
+
+[[bench]]
+name = "root_store"
 harness = false
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/firewood/benches/root_store.rs
+++ b/firewood/benches/root_store.rs
@@ -1,0 +1,139 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use std::collections::HashMap;
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use firewood::root_store::{LMDBStore, RocksDBStore, RootStore, RootStoreBuilder, SQLiteStore};
+use firewood_storage::{LinearAddress, SeededRng, TrieHash};
+use rand::Rng;
+
+fn bench_lmdb_writes_prepopulated<const NKEYS: usize>(criterion: &mut Criterion) {
+    bench_writes_with_prepopulated_root_store::<LMDBStore>(criterion, NKEYS, "LMDB");
+}
+
+fn bench_rocksdb_writes_prepopulated<const NKEYS: usize>(criterion: &mut Criterion) {
+    bench_writes_with_prepopulated_root_store::<RocksDBStore>(criterion, NKEYS, "RocksDB");
+}
+
+fn bench_sqlite_writes_prepopulated<const NKEYS: usize>(criterion: &mut Criterion) {
+    bench_writes_with_prepopulated_root_store::<SQLiteStore>(criterion, NKEYS, "SQLite");
+}
+
+fn bench_lmdb_reads_prepopulated<const NKEYS: usize>(criterion: &mut Criterion) {
+    bench_reads_with_prepopulated_root_state::<LMDBStore>(criterion, NKEYS, "LMDB");
+}
+
+fn bench_rocksdb_reads_prepopulated<const NKEYS: usize>(criterion: &mut Criterion) {
+    bench_reads_with_prepopulated_root_state::<RocksDBStore>(criterion, NKEYS, "RocksDB");
+}
+
+fn bench_sqlite_reads_prepopulated<const NKEYS: usize>(criterion: &mut Criterion) {
+    bench_reads_with_prepopulated_root_state::<SQLiteStore>(criterion, NKEYS, "SQLite");
+}
+
+// bench_writes_with_prepopulated_root_store benchmarks an instance of T by
+// first prepopulating it with 1 million key-value pairs before benchmarking
+// its write performance
+#[expect(clippy::unwrap_used)]
+fn bench_writes_with_prepopulated_root_store<T: RootStore + RootStoreBuilder<T>>(
+    criterion: &mut Criterion,
+    n_keys: usize,
+    group_name: &str,
+) {
+    let mut rng = firewood_storage::SeededRng::new(1234);
+
+    criterion
+        .benchmark_group(group_name)
+        .sample_size(30)
+        .bench_function("writes against prepopulated RootStore", |b| {
+            b.iter_batched(
+                || {
+                    let db_path = tempfile::tempdir().unwrap();
+                    let root_store = T::new(&db_path).unwrap();
+
+                    let prepopulated_pairs = new_kv_pairs(1_000_000, &mut rng);
+
+                    root_store.add_roots_batch(&prepopulated_pairs).unwrap();
+
+                    (root_store, new_kv_pairs(n_keys, &mut rng), db_path)
+                },
+                |(root_store, pairs, db_path)| {
+                    for (key, value) in &pairs {
+                        root_store.add_root(key, value).unwrap();
+                    }
+
+                    db_path.close().unwrap();
+                },
+                BatchSize::SmallInput,
+            );
+        });
+}
+
+// bench_reads_with_prepopulated_root_store benchmarks an instance of T by
+// first prepopulating it with 1 million key-value pairs before benchmarking
+// its read performance
+#[expect(clippy::unwrap_used)]
+fn bench_reads_with_prepopulated_root_state<T: RootStore + RootStoreBuilder<T>>(
+    criterion: &mut Criterion,
+    n_keys: usize,
+    group_name: &str,
+) {
+    let mut rng = firewood_storage::SeededRng::new(1234);
+
+    // Prepopulate ONCE before all iterations
+    let db_path = tempfile::tempdir().unwrap();
+    let root_store = T::new(&db_path).unwrap();
+
+    let prepopulated_pairs = new_kv_pairs(1_000_000, &mut rng);
+    root_store.add_roots_batch(&prepopulated_pairs).unwrap();
+
+    let pairs = new_kv_pairs(n_keys, &mut rng);
+
+    for (key, value) in &pairs {
+        root_store.add_root(key, value).unwrap();
+    }
+
+    criterion
+        .benchmark_group(group_name)
+        .sample_size(20)
+        .bench_function("reads against prepopulated state", |b| {
+            b.iter(|| {
+                for (key, _) in &pairs {
+                    root_store.get(key).unwrap();
+                }
+            });
+        });
+
+    db_path.close().unwrap();
+}
+
+// new_kv_pairs is a helper function that produces num key-value pairs
+#[expect(clippy::unwrap_used)]
+fn new_kv_pairs(num: usize, rng: &mut SeededRng) -> HashMap<TrieHash, LinearAddress> {
+    (0..num)
+        .map(|_| {
+            let mut hash_bytes = [0u8; 32];
+            rng.fill(&mut hash_bytes);
+
+            let key = TrieHash::from_bytes(hash_bytes);
+            let value = LinearAddress::new(rng.random_range(1..u64::MAX)).unwrap();
+
+            (key, value)
+        })
+        .collect()
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().measurement_time(std::time::Duration::from_secs(10));
+    targets =
+        bench_rocksdb_writes_prepopulated::<20>,
+        bench_lmdb_writes_prepopulated::<20>,
+        bench_sqlite_writes_prepopulated::<20>,
+        bench_rocksdb_reads_prepopulated<20>,
+        bench_lmdb_reads_prepopulated<20>,
+        bench_sqlite_reads_prepopulated<20>,
+}
+
+criterion_main!(benches);

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -145,6 +145,9 @@ pub use firewood_macros::metrics;
 /// Range proof module
 pub mod range_proof;
 
+/// Root store module
+pub mod root_store;
+
 /// Version 2 API
 pub mod v2;
 

--- a/firewood/src/root_store.rs
+++ b/firewood/src/root_store.rs
@@ -1,0 +1,434 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use std::path::Path;
+use std::sync::Mutex;
+use std::{array::TryFromSliceError, collections::HashMap};
+
+use firewood_storage::{LinearAddress, TrieHash};
+use heed::{
+    Database, Env, EnvOpenOptions, byteorder,
+    types::{self, Bytes},
+};
+use rocksdb::{DB, Options};
+use rusqlite::Connection;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RootStoreError {
+    #[error("Failed to add root: {0}")]
+    AddRoot(String),
+    #[error("Failed to get root address: {0}")]
+    Get(String),
+    #[error("Failed to open RootStore: {0}")]
+    Open(String),
+}
+
+const ERR_EMPTY_ROOT: &str = "empty root address";
+const ERR_ZERO_ADDRESS: &str = "address cannot be zero";
+
+pub trait RootStore {
+    /// `add_root` persists a revision's address to `RootStore`.
+    ///
+    /// Args:
+    /// - hash: the hash of the revision
+    /// - address: the address of the revision
+    ///
+    /// # Errors
+    ///
+    /// Will return an error if unable to persist the revision address to the
+    /// underlying datastore
+    fn add_root(&self, hash: &TrieHash, address: &LinearAddress) -> Result<(), RootStoreError>;
+
+    /// `add_roots_batch` persists a set of revision addresses to `RootStore`.
+    ///
+    /// Args:
+    /// - entries: a mapping of revision hashes to their addresses
+    ///
+    /// # Errors
+    ///
+    /// Will return an error if unable to persist the set of revision addresses
+    /// to the underlying datastore.
+    ///
+    /// XXX: this method is required for benchmarking against pre-populated
+    /// `RootStores` - this will be deleted once `RootStore` is in production.
+    fn add_roots_batch(
+        &self,
+        entries: &HashMap<TrieHash, LinearAddress>,
+    ) -> Result<(), RootStoreError>;
+
+    /// `get` returns the address of a revision.
+    ///
+    /// Args:
+    /// - hash: the hash of the revision
+    ///
+    /// # Errors
+    ///
+    ///  Will return an error if unable to query the underlying datastore.
+    fn get(&self, hash: &TrieHash) -> Result<LinearAddress, RootStoreError>;
+}
+
+pub trait RootStoreBuilder<T: RootStore> {
+    /// new creates an instance of T.
+    ///
+    /// Args:
+    /// - path: the directory where T can operate in
+    ///
+    /// # Errors
+    ///
+    /// Will return an error if unable to create the underlying datastore.
+    ///
+    /// XXX: this method is a facilitator for creating instances of `RootStore`
+    /// during benchmarking - this will be deleted once the final implementation
+    /// of `RootStore` is decided.
+    fn new<P: AsRef<Path>>(path: P) -> Result<T, RootStoreError>;
+}
+
+#[derive(Debug)]
+pub struct LMDBStore {
+    env: Env,
+    db: Database<Bytes, types::U64<byteorder::BigEndian>>,
+}
+
+impl RootStoreBuilder<LMDBStore> for LMDBStore {
+    fn new<P: AsRef<Path>>(path: P) -> Result<Self, RootStoreError> {
+        let dir = path.as_ref().join("lmdb_store");
+
+        // Create the directory if it doesn't exist
+        if !dir.exists() {
+            std::fs::create_dir_all(&dir).map_err(|e| RootStoreError::Open(e.to_string()))?;
+        }
+
+        // SAFETY: EnvOpenOptions::open requires unsafe
+        #[allow(unsafe_code)]
+        let env = unsafe { EnvOpenOptions::new().map_size(100 * 1024 * 1024).open(dir) }
+            .map_err(|e| RootStoreError::Open(e.to_string()))?;
+
+        let mut wtxn = env
+            .write_txn()
+            .map_err(|e| RootStoreError::Open(e.to_string()))?;
+        let db: Database<Bytes, types::U64<byteorder::BigEndian>> = env
+            .create_database(&mut wtxn, None)
+            .map_err(|e| RootStoreError::Open(e.to_string()))?;
+        wtxn.commit()
+            .map_err(|e| RootStoreError::Open(e.to_string()))?;
+
+        Ok(Self { env, db })
+    }
+}
+
+impl RootStore for LMDBStore {
+    fn add_root(&self, hash: &TrieHash, address: &LinearAddress) -> Result<(), RootStoreError> {
+        let mut wtxn = self
+            .env
+            .write_txn()
+            .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+
+        let hash_bytes: [u8; 32] = hash.to_bytes();
+
+        self.db
+            .put(&mut wtxn, &hash_bytes, &address.get())
+            .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+        wtxn.commit()
+            .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn add_roots_batch(
+        &self,
+        entries: &HashMap<TrieHash, LinearAddress>,
+    ) -> Result<(), RootStoreError> {
+        let mut wtxn = self
+            .env
+            .write_txn()
+            .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+
+        for (hash, address) in entries {
+            let hash_bytes: [u8; 32] = hash.to_bytes();
+            self.db
+                .put(&mut wtxn, &hash_bytes, &address.get())
+                .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+        }
+
+        wtxn.commit()
+            .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+        Ok(())
+    }
+
+    fn get(&self, hash: &TrieHash) -> Result<LinearAddress, RootStoreError> {
+        let rtxn = self
+            .env
+            .read_txn()
+            .map_err(|e| RootStoreError::Get(e.to_string()))?;
+        let hash_bytes: [u8; 32] = hash.to_bytes();
+
+        let v = self
+            .db
+            .get(&rtxn, &hash_bytes)
+            .map_err(|e| RootStoreError::Get(e.to_string()))?
+            .ok_or(RootStoreError::Get(ERR_EMPTY_ROOT.to_string()))?;
+
+        LinearAddress::new(v).ok_or(RootStoreError::Get(ERR_ZERO_ADDRESS.to_string()))
+    }
+}
+
+#[derive(Debug)]
+pub struct SQLiteStore {
+    db: Mutex<Connection>,
+}
+
+impl RootStoreBuilder<SQLiteStore> for SQLiteStore {
+    fn new<P: AsRef<Path>>(path: P) -> Result<Self, RootStoreError> {
+        let db_path = path.as_ref().join("sqlite.db");
+        let conn = Connection::open(db_path).map_err(|e| RootStoreError::Open(e.to_string()))?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS roots (
+                hash BLOB PRIMARY KEY NOT NULL,
+                address BLOB NOT NULL
+            )",
+            [],
+        )
+        .map_err(|e| RootStoreError::Open(e.to_string()))?;
+
+        Ok(Self {
+            db: Mutex::new(conn),
+        })
+    }
+}
+
+impl RootStore for SQLiteStore {
+    fn add_root(&self, hash: &TrieHash, address: &LinearAddress) -> Result<(), RootStoreError> {
+        let hash_bytes: [u8; 32] = hash.to_bytes();
+        let addr_bytes = address.get().to_be_bytes();
+
+        let db = self.db.lock().expect("poisoned lock");
+        db.execute(
+            "INSERT OR REPLACE INTO roots (hash, address) VALUES (?1, ?2)",
+            (&hash_bytes, &addr_bytes),
+        )
+        .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn add_roots_batch(
+        &self,
+        entries: &HashMap<TrieHash, LinearAddress>,
+    ) -> Result<(), RootStoreError> {
+        let db = self.db.lock().expect("poisoned lock");
+
+        let tx = db
+            .unchecked_transaction()
+            .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+
+        for (hash, address) in entries {
+            let hash_bytes: [u8; 32] = hash.to_bytes();
+            let addr_bytes = address.get().to_be_bytes();
+
+            tx.execute(
+                "INSERT OR REPLACE INTO roots (hash, address) VALUES (?1, ?2)",
+                (&hash_bytes, &addr_bytes),
+            )
+            .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+        }
+
+        tx.commit()
+            .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn get(&self, hash: &TrieHash) -> Result<LinearAddress, RootStoreError> {
+        let hash_bytes: [u8; 32] = hash.to_bytes();
+
+        let db = self.db.lock().expect("poisoned lock");
+
+        let addr_bytes: Vec<u8> = db
+            .query_row(
+                "SELECT address FROM roots WHERE hash = ?1",
+                [&hash_bytes],
+                |row| row.get(0),
+            )
+            .map_err(|e| RootStoreError::Get(e.to_string()))?;
+
+        let addr_array: [u8; 8] = addr_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|e: TryFromSliceError| RootStoreError::Get(e.to_string()))?;
+        let addr_u64 = u64::from_be_bytes(addr_array);
+
+        LinearAddress::new(addr_u64).ok_or(RootStoreError::Get(ERR_ZERO_ADDRESS.to_string()))
+    }
+}
+
+#[derive(Debug)]
+pub struct RocksDBStore {
+    db: DB,
+}
+
+impl RootStoreBuilder<RocksDBStore> for RocksDBStore {
+    fn new<P: AsRef<Path>>(path: P) -> Result<Self, RootStoreError> {
+        let dir = path.as_ref().join("rocksdb_store");
+
+        // Create the directory if it doesn't exist
+        if !dir.exists() {
+            std::fs::create_dir_all(&dir).map_err(|e| RootStoreError::Open(e.to_string()))?;
+        }
+
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+
+        let db = DB::open(&opts, dir).map_err(|e| RootStoreError::Open(e.to_string()))?;
+
+        Ok(Self { db })
+    }
+}
+
+impl RootStore for RocksDBStore {
+    fn add_root(&self, hash: &TrieHash, address: &LinearAddress) -> Result<(), RootStoreError> {
+        let hash_bytes: [u8; 32] = hash.to_bytes();
+        let addr_bytes = address.get().to_be_bytes();
+
+        self.db
+            .put(hash_bytes, addr_bytes)
+            .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn add_roots_batch(
+        &self,
+        entries: &HashMap<TrieHash, LinearAddress>,
+    ) -> Result<(), RootStoreError> {
+        let mut batch = rocksdb::WriteBatch::default();
+
+        for (hash, address) in entries {
+            let hash_bytes: [u8; 32] = hash.to_bytes();
+            let addr_bytes = address.get().to_be_bytes();
+            batch.put(hash_bytes, addr_bytes);
+        }
+
+        self.db
+            .write(batch)
+            .map_err(|e| RootStoreError::AddRoot(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn get(&self, hash: &TrieHash) -> Result<LinearAddress, RootStoreError> {
+        let hash_bytes: [u8; 32] = hash.to_bytes();
+
+        let value = self
+            .db
+            .get(hash_bytes)
+            .map_err(|e| RootStoreError::Get(e.to_string()))?
+            .ok_or(RootStoreError::Get(ERR_EMPTY_ROOT.to_string()))?;
+
+        let addr_bytes: [u8; 8] = value
+            .as_slice()
+            .try_into()
+            .map_err(|e: TryFromSliceError| RootStoreError::Get(e.to_string()))?;
+        let addr_u64 = u64::from_be_bytes(addr_bytes);
+
+        LinearAddress::new(addr_u64).ok_or(RootStoreError::Get(ERR_ZERO_ADDRESS.to_string()))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod test {
+    use firewood_storage::{LinearAddress, TrieHash};
+
+    use crate::root_store::{LMDBStore, RocksDBStore, RootStore, RootStoreBuilder, SQLiteStore};
+
+    #[test]
+    fn test_new_lmdb_store() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let lmdb_store = LMDBStore::new(tmpdir.path()).unwrap();
+
+        test_simple_kv_pair(lmdb_store);
+
+        tmpdir.close().unwrap();
+    }
+
+    #[test]
+    fn test_fuzz_lmdb_store() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let lmdb_store = LMDBStore::new(tmpdir.path()).unwrap();
+
+        test_fuzz(lmdb_store);
+
+        tmpdir.close().unwrap();
+    }
+
+    #[test]
+    fn test_new_sqlite_store() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let sqlite_store = SQLiteStore::new(&tmpdir).unwrap();
+
+        test_simple_kv_pair(sqlite_store);
+
+        tmpdir.close().unwrap();
+    }
+
+    #[test]
+    fn test_fuzz_sqlite_store() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let sqlite_store = SQLiteStore::new(&tmpdir).unwrap();
+
+        test_fuzz(sqlite_store);
+
+        tmpdir.close().unwrap();
+    }
+
+    #[test]
+    fn test_new_rocksdb_store() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let rocksdb_store = RocksDBStore::new(&tmpdir).unwrap();
+
+        test_simple_kv_pair(rocksdb_store);
+
+        tmpdir.close().unwrap();
+    }
+
+    #[test]
+    fn test_fuzz_rocksdb_store() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let rocksdb_store = RocksDBStore::new(&tmpdir).unwrap();
+
+        test_fuzz(rocksdb_store);
+
+        tmpdir.close().unwrap();
+    }
+
+    fn test_simple_kv_pair<T: RootStore>(root_store: T) {
+        // First, store KV-pair
+        let hash = TrieHash::from_bytes([1; 32]);
+        let address = LinearAddress::new(1).unwrap();
+
+        root_store.add_root(&hash, &address).unwrap();
+
+        // Now, get KV-pair
+        assert_eq!(address, root_store.get(&hash).unwrap());
+    }
+
+    fn test_fuzz<T: RootStore>(root_store: T) {
+        let rng = firewood_storage::SeededRng::new(1234);
+
+        // Insert 256 random key-value pairs
+        for _ in 0..256 {
+            let mut hash_bytes = [0u8; 32];
+            rng.fill_bytes(&mut hash_bytes);
+            let hash = TrieHash::from_bytes(hash_bytes);
+
+            let addr_value = rng.random_range(1..u64::MAX);
+            let address = LinearAddress::new(addr_value).unwrap();
+
+            root_store.add_root(&hash, &address).unwrap();
+
+            let retrieved_address = root_store.get(&hash).unwrap();
+            assert_eq!(address, retrieved_address);
+        }
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -50,7 +50,7 @@ pub use node::{
 };
 pub use nodestore::{
     AreaIndex, Committed, HashedNodeReader, ImmutableProposal, LinearAddress, MutableProposal,
-    NodeReader, NodeStore, Parentable, RootReader, TrieReader,
+    NodeReader, NodeStore, NodeStoreHeader, Parentable, RootReader, TrieReader,
 };
 
 pub use linear::filebacked::FileBacked;

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -90,7 +90,8 @@ use crate::hashednode::hash_node;
 use crate::node::Node;
 use crate::node::persist::MaybePersistedNode;
 use crate::{
-    CacheReadStrategy, Child, FileIoError, HashType, Path, ReadableStorage, SharedNode, TrieHash,
+    CacheReadStrategy, Child, FileBacked, FileIoError, HashType, Path, ReadableStorage, SharedNode,
+    TrieHash,
 };
 
 use super::linear::WritableStorage;
@@ -441,6 +442,38 @@ impl<T, S> NodeStore<T, S> {
 
     pub(crate) const fn freelists_mut(&mut self) -> &mut alloc::FreeLists {
         self.header.free_lists_mut()
+    }
+}
+
+impl NodeStore<Committed, FileBacked> {
+    /// `new_committed` returns a committed instance of NodeStore
+    /// This is called by RootStore to construct prior committed revisions
+    ///
+    /// Args:
+    /// - header: the header of the committed nodestore
+    /// - root_hash: the hash of the nodestore
+    /// - root_address: the address of the nodestore
+    /// - storage: the underlying storage to access the nodestore
+    pub fn new_committed(
+        header: NodeStoreHeader,
+        root_hash: HashType,
+        root_address: LinearAddress,
+        storage: Arc<FileBacked>,
+    ) -> Self {
+        NodeStore {
+            header,
+            kind: Committed {
+                deleted: Box::new([]),
+                root: Some(Child::AddressWithHash(root_address, root_hash)),
+            },
+            storage,
+        }
+    }
+
+    /// `get_underlying_storage` returns the underlying storage of this nodestore.
+    /// This is called by the RootStore to construct prior committed revisions.
+    pub fn get_underlying_storage(&self) -> Arc<FileBacked> {
+        self.storage.clone()
     }
 }
 

--- a/storage/src/trie_hash.rs
+++ b/storage/src/trie_hash.rs
@@ -103,6 +103,12 @@ impl TrieHash {
         self
     }
 
+    /// Converts `TrieHash` to an array of bytes.
+    #[must_use]
+    pub fn to_bytes(&self) -> [u8; TRIE_HASH_LEN] {
+        self.0.into()
+    }
+
     /// Creates a new `TrieHash` from an array of bytes.
     #[must_use]
     pub fn from_bytes(bytes: [u8; TRIE_HASH_LEN]) -> Self {


### PR DESCRIPTION
A prerequisite of #1299 is choosing the underlying datastore for `RootStore`.  This PR sets to finalize the underlying choice of datastore by providing the following:

- Three implementations of `RootStore` using SQLite, LMDB, and RocksDB. 
- Read and write benchmarks for each implementation
- An initial integration of `RootStore` into both the `RevisionManager` and `DB`

I don't expect this PR to be merged in; rather, this PR complements the archival support design document by giving reviewers an idea of what the final `RootStore` implementation will look like. Once the underlying data store is selected, I will cherry-pick the relevant implementation details from this PR and utilize them in a future PR.

## Tips for Reviewing

If you want to just run the implementation benchmarks, execute the following:

```
cargo bench --bench root_store
```

This will benchmark the read and write performance of each implementation with 1m kv-pairs already inserted. 

For those wishing to understand the file structure of this PR:
- `firewood/benches/root_store.rs`: contains implementation benchmarks
- `firewood/src/root_store.rs`: contains the three implementations of `RootStore`
- `firewood/src/db.rs`: contains a simple unit test for what a correct integration of `RootStore` would look like
- `firewood/src/manager.rs`: a draft of what `RootStore` integration into the `RevisionManager` would look like
