### PR TITLE
feat: Add ffi support for dump()

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -405,3 +405,23 @@ func (db *Database) Close(ctx context.Context) error {
 
 	return nil
 }
+
+// Dump returns a DOT (Graphviz) format representation of the trie structure
+// of the latest revision for debugging purposes.
+//
+// Returns an error if the database is closed or if there was an error
+// dumping the trie.
+func (db *Database) Dump() (string, error) {
+	db.handleLock.RLock()
+	defer db.handleLock.RUnlock()
+	if db.handle == nil {
+		return "", errDBClosed
+	}
+
+	bytes, err := getValueFromValueResult(C.fwd_db_dump(db.handle))
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1205,6 +1205,30 @@ struct ChangeProofResult fwd_db_change_proof(const struct DatabaseHandle *_db,
                                              struct CreateChangeProofArgs _args);
 
 /**
+ * Dumps the Trie structure of the latest revision of the database to a DOT
+ * (Graphviz) format string for debugging.
+ *
+ * # Arguments
+ *
+ * * `db` - The database handle returned by [`fwd_open_db`]
+ *
+ * # Returns
+ *
+ * - [`ValueResult::NullHandlePointer`] if the provided database handle is null.
+ * - [`ValueResult::Some`] with the DOT format string if successful (the data is
+ *   guaranteed to be utf-8 data, not null terminated).
+ * - [`ValueResult::Err`] if an error occurred while dumping the database.
+ *
+ * # Safety
+ *
+ * The caller must:
+ * * ensure that `db` is a valid pointer to a [`DatabaseHandle`].
+ * * call [`fwd_free_owned_bytes`] to free the memory associated with the
+ *   returned value.
+ */
+struct ValueResult fwd_db_dump(const struct DatabaseHandle *db);
+
+/**
  * Generate a range proof for the given range of keys for the latest revision.
  *
  * # Arguments
@@ -1790,6 +1814,30 @@ struct IteratorResult fwd_iter_on_revision(const struct RevisionHandle *revision
 struct HandleResult fwd_open_db(struct DatabaseHandleArgs args);
 
 /**
+ * Dumps the Trie structure of a proposal to a DOT (Graphviz) format string for debugging.
+ *
+ * # Arguments
+ *
+ * * `proposal` - The proposal handle returned by [`fwd_propose_on_db`] or
+ *   [`fwd_propose_on_proposal`].
+ *
+ * # Returns
+ *
+ * - [`ValueResult::NullHandlePointer`] if the provided proposal handle is null.
+ * - [`ValueResult::Some`] with the DOT format string if successful (the data is
+ *   guaranteed to be utf-8 data, not null terminated).
+ * - [`ValueResult::Err`] if an error occurred while dumping the proposal.
+ *
+ * # Safety
+ *
+ * The caller must:
+ * * ensure that `proposal` is a valid pointer to a [`ProposalHandle`].
+ * * call [`fwd_free_owned_bytes`] to free the memory associated with the
+ *   returned value.
+ */
+struct ValueResult fwd_proposal_dump(const struct ProposalHandle *proposal);
+
+/**
  * Proposes a batch of operations to the database.
  *
  * # Arguments
@@ -1933,6 +1981,30 @@ struct ValueResult fwd_range_proof_to_bytes(const struct RangeProofContext *proo
  * for the duration of the call.
  */
 struct VoidResult fwd_range_proof_verify(struct VerifyRangeProofArgs args);
+
+/**
+ * Dumps the Trie structure of a revision to a DOT (Graphviz) format string for debugging.
+ *
+ * # Arguments
+ *
+ * * `revision` - A pointer to a [`RevisionHandle`] previously returned by
+ *   [`fwd_get_revision`].
+ *
+ * # Returns
+ *
+ * - [`ValueResult::NullHandlePointer`] if the provided revision handle is null.
+ * - [`ValueResult::Some`] with the DOT format string if successful (the data is
+ *   guaranteed to be utf-8 data, not null terminated).
+ * - [`ValueResult::Err`] if an error occurred while dumping the revision.
+ *
+ * # Safety
+ *
+ * The caller must:
+ * * ensure that `revision` is a valid pointer to a [`RevisionHandle`].
+ * * call [`fwd_free_owned_bytes`] to free the memory associated with the
+ *   returned value.
+ */
+struct ValueResult fwd_revision_dump(const struct RevisionHandle *revision);
 
 /**
  * Get the root hash of the latest version of the database

--- a/ffi/proposal.go
+++ b/ffi/proposal.go
@@ -159,6 +159,23 @@ func (p *Proposal) Drop() error {
 	})
 }
 
+// Dump returns a DOT (Graphviz) format representation of the trie structure
+// of this proposal for debugging purposes.
+//
+// Returns errDroppedProposal if Commit or Drop has already been called.
+func (p *Proposal) Dump() (string, error) {
+	if p.handle == nil {
+		return "", errDroppedProposal
+	}
+
+	bytes, err := getValueFromValueResult(C.fwd_proposal_dump(p.handle))
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}
+
 // getProposalFromProposalResult converts a C.ProposalResult to a Proposal or error.
 func getProposalFromProposalResult(result C.ProposalResult, wg *sync.WaitGroup, commitLock *sync.Mutex) (*Proposal, error) {
 	switch result.tag {

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -111,6 +111,23 @@ func (r *Revision) Root() Hash {
 	return r.root
 }
 
+// Dump returns a DOT (Graphviz) format representation of the trie structure
+// of this revision for debugging purposes.
+//
+// Returns ErrDroppedRevision if Drop has already been called.
+func (r *Revision) Dump() (string, error) {
+	if r.handle == nil {
+		return "", ErrDroppedRevision
+	}
+
+	bytes, err := getValueFromValueResult(C.fwd_revision_dump(r.handle))
+	if err != nil {
+		return "", err
+	}
+
+	return string(bytes), nil
+}
+
 // getRevisionFromResult converts a C.RevisionResult to a Revision or error.
 func getRevisionFromResult(result C.RevisionResult, wg *sync.WaitGroup) (*Revision, error) {
 	switch result.tag {

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -246,6 +246,15 @@ impl DatabaseHandle {
                 .merge_key_value_range(first_key, last_key, key_values)
         })
     }
+
+    /// Dumps the Trie structure of the latest revision to a DOT (Graphviz) format string.
+    ///
+    /// # Errors
+    ///
+    /// An error is returned if there was an i/o error while dumping the trie.
+    pub fn dump_to_string(&self) -> Result<String, api::Error> {
+        self.db.dump_to_string().map_err(api::Error::from)
+    }
 }
 
 impl From<Db> for DatabaseHandle {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -769,3 +769,78 @@ pub unsafe extern "C" fn fwd_free_owned_key_value_batch(batch: OwnedKeyValueBatc
 pub unsafe extern "C" fn fwd_free_owned_kv_pair(kv: OwnedKeyValuePair) -> VoidResult {
     invoke(move || drop(kv))
 }
+
+/// Dumps the Trie structure of the latest revision of the database to a DOT
+/// (Graphviz) format string for debugging.
+///
+/// # Arguments
+///
+/// * `db` - The database handle returned by [`fwd_open_db`]
+///
+/// # Returns
+///
+/// - [`ValueResult::NullHandlePointer`] if the provided database handle is null.
+/// - [`ValueResult::Some`] with the DOT format string if successful (the data is
+///   guaranteed to be utf-8 data, not null terminated).
+/// - [`ValueResult::Err`] if an error occurred while dumping the database.
+///
+/// # Safety
+///
+/// The caller must:
+/// * ensure that `db` is a valid pointer to a [`DatabaseHandle`].
+/// * call [`fwd_free_owned_bytes`] to free the memory associated with the
+///   returned value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_db_dump(db: Option<&DatabaseHandle>) -> ValueResult {
+    invoke_with_handle(db, handle::DatabaseHandle::dump_to_string)
+}
+
+/// Dumps the Trie structure of a revision to a DOT (Graphviz) format string for debugging.
+///
+/// # Arguments
+///
+/// * `revision` - A pointer to a [`RevisionHandle`] previously returned by
+///   [`fwd_get_revision`].
+///
+/// # Returns
+///
+/// - [`ValueResult::NullHandlePointer`] if the provided revision handle is null.
+/// - [`ValueResult::Some`] with the DOT format string if successful (the data is
+///   guaranteed to be utf-8 data, not null terminated).
+/// - [`ValueResult::Err`] if an error occurred while dumping the revision.
+///
+/// # Safety
+///
+/// The caller must:
+/// * ensure that `revision` is a valid pointer to a [`RevisionHandle`].
+/// * call [`fwd_free_owned_bytes`] to free the memory associated with the
+///   returned value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_revision_dump(revision: Option<&RevisionHandle>) -> ValueResult {
+    invoke_with_handle(revision, firewood::v2::api::DbView::dump_to_string)
+}
+
+/// Dumps the Trie structure of a proposal to a DOT (Graphviz) format string for debugging.
+///
+/// # Arguments
+///
+/// * `proposal` - The proposal handle returned by [`fwd_propose_on_db`] or
+///   [`fwd_propose_on_proposal`].
+///
+/// # Returns
+///
+/// - [`ValueResult::NullHandlePointer`] if the provided proposal handle is null.
+/// - [`ValueResult::Some`] with the DOT format string if successful (the data is
+///   guaranteed to be utf-8 data, not null terminated).
+/// - [`ValueResult::Err`] if an error occurred while dumping the proposal.
+///
+/// # Safety
+///
+/// The caller must:
+/// * ensure that `proposal` is a valid pointer to a [`ProposalHandle`].
+/// * call [`fwd_free_owned_bytes`] to free the memory associated with the
+///   returned value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fwd_proposal_dump(proposal: Option<&ProposalHandle>) -> ValueResult {
+    invoke_with_handle(proposal, firewood::v2::api::DbView::dump_to_string)
+}

--- a/ffi/src/proposal.rs
+++ b/ffi/src/proposal.rs
@@ -48,6 +48,10 @@ impl<'db> DbView for ProposalHandle<'db> {
     ) -> Result<Self::Iter<'_>, api::Error> {
         self.proposal.iter_option(first_key)
     }
+
+    fn dump_to_string(&self) -> Result<String, api::Error> {
+        self.proposal.dump_to_string()
+    }
 }
 
 impl ProposalHandle<'_> {

--- a/ffi/src/revision.rs
+++ b/ffi/src/revision.rs
@@ -65,6 +65,10 @@ impl DbView for RevisionHandle {
     ) -> Result<Self::Iter<'_>, api::Error> {
         self.view.iter_option(first_key.as_ref().map(AsRef::as_ref))
     }
+
+    fn dump_to_string(&self) -> Result<String, api::Error> {
+        self.view.dump_to_string()
+    }
 }
 
 #[derive(Debug)]

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -95,6 +95,11 @@ where
             None => Ok(MerkleKeyValueIter::from(self)),
         }
     }
+
+    fn dump_to_string(&self) -> Result<String, api::Error> {
+        let merkle = Merkle::from(self);
+        merkle.dump_to_string().map_err(api::Error::from)
+    }
 }
 
 #[allow(dead_code)]
@@ -192,6 +197,17 @@ impl Db {
         let latest_rev_nodestore = self.manager.current_revision();
         let merkle = Merkle::from(latest_rev_nodestore);
         merkle.dump(w).map_err(std::io::Error::other)
+    }
+
+    /// Dump the Trie of the latest revision to a String
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the dump operation fails
+    pub fn dump_to_string(&self) -> Result<String, std::io::Error> {
+        let latest_rev_nodestore = self.manager.current_revision();
+        let merkle = Merkle::from(latest_rev_nodestore);
+        merkle.dump_to_string().map_err(std::io::Error::other)
     }
 
     /// Get a copy of the database metrics
@@ -347,6 +363,10 @@ impl api::DbView for Proposal<'_> {
 
     fn iter_option<K: KeyType>(&self, first_key: Option<K>) -> Result<Self::Iter<'_>, api::Error> {
         api::DbView::iter_option(&*self.nodestore, first_key)
+    }
+
+    fn dump_to_string(&self) -> Result<String, api::Error> {
+        api::DbView::dump_to_string(&*self.nodestore)
     }
 }
 

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -331,6 +331,13 @@ pub trait DbView {
     fn iter_from<K: KeyType>(&self, first_key: K) -> Result<Self::Iter<'_>, Error> {
         self.iter_option(Some(first_key))
     }
+
+    /// Dump the Trie structure in DOT (Graphviz) format
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the dump operation fails
+    fn dump_to_string(&self) -> Result<String, Error>;
 }
 
 /// A boxed iterator over key/value pairs.
@@ -399,6 +406,13 @@ pub trait DynDbView: Debug + Send + Sync + 'static {
     fn iter_from(&self, first_key: &[u8]) -> Result<BoxKeyValueIter<'_>, Error> {
         self.iter_option(Some(first_key))
     }
+
+    /// Dump the Trie structure in DOT (Graphviz) format
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the dump operation fails
+    fn dump_to_string(&self) -> Result<String, Error>;
 }
 
 impl<T: Debug + DbView + Send + Sync + 'static> DynDbView for T
@@ -433,6 +447,10 @@ where
             Ok(iter) => Ok(Box::new(iter)),
             Err(e) => Err(e),
         }
+    }
+
+    fn dump_to_string(&self) -> Result<String, Error> {
+        DbView::dump_to_string(self)
     }
 }
 

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -696,6 +696,16 @@ where
     }
 }
 
+impl<T: HashedNodeReader> HashedNodeReader for &T {
+    fn root_address(&self) -> Option<LinearAddress> {
+        (**self).root_address()
+    }
+
+    fn root_hash(&self) -> Option<TrieHash> {
+        (**self).root_hash()
+    }
+}
+
 // TODO: return only the index since we can easily get the size from the index
 fn area_index_and_size<S: ReadableStorage>(
     storage: &S,


### PR DESCRIPTION
Expose Firewood's trie dump() functionality through the FFI layer to Golang for debugging purposes. The dump() method generates DOT (Graphviz) format output that can be visualized or analyzed.

Changes:
- Added dump_to_string() method to DbView and DynDbView traits
- Implemented dump_to_string() for Db, NodeStore, and Proposal types
- Made Merkle::dump_to_string() public
- Added blanket impl for &T: HashedNodeReader to support references
- Added FFI C functions: fwd_db_dump, fwd_revision_dump, fwd_proposal_dump
- Added Go wrapper methods: Database.Dump(), Revision.Dump(), Proposal.Dump()
- Added comprehensive test coverage in TestDump

The implementation follows existing FFI patterns and is optimized for simplicity over efficiency as it's intended for debugging use cases only.

## Why this should be merged

## How this works

## How this was tested

## Need to be documented in RELEASES.md?
