### PR TITLE
chore: pr feedback

### DIFF
--- a/ffi/src/proofs/change.rs
+++ b/ffi/src/proofs/change.rs
@@ -15,6 +15,13 @@ use crate::{
     NextKeyRangeResult, OwnedBytes, ValueResult, VoidResult,
 };
 
+#[cfg(feature = "ethhash")]
+const EMPTY_CODE_HASH: [u8; 32] = [
+    // "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c, 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0,
+    0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b, 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70,
+];
+
 /// Arguments for creating a change proof.
 #[derive(Debug)]
 #[repr(C)]
@@ -90,52 +97,42 @@ pub struct NextKeyRange {
 }
 
 #[derive(Debug)]
-#[cfg_attr(not(feature = "ethhash"), allow(dead_code))]
+#[non_exhaustive]
 pub struct CodeIteratorHandle<'a> {
-    key_values: &'a KeyValueBox,
-    i: usize,
+    #[cfg(feature = "ethhash")]
+    inner: std::slice::Iter<'a, KeyValuePair>,
+    // uninhabitable fields make the struct impossible to construct when the feature is disabled
+    #[cfg(not(feature = "ethhash"))]
+    void: std::convert::Infallible,
+    #[cfg(not(feature = "ethhash"))]
+    marker: std::marker::PhantomData<&'a ()>,
 }
 
-type KeyValueBox = [(Box<[u8]>, Box<[u8]>)];
+type KeyValuePair = (Box<[u8]>, Box<[u8]>);
 
 impl Iterator for CodeIteratorHandle<'_> {
     type Item = Result<HashKey, api::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         #[cfg(not(feature = "ethhash"))]
-        {
-            None
-        }
+        match self.void {}
 
         #[cfg(feature = "ethhash")]
-        {
-            const EMPTY_CODE_HASH: [u8; 32] = [
-                // "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
-                0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c, 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7,
-                0x03, 0xc0, 0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b, 0x7b, 0xfa, 0xd8, 0x04,
-                0x5d, 0x85, 0xa4, 0x70,
-            ];
-            while self.i < self.key_values.len() {
-                let (key, value) = &self.key_values.get(self.i)?;
-                #[expect(clippy::arithmetic_side_effects)]
-                {
-                    self.i += 1;
-                }
-                if key.len() != 32 {
-                    continue;
-                }
-
-                let Ok(code_hash_slice) = Rlp::new(value).at(3).and_then(|r| r.data()) else {
-                    return Some(Err(api::Error::ProofError(ProofError::InvalidValueFormat)));
-                };
-                let code_hash: HashKey = TrieHash::try_from(code_hash_slice).ok()?.into();
-                if code_hash == TrieHash::from(EMPTY_CODE_HASH).into() {
-                    continue;
-                }
-                return Some(Ok(code_hash));
+        self.inner.find_map(|(key, value)| {
+            if key.len() != 32 {
+                return None;
             }
-            None
-        }
+
+            let Ok(code_hash_slice) = Rlp::new(value).at(3).and_then(|r| r.data()) else {
+                return Some(Err(api::Error::ProofError(ProofError::InvalidValueFormat)));
+            };
+            let code_hash: HashKey = TrieHash::try_from(code_hash_slice).ok()?.into();
+            if code_hash == TrieHash::from(EMPTY_CODE_HASH).into() {
+                return None;
+            }
+
+            Some(Ok(code_hash))
+        })
     }
 }
 
@@ -159,7 +156,7 @@ impl<'a> CodeIteratorHandle<'a> {
     ///   is not enabled.
     #[cfg_attr(feature = "ethhash", allow(clippy::missing_const_for_fn))]
     #[cfg_attr(not(feature = "ethhash"), allow(unused_variables))]
-    pub fn new(key_values: &'a KeyValueBox) -> Result<Self, api::Error> {
+    pub fn new(key_values: &'a [KeyValuePair]) -> Result<Self, api::Error> {
         #[cfg(not(feature = "ethhash"))]
         {
             Err(api::Error::FeatureNotSupported(
@@ -169,7 +166,9 @@ impl<'a> CodeIteratorHandle<'a> {
 
         #[cfg(feature = "ethhash")]
         {
-            Ok(CodeIteratorHandle { key_values, i: 0 })
+            Ok(CodeIteratorHandle {
+                inner: key_values.iter(),
+            })
         }
     }
 }


### PR DESCRIPTION
Relatively minor feedback for #1597, but it was too much to put in a comment so I created a commit for it.

- Manually indexing and incrementing the counter is an anti-pattern and wrapping the built-in Iter is preferred
- The void field is [uninhabitable](https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types) (not even "zero-sized") which prevents the compiler from even emitting the struct during compilation (and all associated code as well).