### PR TITLE
ci: build and lint with --all-features

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,8 @@ jobs:
             os: macos-latest
           - profile-key: debug-ethhash-logger
             profile-args: "--features ethhash,logger"
+          - profile-key: debug-all-features
+            profile-args: "--all-features"
           - profile-key: maxperf-ethhash-logger
             profile-args: "--profile maxperf --features ethhash,logger"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
@@ -89,6 +91,8 @@ jobs:
             os: macos-latest
           - profile-key: debug-ethhash-logger
             profile-args: "--features ethhash,logger"
+          - profile-key: debug-all-features
+            profile-args: "--all-features"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
@@ -121,6 +125,8 @@ jobs:
             os: macos-latest
           - profile-key: debug-ethhash-logger
             profile-args: "--features ethhash,logger"
+          - profile-key: debug-all-features
+            profile-args: "--all-features"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
@@ -150,6 +156,8 @@ jobs:
             os: macos-latest
           - profile-key: debug-ethhash-logger
             profile-args: "--features ethhash,logger"
+          - profile-key: debug-all-features
+            profile-args: "--all-features"
           - profile-key: maxperf-ethhash-logger
             profile-args: "--cargo-profile maxperf --features ethhash,logger"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
@@ -178,6 +186,8 @@ jobs:
             os: macos-latest
           - profile-key: debug-ethhash-logger
             profile-args: "--features ethhash,logger"
+          - profile-key: debug-all-features
+            profile-args: "--all-features"
           - profile-key: maxperf-ethhash-logger
             profile-args: "--profile maxperf --features ethhash,logger"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}


### PR DESCRIPTION
This adds a step to the CI matrix to build and lint the project with `--all-features` enabled. This solves the original problem of the CI not running with `replay` and `io-uring` features enabled. This will also catch any future optional features and also ensure that all features comply with the additive property of Rust features.

Closes: #1633
