### PR TITLE
feat: add SplitPath trait

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -54,7 +54,10 @@ pub use nodestore::{
     AreaIndex, Committed, HashedNodeReader, ImmutableProposal, LinearAddress, MutableProposal,
     NodeReader, NodeStore, Parentable, RootReader, TrieReader,
 };
-pub use path::{JoinedPath, PathComponent, TriePath, TriePathFromUnpackedBytes};
+pub use path::{
+    AsSplittablePath, JoinedPath, PathCommonPrefix, PathComponent, SplitPath, TriePath,
+    TriePathFromUnpackedBytes,
+};
 pub use u4::{TryFromIntError, U4};
 
 pub use linear::filebacked::FileBacked;

--- a/storage/src/path/joined.rs
+++ b/storage/src/path/joined.rs
@@ -3,7 +3,7 @@
 
 use std::iter::Chain;
 
-use super::TriePath;
+use super::{AsSplittablePath, SplitPath, TriePath};
 
 /// Joins two path segments into a single path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -35,5 +35,69 @@ impl<P: TriePath, S: TriePath> TriePath for JoinedPath<P, S> {
 
     fn components(&self) -> Self::Components<'_> {
         self.prefix.components().chain(self.suffix.components())
+    }
+}
+
+impl<P: AsSplittablePath, S: AsSplittablePath> AsSplittablePath for JoinedPath<P, S> {
+    type Path<'a>
+        = JoinedPath<P::Path<'a>, S::Path<'a>>
+    where
+        Self: 'a;
+
+    fn as_splittable_path(&self) -> Self::Path<'_> {
+        JoinedPath {
+            prefix: self.prefix.as_splittable_path(),
+            suffix: self.suffix.as_splittable_path(),
+        }
+    }
+}
+
+impl<P: SplitPath, S: SplitPath> SplitPath for JoinedPath<P, S> {
+    fn split_at(self, mid: usize) -> (Self, Self) {
+        if let Some(mid) = mid.checked_sub(self.prefix.len()) {
+            let (a_suffix, b_suffix) = self.suffix.split_at(mid);
+            let prefix: Self = Self {
+                prefix: self.prefix,
+                suffix: a_suffix,
+            };
+            let suffix = Self {
+                prefix: P::default(),
+                suffix: b_suffix,
+            };
+            (prefix, suffix)
+        } else {
+            let (a_prefix, b_prefix) = self.prefix.split_at(mid);
+            let prefix = Self {
+                prefix: a_prefix,
+                suffix: S::default(),
+            };
+            let suffix: Self = Self {
+                prefix: b_prefix,
+                suffix: self.suffix,
+            };
+            (prefix, suffix)
+        }
+    }
+
+    fn split_first(self) -> Option<(super::PathComponent, Self)> {
+        if let Some((first, prefix)) = self.prefix.split_first() {
+            Some((
+                first,
+                Self {
+                    prefix,
+                    suffix: self.suffix,
+                },
+            ))
+        } else if let Some((first, suffix)) = self.suffix.split_first() {
+            Some((
+                first,
+                Self {
+                    prefix: P::default(),
+                    suffix,
+                },
+            ))
+        } else {
+            None
+        }
     }
 }

--- a/storage/src/path/mod.rs
+++ b/storage/src/path/mod.rs
@@ -3,9 +3,11 @@
 
 mod component;
 mod joined;
+mod split;
 
 pub use self::component::PathComponent;
 pub use self::joined::JoinedPath;
+pub use self::split::{AsSplittablePath, PathCommonPrefix, SplitPath};
 
 /// A trie path of components with different underlying representations.
 ///

