### PR TITLE
chore(ci): Add elvis when tagged observability

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,4 @@
+addReviewers: true
+reviewers:
+  - Elvis339
+labelTrigger: "observability"


### PR DESCRIPTION
## Why this should be merged

Any observability changes should get reviewed by Elvis, this might do that.

## How this works

Supposedly this will auto assign when the tag is added, but I'm not 100% sure. Let's try it.

## How this was tested

I don't know how other than to merge it :(