### PR TITLE
refactor(metrics): migrate ffi histogram recording to macros

### DIFF
--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -53,4 +53,4 @@ cbindgen = "0.29.2"
 workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["cbindgen", "metrics"]
+ignored = ["cbindgen", "coarsetime"]

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -16,7 +16,9 @@ use firewood::{
 use crate::{BatchOp, BorrowedBytes, CView, CreateProposalResult, arc_cache::ArcCache};
 
 use crate::revision::{GetRevisionResult, RevisionHandle};
-use firewood_metrics::{MetricsContext, firewood_increment, firewood_record};
+use firewood_metrics::{
+    MetricsContext, firewood_increment, firewood_record, fwd_expensive_timed_result,
+};
 
 /// The hashing mode to use for the database.
 ///
@@ -215,7 +217,7 @@ impl DatabaseHandle {
         self.db.revision(root)?.val(key)
     }
 
-    /// Creates a proposal with the given values and returns the proposal and the start time.
+    /// Creates and commits a proposal with the given values.
     ///
     /// # Errors
     ///
@@ -224,19 +226,13 @@ impl DatabaseHandle {
         &self,
         values: impl AsRef<[BatchOp<'a>]> + 'a,
     ) -> Result<Option<HashKey>, api::Error> {
-        let CreateProposalResult { handle, start_time } =
-            self.create_proposal_handle(values.as_ref())?;
-
-        let root_hash = handle.commit_proposal(|commit_time| {
-            firewood_increment!(crate::registry::COMMIT_MS, commit_time.as_millis());
-            firewood_record!(
-                crate::registry::COMMIT_MS_BUCKET,
-                commit_time.as_f64() * 1000.0,
-                expensive
-            );
-        })?;
-
-        let elapsed = start_time.elapsed();
+        let (root_hash_result, elapsed) =
+            fwd_expensive_timed_result!(crate::registry::BATCH_MS_BUCKET, {
+                let CreateProposalResult { handle } =
+                    self.create_proposal_handle(values.as_ref())?;
+                handle.commit_proposal()
+            });
+        let root_hash = root_hash_result?;
         firewood_increment!(crate::registry::BATCH_MS, elapsed.as_millis());
         firewood_increment!(crate::registry::BATCH_COUNT, 1);
         firewood_record!(

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -36,7 +36,7 @@ mod revision;
 mod value;
 
 use firewood::v2::api::DbView;
-use firewood_metrics::{firewood_increment, firewood_record, set_metrics_context};
+use firewood_metrics::set_metrics_context;
 
 pub use crate::handle::*;
 pub use crate::iterator::*;
@@ -516,17 +516,7 @@ pub extern "C" fn fwd_commit_proposal(proposal: Option<Box<ProposalHandle<'_>>>)
     #[cfg(feature = "block-replay")]
     let proposal_ptr = proposal.as_ref().map(|h| std::ptr::from_ref(&**h));
 
-    let result = invoke_with_handle(proposal, move |proposal| {
-        proposal.commit_proposal(|commit_time| {
-            firewood_increment!(crate::registry::COMMIT_MS, commit_time.as_millis());
-            firewood_increment!(crate::registry::COMMIT_COUNT, 1);
-            firewood_record!(
-                crate::registry::COMMIT_MS_BUCKET,
-                commit_time.as_f64() * 1000.0,
-                expensive
-            );
-        })
-    });
+    let result = invoke_with_handle(proposal, move |proposal| proposal.commit_proposal());
 
     #[cfg(feature = "block-replay")]
     replay::record_commit(proposal_ptr, &result);

--- a/ffi/src/proofs/change.rs
+++ b/ffi/src/proofs/change.rs
@@ -247,13 +247,9 @@ impl<'db> ProposedChangeProofContext<'db> {
             return Err(api::Error::ProofError(ProofError::ProposalIsNone));
         };
 
-        let metrics_cb = |commit_time: coarsetime::Duration| {
-            firewood_increment!(crate::registry::COMMIT_MS, commit_time.as_millis(), "change" => "commit");
-            firewood_increment!(crate::registry::MERGE_COUNT, 1, "change" => "commit");
-        };
-
-        let result = proposal_handle.commit_proposal(metrics_cb);
+        let result = proposal_handle.commit_proposal();
         let hash = result?.map(Into::into);
+        firewood_increment!(crate::registry::MERGE_COUNT, 1, "change" => "commit");
         Ok(hash)
     }
 }

--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -224,12 +224,7 @@ impl<'db> RangeProofContext<'db> {
             }
         };
 
-        let metrics_cb = |commit_time: coarsetime::Duration| {
-            firewood_increment!(crate::registry::COMMIT_MS, commit_time.as_millis());
-            firewood_increment!(crate::registry::MERGE_COUNT, 1);
-        };
-
-        let result = proposal_handle.commit_proposal(metrics_cb);
+        let result = proposal_handle.commit_proposal();
         let result = if let Err(api::Error::ParentNotLatest { .. }) = result
             && allow_rebase
         {
@@ -237,12 +232,13 @@ impl<'db> RangeProofContext<'db> {
             let proposal_handle = db
                 .merge_key_value_range(start_key, end_key, self.proof.key_values())?
                 .handle;
-            proposal_handle.commit_proposal(metrics_cb)
+            proposal_handle.commit_proposal()
         } else {
             result
         };
 
         let hash = result?;
+        firewood_increment!(crate::registry::MERGE_COUNT, 1);
         self.proposal_state = Some(ProposalState::Committed(hash.clone()));
 
         Ok(hash)

--- a/ffi/src/proposal.rs
+++ b/ffi/src/proposal.rs
@@ -4,7 +4,7 @@
 use firewood::v2::api::{self, BoxKeyValueIter, DbView, HashKey, IntoBatchIter, Proposal as _};
 
 use crate::{IteratorHandle, iterator::CreateIteratorResult, metrics::MetricsContextExt};
-use firewood_metrics::{firewood_increment, firewood_record};
+use firewood_metrics::{firewood_increment, firewood_record, fwd_expensive_timed_result};
 
 /// An opaque wrapper around a Proposal that also retains a reference to the
 /// database handle it was created from.
@@ -63,20 +63,11 @@ impl ProposalHandle<'_> {
 
     /// Consume and commit a proposal.
     ///
-    /// # Arguments
-    ///
-    /// - `token`: An callback function that will be called with the duration
-    ///   of the commit operation. This will be dropped without being called if
-    ///   the commit fails.
-    ///
     /// # Errors
     ///
     /// This function will return an error if committing the proposal fails or if the
     /// proposal is empty.
-    pub fn commit_proposal(
-        self,
-        token: impl FnOnce(coarsetime::Duration),
-    ) -> Result<Option<HashKey>, api::Error> {
+    pub fn commit_proposal(self) -> Result<Option<HashKey>, api::Error> {
         let ProposalHandle {
             hash_key,
             proposal,
@@ -89,14 +80,15 @@ impl ProposalHandle<'_> {
             _ = handle.get_root(hash_key.clone());
         }
 
-        let start_time = coarsetime::Instant::now();
-        proposal.commit()?;
-        let commit_time = start_time.elapsed();
+        let (commit_result, commit_time) =
+            fwd_expensive_timed_result!(crate::registry::COMMIT_MS_BUCKET, proposal.commit());
+        commit_result?;
 
         // clear the cached view so that it does not hold onto the proposal view
         handle.clear_cached_view();
 
-        token(commit_time);
+        firewood_increment!(crate::registry::COMMIT_MS, commit_time.as_millis());
+        firewood_increment!(crate::registry::COMMIT_COUNT, 1);
 
         Ok(hash_key)
     }
@@ -119,7 +111,6 @@ impl ProposalHandle<'_> {
 #[derive(Debug)]
 pub struct CreateProposalResult<'db> {
     pub handle: ProposalHandle<'db>,
-    pub start_time: coarsetime::Instant,
 }
 
 impl<'db> CreateProposalResult<'db> {
@@ -127,9 +118,9 @@ impl<'db> CreateProposalResult<'db> {
         handle: &'db crate::DatabaseHandle,
         f: impl FnOnce() -> Result<firewood::db::Proposal<'db>, api::Error>,
     ) -> Result<Self, api::Error> {
-        let start_time = coarsetime::Instant::now();
-        let proposal = f()?;
-        let propose_time = start_time.elapsed();
+        let (proposal_result, propose_time) =
+            fwd_expensive_timed_result!(crate::registry::PROPOSE_MS_BUCKET, f());
+        let proposal = proposal_result?;
         firewood_increment!(crate::registry::PROPOSE_MS, propose_time.as_millis());
         firewood_increment!(crate::registry::PROPOSE_COUNT, 1);
         firewood_record!(
@@ -146,7 +137,6 @@ impl<'db> CreateProposalResult<'db> {
                 proposal,
                 handle,
             },
-            start_time,
         })
     }
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -58,6 +58,8 @@
 //! | `firewood_set!(name, value, expensive)` | Set only if expensive metrics enabled |
 //! | `firewood_record!(name, value)` | Always record to histogram |
 //! | `firewood_record!(name, value, expensive)` | Record only if expensive metrics enabled |
+//! | `fwd_timed_result!(name, expr)` | Time a `Result` expression and record histogram on `Ok` |
+//! | `fwd_expensive_timed_result!(name, expr)` | Same as `fwd_timed_result!`, gated by expensive metrics |
 //!
 //! For registration, use `metrics::describe_*` macros or [`register_histogram_with_buckets`].
 
@@ -263,6 +265,53 @@ macro_rules! firewood_record {
     ($name:expr, $value:expr, $($labels:tt)+) => {
         ::metrics::histogram!($name, $($labels)+).record($value)
     };
+}
+
+/// Times a `Result` expression and records elapsed milliseconds to a histogram on success.
+///
+/// Returns a tuple `(result, elapsed_duration)` where `elapsed_duration` is a
+/// `coarsetime::Duration`.
+///
+/// # Usage
+/// ```ignore
+/// let (result, elapsed) = fwd_timed_result!(registry::LATENCY_MS_BUCKET, work());
+/// let value = result?;
+/// ```
+#[macro_export]
+macro_rules! fwd_timed_result {
+    ($name:expr, $expr:expr) => {{
+        let __fwd_start = ::coarsetime::Instant::now();
+        let __fwd_result = $expr;
+        let __fwd_elapsed = __fwd_start.elapsed();
+        if __fwd_result.is_ok() {
+            $crate::firewood_record!($name, __fwd_elapsed.as_f64() * 1000.0);
+        }
+        (__fwd_result, __fwd_elapsed)
+    }};
+}
+
+/// Times a `Result` expression and records elapsed milliseconds to a histogram on success
+/// (only when expensive metrics are enabled).
+///
+/// Returns a tuple `(result, elapsed_duration)` where `elapsed_duration` is a
+/// `coarsetime::Duration`.
+///
+/// # Usage
+/// ```ignore
+/// let (result, elapsed) = fwd_expensive_timed_result!(registry::LATENCY_MS_BUCKET, work());
+/// let value = result?;
+/// ```
+#[macro_export]
+macro_rules! fwd_expensive_timed_result {
+    ($name:expr, $expr:expr) => {{
+        let __fwd_start = ::coarsetime::Instant::now();
+        let __fwd_result = $expr;
+        let __fwd_elapsed = __fwd_start.elapsed();
+        if __fwd_result.is_ok() {
+            $crate::firewood_record!($name, __fwd_elapsed.as_f64() * 1000.0, expensive);
+        }
+        (__fwd_result, __fwd_elapsed)
+    }};
 }
 
 /// Returns a histogram handle for advanced operations.


### PR DESCRIPTION
## Why this should be merged

Centralize the histogram code and follow the same pattern as used for the counters and timing metrics.

## How this works

Brand new macro. I kept "expensive" as a specific option because I think we might want some histograms even if expensive is disabled.

## How this was tested

Just unit tests and CI.