### PR TITLE
refactor: close consumes itself

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -14,7 +14,7 @@ use std::num::{NonZero, NonZeroU64};
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 
-use firewood_storage::logger::{error, trace, warn};
+use firewood_storage::logger::{trace, warn};
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use typed_builder::TypedBuilder;
 
@@ -517,22 +517,12 @@ impl RevisionManager {
 
     /// Closes the revision manager gracefully.
     ///
-    /// This method shuts down the background persistence worker. If not called
-    /// explicitly, `Drop` will attempt a best-effort shutdown but cannot report
-    /// errors.
-    pub fn close(&mut self) -> Result<(), RevisionManagerError> {
+    /// This method shuts down the background persistence worker and persists
+    /// the latest committed revision.
+    pub fn close(self) -> Result<(), RevisionManagerError> {
         self.persist_worker
             .close()
             .map_err(RevisionManagerError::PersistError)
-    }
-}
-
-impl Drop for RevisionManager {
-    fn drop(&mut self) {
-        // Best-effort graceful shutdown - users are suggested to call `close()` instead.
-        if let Err(e) = self.close() {
-            error!("Error during RevisionManager shutdown: {e}");
-        }
     }
 }
 

--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -186,7 +186,7 @@ impl PersistWorker {
     ///
     /// This method is idempotent for compatibility with `drop` (as `drop` is
     /// called after this function).
-    pub(crate) fn close(&mut self) -> Result<(), PersistError> {
+    pub(crate) fn close(mut self) -> Result<(), PersistError> {
         // Drop the sender to close the channel, signaling the background
         // thread to exit.
         drop(self.sender.take());

--- a/fwdctl/src/create.rs
+++ b/fwdctl/src/create.rs
@@ -56,10 +56,10 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let db_config = new(opts);
     log::debug!("database configuration parameters: \n{db_config:?}\n");
 
-    Db::new(opts.database.dbpath.clone(), db_config)?;
+    let db = Db::new(opts.database.dbpath.clone(), db_config)?;
     println!(
         "created firewood database in {}",
         opts.database.dbpath.display()
     );
-    Ok(())
+    db.close()
 }

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -33,5 +33,5 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     proposal.commit()?;
 
     println!("key {} deleted successfully", opts.key);
-    Ok(())
+    db.close()
 }

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -150,7 +150,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let latest_hash = db.root_hash()?;
     let Some(latest_hash) = latest_hash else {
         println!("Database is empty");
-        return Ok(());
+        return db.close();
     };
     let latest_rev = db.revision(latest_hash)?;
 
@@ -158,7 +158,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
         create_output_handler(opts, &db).expect("Error creating output handler")
     else {
         // dot format is generated in the handler
-        return Ok(());
+        return db.close();
     };
 
     let start_key = opts
@@ -190,7 +190,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     }
     output_handler.flush()?;
 
-    Ok(())
+    db.close()
 }
 
 fn key_count_exceeded(max: Option<u32>, key_count: u32) -> bool {

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -31,7 +31,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
 
     let Some(hash) = hash else {
         println!("Database is empty");
-        return Ok(());
+        return db.close();
     };
 
     let rev = db.revision(hash)?;
@@ -40,12 +40,11 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
         Ok(Some(val)) => {
             let s = String::from_utf8_lossy(val.as_ref());
             println!("{s:?}");
-            Ok(())
         }
         Ok(None) => {
             eprintln!("Key '{}' not found", opts.key);
-            Ok(())
         }
-        Err(e) => Err(e),
+        Err(e) => return Err(e),
     }
+    db.close()
 }

--- a/fwdctl/src/graph.rs
+++ b/fwdctl/src/graph.rs
@@ -23,5 +23,5 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
 
     let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
     db.dump(&mut stdout())?;
-    Ok(())
+    db.close()
 }

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -38,5 +38,5 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     proposal.commit()?;
 
     println!("{}", opts.key);
-    Ok(())
+    db.close()
 }

--- a/fwdctl/src/replay.rs
+++ b/fwdctl/src/replay.rs
@@ -84,5 +84,5 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
         println!("Database root: {}", hex::encode(root));
     }
 
-    Ok(())
+    db.close()
 }

--- a/fwdctl/src/root.rs
+++ b/fwdctl/src/root.rs
@@ -25,5 +25,5 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let hash = db.root_hash()?;
 
     println!("{hash:?}");
-    Ok(())
+    db.close()
 }


### PR DESCRIPTION
## Why this should be merged

Closes #1699.

## How this works

Follows the [RAII](https://doc.rust-lang.org/rust-by-example/scope/raii.html) design by having the revision manager consume itself upon closing. This eliminates the previous scenario where, after calling `close()`, the revision manager was still usable even though calls such as `commit()` would fail.

In particular, this PR does the following:

- Makes `RevisionManager::close()` consume itself + eliminates its `Drop` implementation
- Refactors `TestDb` to automatically close the inner database at the end of the test
- Adds `close()` calls to the `fwdctl` crate.

## How this was tested

CI.
