### PR TITLE
feat: Added DB configuration option to turn on/off parallel insert and hashing

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -60,7 +60,7 @@ pub struct ConfigManager {
     /// Revision manager configuration.
     #[builder(default = RevisionManagerConfig::builder().build())]
     pub manager: RevisionManagerConfig,
-    /// Whether to turn on parallel insert and hashing for proposal
+    /// Whether to turn on parallel insert and hashing for propose.
     #[builder(default = false)]
     pub parallel: bool,
 }


### PR DESCRIPTION
Added an option to DB config and Configuration manager to turn on/off parallel propose when the database is opened. If it is turned off, then the threadpool option is set to None and normal propose is used. The current default is off, but it is always turned on for the test_proposal_parallel test case.

Also added a fastrace::span for parallel_merkle for parallel propose.