### PR TITLE
chore: bump go to 1.25.7

### DIFF
--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -1471,12 +1471,9 @@ func TestCloseWithCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		err = db.Close(ctx)
-	}()
+	})
 
 	cancel()
 	wg.Wait()

--- a/ffi/flake.lock
+++ b/ffi/flake.lock
@@ -39,17 +39,17 @@
       },
       "locked": {
         "dir": "nix/go",
-        "lastModified": 1770147937,
-        "narHash": "sha256-E4KqXxTqS8AJspmVjNDjF9QMyXnceaV/PCngD6YdZac=",
+        "lastModified": 1771869261,
+        "narHash": "sha256-2B5tyF6GihyZtj0133MWiu3rD1stmtK/eZ7onNx23Rs=",
         "owner": "ava-labs",
         "repo": "avalanchego",
-        "rev": "9fe96cc60530f55a2b0d7892561455f916080703",
+        "rev": "4aa7f05e07636567e956d2c0f0d6146bf8b5d144",
         "type": "github"
       },
       "original": {
         "dir": "nix/go",
         "owner": "ava-labs",
-        "ref": "9fe96cc60530f55a2b0d7892561455f916080703",
+        "ref": "4aa7f05e07636567e956d2c0f0d6146bf8b5d144",
         "repo": "avalanchego",
         "type": "github"
       }

--- a/ffi/flake.nix
+++ b/ffi/flake.nix
@@ -12,7 +12,7 @@
     rust-overlay.url = "github:oxalica/rust-overlay";
     crane.url = "github:ipetkov/crane";
     flake-utils.url = "github:numtide/flake-utils";
-    golang.url = "github:ava-labs/avalanchego?dir=nix/go&ref=9fe96cc60530f55a2b0d7892561455f916080703";
+    golang.url = "github:ava-labs/avalanchego?dir=nix/go&ref=4aa7f05e07636567e956d2c0f0d6146bf8b5d144";
   };
 
   outputs = { self, nixpkgs, rust-overlay, crane, flake-utils, golang }:

--- a/ffi/go.mod
+++ b/ffi/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/firewood/ffi
 
-go 1.24
+go 1.25
 
 // Changes to the toolchain version should be replicated in:
 //   - ffi/go.mod (here)
@@ -8,7 +8,7 @@ go 1.24
 //   - ffi/tests/eth/go.mod
 //   - ffi/tests/firewood/go.mod
 // `just check-golang-version` validates that these versions are in sync and will run in CI as part of the ffi-nix job.
-toolchain go1.24.12
+toolchain go1.25.7
 
 require (
 	github.com/prometheus/client_golang v1.22.0

--- a/ffi/tests/eth/go.mod
+++ b/ffi/tests/eth/go.mod
@@ -1,8 +1,8 @@
 module github.com/ava-labs/firewood/ffi/tests/eth
 
-go 1.24.0
+go 1.25
 
-toolchain go1.24.12
+toolchain go1.25.7
 
 require (
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.0 // this is replaced to use the parent folder

--- a/ffi/tests/firewood/go.mod
+++ b/ffi/tests/firewood/go.mod
@@ -1,8 +1,8 @@
 module github.com/ava-labs/firewood/ffi/tests/firewood
 
-go 1.24.0
+go 1.25
 
-toolchain go1.24.12
+toolchain go1.25.7
 
 require (
 	github.com/ava-labs/firewood-go/ffi v0.0.0 // this is replaced to use the parent folder


### PR DESCRIPTION
## Why this should be merged

Matches version of Go used in AvalancheGo.

## How this works

Followed the instructions in `ffi/go.mod`.

## How this was tested
CI