### PR TITLE
refactor: Fix histogram buckets

### DIFF
--- a/ffi/src/registry.rs
+++ b/ffi/src/registry.rs
@@ -24,8 +24,9 @@ pub const CACHED_VIEW_HIT: &str = "ffi.cached_view.hit";
 pub const MERGE_COUNT: &str = "firewood.ffi.merge";
 
 const FFI_TIMING_BUCKETS: &[f64] = &[
-    0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0, 12.0, 15.0, 20.0,
-    30.0, 50.0,
+    0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 2.5, 5.0, // lowest range, proposals mostly
+    10.0, 15.0, 20.0, 50.0, // mid. and
+    100.0, 200.0, 500.0, // high breakdown for commit buckets
 ];
 
 /// Registers all FFI metric descriptions.


### PR DESCRIPTION
## Why this should be merged

The previous histogram bucket boundaries for FFI timing metrics (`ffi.commit_ms_bucket`, `ffi.propose_ms_bucket`, `ffi.batch_ms_bucket`) capped out at 50ms. Any operation exceeding that threshold was lumped into the implicit `+Inf` bucket, losing all distribution information for tail latencies — particularly for commit operations that can take well over 50ms.

## How this works

Adjusts the `FFI_TIMING_BUCKETS` constant in `ffi/src/registry.rs`:

- **Extends the upper range** from 50ms to 500ms (adds 100, 200, 500ms buckets) to capture slow commit operations.
- **Reduces mid-range granularity** (removes 3.0, 4.0, 6.0, 7.0, 8.0, 12.0ms buckets) where excessive detail provided little actionable signal.
- Keeps fine-grained buckets in the 0.1–2.5ms range where proposals typically land.

## How this was tested

This is a constant-only change. Existing Go-side tests (`TestMetrics`, `TestExpensiveMetrics`) validate metric existence and type, not specific bucket boundaries. Bucket values are monotonically increasing and units remain consistent (milliseconds) with all recording call sites.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [x] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl

The FFI breaking change box is checked because external consumers that parse or rely on specific Prometheus histogram bucket boundaries (e.g., dashboards, alerts) will see a different set of `le` labels after this change. The Go API itself is unaffected since it doesn't expose bucket configuration — but any downstream monitoring that _hard-codes_ bucket thresholds will need updating.