### PR TITLE
chore: add RootStore metrics

### DIFF
--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -56,7 +56,8 @@ use std::{
 };
 
 use firewood_storage::{
-    Committed, FileBacked, FileIoError, HashedNodeReader, NodeStore, NodeStoreHeader,
+    Committed, FileBacked, FileIoError, HashedNodeReader, LinearAddress, NodeStore,
+    NodeStoreHeader, TrieHash,
 };
 use parking_lot::{Condvar, Mutex, MutexGuard};
 
@@ -396,7 +397,7 @@ impl PersistLoop {
     ) -> Result<(), PersistError> {
         let result = self
             .persist_to_disk(revision)
-            .and_then(|()| self.save_to_root_store(revision));
+            .and_then(|()| self.maybe_save_to_root_store(revision));
         self.release_permits(commits_since_persist);
         result
     }
@@ -426,16 +427,25 @@ impl PersistLoop {
     }
 
     /// Saves the revision's root address to `RootStore` if configured.
-    fn save_to_root_store(&self, revision: &CommittedRevision) -> Result<(), PersistError> {
+    fn maybe_save_to_root_store(&self, revision: &CommittedRevision) -> Result<(), PersistError> {
         if let Some(ref store) = self.shared.root_store
             && let (Some(hash), Some(addr)) = (revision.root_hash(), revision.root_address())
         {
-            store.add_root(&hash, &addr).map_err(|e| {
-                error!("Failed to persist revision address to RootStore: {e}");
-                PersistError::RootStore(e.into())
-            })?;
+            save_to_root_store(store, &hash, &addr)?;
         }
 
         Ok(())
     }
+}
+
+#[crate::metrics("persist.root_store", "persist revision address to root store")]
+fn save_to_root_store(
+    store: &RootStore,
+    hash: &TrieHash,
+    addr: &LinearAddress,
+) -> Result<(), PersistError> {
+    store.add_root(hash, addr).map_err(|e| {
+        error!("Failed to persist revision address to RootStore: {e}");
+        PersistError::RootStore(e.into())
+    })
 }


### PR DESCRIPTION
## Why this should be merged

With the time-to-persist now decoupled from the time-to-commit, it would be great if we could capture data on how long it takes to persist + other similar processes.

## How this works

- Adds timer to track how long it takes to persist
- Adds timer to track how long it takes to persisting root addresses to `RootStore`
- Adds counter to track how many times we block on commit

## How this was tested

CI
