### PR TITLE
refactor(db): `TestDb` constructor

### DIFF
--- a/storage/src/trie_hash.rs
+++ b/storage/src/trie_hash.rs
@@ -1,8 +1,8 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use crate::node::ExtendableBytes;
 use crate::node::branch::Serializable;
-use crate::{HashType, node::ExtendableBytes};
 use sha2::digest::generic_array::GenericArray;
 use sha2::digest::typenum;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -100,28 +100,6 @@ impl TrieHash {
     /// This function is a no-op, as `HashType` is a `TrieHash` in this context.
     #[must_use]
     pub const fn into_triehash(self) -> Self {
-        self
-    }
-
-    /// Converts this `TrieHash` into a `HashType`.
-    ///
-    /// When the `ethhash` feature is enabled, this converts the `TrieHash` into a
-    /// `HashOrRlp::Hash` variant. Otherwise, this is a no-op since `HashType` is
-    /// a type alias for `TrieHash`.
-    #[must_use]
-    #[cfg(feature = "ethhash")]
-    pub fn into_hashtype(self) -> HashType {
-        self.into()
-    }
-
-    /// Converts this `TrieHash` into a `HashType`.
-    ///
-    /// When the `ethhash` feature is enabled, this converts the `TrieHash` into a
-    /// `HashOrRlp::Hash` variant. Otherwise, this is a no-op since `HashType` is
-    /// a type alias for `TrieHash`.
-    #[must_use]
-    #[cfg(not(feature = "ethhash"))]
-    pub const fn into_hashtype(self) -> HashType {
         self
     }
 


### PR DESCRIPTION
I recently learned from @demosdemon that in Rust, the default constructor of a type is generally called `new()` while additional constructors are called `with_X()`.

This PR refactors the `TestDb` code to have a `new()` constructor with this function being called through the database tests instead of `testdb()`. This helps break up #1346 as we'll just then need to add a `with_mockstore()` method to `TestDb` to allow for injecting instances of `MockStore` to `TestDb`.