### PR TITLE
feat: define explicit associated types on Hashable

### DIFF
--- a/firewood/src/proof.rs
+++ b/firewood/src/proof.rs
@@ -108,17 +108,32 @@ impl std::fmt::Debug for ProofNode {
 }
 
 impl Hashable for ProofNode {
-    fn parent_prefix_path(&self) -> impl IntoSplitPath + '_ {
+    type LeadingPath<'a>
+        = &'a [PathComponent]
+    where
+        Self: 'a;
+
+    type PartialPath<'a>
+        = &'a [PathComponent]
+    where
+        Self: 'a;
+
+    type FullPath<'a>
+        = &'a [PathComponent]
+    where
+        Self: 'a;
+
+    fn parent_prefix_path(&self) -> Self::LeadingPath<'_> {
         let (prefix, _) = self.key.split_at(self.partial_len);
         prefix
     }
 
-    fn partial_path(&self) -> impl IntoSplitPath + '_ {
+    fn partial_path(&self) -> Self::PartialPath<'_> {
         let (_, suffix) = self.key.split_at(self.partial_len);
         suffix
     }
 
-    fn full_path(&self) -> impl IntoSplitPath + '_ {
+    fn full_path(&self) -> Self::FullPath<'_> {
         &self.key
     }
 

--- a/storage/src/hashedshunt.rs
+++ b/storage/src/hashedshunt.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::{Children, HashType, Hashable, IntoSplitPath, SplitPath, ValueDigest};
+use crate::{Children, HashType, Hashable, JoinedPath, SplitPath, ValueDigest};
 
 /// A shunt for a hasheable trie that we can use to compute the hash of a node
 /// using component parts.
@@ -51,12 +51,31 @@ impl<P1: SplitPath, P2: SplitPath> std::fmt::Debug for HashableShunt<'_, P1, P2>
 }
 
 impl<P1: SplitPath, P2: SplitPath> Hashable for HashableShunt<'_, P1, P2> {
-    fn parent_prefix_path(&self) -> impl IntoSplitPath + '_ {
+    type LeadingPath<'a>
+        = P1
+    where
+        Self: 'a;
+
+    type PartialPath<'a>
+        = P2
+    where
+        Self: 'a;
+
+    type FullPath<'a>
+        = JoinedPath<P1, P2>
+    where
+        Self: 'a;
+
+    fn parent_prefix_path(&self) -> Self::LeadingPath<'_> {
         self.parent_prefix
     }
 
-    fn partial_path(&self) -> impl IntoSplitPath + '_ {
+    fn partial_path(&self) -> Self::PartialPath<'_> {
         self.partial_path
+    }
+
+    fn full_path(&self) -> Self::FullPath<'_> {
+        self.parent_prefix_path().append(self.partial_path())
     }
 
     fn value_digest(&self) -> Option<ValueDigest<&[u8]>> {

--- a/storage/src/tries/mod.rs
+++ b/storage/src/tries/mod.rs
@@ -4,7 +4,7 @@
 mod iter;
 mod kvp;
 
-use crate::{HashType, PathComponent, SplitPath};
+use crate::{HashType, IntoSplitPath, PathComponent};
 
 pub use self::iter::{IterAscending, IterDescending, TrieEdgeIter, TrieValueIter};
 pub use self::kvp::{DuplicateKeyError, HashedKeyValueTrieRoot, KeyValueTrieRoot};
@@ -38,8 +38,13 @@ pub enum TrieEdgeState<'a, N: ?Sized> {
 
 /// A node in a fixed-arity radix trie.
 pub trait TrieNode<V: AsRef<[u8]> + ?Sized> {
+    /// The type of path from this node's parent to this node.
+    type PartialPath<'a>: IntoSplitPath + 'a
+    where
+        Self: 'a;
+
     /// The path from this node's parent to this node.
-    fn partial_path(&self) -> impl SplitPath + '_;
+    fn partial_path(&self) -> Self::PartialPath<'_>;
 
     /// The value stored at this node, if any.
     fn value(&self) -> Option<&V>;


### PR DESCRIPTION
In my next pull request, I have a need for these to be defined as explicit associated types. This was pulled out into a separate change for simplicity. 