### PR TITLE
refactor: partially refactor iter types into submodules

### DIFF
--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -1,9 +1,12 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::merkle::{Key, Value};
-use crate::v2::api::{KeyType, KeyValuePair};
+mod filtered_key_range;
+pub(crate) mod returnable;
 
+use crate::merkle::{Key, Value};
+
+pub use self::filtered_key_range::{FilteredKeyRangeExt, FilteredKeyRangeIter};
 use firewood_storage::{
     BranchNode, Child, FileIoError, NibblesIterator, Node, PathBuf, PathComponent, PathIterItem,
     SharedNode, TriePathFromUnpackedBytes, TrieReader,
@@ -298,12 +301,6 @@ impl<'a, T: TrieReader> MerkleKeyValueIter<'a, T> {
             iter: MerkleNodeIter::new(merkle, key.as_ref().into()),
         }
     }
-
-    /// Returns a new iterator that will emit key-value pairs up to and
-    /// including `last_key`.
-    pub fn stop_after_key<K: KeyType>(self, last_key: Option<K>) -> FilteredKeyRangeIter<Self, K> {
-        FilteredKeyRangeIter::new(self, last_key)
-    }
 }
 
 impl<T: TrieReader> Iterator for MerkleKeyValueIter<'_, T> {
@@ -566,61 +563,6 @@ fn key_from_nibble_iter<Iter: Iterator<Item = u8>>(mut nibbles: Iter) -> Key {
     }
 
     data.into_boxed_slice()
-}
-
-/// An iterator over key-value pairs that stops after a specified final key.
-#[derive(Debug)]
-#[must_use = "iterators are lazy and do nothing unless consumed"]
-pub enum FilteredKeyRangeIter<I, K> {
-    Unfiltered { iter: I },
-    Filtered { iter: I, last_key: K },
-    Exhausted,
-}
-
-impl<I: Iterator<Item = T>, T: KeyValuePair, K: KeyType> FilteredKeyRangeIter<I, K> {
-    /// Creates a new [`FilteredKeyRangeIter`] that will iterate over `iter`
-    /// stopping early if `last_key` is `Some` and a key greater than it is
-    /// encountered.
-    pub fn new(iter: I, last_key: Option<K>) -> Self {
-        match last_key {
-            Some(k) => FilteredKeyRangeIter::Filtered { iter, last_key: k },
-            None => FilteredKeyRangeIter::Unfiltered { iter },
-        }
-    }
-}
-
-impl<I: Iterator<Item = T>, T: KeyValuePair, K: KeyType> Iterator for FilteredKeyRangeIter<I, K> {
-    type Item = Result<(T::Key, T::Value), T::Error>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            FilteredKeyRangeIter::Unfiltered { iter } => iter.next().map(T::try_into_tuple),
-            FilteredKeyRangeIter::Filtered { iter, last_key } => {
-                match iter.next().map(T::try_into_tuple) {
-                    Some(Ok((key, value))) if key.as_ref() <= last_key.as_ref() => {
-                        Some(Ok((key, value)))
-                    }
-                    Some(Err(e)) => Some(Err(e)),
-                    _ => {
-                        *self = FilteredKeyRangeIter::Exhausted;
-                        None
-                    }
-                }
-            }
-            FilteredKeyRangeIter::Exhausted => None,
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        match self {
-            FilteredKeyRangeIter::Unfiltered { iter } => iter.size_hint(),
-            FilteredKeyRangeIter::Filtered { iter, .. } => {
-                let (_, upper) = iter.size_hint();
-                (0, upper)
-            }
-            FilteredKeyRangeIter::Exhausted => (0, Some(0)),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/firewood/src/iter/filtered_key_range.rs
+++ b/firewood/src/iter/filtered_key_range.rs
@@ -1,0 +1,69 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use crate::v2::api::{KeyType, KeyValuePair};
+
+pub trait FilteredKeyRangeExt: Iterator<Item: KeyValuePair> + Sized {
+    /// Returns a new iterator that will emit key-value pairs up to and
+    /// including `last_key`.
+    fn stop_after_key<K: KeyType>(self, last_key: Option<K>) -> FilteredKeyRangeIter<Self, K> {
+        FilteredKeyRangeIter::new(self, last_key)
+    }
+}
+
+impl<I: Iterator<Item: KeyValuePair>> FilteredKeyRangeExt for I {}
+
+/// An iterator over key-value pairs that stops after a specified final key.
+#[derive(Debug)]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+pub enum FilteredKeyRangeIter<I, K> {
+    Unfiltered { iter: I },
+    Filtered { iter: I, last_key: K },
+    Exhausted,
+}
+
+impl<I: Iterator<Item = T>, T: KeyValuePair, K: KeyType> FilteredKeyRangeIter<I, K> {
+    /// Creates a new [`FilteredKeyRangeIter`] that will iterate over `iter`
+    /// stopping early if `last_key` is `Some` and a key greater than it is
+    /// encountered.
+    pub fn new(iter: I, last_key: Option<K>) -> Self {
+        match last_key {
+            Some(k) => FilteredKeyRangeIter::Filtered { iter, last_key: k },
+            None => FilteredKeyRangeIter::Unfiltered { iter },
+        }
+    }
+}
+
+impl<I: Iterator<Item = T>, T: KeyValuePair, K: KeyType> Iterator for FilteredKeyRangeIter<I, K> {
+    type Item = Result<(T::Key, T::Value), T::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            FilteredKeyRangeIter::Unfiltered { iter } => iter.next().map(T::try_into_tuple),
+            FilteredKeyRangeIter::Filtered { iter, last_key } => {
+                match iter.next().map(T::try_into_tuple) {
+                    Some(Ok((key, value))) if key.as_ref() <= last_key.as_ref() => {
+                        Some(Ok((key, value)))
+                    }
+                    Some(Err(e)) => Some(Err(e)),
+                    _ => {
+                        *self = FilteredKeyRangeIter::Exhausted;
+                        None
+                    }
+                }
+            }
+            FilteredKeyRangeIter::Exhausted => None,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            FilteredKeyRangeIter::Unfiltered { iter } => iter.size_hint(),
+            FilteredKeyRangeIter::Filtered { iter, .. } => {
+                let (_, upper) = iter.size_hint();
+                (0, upper)
+            }
+            FilteredKeyRangeIter::Exhausted => (0, Some(0)),
+        }
+    }
+}

