### PR TITLE
fix(benchmark/bootstrap): update script to use new task

### DIFF
--- a/benchmark/bootstrap/aws-launch.sh
+++ b/benchmark/bootstrap/aws-launch.sh
@@ -481,7 +481,7 @@ runcmd:
   # execute bootstrapping
   - >
     sudo -u ubuntu -D /mnt/nvme/ubuntu/avalanchego --login
-    METRICS_SERVER_ENABLED=__METRICS_SERVER__ CURRENT_STATE_DIR=/mnt/nvme/ubuntu/exec-data/current-state BLOCK_DIR=/mnt/nvme/ubuntu/exec-data/blocks START_BLOCK=1 END_BLOCK=__END_BLOCK__ CONFIG=__CONFIG__ time task test-cchain-reexecution
+    time METRICS_SERVER_ENABLED=__METRICS_SERVER__ CURRENT_STATE_DIR=/mnt/nvme/ubuntu/exec-data/current-state BLOCK_DIR=/mnt/nvme/ubuntu/exec-data/blocks START_BLOCK=1 END_BLOCK=__END_BLOCK__ CONFIG=__CONFIG__ task test-cchain-reexecution
     > /var/log/bootstrap.log 2>&1
 END_HEREDOC
 )


### PR DESCRIPTION
## Why this should be merged

With https://github.com/ava-labs/avalanchego/pull/4761, invocation of the reexecution test underwent a major refactor. Running the current bootstrap script against the latest version of AvalancheGo results in an error.

## How this works

Updates bootstrapping script to use the new invocation of the reexecution test.

## How this was tested

Ran `./aws-launch.sh --firewood-branch main --avalanchego-branch master --libevm-branch b8e76562a300 --nblocks 1m` and observed a successful reexecution test.