### PR TITLE
chore: update Go to 1.24.8

### DIFF
--- a/ffi/go.mod
+++ b/ffi/go.mod
@@ -2,7 +2,7 @@ module github.com/ava-labs/firewood/ffi
 
 go 1.24
 
-toolchain go1.24.7
+toolchain go1.24.8
 
 require (
 	github.com/prometheus/client_golang v1.22.0

--- a/ffi/tests/eth/go.mod
+++ b/ffi/tests/eth/go.mod
@@ -2,7 +2,7 @@ module github.com/ava-labs/firewood/ffi/tests
 
 go 1.24
 
-toolchain go1.24.7
+toolchain go1.24.8
 
 require (
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.0 // this is replaced to use the parent folder

--- a/ffi/tests/firewood/go.mod
+++ b/ffi/tests/firewood/go.mod
@@ -2,7 +2,7 @@ module github.com/ava-labs/firewood/ffi/tests
 
 go 1.24
 
-toolchain go1.24.7
+toolchain go1.24.8
 
 require (
 	github.com/ava-labs/firewood-go/ffi v0.0.0 // this is replaced to use the parent folder


### PR DESCRIPTION
Go 1.24.7 had a bunch of vulnerable packages in it (nothing we use directly). However, let's use a stable version of Go for consistency.