### PR TITLE
fix: Race condition between view and commit

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -442,7 +442,6 @@ mod tests {
 
         let config = ConfigManager::builder()
             .create(true)
-            .truncate(true)
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(100_000) // Set very high to prevent reaping during test


### PR DESCRIPTION
During commit(), a revision transitions from being in proposals (step 6) to by_hash (step 5). The view() method was checking by_hash first, then proposals, creating a window where a concurrent view() could fail to find a revision that exists but is mid-transition.

Fix by reversing the check order in view() to match the write order in commit(). Now view() checks proposals first (where revisions start), then by_hash (where they end up), ensuring the revision is always findable during the transition.

Also added a concurrency stress test that reproduces the race condition with 10 viewer threads and 5 committer thread over 1000 iterations. This fails without the fix and works with it.