### PR TITLE
ci: relegate build equivalent check to post-merge job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,17 +244,6 @@ jobs:
         # cgocheck2 is expensive but provides complete pointer checks
         run: GOEXPERIMENT=cgocheck2 TEST_FIREWOOD_HASH_MODE=firewood go test -race ./...
 
-  ffi-nix:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 #v20
-      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 #v13
-      - name: Check that FFI flake is up-to-date
-        run: ./scripts/run-just.sh check-ffi-flake
-      - name: Test nix build of Golang FFI bindings
-        run: ./scripts/run-just.sh test-ffi-nix
-
   firewood-ethhash-differential-fuzz:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/ffi-nix.yaml
+++ b/.github/workflows/ffi-nix.yaml
@@ -1,0 +1,18 @@
+name: ffi-nix
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  ffi-nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 #v20
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 #v13
+      - name: Check that FFI flake is up-to-date
+        run: ./scripts/run-just.sh check-ffi-flake
+      - name: Test nix build of Golang FFI bindings
+        run: ./scripts/run-just.sh test-ffi-nix
+


### PR DESCRIPTION
As discussed offline and in #1460, the `ffi-nix` job takes around 15 minutes to complete and runs on every PR. This PR changes it so that the `ffi-nix` job runs only on commits to `main`.