### PR TITLE
fix(bootstrap): Enable bootstrap metrics listener

### DIFF
--- a/benchmark/bootstrap/aws-launch.sh
+++ b/benchmark/bootstrap/aws-launch.sh
@@ -454,7 +454,7 @@ runcmd:
   # execute bootstrapping
   - >
     sudo -u ubuntu -D /mnt/nvme/ubuntu/avalanchego --login
-    time task reexecute-cchain-range CURRENT_STATE_DIR=/mnt/nvme/ubuntu/exec-data/current-state BLOCK_DIR=/mnt/nvme/ubuntu/exec-data/blocks START_BLOCK=1 END_BLOCK=__END_BLOCK__ CONFIG=__CONFIG__ METRICS_ENABLED=false
+    time task reexecute-cchain-range CURRENT_STATE_DIR=/mnt/nvme/ubuntu/exec-data/current-state BLOCK_DIR=/mnt/nvme/ubuntu/exec-data/blocks START_BLOCK=1 END_BLOCK=__END_BLOCK__ CONFIG=__CONFIG__ METRICS_ENABLED=true METRICS_SERVER_PORT=6060
     > /var/log/bootstrap.log 2>&1
 END_HEREDOC
 )


### PR DESCRIPTION
Due to a change in avalanchego, we're no longer collecting metrics locally when running the bootstrapping tests. This was super convenient before, and adding new metrics and changing dashboards is much harder without this test grafana environment working.

This appears to be the result of several separate problems:

 1. Avalanchego doesn't enable a prometheus listener on port 6060, most likely due to the changes in https://github.com/ava-labs/avalanchego/pull/4418.
 2. Firewood is no longer opened with a prometheus listener on port 3000.
 3. Firewood does not enable the metrics server when opening the database, unless expensive metrics are enabled.

I think we don't want firewood listening directly, so I'm not fixing #2. However, prometheus should still attempt to listen on port 3000 for the other benchmark tests, so I'm leaving the prometheus listener running on that port for launched instances.

Issue #3 is a problem in avalanchego. We probably should not consider all metrics expensive though, so we should initialize the metrics server regardless of this setting. This is a separate avalanchego bug that should be fixed as part of https://github.com/ava-labs/firewood/issues/1524

## Why this should be merged

## How this works

## How this was tested
