### PR TITLE
chore(release): prepare for v0.0.17

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,11 +20,12 @@ jobs:
         run: |
           cargo login ${{ secrets.CARGO_TOKEN }}
           cargo publish -p firewood-macros
-      - name: publish firewood-triehash crate
-        continue-on-error: false
-        run: |
-          cargo login ${{ secrets.CARGO_TOKEN }}
-          cargo publish -p firewood-triehash
+      # TODO(demosdemon): detect when version is bumped and only publish then
+      # - name: publish firewood-triehash crate
+      #   continue-on-error: false
+      #   run: |
+      #     cargo login ${{ secrets.CARGO_TOKEN }}
+      #     cargo publish -p firewood-triehash
       - name: publish firewood-storage crate
         continue-on-error: false
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.17] - 2025-12-16
+
+### 🚀 Features
+
+- *(ffi)* Stub for code hashes in proof ([#1526](https://github.com/ava-labs/firewood/pull/1526))
+- Add ffi support for dump() ([#1527](https://github.com/ava-labs/firewood/pull/1527))
+- Disable automatic io-uring enablement ([#1528](https://github.com/ava-labs/firewood/pull/1528))
+- [**breaking**] Open database with directory instead of filepath ([#1532](https://github.com/ava-labs/firewood/pull/1532))
+
+### 🐛 Bug Fixes
+
+- *(io-uring)* Use sqwait to correctly synchronize kernel updates ([#1523](https://github.com/ava-labs/firewood/pull/1523))
+- *(rootstore)* Respect db truncation ([#1538](https://github.com/ava-labs/firewood/pull/1538))
+- *(ffi/iterator)* Keep view alive for iterator lifetime ([#1542](https://github.com/ava-labs/firewood/pull/1542))
+- Generated instance names have whitespace ([#1550](https://github.com/ava-labs/firewood/pull/1550))
+
+### 🚜 Refactor
+
+- [**breaking**] Remove branch_factor_256 ([#1533](https://github.com/ava-labs/firewood/pull/1533))
+- [**breaking**] Go DB config to functional options pattern ([#1534](https://github.com/ava-labs/firewood/pull/1534))
+- *(ffi/iterator)* Move tests into a separate file ([#1543](https://github.com/ava-labs/firewood/pull/1543))
+
+### 🧪 Testing
+
+- *(fwdctl)* Parallelize test suite ([#1540](https://github.com/ava-labs/firewood/pull/1540))
+- *(firewood)* Reduce thread spawn count ([#1547](https://github.com/ava-labs/firewood/pull/1547))
+
+### ⚙️ Miscellaneous Tasks
+
+- Update GitHub templates ([#1525](https://github.com/ava-labs/firewood/pull/1525))
+- *(benchmark/bootstrap)* Remove Coreth branch option ([#1530](https://github.com/ava-labs/firewood/pull/1530))
+- *(firewood)* Clean up RevisionManager fields ([#1536](https://github.com/ava-labs/firewood/pull/1536))
+- Remove reference to RELEASES.md ([#1544](https://github.com/ava-labs/firewood/pull/1544))
+- Switch to cargo-nextest ([#1541](https://github.com/ava-labs/firewood/pull/1541))
+- Aws-launch.sh: libevm-commit -> libevm-branch ([#1552](https://github.com/ava-labs/firewood/pull/1552))
+- *(nextest)* Skip slow tests in local development ([#1551](https://github.com/ava-labs/firewood/pull/1551))
+
 ## [0.0.16] - 2025-12-09
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,9 +522,9 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "b042e5d8a74ae91bb0961acd039822472ec99f8ab0948cbf6d1369588f8be586"
 dependencies = [
  "cc",
 ]
@@ -554,9 +554,9 @@ checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
 name = "console"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "fastrace"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318783b9fefe06130ab664ff1779215657586b004c0c7f3d6ece16d658936d06"
+checksum = "028c5196da5db5bc70bdd05e1b98837aab50ef4ffbd92f6dfe51644611fd10ae"
 dependencies = [
  "fastant",
  "fastrace-macro",
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "fastrace-macro"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7079009cf129d63c850dee732b58d7639d278a47ad99c607954ac94cfd57ef4"
+checksum = "b1dcf8996d31b7f8642343a4205c6e1aeda9514ee114173f70b3f841801ee8a3"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "firewood"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-benchmark"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "clap",
  "env_logger",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-ffi"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-fwdctl"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "askama",
  "assert_cmd",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-macros"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "coarsetime",
  "metrics",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-storage"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "aquamarine",
  "bitfield",
@@ -2913,9 +2913,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.25"
+version = "0.12.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eff9328d40131d43bd911d42d79eb6a47312002a4daefc9e37f17e74a7701a"
+checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
 dependencies = [
  "base64",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 # NOTE: when bumping to 0.1.0, this will be removed and each crate will have its
 # version set independently.
-version = "0.0.16"
+version = "0.0.17"
 edition = "2024"
 license-file = "LICENSE.md"
 homepage = "https://avalabs.org"
@@ -56,10 +56,12 @@ cast_possible_truncation = "allow"
 
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.0.16" }
-firewood-macros = { path = "firewood-macros", version = "0.0.16" }
-firewood-storage = { path = "storage", version = "0.0.16" }
-firewood-ffi = { path = "ffi", version = "0.0.16" }
+firewood = { path = "firewood", version = "0.0.17" }
+firewood-macros = { path = "firewood-macros", version = "0.0.17" }
+firewood-storage = { path = "storage", version = "0.0.17" }
+firewood-ffi = { path = "ffi", version = "0.0.17" }
+
+# no longer bumping with workspace
 firewood-triehash = { path = "triehash", version = "0.0.16" }
 
 # common dependencies
@@ -69,7 +71,7 @@ bytemuck_derive = "1.10.2"
 clap = { version = "4.5.53", features = ["derive"] }
 coarsetime = "0.1.36"
 env_logger = "0.11.8"
-fastrace = "0.7.14"
+fastrace = "0.7.15"
 hex = "0.4.3"
 integer-encoding = "4.1.0"
 log = "0.4.29"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,9 +20,9 @@ Before making changes, create a new branch (if not already on one):
 
 ```console
 $ git fetch
-$ git switch -c release/v0.0.17 origin/main
-branch 'release/v0.0.17' set up to track 'origin/main'.
-Switched to a new branch 'release/v0.0.17'
+$ git switch -c release/v0.0.18 origin/main
+branch 'release/v0.0.18' set up to track 'origin/main'.
+Switched to a new branch 'release/v0.0.18'
 ```
 
 If already on a new branch, ensure `HEAD` is the same as the remote's `main`.
@@ -32,7 +32,7 @@ from `git cliff` follow the repository history in the correct linear order.
 On rebase, quickly redo the generative steps with `just`:
 
 ```shell
-just release-step-update-rust-dependencies && just release-step-refresh-changelog v0.0.17
+just release-step-update-rust-dependencies && just release-step-refresh-changelog v0.0.18
 ```
 
 ## Dependency upgrades
@@ -81,7 +81,7 @@ table to define the version for all subpackages.
 
 ```toml
 [workspace.package]
-version = "0.0.17"
+version = "0.0.18"
 ```
 
 Each package inherits this version by setting `package.version.workspace = true`.
@@ -105,7 +105,7 @@ table. E.g.,:
 ```toml
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.0.17" }
+firewood = { path = "firewood", version = "0.0.18" }
 ```
 
 This allows packages within the workspace to inherit the dependency,
@@ -136,10 +136,10 @@ is correct and reflects the new package versions.
 To build the changelog, see git-cliff.org. Short version:
 
 ```sh
-just release-step-refresh-changelog v0.0.17
+just release-step-refresh-changelog v0.0.18
 ```
 
-where `v0.0.17` is the newest tag. This is a required paramter to ensure the
+where `v0.0.18` is the newest tag. This is a required paramter to ensure the
 changelog has the correct headers.
 
 ## Commit
@@ -169,11 +169,11 @@ To trigger a release, push a tag to the main branch matching the new version,
 # be sure to switch back to the main branch before tagging
 git checkout main
 git pull --prune
-git tag -s -a v0.0.17 -m 'Release v0.0.17'
-git push origin v0.0.17
+git tag -s -a v0.0.18 -m 'Release v0.0.18'
+git push origin v0.0.18
 ```
 
-for `v0.0.17` for the merged version change. The CI will automatically publish a
+for `v0.0.18` for the merged version change. The CI will automatically publish a
 draft release which consists of release notes and changes (see
 [.github/workflows/release.yaml](.github/workflows/release.yaml)).
 

--- a/triehash/Cargo.toml
+++ b/triehash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-triehash"
-version.workspace = true
+version = "0.0.16"
 authors = ["Parity Technologies <admin@parity.io>", "Ron Kuris <swcafe@gmail.com>"]
 description = "In-memory patricia trie operations"
 repository.workspace = true


### PR DESCRIPTION
## Why this should be merged

Prepare for next release.

## How this works

Bumps the version, updates the changelog, and updates the dependencies.

The `firewood-triehash` crate hasn't had any code changes since July and does not need its version bumped. Therefore, I've removed it's connection to the workspace version.

## How this was tested

CI