### PR TITLE
chore: Add Bernard as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
 # CODEOWNERS
 # Note: more specific rules overrule wildcard
-*        @rkuris @demosdemon @RodrigoVillar
-/ffi     @rkuris @demosdemon @alarso16 @RodrigoVillar
-/.github @rkuris @demosdemon @aaronbuchwald @RodrigoVillar
+*        @rkuris @demosdemon @RodrigoVillar @bernard-avalabs
+/ffi     @rkuris @demosdemon @alarso16 @RodrigoVillar @bernard-avalabs


### PR DESCRIPTION
## Why this should be merged

Adding myself to codeowners to help with code review. @rkuris also suggested that the "/.github" be removed.

## How this works

Added @bernard-avalabs to "*" and "/ffi" and removed "/.github"

## How this was tested

CI