### PR TITLE
refactor(checker): extract `check_area_aligned()` from `NodeStore`

### DIFF
--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -49,6 +49,7 @@ fn is_valid_key(key: &Path) -> bool {
     key.0.len().is_multiple_of(2)
 }
 
+#[expect(clippy::result_large_err)]
 const fn check_area_aligned(
     address: LinearAddress,
     parent: StoredAreaParent,
@@ -165,7 +166,6 @@ struct SubTrieMetadata {
 }
 
 /// [`NodeStore`] checker
-#[expect(clippy::result_large_err)]
 impl<T, S: ReadableStorage> NodeStore<T, S>
 where
     NodeStore<T, S>: HashedNodeReader,


### PR DESCRIPTION
## Why this should be merged

`check_area_aligned()` is defined on `NodeStore`, but doesn't use any of `NodeStore`'s fields or methods.

## How this works

Extracts `check_area_aligned()` to be it's own standalone function.

## How this was tested

CI
