### PR TITLE
feat: join two key proofs into one trie

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -66,8 +66,8 @@ pub use path::{
 pub use path::{PackedBytes, PackedPathComponents};
 pub use tries::{
     DuplicateKeyError, FromKeyProofError, HashedKeyValueTrieRoot, HashedTrieNode, IterAscending,
-    IterDescending, KeyProofTrieRoot, KeyValueTrieRoot, TrieEdgeIter, TrieEdgeState, TrieNode,
-    TriePathIter, TrieValueIter,
+    IterDescending, KeyProofTrieRoot, KeyRangeProofTrieRoot, KeyValueTrieRoot, MergeKeyProofError,
+    TrieEdgeIter, TrieEdgeState, TrieNode, TriePathIter, TrieValueIter,
 };
 pub use u4::{TryFromIntError, U4};
 

--- a/storage/src/path/buf.rs
+++ b/storage/src/path/buf.rs
@@ -189,6 +189,20 @@ impl<'a> PathGuard<'a> {
     pub fn push(&mut self, component: PathComponent) {
         self.buf.push(component);
     }
+
+    /// A convenience method for cloning the inner path buffer.
+    ///
+    /// This is a convenience method that avoids needing to deref the guard in
+    /// order to correctly clone the inner buffer.
+    ///
+    /// ```ignore
+    /// (*guard).clone() // works, but is cumbersome
+    /// guard.cloned()   // same thing, but doesn't require the parens and deref
+    /// ```
+    #[must_use]
+    pub fn cloned(&self) -> PathBuf {
+        self.buf.clone()
+    }
 }
 
 impl std::ops::Deref for PathGuard<'_> {

--- a/storage/src/tries/mod.rs
+++ b/storage/src/tries/mod.rs
@@ -9,7 +9,9 @@ use crate::{HashType, IntoSplitPath, PathComponent, SplitPath};
 
 pub use self::iter::{IterAscending, IterDescending, TrieEdgeIter, TriePathIter, TrieValueIter};
 pub use self::kvp::{DuplicateKeyError, HashedKeyValueTrieRoot, KeyValueTrieRoot};
-pub use self::proof::{FromKeyProofError, KeyProofTrieRoot};
+pub use self::proof::{
+    FromKeyProofError, KeyProofTrieRoot, KeyRangeProofTrieRoot, MergeKeyProofError,
+};
 
 /// The state of an edge from a parent node to a child node in a trie.
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/storage/src/tries/proof.rs
+++ b/storage/src/tries/proof.rs
@@ -2,8 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 use crate::{
-    Children, HashType, Hashable, IntoSplitPath, PathBuf, PathComponent, SplitPath, TrieEdgeState,
-    TrieNode, TriePath, ValueDigest,
+    Children, HashType, Hashable, IntoSplitPath, PathBuf, PathComponent, PathGuard, SplitPath,
+    TrieEdgeState, TrieNode, TriePath, ValueDigest,
 };
 
 /// An error indicating that a slice of proof nodes is invalid.
@@ -36,6 +36,52 @@ pub enum FromKeyProofError {
     },
 }
 
+/// An error indicating that merging two key proof tries failed.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, thiserror::Error)]
+pub enum MergeKeyProofError {
+    /// The two key proofs are from disjoint tries.
+    #[error(
+        "the two key proofs are from disjoint tries starting at {leading_path}, with lower bound {lower_path} and upper bound {upper_path}",
+        leading_path = leading_path.display(),
+        lower_path = lower_path.display(),
+        upper_path = upper_path.display(),
+    )]
+    DisjointEdges {
+        /// The path leading to the point where the two tries diverge.
+        leading_path: PathBuf,
+        /// The path of the lower bound proof.
+        lower_path: PathBuf,
+        /// The path of the upper bound proof.
+        upper_path: PathBuf,
+    },
+    /// The two key proofs contain a child node that is only present in one of
+    /// the two tries.
+    #[error("only one of the two key proofs contains a child starting at {path}", path = path.display())]
+    DisjointChildren {
+        /// The path of the child node that is only present in one of the two tries.
+        path: PathBuf,
+    },
+    /// The two key proofs contain a child node with differing hashes.
+    #[error("the two nodes at {path} have differing hashes", path = path.display())]
+    DifferentHash {
+        /// The path of the node with differing hashes.
+        path: PathBuf,
+        /// The hash of the node in the lower bound proof.
+        lower_hash: HashType,
+        /// The hash of the node in the upper bound proof.
+        upper_hash: HashType,
+    },
+    /// The two key proofs both contain the same key with different values.
+    #[error(
+        "the two key proofs both contain the key {key_path} with different values",
+        key_path = key_path.display(),
+    )]
+    DuplicateKeys {
+        /// The path of the duplicate key.
+        key_path: PathBuf,
+    },
+}
+
 /// A root node in a trie formed from a key proof.
 ///
 /// A proof trie follows a linear path from the root to a terminal node, and
