### PR TITLE
docs: Update comments on Arc::try_unwrap safety

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -271,11 +271,8 @@ impl RevisionManager {
 
             // We reap the revision's nodes only if `RootStore` does not exist.
             if self.root_store.is_none() {
-                // This `try_unwrap` is safe because nobody else will call `try_unwrap` on this Arc
-                // in a different thread, so we don't have to worry about the race condition where
-                // the Arc we get back is not usable as indicated in the docs for `try_unwrap`.
-                // This guarantee is there because we have a `&mut self` reference to the manager, so
-                // the compiler guarantees we are the only one using this manager.
+                // The warning in the docs for `Arc::try_unwrap` does not apply here
+                // because `original` is retained and not immediately dropped.
                 match Arc::try_unwrap(oldest) {
                     Ok(oldest) => oldest.reap_deleted(&mut header)?,
                     Err(original) => {


### PR DESCRIPTION
The previous comment did not make sense with regards to the warning in [`try_unwrap`](https://doc.rust-lang.org/stable/std/sync/struct.Arc.html#method.try_unwrap).

The warning in the docs for `try_unwrap` does not apply to this because the `original` value is retained in the `Err` case.

That warning exists to discourage someone from doing `Arc::try_unwrap(arc).ok()` which has the same logical output as `Arc::into_unique(arc)` but is not functionally equivalent because the former imposes a risk that the arc becomes unique in between the time `try_unwrap` returns and the arc is actually dropped. 

Because the `original` value is always retained, that risk does not exist here.
