### PR TITLE
fix(flake): grab version from correct location

### DIFF
--- a/.github/workflows/ffi-nix.yaml
+++ b/.github/workflows/ffi-nix.yaml
@@ -3,6 +3,12 @@ name: ffi-nix
 on:
   push:
     branches: [main]
+  pull_request:
+    paths:
+      - ffi/flake.nix
+      - ffi/flake.lock
+      - ffi/go.mod
+      - ffi/go.sum
 
 jobs:
   ffi-nix:

--- a/ffi/flake.nix
+++ b/ffi/flake.nix
@@ -32,7 +32,6 @@
 
       # Extract crate info from Cargo.toml files
       ffiCargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-      workspaceCargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
 
       src = lib.cleanSourceWith {
         src = craneLib.path ./..;
@@ -52,7 +51,7 @@
 
         # Build only the firewood-ffi crate
         pname = ffiCargoToml.package.name;
-        version = workspaceCargoToml.workspace.package.version;
+        version = ffiCargoToml.package.version;
 
         nativeBuildInputs = with pkgs; [
           pkg-config


### PR DESCRIPTION
## Why this should be merged

#1627 broke the flake nix by removing a field from the cargo.toml that is parsed.

## How this works

This corrects the flake to grab the version from the correct location.

## How this was tested

Added a PR trigger for the flake nix when touching the flake file or go modules.