@@ -50,6 +96,33 @@ pub struct KeyProofTrieRoot<'a, P> {
     partial_path: P,
     value_digest: Option<ValueDigest<&'a [u8]>>,
     children: Children<Option<KeyProofTrieNode<'a, P>>>,
+}
+
+/// A key range proof is a combination of zero, one, or two key proofs.
+///
+/// The key proofs represent the lower and upper bounds of the range, if they
+/// exist. A key range proof trie is formed by merging the two bounding key
+/// proofs into a single trie, which is later merged with the key-value pairs
+/// within the range to form a complete range proof trie.
+///
+/// If there are zero bounding key proofs, the range is unbounded in both
+/// directions. In which case, this trie is empty as there was no information
+/// to include.
+///
+/// If there is only one bounding key proof, the range is unbounded in the
+/// direction opposite the provided bound. In which case, this trie is simply
+/// the provided key proof trie.
+///
+/// When there are two bounding key proofs, the range is inclusively bounded
+/// in both directions. In which case, this trie is the merging of the two
+/// proof tries. Upon merging, the two tries must overlap at the root and every
+/// node along the path until the two paths diverge.
+///
+/// When merging the key-value pairs into this trie, key-values must be within
+/// the bounds set by the two key proofs, if they exist.
+#[derive(Debug)]
+pub struct KeyRangeProofTrieRoot<'a, P> {
+    root: Box<KeyProofTrieRoot<'a, P>>,
 }
 
 #[derive(Debug)]
@@ -68,7 +141,7 @@ enum KeyProofTrieNode<'a, P> {
     Remote { hash: HashType },
 }
 
-impl<'a, P: SplitPath> KeyProofTrieRoot<'a, P> {
+impl<'a, P: SplitPath + 'a> KeyProofTrieRoot<'a, P> {
     /// Constructs a trie root from a slice of proof nodes.
     ///
     /// Each node in the slice must be a strict prefix of the following node. And,
@@ -149,9 +222,91 @@ impl<'a, P: SplitPath> KeyProofTrieRoot<'a, P> {
             }),
         }
     }
+
+    fn merge_opt(
+        leading_path: PathGuard<'_>,
+        lower: Option<Box<Self>>,
+        upper: Option<Box<Self>>,
+    ) -> Result<Option<Box<Self>>, MergeKeyProofError> {
+        match (lower, upper) {
+            (None, None) => Ok(None),
+            (Some(root), None) | (None, Some(root)) => Ok(Some(root)),
+            (Some(lower), Some(upper)) => Self::merge(leading_path, lower, upper).map(Some),
+        }
+    }
+
+    /// Iteratively merges two key proofs into a single key proof.
+    ///
+    /// The two proofs must overlap at the root and every `Described` node along
+    /// the path until the two paths diverge.
+    fn merge(
+        mut leading_path: PathGuard<'_>,
+        mut lower: Box<Self>,
+        #[expect(clippy::boxed_local)] mut upper: Box<Self>,
+    ) -> Result<Box<Self>, MergeKeyProofError> {
+        if !lower.partial_path.path_eq(&upper.partial_path) {
+            return Err(MergeKeyProofError::DisjointEdges {
+                leading_path: leading_path.cloned(),
+                lower_path: lower.partial_path.as_component_slice().into_owned(),
+                upper_path: upper.partial_path.as_component_slice().into_owned(),
+            });
+        }
+
+        leading_path.extend(lower.partial_path.components());
+
+        if lower.value_digest != upper.value_digest {
+            return Err(MergeKeyProofError::DuplicateKeys {
+                key_path: leading_path.cloned(),
+            });
+        }
+
+        lower.children = std::mem::take(&mut lower.children).merge(
+            std::mem::take(&mut upper.children),
+            |pc, lower, upper| {
+                KeyProofTrieNode::merge_opt(leading_path.fork_append(pc), lower, upper)
+            },
+        )?;
+
+        Ok(lower)
+    }
 }
 
