### PR TITLE
test: optimize init_merkle by removing redundant verification passes

### DIFF
--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -60,40 +60,12 @@ where
         let value = v.as_ref();
 
         merkle.insert(key, value.into()).unwrap();
-
-        assert_eq!(
-            merkle.get_value(key).unwrap().as_deref(),
-            Some(value),
-            "Failed to insert key: {key:?}",
-        );
-    }
-
-    for (k, v) in iter.clone() {
-        let key = k.as_ref();
-        let value = v.as_ref();
-
-        assert_eq!(
-            merkle.get_value(key).unwrap().as_deref(),
-            Some(value),
-            "Failed to get key after insert: {key:?}",
-        );
     }
 
     let merkle = merkle.hash();
-
-    for (k, v) in iter.clone() {
-        let key = k.as_ref();
-        let value = v.as_ref();
-
-        assert_eq!(
-            merkle.get_value(key).unwrap().as_deref(),
-            Some(value),
-            "Failed to get key after hashing: {key:?}"
-        );
-    }
-
     let merkle = into_committed(merkle, base.nodestore());
 
+    // Single verification pass at the end to ensure correctness
     for (k, v) in iter {
         let key = k.as_ref();
         let value = v.as_ref();


### PR DESCRIPTION
The init_merkle test helper was performing verification after each insert and after each phase (insert, hash, commit), resulting in 3 full passes over the dataset with get_value() calls.

This change removes the redundant verification passes and keeps only a single final verification pass at the end to ensure correctness.

Performance improvements:
- Debug mode: 33.4s → 0.35s (95x faster)
- Release mode: 4.2s → 0.015s (280x faster)

33s is way too long, especially since this method will be used to initialize quite a few merkles in some upcoming tests.

The merkle tree is still fully verified at the end by checking that all key-value pairs can be retrieved correctly from the committed state.