### PR TITLE
fix(ffi): prevent potential use-after-free in Go Iterator

### DIFF
--- a/ffi/iterator.go
+++ b/ffi/iterator.go
@@ -184,9 +184,11 @@ func (it *Iterator) Drop() error {
 	if it.handle != nil {
 		// Always free the iterator even if releasing the current KV/batch failed.
 		// The iterator holds a NodeStore ref that must be dropped.
-		return errors.Join(
+		err = errors.Join(
 			err,
 			getErrorFromVoidResult(C.fwd_free_iterator(it.handle)))
+		// prevent use-after-free/double-free
+		it.handle = nil
 	}
 	return err
 }

--- a/ffi/iterator_test.go
+++ b/ffi/iterator_test.go
@@ -255,6 +255,9 @@ func TestIterDone(t *testing.T) {
 
 	// get a new iterator
 	it2, err := rev.Iter(nil)
+	t.Cleanup(func() {
+		r.NoError(it2.Drop())
+	})
 	r.NoError(err)
 	// set batch size to 5
 	it2.SetBatchSize(5)
@@ -263,6 +266,7 @@ func TestIterDone(t *testing.T) {
 	// calling next again should be safe and return false
 	r.False(it.Next())
 	r.NoError(it.Err())
+	r.NoError(it2.Drop())
 }
 
 // Tests the iterator's behavior after revision is dropped, should safely


### PR DESCRIPTION
## Why this should be merged

Fixes: #1687

## How this works

This sets the handle to nil after calling free.

## How this was tested

Added a test that calls `Drop` twice on an iterator which otherwise caused a memory access violation.
