### PR TITLE
chore(ffi): add `io-uring` feature flag

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -42,6 +42,7 @@ test-case.workspace = true
 [features]
 logger = ["dep:env_logger", "firewood/logger"]
 ethhash = ["firewood/ethhash"]
+io-uring = ["firewood/io-uring", "firewood-storage/io-uring"]
 
 [build-dependencies]
 cbindgen = "0.29.2"


### PR DESCRIPTION
## Why this should be merged

Since `io-uring` was made optional, there now needs to be a way for users to enable it when building `firewood-ffi`.

## Why this should be merged

This adds the `io-uring` feature flag to the ffi crate, allows us to build with `io-uring` support when desired.

## How this was tested

`cargo build -p firewood-ffi -F io-uring`