### PR TITLE
refactor: stop keeping around the last committed revision

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -520,8 +520,9 @@ impl RevisionManager {
     /// This method shuts down the background persistence worker and persists
     /// the latest committed revision.
     pub fn close(self) -> Result<(), RevisionManagerError> {
+        let current_revision = self.current_revision();
         self.persist_worker
-            .close()
+            .close(current_revision)
             .map_err(RevisionManagerError::PersistError)
     }
 }


### PR DESCRIPTION
## Why this should be merged

Builds on the readability improvements of #1685 by no longer having the `PersistLoop` track what the last committed revision was. By never tracking what the latest committed revision, the `PersistLoop` can no longer be the source of contention for trying to gain ownership of a revision during reaping.

## How this works

Moves the `persist_on_shutdown` field from the `PersistLoop` to `SharedState`. This field is populated on `close()` and is read by the `PersistLoop` when the channel closes. 

Here are some alternative designs I considered:
- Having the `PersistWorker` persist the last committed revision - this would involve the worker having a reference to the `header`. I would prefer for the `PersisWorker` to be the only thing persisting.
- Adding a `Shutdown` message type - from reading online, dropping the channel is strongly preferred (and more idiomatic) versus having a shutdown signal via a `Shutdown` message. 

## How this was tested

CI