### PR TITLE
chore(release): prepare for v0.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.18] - 2025-12-17
+
+### 🐛 Bug Fixes
+
+- Hash mismatch when proposing on uncommitted proposal ([#1557](https://github.com/ava-labs/firewood/pull/1557))
+
+### 🧪 Testing
+
+- Guarantee that revisions work after commit ([#1558](https://github.com/ava-labs/firewood/pull/1558))
+
 ## [0.0.17] - 2025-12-16
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,9 +236,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
 dependencies = [
  "cc",
  "cmake",
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "firewood"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-benchmark"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "clap",
  "env_logger",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-ffi"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "cbindgen",
  "chrono",
@@ -1129,7 +1129,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-fwdctl"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "askama",
  "assert_cmd",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-macros"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "coarsetime",
  "metrics",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-storage"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "aquamarine",
  "bitfield",
@@ -3043,9 +3043,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "zeroize",
 ]
@@ -3178,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
@@ -3550,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.9+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "eb5238e643fc34a1d5d7e753e1532a91912d74b63b92b3ea51fde8d1b7bc79dd"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3565,18 +3565,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.4+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "fe3cea6b2aa3b910092f6abd4053ea464fab5f9c170ba5e9a6aead16ec4af2b6"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.9"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3586,18 +3586,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.5+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "4c03bee5ce3696f31250db0bbaff18bc43301ce0e8db2ed1f07cbb2acf89984c"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.0.5+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "a9cd6190959dce0994aa8970cd32ab116d1851ead27e866039acaf2524ce44fa"
 
 [[package]]
 name = "tonic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 # NOTE: when bumping to 0.1.0, this will be removed and each crate will have its
 # version set independently.
-version = "0.0.17"
+version = "0.0.18"
 edition = "2024"
 license-file = "LICENSE.md"
 homepage = "https://avalabs.org"
@@ -56,10 +56,10 @@ cast_possible_truncation = "allow"
 
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.0.17" }
-firewood-macros = { path = "firewood-macros", version = "0.0.17" }
-firewood-storage = { path = "storage", version = "0.0.17" }
-firewood-ffi = { path = "ffi", version = "0.0.17" }
+firewood = { path = "firewood", version = "0.0.18" }
+firewood-macros = { path = "firewood-macros", version = "0.0.18" }
+firewood-storage = { path = "storage", version = "0.0.18" }
+firewood-ffi = { path = "ffi", version = "0.0.18" }
 
 # no longer bumping with workspace
 firewood-triehash = { path = "triehash", version = "0.0.16" }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,9 +20,9 @@ Before making changes, create a new branch (if not already on one):
 
 ```console
 $ git fetch
-$ git switch -c release/v0.0.18 origin/main
-branch 'release/v0.0.18' set up to track 'origin/main'.
-Switched to a new branch 'release/v0.0.18'
+$ git switch -c release/v0.0.19 origin/main
+branch 'release/v0.0.19' set up to track 'origin/main'.
+Switched to a new branch 'release/v0.0.19'
 ```
 
 If already on a new branch, ensure `HEAD` is the same as the remote's `main`.
@@ -32,7 +32,7 @@ from `git cliff` follow the repository history in the correct linear order.
 On rebase, quickly redo the generative steps with `just`:
 
 ```shell
-just release-step-update-rust-dependencies && just release-step-refresh-changelog v0.0.18
+just release-step-update-rust-dependencies && just release-step-refresh-changelog v0.0.19
 ```
 
 ## Dependency upgrades
@@ -81,7 +81,7 @@ table to define the version for all subpackages.
 
 ```toml
 [workspace.package]
-version = "0.0.18"
+version = "0.0.19"
 ```
 
 Each package inherits this version by setting `package.version.workspace = true`.
@@ -105,7 +105,7 @@ table. E.g.,:
 ```toml
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.0.18" }
+firewood = { path = "firewood", version = "0.0.19" }
 ```
 
 This allows packages within the workspace to inherit the dependency,
@@ -136,10 +136,10 @@ is correct and reflects the new package versions.
 To build the changelog, see git-cliff.org. Short version:
 
 ```sh
-just release-step-refresh-changelog v0.0.18
+just release-step-refresh-changelog v0.0.19
 ```
 
-where `v0.0.18` is the newest tag. This is a required paramter to ensure the
+where `v0.0.19` is the newest tag. This is a required paramter to ensure the
 changelog has the correct headers.
 
 ## Commit
@@ -169,11 +169,11 @@ To trigger a release, push a tag to the main branch matching the new version,
 # be sure to switch back to the main branch before tagging
 git checkout main
 git pull --prune
-git tag -s -a v0.0.18 -m 'Release v0.0.18'
-git push origin v0.0.18
+git tag -s -a v0.0.19 -m 'Release v0.0.19'
+git push origin v0.0.19
 ```
 
-for `v0.0.18` for the merged version change. The CI will automatically publish a
+for `v0.0.19` for the merged version change. The CI will automatically publish a
 draft release which consists of release notes and changes (see
 [.github/workflows/release.yaml](.github/workflows/release.yaml)).
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -47,7 +47,7 @@ io-uring = { version = "0.7.11", optional = true }
 log = { version = "0.4.29", optional = true }
 rlp = { version = "0.6.1", optional = true }
 sha3 = { version = "0.10.8", optional = true }
-bumpalo = { version = "3.19.0", features = ["collections", "std"] }
+bumpalo = { version = "3.19.1", features = ["collections", "std"] }
 
 [dev-dependencies]
 cfg-if = "1.0.4"


### PR DESCRIPTION
## Why this should be merged

Prepare for next release.

## How this works

Bump deps, version, and updates changelog.

## How this was tested

CI
