### PR TITLE
fix: mark node as allocated before serializing parent

### DIFF
--- a/storage/src/nodestore/persist_io_uring.rs
+++ b/storage/src/nodestore/persist_io_uring.rs
@@ -84,8 +84,7 @@ fn handle_completion_queue(
                 Some("write failure".to_string()),
             ));
         }
-        // I/O completed successfully - mark node as persisted and cache it
-        pbe_entry.node.allocate_at(pbe_entry.address);
+        // I/O completed successfully - enqueue node for caching at the end
         cached_nodes.push(pbe_entry.node);
     }
     Ok(())


### PR DESCRIPTION
#1488 found a panic during serialization of a node, indicating that a child node was either not hashed or not allocated and therefore could not serialize the parent node. After a walk through of the code, I noticed that after #1389, we began serializing nodes in batches in order to prevent corrupting the free-list after a failed write and introduced a case where this could occur. Previously, we would serialize a node, write it to storage, and then mark it as allocated in one step. Now we serialize and allocate the node and add the node to a batch before moving onto the next node. Like before, we only mark the node as allocated after writing it to disk. This means that if the batch contained child and parent, the parent node fails to serialize because it cannot reference the address.

This change refactors the allocation logic to mark nodes as allocated during batching. This ensures that if its parent is also in the batch, it can successfully serialize. This linear address itself is not read from by viewers of the `Allocated` state because the node is not considered committed until the entire write has completed (i.e., after the root and header are written). This means this change does not introduce any early reads of uncommitted data.

In the course of writing tests, I discovered that the arena allocator returns the number of bytes by the arena, not the number of bytes occupied by items within the arena. This meant that the batching logic should have always generated a batch of 1 element. To fix this, I track the allocated length of each area. This successfully triggered the bug I discovered; however, this also means the bug might not be the source of the original panic.
