### PR TITLE
chore(storage): add `into_hashtype()`

### DIFF
--- a/storage/src/trie_hash.rs
+++ b/storage/src/trie_hash.rs
@@ -1,8 +1,8 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::node::ExtendableBytes;
 use crate::node::branch::Serializable;
+use crate::{HashType, node::ExtendableBytes};
 use sha2::digest::generic_array::GenericArray;
 use sha2::digest::typenum;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -100,6 +100,28 @@ impl TrieHash {
     /// This function is a no-op, as `HashType` is a `TrieHash` in this context.
     #[must_use]
     pub const fn into_triehash(self) -> Self {
+        self
+    }
+
+    /// Converts this `TrieHash` into a `HashType`.
+    ///
+    /// When the `ethhash` feature is enabled, this converts the `TrieHash` into a
+    /// `HashOrRlp::Hash` variant. Otherwise, this is a no-op since `HashType` is
+    /// a type alias for `TrieHash`.
+    #[must_use]
+    #[cfg(feature = "ethhash")]
+    pub fn into_hashtype(self) -> HashType {
+        self.into()
+    }
+
+    /// Converts this `TrieHash` into a `HashType`.
+    ///
+    /// When the `ethhash` feature is enabled, this converts the `TrieHash` into a
+    /// `HashOrRlp::Hash` variant. Otherwise, this is a no-op since `HashType` is
+    /// a type alias for `TrieHash`.
+    #[must_use]
+    #[cfg(not(feature = "ethhash"))]
+    pub const fn into_hashtype(self) -> HashType {
         self
     }
 


### PR DESCRIPTION
This PR breaks up #1346 by adding the `into_hashtype()` method.

Currently, `RootStore` plans to be a mapping from root hashes (`TrieHash`) to root addresses (`LinearAddress`). However, to construct a `NodeStore` (and therefore, a `Child`), we need to use a `HashType` value as seen:

https://github.com/ava-labs/firewood/blob/18a95bdfcebf86f7843bfd9d88bcd42ae8cc4985/storage/src/node/branch.rs#L97-L107

This PR fixes this by allowing root hashes of type `TrieHash` to convert to a `HashType` value, allowing for their usage in constructing a `Child`.