### PR TITLE
fix(ci): update golang-ci patch

### DIFF
--- a/.github/.golangci.yaml.patch
+++ b/.github/.golangci.yaml.patch
@@ -1,5 +1,5 @@
---- .github/.golangci.yaml	2025-11-26 17:52:36.814736814 +0000
-+++ ffi/.golangci.yaml	2025-11-26 17:52:31.624079933 +0000
+--- .github/.golangci.yaml	2025-12-29 01:55:58
++++ ffi/.golangci.yaml	2025-12-29 00:09:32
 @@ -40,7 +40,7 @@
          - standard
          - default
@@ -9,7 +9,7 @@
          - alias
          - dot
        custom-order: true
-@@ -93,8 +93,6 @@
+@@ -93,12 +93,10 @@
        rules:
          packages:
            deny:
@@ -17,16 +17,27 @@
 -              desc: github.com/ava-labs/avalanchego/utils/linked should be used instead.
              - pkg: github.com/golang/mock/gomock
                desc: go.uber.org/mock/gomock should be used instead.
-             - pkg: github.com/stretchr/testify/assert
-@@ -109,29 +107,10 @@
+-            # Note: testify/assert is checked separately by test_warn_testify_assert
+-            # in lint.sh to produce warnings instead of errors.
++            - pkg: github.com/stretchr/testify/assert
++              desc: github.com/stretchr/testify/require should be used instead.
+             - pkg: io/ioutil
+               desc: io/ioutil is deprecated. Use package io or os instead.
+     errorlint:
+@@ -109,33 +107,10 @@
      forbidigo:
        # Forbid the following identifiers (list of regexp).
        forbid:
+-        - pattern: assert\.Error$(# ErrorIs should be used instead)?
+-        - pattern: assert\.ErrorContains$(# ErrorIs should be used instead)?
+-        - pattern: assert\.EqualValues$(# Equal should be used instead)?
+-        - pattern: assert\.NotEqualValues$(# NotEqual should be used instead)?
 -        - pattern: require\.Error$(# ErrorIs should be used instead)?
 -        - pattern: require\.ErrorContains$(# ErrorIs should be used instead)?
 -        - pattern: require\.EqualValues$(# Equal should be used instead)?
 -        - pattern: require\.NotEqualValues$(# NotEqual should be used instead)?
-         - pattern: ^(t|b|tb|f)\.(Fatal|Fatalf|Error|Errorf)$(# the require library should be used instead)?
+-        - pattern: ^(t|b|tb|f)\.(Fatal|Fatalf|Error|Errorf)$(# the assert and require libraries should be used instead)?
++        - pattern: ^(t|b|tb|f)\.(Fatal|Fatalf|Error|Errorf)$(# the require library should be used instead)?
          - pattern: ^sort\.(Slice|Strings)$(# the slices package should be used instead)?
        # Exclude godoc examples from forbidigo checks.
        exclude-godoc-examples: false
@@ -48,7 +59,7 @@
      revive:
        rules:
          # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
-@@ -195,17 +174,6 @@
+@@ -199,17 +174,6 @@
          # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
          - name: useless-break
            disabled: false


### PR DESCRIPTION
## Why this should be merged
The `expected-golangci-yaml-diff` CI workflow is failing because AvalancheGo updated their `.golangci.yml` file, adding new `assert.*` forbidigo patterns and a comment about testify/assert. The existing patch no longer applies cleanly (hunk #3 fails at line 107).

## How this works
Regenerates `.github/.golangci.yaml.patch` against the current upstream AvalancheGo `.golangci.yml` so all hunks apply cleanly.

## How this was tested
Ran `.github/scripts/verify_golangci_yaml_changes.sh` check locally - patch applies successfully and `ffi/.golangci.yaml` matches the expected patched output.
