### PR TITLE
chore(ci): update .golangci.yaml

### DIFF
--- a/.github/.golangci.yaml.patch
+++ b/.github/.golangci.yaml.patch
@@ -1,5 +1,5 @@
---- .github/.golangci.yaml	2025-12-29 01:55:58
-+++ ffi/.golangci.yaml	2025-12-29 00:09:32
+--- .github/.golangci.yaml	2026-02-20 16:14:53.739528860 +0000
++++ ffi/.golangci.yaml	2026-02-20 16:00:50.182324273 +0000
 @@ -40,7 +40,7 @@
          - standard
          - default
@@ -9,7 +9,39 @@
          - alias
          - dot
        custom-order: true
-@@ -93,12 +93,10 @@
+@@ -56,26 +56,26 @@
+     - copyloopvar
+     - depguard
+     - durationcheck
+-    # - embeddedstructfieldcheck
++    - embeddedstructfieldcheck
+     - errcheck
+     - errorlint
+     - forbidigo
+     - goconst
+     - gocheckcompilerdirectives
+-    # - godoclint
++    - godoclint
+     - gocritic
+     - goprintffuncname
+     - gosec
+     - govet
+     - importas
+     - ineffassign
+-    # - iotamixing
++    - iotamixing
+     - mirror
+     - misspell
+-    # - modernize
++    - modernize
+     - nakedret
+     - nilerr
+-    # - noctx
++    - noctx
+     - nolintlint
+     - perfsprint
+     - prealloc
+@@ -97,12 +97,10 @@
        rules:
          packages:
            deny:
@@ -24,7 +56,7 @@
              - pkg: io/ioutil
                desc: io/ioutil is deprecated. Use package io or os instead.
      errorlint:
-@@ -109,33 +107,10 @@
+@@ -113,33 +111,10 @@
      forbidigo:
        # Forbid the following identifiers (list of regexp).
        forbid:
@@ -59,7 +91,7 @@
      revive:
        rules:
          # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
-@@ -199,17 +174,6 @@
+@@ -203,17 +178,6 @@
          # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
          - name: useless-break
            disabled: false

--- a/ffi/.golangci.yaml
+++ b/ffi/.golangci.yaml
@@ -56,19 +56,23 @@ linters:
     - copyloopvar
     - depguard
     - durationcheck
+    - embeddedstructfieldcheck
     - errcheck
     - errorlint
     - forbidigo
     - goconst
     - gocheckcompilerdirectives
+    - godoclint
     - gocritic
     - goprintffuncname
     - gosec
     - govet
     - importas
     - ineffassign
-    - mirror 
+    - iotamixing
+    - mirror
     - misspell
