### PR TITLE
fix(storage): handle possible short writes

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -11,6 +11,7 @@ doc-valid-idents = [
 
 disallowed-methods = [
   { path = "rand::rng", replacement = "firewood_storage::SeededRng::from_env_or_random", reason = "use a prng with a user-defined seed instead", allow-invalid = true },
+  { path = "std::os::unix::fs::FileExt::write_at", replacement = "write_all_at", reason = "use write_all_at instead of write_at to handle short writes ensuring the entire buffer is written", allow-invalid = true },
 ]
 
 disallowed-types = [

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -1284,7 +1284,7 @@ mod test {
         assert_eq!(&version, b"firewood-v1\0\0\0\0\0");
 
         // overwrite the magic string to simulate an older version
-        file.write_at(b"firewood 0.0.18\0", 0).unwrap();
+        file.write_all_at(b"firewood 0.0.18\0", 0).unwrap();
         drop(file);
 
         let testdb = testdb.reopen();

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -167,7 +167,8 @@ impl ReadableStorage for FileBacked {
 impl WritableStorage for FileBacked {
     fn write(&self, offset: u64, object: &[u8]) -> Result<usize, FileIoError> {
         self.fd
-            .write_at(object, offset)
+            .write_all_at(object, offset)
+            .map(|()| object.len())
             .map_err(|e| self.file_io_error(e, offset, Some("write".to_string())))
     }
 


### PR DESCRIPTION
As mentioned in #1618 and #1634, `write_at` does not guarantee the entire object was written. [`write_all_at`](https://doc.rust-lang.org/1.92.0/src/std/os/unix/fs.rs.html#330-345) does handle the short write. The [io-uring](https://github.com/ava-labs/firewood/blob/3857353c96ceb61a5946314f3ec8bd118090a82d/storage/src/linear/io_uring.rs#L336-L356) code already handled a short write and no changes were needed and [`copy_from_slice`](https://github.com/ava-labs/firewood/blob/3857353c96ceb61a5946314f3ec8bd118090a82d/storage/src/linear/memory.rs#L54) cannot do a short copy; thus, only changes to the plain `write` method for `FileBacked` was needed.

The clippy.toml changes will provide hints when using the incorrect method, example:

```raw
warning: use of a disallowed method `std::os::unix::fs::FileExt::write_at`
    --> firewood/src/db.rs:1287:14
     |
1287 |         file.write_at(b"firewood 0.0.18\0", 0).unwrap();
     |              ^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#disallowed_methods
     = note: `#[warn(clippy::disallowed_methods)]` on by default
help: use write_all_at instead of write_at to handle short writes ensuring the entire buffer is written
     |
1287 |         file.write_all_at(b"firewood 0.0.18\0", 0).unwrap();
     |                     ++++
```

Closes: #1634
