### PR TITLE
feat: verify node hashes on read

### DIFF
--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -281,7 +281,7 @@ fn remove_root() {
     assert!(merkle.get_value(&key3).unwrap().is_none());
     assert!(merkle.remove(&key3).unwrap().is_none());
 
-    assert!(merkle.nodestore.root_node().is_none());
+    assert!(merkle.nodestore.read_root().unwrap().is_none());
 }
 
 #[test]
@@ -357,7 +357,7 @@ fn remove_many() {
         let got = merkle.get_value(&key).unwrap();
         assert!(got.is_none());
     }
-    assert!(merkle.nodestore.root_node().is_none());
+    assert!(merkle.nodestore.read_root().unwrap().is_none());
 }
 
 #[test]


### PR DESCRIPTION
When we read nodes from storage, we currently assume the data is consistent and return it as-is to the caller. However, that is a bad assumption as data on disk can easily be corrupted. As an extreme example, cosmic background radiation can cause bit flips for non-ECC hardware. And as a more realistic example, there could be a bug in Firewood that causes data to be overwritten or serialized incorrectly.

This change adds verifying reads to the database, with two exceptions. Reading the root upon opening the database is unable to verify the root hash. Unless we're running with a root store, the root hash will be unknown to firewood on startup. This likely means we should include the root hash in the header. I will revisit that soon. Additionally, reading leaked areas via the fsck util is unable to verify the hash; which is to be expected for a leaked area.

Closes: #1768