### PR TITLE
chore: add Rodrigo as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # CODEOWNERS
 # Note: more specific rules overrule wildcard
-*        @rkuris @demosdemon
-/ffi     @rkuris @demosdemon @alarso16
-/.github @rkuris @demosdemon @aaronbuchwald
+*        @rkuris @demosdemon @RodrigoVillar
+/ffi     @rkuris @demosdemon @alarso16 @RodrigoVillar
+/.github @rkuris @demosdemon @aaronbuchwald @RodrigoVillar


### PR DESCRIPTION
## Why this should be merged

@rkuris mentioned that since I've been working on Firewood most of the time now, it makes sense to add myself as a code owner.

## How this works

Adds @RodrigoVillar to CODEOWNERS

## How this was tested

CI