--- a/firewood/src/iter/returnable.rs
+++ b/firewood/src/iter/returnable.rs
@@ -1,0 +1,68 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+pub(crate) trait ReturnableIteratorExt: Iterator + Sized {
+    /// Wraps this iterator in a [`ReturnableIterator`].
+    fn returnable(self) -> ReturnableIterator<Self> {
+        ReturnableIterator::new(self)
+    }
+}
+
+impl<I: Iterator> ReturnableIteratorExt for I {}
+
+/// Similar to a peekable iterator. In addition to being able to peek at the
+/// next item without consuming it, it also allows "returning" an item back to
+/// the iterator to be yielded on the next call to [`next()`].
+///
+/// [`next()`]: Iterator::next
+pub(crate) struct ReturnableIterator<I: Iterator> {
+    iter: I,
+    next: Option<I::Item>,
+}
+
+impl<I: Iterator> ReturnableIterator<I> {
+    pub(crate) const fn new(iter: I) -> Self {
+        Self { iter, next: None }
+    }
+
+    /// Peeks at the next item without consuming it. The next call to
+    /// [`next()`] will still return this item.
+    ///
+    /// [`next()`]: Iterator::next
+    pub(crate) fn peek(&mut self) -> Option<&mut I::Item> {
+        if self.next.is_none() {
+            self.next = self.iter.next();
+        }
+
+        self.next.as_mut()
+    }
+
+    /// Puts an item back to be returned on the next call to [`next()`]. This
+    /// makes it easy to "un-read" a single item from the iterator without
+    /// needing to implement complex buffering logic.
+    ///
+    /// NOTE: This will replace and return any item that was already in the
+    /// return slot.
+    ///
+    /// [`next()`]: Iterator::next
+    pub(crate) const fn return_item(&mut self, head: I::Item) -> Option<I::Item> {
+        self.next.replace(head)
+    }
+}
+
+impl<I: Iterator> Iterator for ReturnableIterator<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next.take().or_else(|| self.iter.next())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.iter.size_hint();
+        let head_count = usize::from(self.next.is_some());
+        (
+            lower.saturating_add(head_count),
+            upper.and_then(|u| u.checked_add(head_count)),
+        )
+    }
+}

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -8,7 +8,8 @@ mod merge;
 /// Parallel merkle
 pub mod parallel;
 
-use crate::iter::{MerkleKeyValueIter, PathIterator};
+use crate::iter::FilteredKeyRangeExt;
+use crate::iter::{MerkleKeyValueIter, PathIterator, returnable::ReturnableIteratorExt};
 use crate::v2::api::{
     self, BatchIter, FrozenProof, FrozenRangeProof, KeyType, KeyValuePair, ValueType,
 };
@@ -406,7 +407,8 @@ impl<T: TrieReader> Merkle<T> {
 
         let mut iter = self
             .key_value_iter_from_key(start_key.unwrap_or_default())
-            .stop_after_key(end_key);
+            .stop_after_key(end_key)
+            .returnable();
 
         // don't consume the iterator so we can determine if we hit the
         // limit or exhausted the iterator later
@@ -422,7 +424,7 @@ impl<T: TrieReader> Merkle<T> {
 
         let end_proof = if let Some(limit) = limit
             && limit.get() <= key_values.len()
-            && iter.next().is_some()
+            && iter.peek().is_some()
         {
             // limit was provided, we hit it, and there is at least one more key
             // end proof is for the last key provided


### PR DESCRIPTION
This partially refactors some of the iterator types into submodules. 

The `peek` method was added to `ReturnableIterator` because it will be necessary in a future PR  for #1441.