+    - modernize
     - nakedret
     - nilerr
     - noctx

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -350,7 +350,7 @@ func sortKV(keys, vals [][]byte) error {
 	for dest, orig := range ord {
 		perm[orig] = dest
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		for perm[i] != i {
 			j := perm[i]
 			keys[i], keys[j] = keys[j], keys[i]
@@ -535,7 +535,7 @@ func TestConflictingProposals(t *testing.T) {
 	for i := range proposals {
 		keys := make([][]byte, numKeys)
 		vals := make([][]byte, numKeys)
-		for j := 0; j < numKeys; j++ {
+		for j := range numKeys {
 			keys[j] = keyForTest(i*numKeys + j)
 			vals[j] = valForTest(i*numKeys + j)
 		}
@@ -546,7 +546,7 @@ func TestConflictingProposals(t *testing.T) {
 
 	// Check that each value is present in each proposal.
 	for i, p := range proposals {
-		for j := 0; j < numKeys; j++ {
+		for j := range numKeys {
 			got, err := p.Get(keyForTest(i*numKeys + j))
 			r.NoError(err)
 			r.Equal(valForTest(i*numKeys+j), got, "Get(%d)", i*numKeys+j)
@@ -557,14 +557,14 @@ func TestConflictingProposals(t *testing.T) {
 	err := proposals[0].Commit()
 	r.NoError(err)
 	// Check that the first proposal's keys are present.
-	for j := 0; j < numKeys; j++ {
+	for j := range numKeys {
 		got, err := db.Get(keyForTest(j))
 		r.NoError(err)
 		r.Equal(valForTest(j), got, "Get(%d)", j)
 	}
 	// Check that the other proposals' keys are not present.
 	for i := 1; i < numProposals; i++ {
-		for j := 0; j < numKeys; j++ {
+		for j := range numKeys {
 			got, err := db.Get(keyForTest(i*numKeys + j))
 			r.Empty(got, "Get(%d)", i*numKeys+j)
 			r.NoError(err, "Get(%d)", i*numKeys+j)
@@ -573,7 +573,7 @@ func TestConflictingProposals(t *testing.T) {
 
 	// Ensure we can still get values from the other proposals.
 	for i := 1; i < numProposals; i++ {
-		for j := 0; j < numKeys; j++ {
+		for j := range numKeys {
 			got, err := proposals[i].Get(keyForTest(i*numKeys + j))
 			r.NoError(err, "Get(%d)", i*numKeys+j)
 			r.Equal(valForTest(i*numKeys+j), got, "Get(%d)", i*numKeys+j)
@@ -594,7 +594,7 @@ func TestConflictingProposals(t *testing.T) {
 
 	// Because they're invalid, we should not be able to get values from them.
 	for i := 1; i < numProposals; i++ {
-		for j := 0; j < numKeys; j++ {
+		for j := range numKeys {
 			got, err := proposals[i].Get(keyForTest(i*numKeys + j))
 			r.ErrorIs(err, errDroppedProposal, "Get(%d)", i*numKeys+j)
 			r.Empty(got, "Get(%d)", i*numKeys+j)

--- a/ffi/metrics.go
+++ b/ffi/metrics.go
@@ -45,7 +45,7 @@ func (Gatherer) Gather() ([]*dto.MetricFamily, error) {
 	return lst, nil
 }
 
-// Starts global recorder for metrics.
+// StartMetrics starts the global recorder for metrics.
 // This function only needs to be called once.
 // An error is returned if this method is called a second time, or if it is
 // called after StartMetricsWithExporter.
@@ -54,7 +54,8 @@ func StartMetrics() error {
 	return getErrorFromVoidResult(C.fwd_start_metrics())
 }
 
-// Start global recorder for metrics along with an HTTP exporter.
+// StartMetricsWithExporter starts the global recorder for metrics along with an
+// HTTP exporter.
 // This function only needs to be called once.
 // An error is returned if this method is called a second time, if it is
 // called after StartMetrics, or if the exporter failed to start.
@@ -62,7 +63,7 @@ func StartMetricsWithExporter(metricsPort uint16) error {
 	return getErrorFromVoidResult(C.fwd_start_metrics_with_exporter(C.uint16_t(metricsPort)))
 }
 
-// Collect metrics from global recorder
+// GatherMetrics collects metrics from global recorder.
 // Returns an error if the global recorder is not initialized.
 // This method must be called after StartMetrics or StartMetricsWithExporter
 func GatherMetrics() (string, error) {
@@ -80,7 +81,8 @@ type LogConfig struct {
 	FilterLevel string
 }
 
-// Starts global logs.
+// StartLogs initialized the log factor in the Rust library with the provided
+// configuration.
 // This function only needs to be called once.
 // An error is returned if this method is called a second time.
 func StartLogs(config *LogConfig) error {

--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -130,7 +130,7 @@ func (p *RangeProof) Verify(
 	return getErrorFromVoidResult(C.fwd_range_proof_verify(args))
 }
 
-// VerifyChangeProof verifies the provided change [proof] proves the changes
+// VerifyRangeProof verifies the provided range [proof] proves the changes
 // between [startRoot] and [endRoot] for keys in the range [startKey, endKey]. If
 // the proof is valid, a proposal containing the changes is prepared. The
 // call to [*Database.VerifyAndCommitRangeProof] will skip verification and commit the


### PR DESCRIPTION
## Why this should be merged

Upstream changes were made to the yaml file triggering the [detector](https://github.com/ava-labs/firewood/actions/runs/22230375383/job/64308059904).

## How this works

This applies the changes from https://github.com/ava-labs/avalanchego/pull/4962.

The upstream PR added a few linters but left them commented out citing the amount of work it would require to later add them. We didn't have that problem so I enabled them now in anticipation of when upstream enables them.

### Steps

1. Update golangci-lint locally
2. exec: `.github/scripts/verify_golangci_yaml_changes.sh apply` to apply changes
3. edit: `ffi/.golangci.yaml` and uncomment commented out linters
4. exec: `.github/scripts/verify_golangci_yaml_changes.sh update` to update patch file
5. exec: `cd ffi && golangci-lint run --path-mode=abs` to invoke linters

## How this was tested

Invoking the linter locally, described above, and CI.
