### PR TITLE
feat: Export RevisionNotFound error

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -315,7 +315,7 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	val, err := getValueFromValueResult(C.fwd_get_latest(db.handle, newBorrowedBytes(key, &pinner)))
 	// The revision won't be found if the database is empty.
 	// This is valid, but should be treated as a non-existent key
-	if errors.Is(err, errRevisionNotFound) {
+	if errors.Is(err, ErrRevisionNotFound) {
 		return nil, nil
 	}
 
@@ -394,7 +394,7 @@ func (db *Database) LatestRevision() (*Revision, error) {
 		return nil, err
 	}
 	if root == EmptyRoot {
-		return nil, errRevisionNotFound
+		return nil, ErrRevisionNotFound
 	}
 	return db.Revision(root)
 }

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -973,7 +973,7 @@ func TestInvalidRevision(t *testing.T) {
 	// Create a fake revision with an valid root.
 	validRoot := Hash([]byte("counting 32 bytes to make a hash"))
 	_, err := db.Revision(validRoot)
-	r.ErrorIs(err, errRevisionNotFound, "Revision(valid root)")
+	r.ErrorIs(err, ErrRevisionNotFound, "Revision(valid root)")
 }
 
 // Tests that edge case `Get` calls are handled correctly.

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -291,7 +291,7 @@ func getValueFromValueResult(result C.ValueResult) ([]byte, error) {
 	case C.ValueResult_RevisionNotFound:
 		// NOTE: the result value contains the provided root hash, we could use
 		// it in the error message if needed.
-		return nil, errRevisionNotFound
+		return nil, ErrRevisionNotFound
 	case C.ValueResult_None:
 		return nil, nil
 	case C.ValueResult_Some:

--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -512,7 +512,7 @@ func getRangeProofFromRangeProofResult(result C.RangeProofResult) (*RangeProof, 
 	case C.RangeProofResult_RevisionNotFound:
 		// NOTE: the result value contains the provided root hash, we could use
 		// it in the error message if needed.
-		return nil, errRevisionNotFound
+		return nil, ErrRevisionNotFound
 	case C.RangeProofResult_EmptyTrie:
 		return nil, errEmptyTrie
 	case C.RangeProofResult_Ok:

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -95,7 +95,7 @@ func TestRangeProofEmptyDB(t *testing.T) {
 	db := newTestDatabase(t)
 
 	proof, err := db.RangeProof(EmptyRoot, nothing(), nothing(), rangeProofLenUnbounded)
-	r.ErrorIs(err, errRevisionNotFound)
+	r.ErrorIs(err, ErrRevisionNotFound)
 	r.Nil(proof)
 }
 
@@ -112,7 +112,7 @@ func TestRangeProofNonExistentRoot(t *testing.T) {
 	root[0] ^= 0xFF
 
 	proof, err := db.RangeProof(root, nothing(), nothing(), rangeProofLenUnbounded)
-	r.ErrorIs(err, errRevisionNotFound)
+	r.ErrorIs(err, ErrRevisionNotFound)
 	r.Nil(proof)
 }
 

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	ErrDroppedRevision  = errors.New("revision already dropped")
-	errRevisionNotFound = errors.New("revision not found")
+	ErrRevisionNotFound = errors.New("revision not found")
 )
 
 // Revision is an immutable view over the state at a specific root hash.
@@ -138,7 +138,7 @@ func getRevisionFromResult(result C.RevisionResult, wg *sync.WaitGroup) (*Revisi
 	case C.RevisionResult_NullHandlePointer:
 		return nil, errDBClosed
 	case C.RevisionResult_RevisionNotFound:
-		return nil, errRevisionNotFound
+		return nil, ErrRevisionNotFound
 	case C.RevisionResult_Ok:
 		body := (*C.RevisionResult_Ok_Body)(unsafe.Pointer(&result.anon0))
 		hashKey := *(*Hash)(unsafe.Pointer(&body.root_hash._0))


### PR DESCRIPTION
## Why this should be merged

In xsync, the "error we couldn't form a range proof" and  the "error we couldn't find the state root you wanted", since one is logged as an error, and the other is dropped. This distinction seems helpful for other contexts as well.

this isn't strictly necessary, but will be used to prevent DoS warning logs

## How this works

Exports an error

## How this was tested

No need
