### PR TITLE
feat: prevent accidental UB on iterators

### DIFF
--- a/ffi/proposal.go
+++ b/ffi/proposal.go
@@ -83,7 +83,7 @@ func (p *Proposal) Iter(key []byte) (*Iterator, error) {
 
 	itResult := C.fwd_iter_on_proposal(p.handle, newBorrowedBytes(key, &pinner))
 
-	return getIteratorFromIteratorResult(itResult)
+	return getIteratorFromIteratorResult(itResult, p.keepAliveHandle.outstandingHandles)
 }
 
 // Propose is equivalent to [Database.Propose] except that the new proposal is

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -85,7 +85,7 @@ func (r *Revision) Iter(key []byte) (*Iterator, error) {
 
 	itResult := C.fwd_iter_on_revision(r.handle, newBorrowedBytes(key, &pinner))
 
-	return getIteratorFromIteratorResult(itResult)
+	return getIteratorFromIteratorResult(itResult, r.keepAliveHandle.outstandingHandles)
 }
 
 // Drop releases the resources backed by the revision handle.


### PR DESCRIPTION
I didn't add the keepAliveHandle to iterators, mostly because I didn't understand how it should be used. I think this is a sufficient test for this. Additionally, I added a big godoc about it, since it was convenient to do now.

Closes #1467