### PR TITLE
refactor(firewood/db): unify reopen methods

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -406,7 +406,6 @@ mod test {
 
     use crate::db::{Db, Proposal, UseParallel};
     use crate::manager::RevisionManagerConfig;
-    use crate::root_store::RootStore;
     use crate::v2::api::{Db as _, DbView, Proposal as _};
 
     use super::{BatchOp, DbConfig};
@@ -446,15 +445,6 @@ mod test {
     }
 
     impl<T: Iterator> IterExt for T {}
-
-    #[cfg(test)]
-    impl Db {
-        /// Extract the root store by consuming the database instance.
-        /// This is primarily used for reopening or replacing the database with the same root store.
-        pub fn into_root_store(self) -> Box<dyn RootStore + Send + Sync> {
-            self.manager.into_root_store()
-        }
-    }
 
     #[test]
     fn test_proposal_reads() {

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -389,14 +389,6 @@ mod tests {
     use crate::root_store::NoOpStore;
     use tempfile::NamedTempFile;
 
-    #[cfg(test)]
-    impl RevisionManager {
-        /// Extract the root store by consuming the revision manager instance.
-        pub fn into_root_store(self) -> Box<dyn RootStore + Send + Sync> {
-            self.root_store
-        }
-    }
-
     #[test]
     fn test_file_advisory_lock() {
         // Create a temporary file for testing


### PR DESCRIPTION
IMO, the `reopen()` method of `TestDb` is a misnomer - while this method does not truncate the existing Firewood file, it uses the default configuration for the new `TestDb` instance, ignoring the prior instance's configuration. As a consumer, I would expect `reopen()` to maintain the existing configuration.

This PR does the following:
- Unifies `reopen()` and `reopen_with_config()` into a single method
- Stores the `dbconfig` in `testDb` to allow the database configuration to persist across reopens
- Adds documentation to both `reopen()` and `replace()`
- Removes `into_root_store()` test helpers since `RootStore` reopens are now handled via the database configuration 

This PR is a precursor to #1481.