### PR TITLE
build(ffi): Run the ffi tests in debug mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -254,7 +254,7 @@ jobs:
           shared-key: "debug-no-features"
       - name: Build Firewood FFI
         working-directory: ffi
-        run: cargo build --locked --release
+        run: cargo build --locked
       - name: Set up Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Why this should be merged

The FFI build step in the `ffi (ubuntu-latest)` / `ffi (macos-26)` jobs loads the `debug-no-features` rust-cache and then runs `cargo build --locked --release`. The release profile doesn't share artifacts with the debug cache, so the cache load is wasted and the build runs from scratch every time.

Two sibling FFI jobs added since this PR was first opened (`Build Firewood FFI (with ethhash)` and the no-default-features FFI job) already build in debug. This change brings the remaining job in line.

## How this works

Drop `--release` from the `Build Firewood FFI` step at `.github/workflows/ci.yaml:257`. The job continues to load the `debug-no-features` shared cache, which now actually applies.

We don't ship anything from this job — it builds the FFI lib so the Go tests can link against it. Debug is fine for that, and matches the other FFI test jobs.

## How this was tested

Cache fetch 21s, build 1m34s with `--release` against the debug cache. Pushed for CI to re-measure with the rebased branch.

## Breaking Changes

None. CI-only.