### PR TITLE
perf(ffi): elide panic handling if not needed

### DIFF
--- a/ffi/src/value/results.rs
+++ b/ffi/src/value/results.rs
@@ -518,6 +518,7 @@ pub(crate) trait NullHandleResult: CResult {
 pub(crate) trait CResult: Sized {
     fn from_err(err: impl ToString) -> Self;
 
+    #[cfg(panic = "unwind")]
     fn from_panic(panic: Box<dyn std::any::Any + Send>) -> Self
     where
         Self: Sized,
@@ -579,6 +580,7 @@ impl_cresult!(
     KeyValueResult,
 );
 
+#[cfg(panic = "unwind")]
 enum Panic {
     Static(&'static str),
     Formatted(String),
@@ -589,6 +591,7 @@ enum Panic {
     // https://doc.rust-lang.org/stable/std/panic/fn.set_hook.html
 }
 
+#[cfg(panic = "unwind")]
 impl From<Box<dyn std::any::Any + Send>> for Panic {
     fn from(panic: Box<dyn std::any::Any + Send>) -> Self {
         macro_rules! downcast {
@@ -609,6 +612,7 @@ impl From<Box<dyn std::any::Any + Send>> for Panic {
     }
 }
 
+#[cfg(panic = "unwind")]
 impl fmt::Display for Panic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
When `cfg(not(panic = "unwind"))`, the panic handler does not unwind the stack (usually by aborting the process); which is true when firewood is built with the `maxperf` profile (`firewood-go-ethhash` does this for release). This makes the overhead of using `catch_unwind` unnecessary in this environment. 

This is inspired by the stdlib mutex which employs some lock poisoning logic if code panics while mutex is acquired. Because of the implication of ``cfg(not(panic = "unwind"))``, it forces the compiler to elide all of the poisoning code by using an uninhabitable type: <https://github.com/rust-lang/rust/blob/137716908d561bfcf0341701ec13a28326926c82/library/std/src/sync/poison.rs#L199-L200>

Also removed are all of the `unsafe` keywords from the `extern "C"` functions, as they are unnecessary and misleading. The `extern "C"` ABI itself does not imply any unsafety; rather, the unsafety comes from the operations performed within the function body. Since these functions do not perform any inherently unsafe operations themselves, they should not be marked as `unsafe`.
