### PR TITLE
fix: generated instance names have whitespace

### DIFF
--- a/benchmark/bootstrap/aws-launch.sh
+++ b/benchmark/bootstrap/aws-launch.sh
@@ -481,7 +481,8 @@ export USERDATA
 fi  # End of DRY_RUN=false conditional
 
 
-SUFFIX=$(hexdump -vn4 -e'4/4 "%08X" 1 "\n"' /dev/urandom)
+# Generate a compact 8-hex-digit suffix without spaces/newlines
+SUFFIX=$(hexdump -vn4 -e '1/4 "%08X"' /dev/urandom)
 
 # Build instance name with branch info
 INSTANCE_NAME="$USER-fw-$SUFFIX"


### PR DESCRIPTION

## Why this should be merged

Instance names have a lot of extra whitespace. This cleans that up.

Probably unnecessary once we have the launch in rust.

## How this works

`hexdump -vn4 -e'4/4 "%08X" 1 "\n"' /dev/urandom` generates lots of extra spaces and newslines, whereas `hexdump -vn4 -e '1/4 "%08X"' /dev/urandom)` does not:

```
$ hexdump -vn4 -e'4/4 "%08X" 1 "\n"' /dev/urandom | od -c
0000000    A   1   0   9   4   3   D   E                                
0000020                                                                 
0000040   \n                                                            
0000041

$ hexdump -vn4 -e '1/4 "%08X"' /dev/urandom | od -c 
0000000    0   7   E   F   4   E   1   4                                
0000010
```

## How this was tested

Cranked up an instance and it doesn't have all that whitespace