-impl<'a, P: IntoSplitPath + 'a> KeyProofTrieNode<'a, P> {
+impl<'a, P: SplitPath + 'a> KeyRangeProofTrieRoot<'a, P> {
+    /// Constructs a key range proof trie from the optional lower and upper
+    /// bounding key proof tries.
+    ///
+    /// # Errors
+    ///
+    /// - [`MergeKeyProofError::DisjointEdges`] if both bounding key proofs are
+    ///   provided but do not overlap at the root or every `Described` node along
+    ///   the path until the two paths diverge.
+    ///
+    /// - [`MergeKeyProofError::DisjointChildren`] if both bounding key proofs are
+    ///   provided but contain a child node that is only present in one of the two
+    ///   tries.
+    ///
+    /// - [`MergeKeyProofError::DifferentHash`] if both bounding key proofs are
+    ///   provided but contain a child node with differing hashes.
+    ///
+    /// - [`MergeKeyProofError::DuplicateKeys`] if both bounding key proofs are
+    ///   provided but both contain the same key with different values.
+    pub fn new(
+        lower: Option<Box<KeyProofTrieRoot<'a, P>>>,
+        upper: Option<Box<KeyProofTrieRoot<'a, P>>>,
+    ) -> Result<Option<Self>, MergeKeyProofError> {
+        KeyProofTrieRoot::merge_opt(PathGuard::new(&mut PathBuf::new_const()), lower, upper)
+            .map(|root| root.map(|root| Self { root }))
+    }
+
+    /// Returns the root key proof trie that was created by merging the two
+    /// bounding key proofs.
+    #[must_use]
+    pub const fn root(&self) -> &KeyProofTrieRoot<'a, P> {
+        &self.root
+    }
+}
+
+impl<'a, P: SplitPath + 'a> KeyProofTrieNode<'a, P> {
     const fn hash(&self) -> &HashType {
         match self {
             KeyProofTrieNode::Described { hash, .. } | KeyProofTrieNode::Remote { hash } => hash,
@@ -169,6 +324,50 @@ impl<'a, P: IntoSplitPath + 'a> KeyProofTrieNode<'a, P> {
         match self {
             KeyProofTrieNode::Described { node, hash } => TrieEdgeState::LocalChild { node, hash },
             KeyProofTrieNode::Remote { hash } => TrieEdgeState::RemoteChild { hash },
+        }
+    }
+
+    fn merge_opt(
+        leading_path: PathGuard<'_>,
+        lower: Option<Self>,
+        upper: Option<Self>,
+    ) -> Result<Option<Self>, MergeKeyProofError> {
+        match (lower, upper) {
+            (None, None) => Ok(None),
+            (Some(_), None) | (None, Some(_)) => Err(MergeKeyProofError::DisjointChildren {
+                path: leading_path.cloned(),
+            }),
+            (Some(lower), Some(upper)) => Self::merge(leading_path, lower, upper).map(Some),
+        }
+    }
+
+    fn merge(
+        leading_path: PathGuard<'_>,
+        lower: Self,
+        upper: Self,
+    ) -> Result<Self, MergeKeyProofError> {
+        match (lower, upper) {
+            (
+                Self::Remote { hash: lower_hash }
+                | Self::Described {
+                    node: _,
+                    hash: lower_hash,
+                },
+                Self::Remote { hash: upper_hash }
+                | Self::Described {
+                    node: _,
+                    hash: upper_hash,
+                },
+            ) if lower_hash != upper_hash => Err(MergeKeyProofError::DifferentHash {
+                path: leading_path.cloned(),
+                lower_hash,
+                upper_hash,
+            }),
+            (edge, Self::Remote { .. }) | (Self::Remote { .. }, edge) => Ok(edge),
+            (Self::Described { node: lower, hash }, Self::Described { node: upper, .. }) => {
+                KeyProofTrieRoot::merge(leading_path, lower, upper)
+                    .map(|node| Self::Described { node, hash })
+            }
         }
     }
 }


### PR DESCRIPTION
This change adds support for merging key proof tries to create key range proof tries, along with error handling for merge failures and corresponding test coverage.

* Added `KeyRangeProofTrieRoot` to represent the merged result of zero, one, or two key proof tries, allowing construction of a trie that bounds a key range. This includes logic for merging tries and handling unbounded ranges.
* Implemented the `merge` and `merge_opt` methods for `KeyProofTrieRoot` and `KeyProofTrieNode`, enabling iterative merging of key proof tries and their nodes.
* Added `MergeKeyProofError` for detailed errors of merge failures, including disjoint edges, disjoint children, differing hashes, and duplicate keys with different values.
