### PR TITLE
chore(release): prepare for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-02-26
+
+### 🚀 Features
+
+- Creating change proofs using FFI ([#1637](https://github.com/ava-labs/firewood/pull/1637))
+- *(db)* Add explicit close() method ([#1650](https://github.com/ava-labs/firewood/pull/1650))
+- Defer persist every commit ([#1656](https://github.com/ava-labs/firewood/pull/1656))
+- *(fwdctl/launch)* Add feature-gated fwdctl EC2 deploy workflow for benchmark setup (1/4) ([#1662](https://github.com/ava-labs/firewood/pull/1662))
+- *(fwdctl/launch)* Add SSM-based monitor/follow flow for cloud-init and bootstrap progress (2/4) ([#1663](https://github.com/ava-labs/firewood/pull/1663))
+- Node cache entry-based to memory-based LRU ([#1677](https://github.com/ava-labs/firewood/pull/1677))
+- Change proof serialization/deserialization ([#1638](https://github.com/ava-labs/firewood/pull/1638))
+- Defer persist every `N` commits ([#1657](https://github.com/ava-labs/firewood/pull/1657))
+- *(ffi)* Remove explicit garbage collection call ([#1681](https://github.com/ava-labs/firewood/pull/1681))
+- Change proof verification and proposal creation ([#1641](https://github.com/ava-labs/firewood/pull/1641))
+- *(fwdctl/launch)* Add scenario-driven deploy, list/kill instance management, and dry-run planning (3/4) ([#1664](https://github.com/ava-labs/firewood/pull/1664))
+- [**breaking**] Remove error returned by Hash ([#1671](https://github.com/ava-labs/firewood/pull/1671))
+- *(fwdctl/launch)* Add docs, deprecate aws-launch.sh (4/4) ([#1665](https://github.com/ava-labs/firewood/pull/1665))
+- *(ffi)* [**breaking**] Add optional node cache memory limit to open args ([#1713](https://github.com/ava-labs/firewood/pull/1713))
+- Change proof commit and find next key ([#1646](https://github.com/ava-labs/firewood/pull/1646))
+
+### 🐛 Bug Fixes
+
+- *(flake)* Grab version from correct location ([#1630](https://github.com/ava-labs/firewood/pull/1630))
+- *(storage)* Handle possible short writes ([#1635](https://github.com/ava-labs/firewood/pull/1635))
+- *(ffi)* Force correct alignment on certain c structs ([#1652](https://github.com/ava-labs/firewood/pull/1652))
+- *(db)* Lock in-memory revisions during commit critical section ([#1661](https://github.com/ava-labs/firewood/pull/1661))
+- *(track-performance)* Fail hard on gh errors  ([#1659](https://github.com/ava-labs/firewood/pull/1659))
+- *(track-performance)* Stale cron expression in daily bench ([#1667](https://github.com/ava-labs/firewood/pull/1667))
+- *(ffi)* Prevent potential use-after-free in Go Iterator ([#1688](https://github.com/ava-labs/firewood/pull/1688))
+- Avoid holding the last_committed_revision arc ([#1685](https://github.com/ava-labs/firewood/pull/1685))
+- Acquire lock for displaying MaybePersistedNode ([#1719](https://github.com/ava-labs/firewood/pull/1719))
+
+### 🚜 Refactor
+
+- Decouple header from `NodeStore` ([#1618](https://github.com/ava-labs/firewood/pull/1618))
+- Close consumes itself ([#1701](https://github.com/ava-labs/firewood/pull/1701))
+- Stop keeping around the last committed revision ([#1690](https://github.com/ava-labs/firewood/pull/1690))
+
+### 📚 Documentation
+
+- Update comments on Arc::try_unwrap safety ([#1649](https://github.com/ava-labs/firewood/pull/1649))
+- Update README to include archival support ([#1674](https://github.com/ava-labs/firewood/pull/1674))
+
+### ⚡ Performance
+
+- Increase limits and monitor freelist cache size better ([#1668](https://github.com/ava-labs/firewood/pull/1668))
+- *(ffi)* [**breaking**] Remove Pinner interface ([#1721](https://github.com/ava-labs/firewood/pull/1721))
+
+### ⚙️ Miscellaneous Tasks
+
+- Build and lint with --all-features ([#1636](https://github.com/ava-labs/firewood/pull/1636))
+- *(perf)* Track Firewood Performance via AvalancheGo Benchmarks ([#1493](https://github.com/ava-labs/firewood/pull/1493))
+- Add Bernard as codeowner ([#1647](https://github.com/ava-labs/firewood/pull/1647))
+- Add benchmark workflow ([#1643](https://github.com/ava-labs/firewood/pull/1643))
+- Add scheduled benchmark runs ([#1639](https://github.com/ava-labs/firewood/pull/1639)) ([#1645](https://github.com/ava-labs/firewood/pull/1645))
+- *(track-performance)* Local iteration ([#1642](https://github.com/ava-labs/firewood/pull/1642))
+- Update to go 1.24.12 ([#1658](https://github.com/ava-labs/firewood/pull/1658))
+- Trace->info logging ([#1682](https://github.com/ava-labs/firewood/pull/1682))
+- Add deferred persistence benchmark ([#1670](https://github.com/ava-labs/firewood/pull/1670))
+- *(ffi)* Update CGO LDFLAGS to include -ldl ([#1686](https://github.com/ava-labs/firewood/pull/1686))
+- Github actions security audit ([#1691](https://github.com/ava-labs/firewood/pull/1691))
+- *(deps)* Bump the github-actions group with 14 updates ([#1695](https://github.com/ava-labs/firewood/pull/1695))
+- *(ci)* Update .golangci.yaml ([#1703](https://github.com/ava-labs/firewood/pull/1703))
+- Add RootStore metrics ([#1680](https://github.com/ava-labs/firewood/pull/1680))
+- Bump go to 1.25.7 ([#1707](https://github.com/ava-labs/firewood/pull/1707))
+
 ## [0.1.0] - 2026-01-20
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.212.0"
+version = "1.214.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c639f5e9a6a1d97a320a22de7d58f0a33dfbb0e267f990126ca800a886a7a660"
+checksum = "f5011a07318505db9ffe5a03e667653b44ee85d392f0e5f36ebd1fff2f2cbfa8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssm"
-version = "1.105.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ae50daa70beefa3d68f7e52a71184f015ebb655d593d1c8e1e774071b85b42"
+checksum = "02c8deffb8e0e7b8729b8b6ed9010c99cb10c61f01aaca86a8f3771cbf94cfcf"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -536,7 +536,7 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -1005,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
+checksum = "af9a108e542ddf1de36743a6126e94d6659dccda38fc8a77e80b915102ac784a"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
@@ -1539,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "fastrace"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df0cb35ba204d668c758a6400c2e43eab9b038843debfab606b26f194ad7f1b"
+checksum = "2130caec636d7a1d23b173576674ced1af967228642ceaeb6a1b4705c282b00e"
 dependencies = [
  "fastant",
  "fastrace-macro",
@@ -1554,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "fastrace-macro"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6ca71d5dfcbab9e09b19b5248e06a4bd8ac779055491fb47e6ebbdd20e5567"
+checksum = "0b35f67e02527fca6515ff61f922360df781f477daf6a806fff16bd59525dee5"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "fastrace-opentelemetry"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e8ec7cff0ea398352764b6ee15c0902ccabf23d823525254b52d7f878fcf60"
+checksum = "4644a8a7ce6d20d83e73d9562f323388e4d817470d40bcb51fa2fe328db58cd2"
 dependencies = [
  "fastrace",
  "log",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "firewood"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-benchmark"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-ffi"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cbindgen",
  "coarsetime",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-fwdctl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "askama",
  "assert_cmd",
@@ -1737,14 +1737,14 @@ dependencies = [
 
 [[package]]
 name = "firewood-metrics"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "metrics",
 ]
 
 [[package]]
 name = "firewood-replay"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "firewood",
  "firewood-metrics",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-storage"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aquamarine",
  "bitfield",
@@ -2319,7 +2319,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -2706,9 +2706,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
+checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
 dependencies = [
  "jiff-static",
  "log",
@@ -2719,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
+checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2740,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2828,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2948,7 +2948,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "thiserror",
  "tokio",
  "tracing",
@@ -3831,9 +3831,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -3871,9 +3871,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
 ]
@@ -3923,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "rtrb"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8388ea1a9e0ea807e442e8263a699e7edcb320ecbcd21b4fa8ff859acce3ba"
+checksum = "7204ed6420f698836b76d4d5c2ec5dec7585fd5c3a788fd1cde855d1de598239"
 
 [[package]]
 name = "rustc-demangle"
@@ -3956,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
@@ -3981,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4217,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
 dependencies = [
  "base64",
  "chrono",
@@ -4236,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4459,9 +4459,9 @@ checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",
@@ -4650,7 +4650,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.36",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -5129,9 +5129,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5142,9 +5142,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5156,9 +5156,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5166,9 +5166,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5179,9 +5179,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
 dependencies = [
  "unicode-ident",
 ]
@@ -5228,9 +5228,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,12 +55,12 @@ cast_possible_truncation = "allow"
 
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.1.0" }
+firewood = { path = "firewood", version = "0.2.0" }
 firewood-macros = { path = "firewood-macros", version = "0.1.0" }
-firewood-storage = { path = "storage", version = "0.1.0" }
-firewood-ffi = { path = "ffi", version = "0.1.0" }
-firewood-metrics = { path = "metrics", version = "0.1.0" }
-firewood-replay = { path = "replay", version = "0.1.0" }
+firewood-storage = { path = "storage", version = "0.2.0" }
+firewood-ffi = { path = "ffi", version = "0.2.0" }
+firewood-metrics = { path = "metrics", version = "0.2.0" }
+firewood-replay = { path = "replay", version = "0.2.0" }
 
 # no longer bumping with workspace
 firewood-triehash = { path = "triehash", version = "0.0.16" }
@@ -72,7 +72,7 @@ bytemuck_derive = "1.10.2"
 clap = { version = "4.5.60", features = ["derive"] }
 coarsetime = "0.1.37"
 env_logger = "0.11.9"
-fastrace = "0.7.16"
+fastrace = "0.7.17"
 hex = "0.4.3"
 integer-encoding = "4.1.0"
 log = "0.4.29"
@@ -92,4 +92,4 @@ ethereum-types = "0.16.0"
 hex-literal = "1.1.0"
 pprof = "0.15.0"
 rand = "0.10.0"
-tempfile = "3.25.0"
+tempfile = "3.26.0"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-benchmark"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors = [
      "Aaron Buchwald <aaron.buchwald56@gmail.com>",
@@ -35,7 +35,7 @@ rand.workspace = true
 rand_distr.workspace = true
 sha2.workspace = true
 # Regular dependencies
-fastrace-opentelemetry = { version = "=0.14.0" }
+fastrace-opentelemetry = { version = "0.16.0" }
 metrics-exporter-prometheus = { version = "0.18.1", optional = true }
 opentelemetry = "=0.31.0"
 opentelemetry-otlp = { version = "=0.31.0", features = ["grpc-tonic"] }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-ffi"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors = [
      "Aaron Buchwald <aaron.buchwald56@gmail.com>",

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors = [
      "Angel Leon <gubatron@gmail.com>",

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-fwdctl"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors = [
      "Dan Laine <daniel.laine@avalabs.org>",
@@ -38,8 +38,8 @@ indicatif = "0.18.4"
 askama = "0.15.4"
 num-format = "0.4.4"
 aws-config = { version = "1.8", optional = true }
-aws-sdk-ec2 = { version = "1.212", optional = true }
-aws-sdk-ssm = { version = "1.105", optional = true }
+aws-sdk-ec2 = { version = "1.214", optional = true }
+aws-sdk-ssm = { version = "1.106", optional = true }
 aws-sdk-sts = { version = "1.99.0", optional = true }
 aws-smithy-runtime-api = { version = "1.11", optional = true }
 base64 = { version = "0.22", optional = true }

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-metrics"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license-file.workspace = true
 homepage.workspace = true

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-replay"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license-file.workspace = true
 homepage.workspace = true
@@ -17,7 +17,7 @@ metrics.workspace = true
 rmp-serde = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
-serde_with = "3.16"
+serde_with = "3.17"
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-storage"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors = [
      "Aaron Buchwald <aaron.buchwald56@gmail.com>",


### PR DESCRIPTION
## Why this should be merged

Preamble for releasing v0.2.0

## How this works

`just release-step-update-rust-dependencies && just release-step-refresh-changelog v0.2.0`

And bumped the versions of all the packages that have changed. Interestingly, `firewood-macros` received zero changes since `v0.1.0` was tagged.

## How this was tested

CI and local testing
