### PR TITLE
feat(reconstruction): 1/7 Scaffolding for Reconstructible

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -21,7 +21,8 @@ use crate::manager::{ConfigManager, RevisionManager, RevisionManagerConfig};
 use firewood_metrics::firewood_counter;
 use firewood_storage::{
     CheckOpt, CheckerReport, Committed, FileBacked, FileIoError, HashedNodeReader,
-    ImmutableProposal, NodeHashAlgorithm, NodeStore, Parentable, ReadableStorage, TrieReader,
+    ImmutableProposal, NodeHashAlgorithm, NodeStore, Parentable, ReadableStorage,
+    Reconstructed as StorageReconstructed, TrieReader,
 };
 use nonzero_ext::nonzero;
 use std::io::Write;
@@ -54,9 +55,9 @@ impl std::fmt::Debug for DbMetrics {
     }
 }
 
-impl<P: Parentable, S: ReadableStorage> api::DbView for NodeStore<P, S>
+impl<P, S: ReadableStorage> api::DbView for NodeStore<P, S>
 where
-    NodeStore<P, S>: TrieReader,
+    NodeStore<P, S>: TrieReader + HashedNodeReader,
 {
     type Iter<'view>
         = MerkleKeyValueIter<'view, Self>
@@ -374,6 +375,12 @@ pub struct Proposal<'db> {
     db: &'db Db,
 }
 
+#[derive(Debug)]
+/// A user-visible reconstructed view.
+pub struct Reconstructed {
+    nodestore: Arc<NodeStore<StorageReconstructed, FileBacked>>,
+}
+
 impl api::DbView for Proposal<'_> {
     type Iter<'view>
         = MerkleKeyValueIter<'view, NodeStore<Arc<ImmutableProposal>, FileBacked>>
@@ -435,6 +442,68 @@ impl Proposal<'_> {
     #[must_use]
     pub fn view(&self) -> ArcDynDbView {
         self.nodestore.clone()
+    }
+}
+
+impl api::DbView for Reconstructed {
+    type Iter<'view>
+        = MerkleKeyValueIter<'view, NodeStore<StorageReconstructed, FileBacked>>
+    where
+        Self: 'view;
+
+    fn root_hash(&self) -> Option<api::HashKey> {
+        api::DbView::root_hash(&*self.nodestore)
+    }
+
+    fn val<K: KeyType>(&self, key: K) -> Result<Option<Value>, api::Error> {
+        api::DbView::val(&*self.nodestore, key)
+    }
+
+    fn single_key_proof<K: KeyType>(&self, key: K) -> Result<FrozenProof, api::Error> {
+        api::DbView::single_key_proof(&*self.nodestore, key)
+    }
+
+    fn range_proof<K: KeyType>(
+        &self,
+        first_key: Option<K>,
+        last_key: Option<K>,
+        limit: Option<NonZeroUsize>,
+    ) -> Result<FrozenRangeProof, api::Error> {
+        api::DbView::range_proof(&*self.nodestore, first_key, last_key, limit)
+    }
+
+    fn iter_option<K: KeyType>(&self, first_key: Option<K>) -> Result<Self::Iter<'_>, api::Error> {
+        api::DbView::iter_option(&*self.nodestore, first_key)
+    }
+
+    fn dump_to_string(&self) -> Result<String, api::Error> {
+        api::DbView::dump_to_string(&*self.nodestore)
+    }
+}
+
+impl api::Reconstructible for &NodeStore<Committed, FileBacked> {
+    type Reconstructed = Reconstructed;
+
+    fn reconstruct(self, batch: impl IntoBatchIter) -> Result<Self::Reconstructed, api::Error>
+    where
+        Self: Sized,
+    {
+        let _ = batch.into_iter();
+        let _ = self;
+        todo!("historical reconstruction pipeline is not implemented yet")
+    }
+}
+
+impl api::Reconstructible for Reconstructed {
+    type Reconstructed = Reconstructed;
+
+    fn reconstruct(self, batch: impl IntoBatchIter) -> Result<Self::Reconstructed, api::Error>
+    where
+        Self: Sized,
+    {
+        let _ = batch.into_iter();
+        let _ = self;
+        todo!("linear reconstructed->reconstructed pipeline is not implemented yet")
     }
 }
 

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -373,6 +373,57 @@ pub trait DbView {
     fn dump_to_string(&self) -> Result<String, Error>;
 }
 