--- a/storage/src/path/split.rs
+++ b/storage/src/path/split.rs
@@ -1,0 +1,184 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use smallvec::SmallVec;
+
+use super::{PathComponent, TriePath};
+
+/// A trie path that can be (cheaply) split into two sub-paths.
+///
+/// Implementations are expected to be cheap to split (i.e. no allocations).
+pub trait SplitPath: AsSplittablePath + TriePath + Default {
+    /// Splits the path at the given index within the path.
+    ///
+    /// The returned tuple contains the two sub-paths `(prefix, suffix)`.
+    ///
+    /// # Panics
+    ///
+    /// - If `mid > self.len()`.
+    fn split_at(self, mid: usize) -> (Self, Self);
+
+    /// Splits the first path component off of this path, returning it along with
+    /// the remaining path.
+    ///
+    /// Returns [`None`] if the path is empty.
+    fn split_first(self) -> Option<(PathComponent, Self)>;
+
+    /// Computes the longest common prefix of this path and another path, along
+    /// with their respective suffixes.
+    fn longest_common_prefix<T: SplitPath>(self, other: T) -> PathCommonPrefix<Self, T> {
+        PathCommonPrefix::new(self, other)
+    }
+}
+
+/// A type that can be cheaply converted into a splittable path.
+pub trait AsSplittablePath {
+    /// The splittable path type.
+    type Path<'a>: SplitPath + 'a
+    where
+        Self: 'a;
+
+    /// Converts this type into a splittable path, borrowing data as needed.
+    fn as_splittable_path(&self) -> Self::Path<'_>;
+}
+
+/// The common prefix of two paths, along with their respective suffixes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PathCommonPrefix<A, B> {
+    /// The common prefix of the two paths.
+    pub common: A,
+    /// The suffix of the first path after the common prefix.
+    pub a_suffix: A,
+    /// The suffix of the second path after the common prefix.
+    pub b_suffix: B,
+}
+
+impl<A: SplitPath, B: SplitPath> PathCommonPrefix<A, B> {
+    /// Computes the common prefix of the two given paths, along with their suffixes.
+    pub fn new(a: A, b: B) -> Self {
+        let mid = a
+            .components()
+            .zip(b.components())
+            .take_while(|&(a, b)| a == b)
+            .count();
+        let (common, a_suffix) = a.split_at(mid);
+        let (_, b_suffix) = b.split_at(mid);
+        Self {
+            common,
+            a_suffix,
+            b_suffix,
+        }
+    }
+}
+
+impl<T: AsSplittablePath + ?Sized> AsSplittablePath for &T {
+    type Path<'a>
+        = T::Path<'a>
+    where
+        Self: 'a;
+
+    fn as_splittable_path(&self) -> Self::Path<'_> {
+        (**self).as_splittable_path()
+    }
+}
+
+impl<T: AsSplittablePath + ?Sized> AsSplittablePath for &mut T {
+    type Path<'a>
+        = T::Path<'a>
+    where
+        Self: 'a;
+
+    fn as_splittable_path(&self) -> Self::Path<'_> {
+        (**self).as_splittable_path()
+    }
+}
+
+impl<T: AsSplittablePath + ?Sized> AsSplittablePath for Box<T> {
+    type Path<'a>
+        = T::Path<'a>
+    where
+        Self: 'a;
+
+    fn as_splittable_path(&self) -> Self::Path<'_> {
+        (**self).as_splittable_path()
+    }
+}
+
+impl<T: AsSplittablePath + ?Sized> AsSplittablePath for std::rc::Rc<T> {
+    type Path<'a>
+        = T::Path<'a>
+    where
+        Self: 'a;
+
+    fn as_splittable_path(&self) -> Self::Path<'_> {
+        (**self).as_splittable_path()
+    }
+}
+
+impl<T: AsSplittablePath + ?Sized> AsSplittablePath for std::sync::Arc<T> {
+    type Path<'a>
+        = T::Path<'a>
+    where
+        Self: 'a;
+
+    fn as_splittable_path(&self) -> Self::Path<'_> {
+        (**self).as_splittable_path()
+    }
+}
+
+impl SplitPath for &[PathComponent] {
+    fn split_at(self, mid: usize) -> (Self, Self) {
+        self.split_at(mid)
+    }
+
+    fn split_first(self) -> Option<(PathComponent, Self)> {
+        match self.split_first() {
+            Some((&first, rest)) => Some((first, rest)),
+            None => None,
+        }
+    }
+}
+
+impl AsSplittablePath for [PathComponent] {
+    type Path<'a>
+        = &'a [PathComponent]
+    where
+        Self: 'a;
+
+    fn as_splittable_path(&self) -> Self::Path<'_> {
+        self
+    }
+}
+
+impl<const N: usize> AsSplittablePath for [PathComponent; N] {
+    type Path<'a>
+        = &'a [PathComponent]
+    where
+        Self: 'a;
+
+    fn as_splittable_path(&self) -> Self::Path<'_> {
+        self
+    }
+}
+
+impl AsSplittablePath for Vec<PathComponent> {
+    type Path<'a>
+        = &'a [PathComponent]
+    where
+        Self: 'a;
+
+    fn as_splittable_path(&self) -> Self::Path<'_> {
+        self
+    }
+}
+
+impl<A: smallvec::Array<Item = PathComponent>> AsSplittablePath for SmallVec<A> {
+    type Path<'a>
+        = &'a [PathComponent]
+    where
+        Self: 'a;
+
+    fn as_splittable_path(&self) -> Self::Path<'_> {
+        self
+    }
+}


### PR DESCRIPTION
One of the most common operations on paths is finding the longest common prefix between two paths. This is useful for a variety of reasons, such as determining if one path is a subpath of another, or finding the relative path between two paths.

A normal `TriePath` implementation does not provide a way to do this because that trait should remain `?Sized`. Whereas, splitting the path requires a sized type in order to produce a new instance of the path when splitting.

This change adds a `SplitPath` trait that provides the ability to split a path. Also added is `AsSplittablePath` which is a conversion trait to yield a splittable path. This also acts as the borrower for owned paths to yield shared references to the path.