### PR TITLE
refactor: simplify `into_committed()`

### DIFF
--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -37,11 +37,8 @@ fn into_committed(
     merkle: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>>,
     parent: &NodeStore<Committed, MemStore>,
 ) -> Merkle<NodeStore<Committed, MemStore>> {
-    let ns = merkle.into_inner();
-    ns.flush_freelist().unwrap();
-    ns.flush_header().unwrap();
-    let ns = ns.as_committed(parent);
-    ns.flush_nodes().unwrap();
+    let mut ns = merkle.into_inner().as_committed(parent);
+    ns.persist().unwrap();
     ns.into()
 }
 


### PR DESCRIPTION
## Why this should be merged

We should strive to use production code as much as possible. We currently have code implemented on `NodeStore` used solely for testing purposes that we can get rid of if we instead call `persist()`.

## How this works

`into_committed()` now uses `persist()`, which handles persistence for us.

## How this was tested

CI