### PR TITLE
feat(benchmark/bootstrap): add config param

### DIFF
--- a/benchmark/bootstrap/aws-launch.sh
+++ b/benchmark/bootstrap/aws-launch.sh
@@ -8,6 +8,7 @@ AVALANCHEGO_BRANCH=""
 CORETH_BRANCH=""
 LIBEVM_COMMIT=""
 NBLOCKS="1m"
+CONFIG="firewood"
 REGION="us-west-2"
 DRY_RUN=false
 SPOT_INSTANCE=false
@@ -60,6 +61,7 @@ show_usage() {
     echo "  --coreth-branch BRANCH      Coreth git branch to checkout"
     echo "  --libevm-commit COMMIT      LibEVM git commit to checkout"
     echo "  --nblocks BLOCKS            Number of blocks to download (default: 1m)"
+    echo "  --config CONFIG             The VM reexecution config to use (default: firewood)"
     echo "  --region REGION             AWS region (default: us-west-2)"
     echo "  --spot                      Use spot instance pricing (default depends on instance type)"
     echo "  --dry-run                   Show the aws command that would be run without executing it"
@@ -122,6 +124,10 @@ while [[ $# -gt 0 ]]; do
             fi
             shift 2
             ;;
+        --config)
+            CONFIG="$2"
+            shift 2
+            ;;
         --region)
             REGION="$2"
             shift 2
@@ -156,6 +162,7 @@ echo "  AvalancheGo Branch: ${AVALANCHEGO_BRANCH:-default}"
 echo "  Coreth Branch: ${CORETH_BRANCH:-default}"
 echo "  LibEVM Commit: ${LIBEVM_COMMIT:-default}"
 echo "  Number of Blocks: $NBLOCKS"
+echo "  Config: $CONFIG"
 echo "  Region: $REGION"
 if [ "$SPOT_INSTANCE" = true ]; then
     echo "  Spot Instance: Yes (max price: \$${MAX_SPOT_PRICES[$INSTANCE_TYPE]})"
@@ -372,7 +379,7 @@ runcmd:
   # execute bootstrapping
   - >
     sudo -u ubuntu -D /mnt/nvme/ubuntu/avalanchego --login
-    time task reexecute-cchain-range CURRENT_STATE_DIR=/mnt/nvme/ubuntu/exec-data/current-state BLOCK_DIR=/mnt/nvme/ubuntu/exec-data/blocks START_BLOCK=1 END_BLOCK=__END_BLOCK__ CONFIG=firewood METRICS_ENABLED=false
+    time task reexecute-cchain-range CURRENT_STATE_DIR=/mnt/nvme/ubuntu/exec-data/current-state BLOCK_DIR=/mnt/nvme/ubuntu/exec-data/blocks START_BLOCK=1 END_BLOCK=__END_BLOCK__ CONFIG=__CONFIG__ METRICS_ENABLED=false
     > /var/log/bootstrap.log 2>&1
 END_HEREDOC
 )
@@ -393,6 +400,7 @@ USERDATA=$(echo "$USERDATA_TEMPLATE" | \
   sed "s|__LIBEVM_COMMIT__|$LIBEVM_COMMIT_CHECKOUT|g" | \
   sed "s|__NBLOCKS__|$NBLOCKS|g" | \
   sed "s|__END_BLOCK__|$END_BLOCK|g" | \
+  sed "s|__CONFIG__|$CONFIG|g" | \
   base64)
 export USERDATA
 


### PR DESCRIPTION
This PR adds a `--config` option to the benchmark script. This is useful as it facilitates benchmarking between different configurations of Coreth (e.g. using vanilla Coreth vs Coreth with Firewood).

The current supported Coreth config options in the reexecution tests can be found here: https://github.com/ava-labs/avalanchego/blob/29075934327672a3cdc091c604264be5ca6fa596/tests/reexecute/c/vm_reexecute_test.go#L80-L91