+impl<T: DbView + ?Sized> DbView for &T {
+    type Iter<'view>
+        = T::Iter<'view>
+    where
+        Self: 'view;
+
+    fn root_hash(&self) -> Option<HashKey> {
+        (*self).root_hash()
+    }
+
+    fn val<K: KeyType>(&self, key: K) -> Result<Option<Value>, Error> {
+        (*self).val(key)
+    }
+
+    fn single_key_proof<K: KeyType>(&self, key: K) -> Result<FrozenProof, Error> {
+        (*self).single_key_proof(key)
+    }
+
+    fn range_proof<K: KeyType>(
+        &self,
+        first_key: Option<K>,
+        last_key: Option<K>,
+        limit: Option<NonZeroUsize>,
+    ) -> Result<FrozenRangeProof, Error> {
+        (*self).range_proof(first_key, last_key, limit)
+    }
+
+    fn iter_option<K: KeyType>(&self, first_key: Option<K>) -> Result<Self::Iter<'_>, Error> {
+        (*self).iter_option(first_key)
+    }
+
+    fn dump_to_string(&self) -> Result<String, Error> {
+        (*self).dump_to_string()
+    }
+}
+
+/// A reconstructable database view.
+///
+/// This trait models linear reconstruction by consuming `self` and returning
+/// a new reconstructed view.
+pub trait Reconstructible: DbView {
+    /// The reconstructed output type.
+    type Reconstructed: DbView + Reconstructible<Reconstructed = Self::Reconstructed>;
+
+    /// Reconstruct a new view from this one by applying `data`.
+    #[expect(clippy::missing_errors_doc)]
+    fn reconstruct(self, data: impl IntoBatchIter) -> Result<Self::Reconstructed, Error>
+    where
+        Self: Sized;
+}
+
 /// A boxed iterator over key/value pairs.
 pub type BoxKeyValueIter<'view> =
     Box<dyn Iterator<Item = Result<(Key, Value), FileIoError>> + 'view>;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -57,7 +57,7 @@ pub use node::{BranchNode, Child, Children, ChildrenSlots, LeafNode, Node, PathI
 pub use nodestore::{
     AreaIndex, Committed, HashedNodeReader, ImmutableProposal, LinearAddress, MutableProposal,
     NodeHashAlgorithm, NodeHashAlgorithmTryFromIntError, NodeReader, NodeStore, NodeStoreHeader,
-    Parentable, RootReader, TrieReader,
+    Parentable, Reconstructed, RootReader, TrieReader,
 };
 pub use path::{
     ComponentIter, IntoSplitPath, JoinedPath, PackedBytes, PackedPathComponents, PackedPathRef,

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -25,6 +25,7 @@
 //! - [`Committed`] - For a committed revision with no in-memory changes
 //! - [`MutableProposal`] - For a proposal being actively modified with in-memory nodes
 //! - [`ImmutableProposal`] - For a proposal that has been hashed and assigned addresses
+//! - [`Reconstructed`] - For a reconstructed read-only view created by applying a batch linearly
 //!
 //! The nodestore follows a lifecycle pattern:
 //! ```text
@@ -70,6 +71,7 @@ pub use header::NodeStoreHeader;
 /// - Committed: A committed revision of the trie. It has no in-memory changes.
 /// - `MutableProposal`: A proposal that is still being modified. It has some nodes in memory.
 /// - `ImmutableProposal`: A proposal that has been hashed and assigned addresses. It has no in-memory changes.
+/// - `Reconstructed`: A reconstructed view that supports read operations and linear reconstruction.
 ///
 /// The general lifecycle of nodestores is as follows:
 /// ```mermaid
@@ -482,13 +484,23 @@ impl ImmutableProposal {
 /// 3. Create a new mutable proposal from either a [Committed] or [`ImmutableProposal`] [`NodeStore`] using [`NodeStore::new`].
 /// 4. Convert a mutable proposal to an immutable proposal using [`std::convert::TryInto`], which hashes the nodes and assigns addresses
 /// 5. Convert an immutable proposal to a committed revision using [`std::convert::TryInto`], which writes the nodes to disk.
+///
+/// Reconstructed views follow a separate linear flow and are not committed:
+/// `Historical/Committed -> Reconstructed -> Reconstructed`.
 
 #[derive(Debug)]
 pub struct NodeStore<T, S> {
-    /// This is one of [Committed], [`ImmutableProposal`], or [`MutableProposal`].
+    /// This is one of [Committed], [`ImmutableProposal`], [`MutableProposal`], or [`Reconstructed`].
     kind: T,
     /// Persisted storage to read nodes from.
     storage: Arc<S>,
+}
+
+/// Contains state for a reconstructed revision of the trie.
+#[derive(Debug, Clone)]
+pub struct Reconstructed {
+    /// The root of the trie in this reconstructed view.
+    root: Option<Child>,
 }
 
 /// Contains the state of a proposal that is still being modified.
@@ -592,9 +604,27 @@ impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
     }
 }
 
+impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>> for NodeStore<Reconstructed, S> {
+    type Error = FileIoError;
+
+    fn try_from(val: NodeStore<MutableProposal, S>) -> Result<Self, Self::Error> {
+        let NodeStore {
+            kind: _kind,
+            storage: _storage,
+        } = val;
+        todo!("convert mutable proposal into reconstructed nodestore")
+    }
+}
+
 impl<S: ReadableStorage> NodeReader for NodeStore<MutableProposal, S> {
     fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
         self.read_node_from_disk(addr, "write")
+    }
+}
+
+impl<S: ReadableStorage> NodeReader for NodeStore<Reconstructed, S> {
+    fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
+        self.read_node_from_disk(addr, "read")
     }
 }
 
@@ -644,6 +674,20 @@ impl<S: ReadableStorage> RootReader for NodeStore<Arc<ImmutableProposal>, S> {
     }
 }
 
+impl<S: ReadableStorage> RootReader for NodeStore<Reconstructed, S> {
+    fn root_node(&self) -> Option<SharedNode> {
+        self.kind
+            .root
+            .as_ref()
+            .map(Child::as_maybe_persisted_node)
+            .and_then(|node| node.as_shared_node(self).ok())
+    }
+
+    fn root_as_maybe_persisted_node(&self) -> Option<MaybePersistedNode> {
+        self.kind.root.as_ref().map(Child::as_maybe_persisted_node)
+    }
+}
+
 impl<T, S> HashedNodeReader for NodeStore<T, S>
 where
     NodeStore<T, S>: TrieReader,
@@ -656,6 +700,22 @@ where
 
     fn root_hash(&self) -> Option<TrieHash> {
         self.kind.root_hash()
+    }
+}
+
+impl<S: ReadableStorage> HashedNodeReader for NodeStore<Reconstructed, S>
+where
+    NodeStore<Reconstructed, S>: TrieReader,
+{
+    fn root_address(&self) -> Option<LinearAddress> {
+        self.kind.root.as_ref().and_then(Child::persisted_address)
+    }
+
+    fn root_hash(&self) -> Option<TrieHash> {
+        self.kind
+            .root
+            .as_ref()
+            .and_then(|root| root.hash().cloned().map(HashType::into_triehash))
     }
 }
 


### PR DESCRIPTION
Scaffolding for linear reconstruction, without enabling full reconstruction behavior yet.

## Why this should be merged

Establishes the API for reconstruction so follow-up commits can implement behavior incrementally.
Adds a dedicated reconstructed view type that is explicit in the type system, instead of overloading proposal or committed flows.
Keeps reconstruction as a separate lifecycle from commit/persist paths.

## How this works

Added new trait Reconstructible to the public API
Added a user-visible Reconstructed db view wrapper and DbView implementation
Added a new storage-level Reconstructed nodestore kind and docs describing its linear flow
Exported Reconstructed from storage public exports
Added NodeReader support for reconstructed nodestores

## How this was tested

No new behavioral tests in this scaffolding PR.
Existing behavior is unchanged for committed/proposal workflows.
Follow-up PRs will add reconstruction behavior tests once TODO paths are implemented.

## Breaking Changes

None