### PR TITLE
feat: remove the last bits of arc-swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,12 +140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1143,7 +1137,6 @@ name = "firewood-storage"
 version = "0.0.14"
 dependencies = [
  "aquamarine",
- "arc-swap",
  "bitfield",
  "bitflags 2.10.0",
  "bumpalo",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -32,7 +32,6 @@ sha2.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true
 # Regular dependencies
-arc-swap = "1.7.1"
 bitfield = "0.19.3"
 bitflags = "2.10.0"
 derive-where = "1.6.0"


### PR DESCRIPTION
I noticed there was one remaining component using arc-swap. This change replaces it with a standard Mutex. And, removes the dependency on arc-swap.