### PR TITLE
chore: Remove reference to RELEASES.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,3 @@
 ## How this works
 
 ## How this was tested
-
-## Need to be documented in RELEASES.md?


### PR DESCRIPTION
We don't use this process and so asking for it on a PR is useless.

## Why this should be merged

Because it's stupid to be asking for updating RELEASES.md

## How this works

Use the source, luke.

## How this was tested

Untested.

## Need to be documented in RELEASES.md?

Totally. Not.