### PR TITLE
chore(release): prepare for v0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.15] - 2025-11-18
+
+### 🚀 Features
+
+- Merge key-value range into trie ([#1427](https://github.com/ava-labs/firewood/pull/1427))
+- *(storage)* Replace `ArcSwap` with `Mutex` for better performance ([#1447](https://github.com/ava-labs/firewood/pull/1447))
+- *(ffi)* [**breaking**] Remove unused kvBackend interface ([#1448](https://github.com/ava-labs/firewood/pull/1448))
+- *(ffi)* Add keepalive struct to own waitgroup logic ([#1437](https://github.com/ava-labs/firewood/pull/1437))
+- Remove the last bits of arc-swap ([#1464](https://github.com/ava-labs/firewood/pull/1464))
+- *(ffi)* Fill in ffi methods for range proofs ([#1429](https://github.com/ava-labs/firewood/pull/1429))
+- *(firewood/ffi)* Add `FjallStore` ([#1395](https://github.com/ava-labs/firewood/pull/1395))
+
+### 🚜 Refactor
+
+- *(rootstore)* Replace RootStoreError with boxed error ([#1446](https://github.com/ava-labs/firewood/pull/1446))
+- Remove default 1-minute timeout on `Database.Close()` and set 1-sec in tests ([#1458](https://github.com/ava-labs/firewood/pull/1458))
+
+### 📚 Documentation
+
+- Add agent instructions ([#1445](https://github.com/ava-labs/firewood/pull/1445))
+- *(firewood)* Clean up commit steps ([#1453](https://github.com/ava-labs/firewood/pull/1453))
+- Merge code review process into CONTRIBUTING.md ([#1397](https://github.com/ava-labs/firewood/pull/1397))
+- Add comprehensive metrics documentation in METRICS.md ([#1402](https://github.com/ava-labs/firewood/pull/1402))
+
+### ⚡ Performance
+
+- *(ffi)* [**breaking**] Use fixed size Hash ([#1449](https://github.com/ava-labs/firewood/pull/1449))
+
+### 🧪 Testing
+
+- Fix `giant_node` test ([#1465](https://github.com/ava-labs/firewood/pull/1465))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Re-enable ffi-nix job ([#1450](https://github.com/ava-labs/firewood/pull/1450))
+- Relegate build equivalent check to post-merge job ([#1469](https://github.com/ava-labs/firewood/pull/1469))
+
 ## [0.0.14] - 2025-11-07
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,22 +101,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -227,9 +227,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+checksum = "5932a7d9d28b0d2ea34c6b3779d35e3dd6f6345317c34e73438c4f1f29144151"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.3"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
+checksum = "1826f2e4cfc2cd19ee53c42fbf68e2f81ec21108e0b7ecf6a71cf062137360fc"
 dependencies = [
  "bindgen",
  "cc",
@@ -300,18 +300,18 @@ dependencies = [
 
 [[package]]
 name = "bitfield"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf79f42d21f18b5926a959280215903e659760da994835d27c3a0c5ff4f898f"
+checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
 dependencies = [
  "bitfield-macros",
 ]
 
 [[package]]
 name = "bitfield-macros"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6115af052c7914c0cbb97195e5c72cb61c511527250074f5c041d1048b0d8b16"
+checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -399,9 +399,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "byteview"
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "aa8120877db0e5c011242f96806ce3c94e0737ab8108532a76a3300a01db2ab8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -524,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "02576b399397b659c26064fbc92a75fede9d18ffd5f80ca1cd74ddab167016e1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -739,9 +739,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1058,9 +1058,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "findshlibs"
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "firewood"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-benchmark"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "clap",
  "env_logger",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-ffi"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-fwdctl"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "askama",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-macros"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "coarsetime",
  "metrics",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-storage"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "aquamarine",
  "bitfield",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-triehash"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "criterion",
  "ethereum-types",
@@ -1408,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1600,9 +1600,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1653,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "base64",
  "bytes",
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade6dfcba0dfb62ad59e59e7241ec8912af34fd29e0e743e3db992bd278e8b65"
+checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
  "console",
  "portable-atomic",
@@ -3429,9 +3429,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.16.3"
+version = "12.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03f433c9befeea460a01d750e698aa86caf86dcfbd77d552885cd6c89d52f50"
+checksum = "b3d8046c5674ab857104bc4559d505f4809b8060d57806e45d49737c97afeb60"
 dependencies = [
  "debugid",
  "memmap2",
@@ -3441,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.16.3"
+version = "12.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d359ef6192db1760a34321ec4f089245ede4342c27e59be99642f12a859de8"
+checksum = "1accb6e5c4b0f682de907623912e616b44be1c9e725775155546669dbff720ec"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -3452,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3883,18 +3883,18 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0dd654273fc253fde1df4172c31fb6615cf8b041d3a4008a028ef8b1119e66"
+checksum = "1cce8e9c8115897e896894868ad4ae6851eff0fb7fd33fa95610e0fa93211886"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c26257f448222014296978b2c8456e2cad4de308c35bdb1e383acd569ef5b"
+checksum = "921d52b8b19b1a455f54fa76a925a1cf49c0d6a7c6b232fc58523400d1f91560"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3945,9 +3945,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 # NOTE: when bumping to 0.1.0, this will be removed and each crate will have its
 # version set independently.
-version = "0.0.14"
+version = "0.0.15"
 edition = "2024"
 license-file = "LICENSE.md"
 homepage = "https://avalabs.org"
@@ -56,17 +56,17 @@ cast_possible_truncation = "allow"
 
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.0.14" }
-firewood-macros = { path = "firewood-macros", version = "0.0.14" }
-firewood-storage = { path = "storage", version = "0.0.14" }
-firewood-ffi = { path = "ffi", version = "0.0.14" }
-firewood-triehash = { path = "triehash", version = "0.0.14" }
+firewood = { path = "firewood", version = "0.0.15" }
+firewood-macros = { path = "firewood-macros", version = "0.0.15" }
+firewood-storage = { path = "storage", version = "0.0.15" }
+firewood-ffi = { path = "ffi", version = "0.0.15" }
+firewood-triehash = { path = "triehash", version = "0.0.15" }
 
 # common dependencies
 aquamarine = "0.6.0"
 bytemuck = "1.24.0"
 bytemuck_derive = "1.10.2"
-clap = { version = "4.5.51", features = ["derive"] }
+clap = { version = "4.5.52", features = ["derive"] }
 coarsetime = "0.1.36"
 env_logger = "0.11.8"
 fastrace = "0.7.14"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,9 +20,9 @@ Before making changes, create a new branch (if not already on one):
 
 ```console
 $ git fetch
-$ git switch -c release/v0.0.15 origin/main
-branch 'release/v0.0.15' set up to track 'origin/main'.
-Switched to a new branch 'release/v0.0.15'
+$ git switch -c release/v0.0.16 origin/main
+branch 'release/v0.0.16' set up to track 'origin/main'.
+Switched to a new branch 'release/v0.0.16'
 ```
 
 If already on a new branch, ensure `HEAD` is the same as the remote's `main`.
@@ -75,7 +75,7 @@ table to define the version for all subpackages.
 
 ```toml
 [workspace.package]
-version = "0.0.15"
+version = "0.0.16"
 ```
 
 Each package inherits this version by setting `package.version.workspace = true`.
@@ -99,7 +99,7 @@ table. E.g.,:
 ```toml
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.0.15" }
+firewood = { path = "firewood", version = "0.0.16" }
 ```
 
 This allows packages within the workspace to inherit the dependency,
@@ -130,7 +130,7 @@ is correct and reflects the new package versions.
 To build the changelog, see git-cliff.org. Short version:
 
 ```sh
-git cliff --tag v0.0.15 -o CHANGELOG.md
+git cliff --tag v0.0.16 -o CHANGELOG.md
 ```
 
 ## Commit
@@ -160,11 +160,11 @@ To trigger a release, push a tag to the main branch matching the new version,
 # be sure to switch back to the main branch before tagging
 git checkout main
 git pull --prune
-git tag -s -a v0.0.15 -m 'Release v0.0.15'
-git push origin v0.0.15
+git tag -s -a v0.0.16 -m 'Release v0.0.16'
+git push origin v0.0.16
 ```
 
-for `v0.0.15` for the merged version change. The CI will automatically publish a
+for `v0.0.16` for the merged version change. The CI will automatically publish a
 draft release which consists of release notes and changes (see
 [.github/workflows/release.yaml](.github/workflows/release.yaml)).
 

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -34,7 +34,7 @@ integer-encoding.workspace = true
 metrics.workspace = true
 thiserror.workspace = true
 # Regular dependencies
-typed-builder = "0.23.0"
+typed-builder = "0.23.1"
 rayon = "1.11.0"
 fjall = "2.11.2"
 derive-where = "1.6.0"

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -34,7 +34,6 @@ impl Hasher for KeccakHasher {
         let mut hasher = Keccak256::new();
         hasher.update(x);
         let result = hasher.finalize();
-        #[expect(deprecated, reason = "transitive dependency on generic-array")]
         H256::from_slice(result.as_slice())
     }
 }
@@ -91,7 +90,6 @@ fn test_eth_compatible_accounts(
     let expected_key_hash = Keccak256::digest(&account);
 
     let items = once((
-        #[expect(deprecated, reason = "transitive dependency on generic-array")]
         Box::from(expected_key_hash.as_slice()),
         make_key(account_value),
     ))

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -479,7 +479,6 @@ mod tests {
 
     #[test]
     #[cfg(feature = "ethhash")]
-    #[expect(deprecated, reason = "transitive dependency on generic-array")]
     fn test_ethhash_compat_default_root_hash_equals_empty_rlp_hash() {
         use sha3::Digest as _;
 

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -33,7 +33,7 @@ log.workspace = true
 nonzero_ext.workspace = true
 # Regular dependencies
 csv = "1.4.0"
-indicatif = "0.18.2"
+indicatif = "0.18.3"
 askama = "0.14.0"
 num-format = "0.4.4"
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -32,16 +32,16 @@ sha2.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true
 # Regular dependencies
-bitfield = "0.19.3"
+bitfield = "0.19.4"
 bitflags = "2.10.0"
 derive-where = "1.6.0"
 enum-as-inner = "0.6.1"
-indicatif = "0.18.2"
+indicatif = "0.18.3"
 lru = "0.16.2"
 semver = "1.0.27"
 triomphe = "0.1.15"
 # Optional dependencies
-bytes = { version = "1.10.1", optional = true }
+bytes = { version = "1.11.0", optional = true }
 io-uring = { version = "0.7.11", optional = true }
 log = { version = "0.4.28", optional = true }
 rlp = { version = "0.6.1", optional = true }

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -114,7 +114,6 @@ impl<T: Hashable> Preimage for T {
             if is_account {
                 // we are a leaf that is at depth 32
                 match self.value_digest() {
-                    #[expect(deprecated, reason = "transitive dependency on generic-array")]
                     Some(ValueDigest::Value(bytes)) => {
                         let new_hash = Keccak256::digest(rlp::NULL_RLP).as_slice().to_vec();
                         let bytes_mut = BytesMut::from(bytes);
@@ -225,7 +224,6 @@ impl<T: Hashable> Preimage for T {
                 final_bytes.append(&&*nibbles_to_eth_compact(partial_path, is_account));
                 // if the RLP is short enough, we can use it as-is, otherwise we hash it
                 // to make the maximum length 32 bytes
-                #[expect(deprecated, reason = "transitive dependency on generic-array")]
                 if updated_bytes.len() > 31 && !is_account {
                     let hashed_bytes = Keccak256::digest(updated_bytes);
                     final_bytes.append(&hashed_bytes.as_slice());

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -246,7 +246,6 @@ mod ethhash {
         fn eq(&self, other: &TrieHash) -> bool {
             match self {
                 HashOrRlp::Hash(h) => h == other,
-                #[expect(deprecated, reason = "transitive dependency on generic-array")]
                 HashOrRlp::Rlp(r) => Keccak256::digest(r.as_ref()).as_slice() == other.as_ref(),
             }
         }
@@ -256,7 +255,6 @@ mod ethhash {
         fn eq(&self, other: &HashOrRlp) -> bool {
             match other {
                 HashOrRlp::Hash(h) => h == self,
-                #[expect(deprecated, reason = "transitive dependency on generic-array")]
                 HashOrRlp::Rlp(r) => Keccak256::digest(r.as_ref()).as_slice() == self.as_ref(),
             }
         }

--- a/storage/src/trie_hash.rs
+++ b/storage/src/trie_hash.rs
@@ -3,7 +3,6 @@
 
 use crate::node::ExtendableBytes;
 use crate::node::branch::Serializable;
-#[expect(deprecated, reason = "transitive dependency on generic-array")]
 use sha2::digest::generic_array::GenericArray;
 use sha2::digest::typenum;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -90,7 +89,6 @@ impl TryFrom<&[u8]> for TrieHash {
     }
 }
 
-#[expect(deprecated, reason = "transitive dependency on generic-array")]
 impl From<GenericArray<u8, typenum::U32>> for TrieHash {
     fn from(value: GenericArray<u8, typenum::U32>) -> Self {
         TrieHash(value.into())


### PR DESCRIPTION
Upgrading dependencies included `crypto-common@0.1.7` which pins its dependency on `generic-array` to `0.14.7`, removing the deprecation warnings we were seeing that were added to `generic-array` in version `0.14.9` (where `0.14.8` was yanked).