### PR TITLE
fix: acquire lock for displaying MaybePersistedNode

### DIFF
--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -188,15 +188,13 @@ impl MaybePersistedNode {
 /// If instead you want the node itself, use [`MaybePersistedNode::as_shared_node`] first.
 impl Display for MaybePersistedNode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.0.try_lock() {
-            Some(guard) => match &*guard {
-                MaybePersisted::Unpersisted(node) => write!(f, "M{:p}", (*node).as_ptr()),
-                MaybePersisted::Allocated(addr, node) => {
-                    write!(f, "A{:p}@{addr}", (*node).as_ptr())
-                }
-                MaybePersisted::Persisted(addr) => write!(f, "{addr}"),
-            },
-            None => write!(f, "<locked>"),
+        let guard = self.0.lock();
+        match &*guard {
+            MaybePersisted::Unpersisted(node) => write!(f, "M{:p}", (*node).as_ptr()),
+            MaybePersisted::Allocated(addr, node) => {
+                write!(f, "A{:p}@{addr}", (*node).as_ptr())
+            }
+            MaybePersisted::Persisted(addr) => write!(f, "{addr}"),
         }
     }
 }


### PR DESCRIPTION
## Why this should be merged

We recently saw the following test flake:

https://github.com/ava-labs/firewood/actions/runs/22413238886/job/64892229362

This flake results from a race condition between `dump()` and the persistence background thread, where the thread may have a lock over the node during persistence when `dump()` is called, resulting in `<locked>` being displayed. 

## How this works

When displaying a `MaybePersistedNode`, we acquire it's lock rather than attempting to. 

## How this was tested

CI