### PR TITLE
ci: print ulimits and set memlock to unlimited before fuzz tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,12 +261,6 @@ jobs:
         with:
           go-version-file: "ffi/tests/eth/go.mod"
           cache-dependency-path: "ffi/tests/eth/go.sum"
-      - name: Set MEMLOCK to unlimited
-        run: |
-          {
-            echo "$USER hard memlock unlimited"
-            echo "$USER soft memlock unlimited"
-          } | sudo tee /etc/security/limits.d/memlock.conf
       - name: Test Go FFI bindings
         working-directory: ffi
         # cgocheck2 is expensive but provides complete pointer checks


### PR DESCRIPTION
This change bumps the `MEMLOCK` limit when running fuzz tests. The limit is 8M by default, set by systemd, and began causing issues with the merkledb fuzz test. I am still uncertain what change caused us to bump up against the MEMLOCK limit and will continue investigating that later; however, this change allows the CI fuzz tests to continue as before. 
