### PR TITLE
chore: add deferred persistence benchmark

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -24,8 +24,10 @@ jobs:
         run: cargo fetch --locked --verbose
       - name: Build
         run: cargo build --frozen --profile maxperf --features ethhash,logger --workspace --benches
-      - name: Run firewood crate benchmarks
+      - name: Run firewood crate hashop benchmark
         run: cargo bench --frozen --profile maxperf --features ethhash,logger -p firewood --bench hashops -- --noplot
+      - name: Run firewood crate defer_persist benchmark
+        run: cargo bench --frozen --profile maxperf --features ethhash,logger -p firewood --bench defer_persist -- --noplot
       - name: Run storage crate benchmarks
         run: cargo bench --frozen --profile maxperf --features ethhash,logger -p firewood-storage --bench serializer -- --noplot
       - name: Upload benchmark results

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -77,6 +77,10 @@ sha3 = "0.10.8"
 name = "hashops"
 harness = false
 
+[[bench]]
+name = "defer_persist"
+harness = false
+
 [lints]
 workspace = true
 

--- a/firewood/benches/defer_persist.rs
+++ b/firewood/benches/defer_persist.rs
@@ -1,0 +1,65 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use firewood::db::{BatchOp, Db, DbConfig};
+use firewood::v2::api::{Db as _, Proposal as _};
+use firewood_storage::NodeHashAlgorithm;
+use rand::{Rng, distr::Alphanumeric};
+use std::iter::repeat_with;
+use std::num::NonZeroU64;
+
+#[expect(clippy::unwrap_used)]
+fn bench_deferred_persistence<const N: usize, const COMMIT_COUNT: u64>(criterion: &mut Criterion) {
+    const KEY_LEN: usize = 4;
+    let rng = &firewood_storage::SeededRng::from_option(Some(1234));
+    let commit_count = NonZeroU64::new(COMMIT_COUNT).unwrap();
+
+    criterion
+        .benchmark_group("deferred_persistence")
+        .sample_size(20)
+        .bench_function(format!("commit_count_{COMMIT_COUNT}"), |b| {
+            b.iter_batched(
+                || {
+                    let batch_ops: Vec<_> =
+                        repeat_with(|| rng.sample_iter(&Alphanumeric).take(KEY_LEN).collect())
+                            .map(|key: Vec<_>| BatchOp::Put {
+                                key,
+                                value: vec![b'v'],
+                            })
+                            .take(N)
+                            .collect();
+                    batch_ops
+                },
+                |batch_ops| {
+                    let tmpdir = tempfile::tempdir().unwrap();
+                    let dbcfg = DbConfig::builder()
+                        .node_hash_algorithm(NodeHashAlgorithm::compile_option())
+                        .deferred_persistence_commit_count(commit_count)
+                        .build();
+                    let db = Db::new(tmpdir, dbcfg).unwrap();
+
+                    for op in batch_ops {
+                        let proposal = db.propose(vec![op]).unwrap();
+                        proposal.commit().unwrap();
+                    }
+
+                    db.close().unwrap();
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+}
+
+// Commit count values span powers of 10 (1, 10, 100, 1_000) to show the
+// performance curve from persisting every commit to persisting just once.
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = bench_deferred_persistence::<1_000, 1>,
+              bench_deferred_persistence::<1_000, 10>,
+              bench_deferred_persistence::<1_000, 100>,
+              bench_deferred_persistence::<1_000, 1_000>
+}
+
+criterion_main!(benches);


### PR DESCRIPTION
## Why this should be merged

Having benchmarks to test the performance of deferred persistence across different commit counts is useful for observability.

## How this works

Adds a benchmark `bench_deferred_persistence()` to test deferred persistence with commit counts `1` and `100`. This benchmark is run daily along with our other benchmarks.

## How this was tested

CI