### PR TITLE
chore: trace->info logging

### DIFF
--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -181,7 +181,7 @@ pub use firewood_storage::logger;
 /// In the event of unexpected behavior in testing, disable this first before
 /// looking elsewhere.
 fn init_logger() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace"))
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
         .is_test(true)
         .try_init()
         .ok();


### PR DESCRIPTION
## Why this should be merged

During testing, trace level logging is excessive. Not only is it slow, but it generates tons and tons of information when a test fails.

## How this works

## How this was tested

While debugging a failing test, it significantly reduced noisy output.