### PR TITLE
chore: update Go to 1.24.9

### DIFF
--- a/ffi/go.mod
+++ b/ffi/go.mod
@@ -2,7 +2,7 @@ module github.com/ava-labs/firewood/ffi
 
 go 1.24
 
-toolchain go1.24.8
+toolchain go1.24.9
 
 require (
 	github.com/prometheus/client_golang v1.22.0

--- a/ffi/tests/eth/go.mod
+++ b/ffi/tests/eth/go.mod
@@ -2,7 +2,7 @@ module github.com/ava-labs/firewood/ffi/tests
 
 go 1.24
 
-toolchain go1.24.8
+toolchain go1.24.9
 
 require (
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.0 // this is replaced to use the parent folder

--- a/ffi/tests/firewood/go.mod
+++ b/ffi/tests/firewood/go.mod
@@ -2,7 +2,7 @@ module github.com/ava-labs/firewood/ffi/tests
 
 go 1.24
 
-toolchain go1.24.8
+toolchain go1.24.9
 
 require (
 	github.com/ava-labs/firewood-go/ffi v0.0.0 // this is replaced to use the parent folder


### PR DESCRIPTION
AvalancheGo currently uses go1.24.9 while Coreth is also has a PR open to use go.1.24.9 [[ref](https://github.com/ava-labs/coreth/pull/1352)]. This PR updates our go version to 1.24.9.