### PR TITLE
feat(remote-storage): Introduce NodeError for remote storage support

### DIFF
--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -5,7 +5,7 @@ use crate::merkle::{Key, Value};
 use crate::v2::api::{KeyType, KeyValuePair};
 
 use firewood_storage::{
-    BranchNode, Child, FileIoError, NibblesIterator, Node, PathBuf, PathComponent, PathIterItem,
+    BranchNode, Child, NibblesIterator, Node, NodeError, PathBuf, PathComponent, PathIterItem,
     SharedNode, TriePathFromUnpackedBytes, TrieReader,
 };
 use std::cmp::Ordering;
@@ -85,7 +85,7 @@ impl<'a, T: TrieReader> MerkleNodeIter<'a, T> {
 }
 
 impl<T: TrieReader> Iterator for MerkleNodeIter<'_, T> {
-    type Item = Result<(Key, SharedNode), FileIoError>;
+    type Item = Result<(Key, SharedNode), NodeError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         'outer: loop {
@@ -126,21 +126,9 @@ impl<T: TrieReader> Iterator for MerkleNodeIter<'_, T> {
                                     continue;
                                 };
 
-                                let child = match child {
-                                    Child::AddressWithHash(addr, _) => {
-                                        match self.merkle.read_node(addr) {
-                                            Ok(node) => node,
-                                            Err(e) => return Some(Err(e)),
-                                        }
-                                    }
-                                    Child::Node(node) => node.clone().into(),
-                                    Child::MaybePersisted(maybe_persisted, _) => {
-                                        // For MaybePersisted, we need to get the node
-                                        match maybe_persisted.as_shared_node(self.merkle) {
-                                            Ok(node) => node,
-                                            Err(e) => return Some(Err(e)),
-                                        }
-                                    }
+                                let child = match child.as_shared_node(self.merkle) {
+                                    Ok(node) => node,
+                                    Err(e) => return Some(Err(e)),
                                 };
 
                                 let child_partial_path = child.partial_path().iter().copied();
@@ -181,7 +169,7 @@ impl<T: TrieReader> FusedIterator for MerkleNodeIter<'_, T> {}
 fn get_iterator_intial_state<T: TrieReader>(
     merkle: &T,
     key: &[u8],
-) -> Result<NodeIterState, FileIoError> {
+) -> Result<NodeIterState, NodeError> {
     let Some(root) = merkle.root_node() else {
         // This merkle is empty.
         return Ok(NodeIterState::Iterating { iter_stack: vec![] });
@@ -261,12 +249,7 @@ fn get_iterator_intial_state<T: TrieReader>(
                     let child = &branch.children[next_unmatched_key_nibble];
                     node = match child {
                         None => return Ok(NodeIterState::Iterating { iter_stack }),
-                        Some(Child::AddressWithHash(addr, _)) => merkle.read_node(*addr)?,
-                        Some(Child::Node(node)) => (*node).clone().into(), // TODO can we avoid cloning this?
-                        Some(Child::MaybePersisted(maybe_persisted, _)) => {
-                            // For MaybePersisted, we need to get the node
-                            maybe_persisted.as_shared_node(merkle)?
-                        }
+                        Some(child) => child.as_shared_node(merkle)?,
                     };
 
                     matched_key_nibbles.push(next_unmatched_key_nibble.as_u8());
@@ -307,7 +290,7 @@ impl<'a, T: TrieReader> MerkleKeyValueIter<'a, T> {
 }
 
 impl<T: TrieReader> Iterator for MerkleKeyValueIter<'_, T> {
-    type Item = Result<(Key, Value), FileIoError>;
+    type Item = Result<(Key, Value), NodeError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.find_map(|result| {
@@ -360,7 +343,7 @@ pub struct PathIterator<'a, 'b, T> {
 }
 
 impl<'a, 'b, T: TrieReader> PathIterator<'a, 'b, T> {
-    pub(super) fn new(merkle: &'a T, key: &'b [u8]) -> Result<Self, FileIoError> {
+    pub(super) fn new(merkle: &'a T, key: &'b [u8]) -> Result<Self, NodeError> {
         let Some(root) = merkle.root_node() else {
             return Ok(Self {
                 state: PathIteratorState::Exhausted,
@@ -380,7 +363,7 @@ impl<'a, 'b, T: TrieReader> PathIterator<'a, 'b, T> {
 }
 
 impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
-    type Item = Result<PathIterItem, FileIoError>;
+    type Item = Result<PathIterItem, NodeError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // destructuring is necessary here because we need mutable access to `state`
@@ -452,35 +435,8 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
                                             next_nibble: None,
                                         }))
                                     }
-                                    Some(Child::AddressWithHash(child_addr, _)) => {
-                                        let child = match merkle.read_node(*child_addr) {
-                                            Ok(child) => child,
-                                            Err(e) => return Some(Err(e)),
-                                        };
-
-                                        matched_key.push(next_unmatched_key_nibble.as_u8());
-
-                                        *node = child;
-
-                                        Some(Ok(PathIterItem {
-                                            key_nibbles: node_key,
-                                            node: saved_node,
-                                            next_nibble: Some(next_unmatched_key_nibble),
-                                        }))
-                                    }
-                                    Some(Child::Node(child)) => {
-                                        matched_key.push(next_unmatched_key_nibble.as_u8());
-
-                                        *node = child.clone().into();
-
-                                        Some(Ok(PathIterItem {
-                                            key_nibbles: node_key,
-                                            node: saved_node,
-                                            next_nibble: Some(next_unmatched_key_nibble),
-                                        }))
-                                    }
-                                    Some(Child::MaybePersisted(maybe_persisted, _)) => {
-                                        let child = match maybe_persisted.as_shared_node(merkle) {
+                                    Some(child) => {
+                                        let child = match child.as_shared_node(merkle) {
                                             Ok(child) => child,
                                             Err(e) => return Some(Err(e)),
                                         };

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -26,7 +26,7 @@ use crate::v2::api::{ArcDynDbView, HashKey, OptionalHashKeyExt};
 use firewood_metrics::{firewood_increment, firewood_set};
 pub use firewood_storage::CacheReadStrategy;
 use firewood_storage::{
-    BranchNode, Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal,
+    BranchNode, Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal, NodeError,
     NodeHashAlgorithm, NodeStore, NodeStoreHeader, TrieHash,
 };
 
@@ -176,13 +176,21 @@ pub(crate) enum RevisionManagerError {
         expected: Option<HashKey>,
     },
     #[error("A FileIO error occurred during the commit: {0}")]
-    FileIoError(#[from] FileIoError),
+    FileIoError(FileIoError),
+    #[error("A node error occurred: {0:?}")]
+    NodeError(#[from] NodeError),
     #[error("An IO error occurred while creating the database directory: {0}")]
     IOError(#[from] io::Error),
     #[error("A RootStore error occurred: {0}")]
     RootStoreError(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("A deferred persistence error occurred: {0}")]
     PersistError(#[source] PersistError),
+}
+
+impl From<FileIoError> for RevisionManagerError {
+    fn from(err: FileIoError) -> Self {
+        RevisionManagerError::FileIoError(err)
+    }
 }
 
 impl RevisionManager {
@@ -562,6 +570,8 @@ mod tests {
             let revision = self.revision(root_hash)?;
             Ok(revision
                 .root_as_maybe_persisted_node()
+                .ok()
+                .flatten()
                 .is_some_and(|node| node.unpersisted().is_none()))
         }
     }

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -6,7 +6,7 @@ use std::{cmp::Ordering, iter::once};
 
 use firewood_metrics::firewood_increment;
 use firewood_storage::{
-    Child, FileIoError, HashedNodeReader, Node, NodeReader, Path, SharedNode, TrieHash,
+    Child, HashedNodeReader, Node, NodeError, NodeReader, Path, SharedNode, TrieHash,
 };
 use lender::{Lender, Lending};
 
@@ -181,7 +181,7 @@ struct ComparableNodeInfo {
 impl ComparableNodeInfo {
     // Creates a `ComparableNodeInfo` from a `Child`, its pre-path, and the trie that the `Child`
     // is from for reading the node from storage.
-    fn new<T: NodeReader>(pre_path: Path, child: &Child, trie: &T) -> Result<Self, FileIoError> {
+    fn new<T: NodeReader>(pre_path: Path, child: &Child, trie: &T) -> Result<Self, NodeError> {
         let node = child.as_shared_node(trie)?;
         // We need the full path as the diff algorithm compares the full paths of the current
         // nodes of the two tries.
@@ -211,7 +211,7 @@ impl<'a, Left: HashedNodeReader, Right: HashedNodeReader> DiffMerkleNodeStream<'
         left_tree: &'a Left,
         right_tree: &'a Right,
         start_key: Key,
-    ) -> Result<Self, FileIoError> {
+    ) -> Result<Self, NodeError> {
         // Create pre-order iterators for the two tries and have them iterate to the start key.
         // If the start key doesn't exist for an iterator, it will set the iterator to the
         // smallest key that is larger than the start key.
@@ -364,7 +364,7 @@ impl<'a, Left: HashedNodeReader, Right: HashedNodeReader> DiffMerkleNodeStream<'
     /// `one_step_compare` to complete the state handling.
     fn next_node_from_both(
         &mut self,
-    ) -> Result<(DiffIterationNodeState, Option<BatchOp<Key, Value>>), FileIoError> {
+    ) -> Result<(DiffIterationNodeState, Option<BatchOp<Key, Value>>), NodeError> {
         // Get the next node from the left trie.
         let Some(left_state) = self.left_tree.next_node_info()? else {
             // No more nodes in the left trie. For this state, the current node from the right trie has already
@@ -388,7 +388,7 @@ impl<'a, Left: HashedNodeReader, Right: HashedNodeReader> DiffMerkleNodeStream<'
 
     /// Only called by `next` to implement the Iterator trait. Separated out into a separate
     /// function mainly to simplify error handling.
-    fn next_internal(&mut self) -> Result<Option<BatchOp<Key, Value>>, FileIoError> {
+    fn next_internal(&mut self) -> Result<Option<BatchOp<Key, Value>>, NodeError> {
         // Loops until there is a value to return or if we have reached the end of the
         // traversal. State processing is based on the value of `state`, which we take at the
         // beginning of the loop and reassign before the next iteration. `state` can only be
@@ -476,7 +476,7 @@ impl<'a, Left: HashedNodeReader, Right: HashedNodeReader> DiffMerkleNodeStream<'
 impl<Left: HashedNodeReader, Right: HashedNodeReader> Iterator
     for DiffMerkleNodeStream<'_, Left, Right>
 {
-    type Item = Result<BatchOp<Key, Value>, FileIoError>;
+    type Item = Result<BatchOp<Key, Value>, NodeError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next_internal().transpose()
@@ -501,20 +501,20 @@ struct PreOrderIterator<'a, T: HashedNodeReader> {
 /// normal iterator is necessary since we want to return a reference to the current
 /// `ComparableNodeInfo` that is inside `PreOrderIterator`.
 impl<'lend, T: HashedNodeReader> Lending<'lend> for PreOrderIterator<'_, T> {
-    type Lend = Result<&'lend ComparableNodeInfo, FileIoError>;
+    type Lend = Result<&'lend ComparableNodeInfo, NodeError>;
 }
 
 impl<T: HashedNodeReader> Lender for PreOrderIterator<'_, T> {
     lender::check_covariance!();
 
-    fn next(&mut self) -> Option<Result<&'_ ComparableNodeInfo, FileIoError>> {
+    fn next(&mut self) -> Option<Result<&'_ ComparableNodeInfo, NodeError>> {
         self.next_node_info().transpose()
     }
 }
 
 impl<'a, T: HashedNodeReader> PreOrderIterator<'a, T> {
     /// Create a pre-order iterator for the trie that starts at `start_key`.
-    fn new(trie: &'a T, start_key: &Key) -> Result<PreOrderIterator<'a, T>, FileIoError> {
+    fn new(trie: &'a T, start_key: &Key) -> Result<PreOrderIterator<'a, T>, NodeError> {
         // If the root node is not None, then push a `ComparableNodeInfo` for the root onto
         // the traversal stack. It will be used on the first call to `next` or `next_node_info`.
         // Because we already have the root node, we create its `ComparableNodeInfo` directly
@@ -549,7 +549,7 @@ impl<'a, T: HashedNodeReader> PreOrderIterator<'a, T> {
     /// traversal stack until the subseqent call to `next` or `next_node_info`. This is done by saving
     /// the `ComparableNodeInfo` of the current node in `node_info` and keeping that available for the
     /// next call. Skipping traversal of the children then just involves setting `node_info` to None.
-    fn next_node_info(&mut self) -> Result<Option<&ComparableNodeInfo>, FileIoError> {
+    fn next_node_info(&mut self) -> Result<Option<&ComparableNodeInfo>, NodeError> {
         firewood_increment!(crate::registry::CHANGE_PROOF_NEXT, 1);
 
         // Take the info of the current node (which will soon be replaced), and check if it is a
@@ -592,7 +592,7 @@ impl<'a, T: HashedNodeReader> PreOrderIterator<'a, T> {
     }
 
     /// Modify the iterator to skip all keys prior to the specified key.
-    fn iterate_to_key(mut self, key: &Key) -> Result<Self, FileIoError> {
+    fn iterate_to_key(mut self, key: &Key) -> Result<Self, NodeError> {
         // Function is a no-op if the key is empty.
         if key.is_empty() {
             return Ok(self);
@@ -698,8 +698,8 @@ mod tests {
     };
 
     use firewood_storage::{
-        Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal, MemStore,
-        MutableProposal, NodeStore, SeededRng, TestRecorder, TrieReader,
+        Committed, FileBacked, HashedNodeReader, ImmutableProposal, MemStore, MutableProposal,
+        NodeError, NodeStore, SeededRng, TestRecorder, TrieReader,
     };
     use lender::Lender;
     use std::{collections::HashSet, ops::Deref, path::PathBuf, sync::Arc};
@@ -735,7 +735,7 @@ mod tests {
         tree_left: &'a Merkle<T>,
         tree_right: &'a Merkle<U>,
         start_key: Key,
-    ) -> Result<DiffMerkleNodeStream<'a, T, U>, FileIoError>
+    ) -> Result<DiffMerkleNodeStream<'a, T, U>, NodeError>
     where
         T: TrieReader + HashedNodeReader,
         U: TrieReader + HashedNodeReader,

--- a/firewood/src/merkle/merge.rs
+++ b/firewood/src/merkle/merge.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use firewood_storage::{FileIoError, TrieReader};
+use firewood_storage::{NodeError, TrieReader};
 
 use crate::{
     db::BatchOp,
@@ -55,10 +55,8 @@ where
     I: Iterator<Item: KeyValuePair>,
     K: KeyType,
 {
-    type Item = Result<
-        BatchOp<EitherKey<Key, <I as BatchIter>::Key>, <I as BatchIter>::Value>,
-        FileIoError,
-    >;
+    type Item =
+        Result<BatchOp<EitherKey<Key, <I as BatchIter>::Key>, <I as BatchIter>::Value>, NodeError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -18,8 +18,8 @@ use crate::{Proof, ProofCollection, ProofError, ProofNode, RangeProof};
 use firewood_metrics::firewood_increment;
 use firewood_storage::{
     BranchNode, Child, Children, FileIoError, HashType, HashedNodeReader, ImmutableProposal,
-    IntoHashType, LeafNode, MaybePersistedNode, MutableProposal, NibblesIterator, Node, NodeStore,
-    Parentable, Path, PathComponent, ReadableStorage, SharedNode, TrieHash, TrieReader,
+    IntoHashType, LeafNode, MaybePersistedNode, MutableProposal, NibblesIterator, Node, NodeError,
+    NodeStore, Parentable, Path, PathComponent, ReadableStorage, SharedNode, TrieHash, TrieReader,
     ValueDigest,
 };
 use std::collections::HashSet;
@@ -38,14 +38,16 @@ pub type Value = Box<[u8]>;
 macro_rules! write_attributes {
     ($writer:ident, $node:expr, $value:expr) => {
         if !$node.partial_path.0.is_empty() {
-            write!($writer, " pp={:x}", $node.partial_path)
-                .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
+            write!($writer, " pp={:x}", $node.partial_path).map_err(|e| {
+                NodeError::from(FileIoError::from_generic_no_file(e, "write attributes"))
+            })?;
         }
         if !$value.is_empty() {
             match std::str::from_utf8($value) {
                 Ok(string) if string.chars().all(char::is_alphanumeric) => {
-                    write!($writer, " val={:.6}", string)
-                        .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
+                    write!($writer, " val={:.6}", string).map_err(|e| {
+                        NodeError::from(FileIoError::from_generic_no_file(e, "write attributes"))
+                    })?;
                     if string.len() > 6 {
                         $writer.write_all(b"...").map_err(|e| {
                             FileIoError::from_generic_no_file(e, "write attributes")
@@ -54,8 +56,9 @@ macro_rules! write_attributes {
                 }
                 _ => {
                     let hex = hex::encode($value);
-                    write!($writer, " val={:.6}", hex)
-                        .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
+                    write!($writer, " val={:.6}", hex).map_err(|e| {
+                        NodeError::from(FileIoError::from_generic_no_file(e, "write attributes"))
+                    })?;
                     if hex.len() > 6 {
                         $writer.write_all(b"...").map_err(|e| {
                             FileIoError::from_generic_no_file(e, "write attributes")
@@ -72,7 +75,7 @@ fn get_helper<T: TrieReader>(
     nodestore: &T,
     node: &Node,
     key: &[u8],
-) -> Result<Option<SharedNode>, FileIoError> {
+) -> Result<Option<SharedNode>, NodeError> {
     // 4 possibilities for the position of the `key` relative to `node`:
     // 1. The node is at `key`
     // 2. The key is above the node (i.e. its ancestor)
@@ -98,13 +101,8 @@ fn get_helper<T: TrieReader>(
                 Node::Leaf(_) => Ok(None),
                 Node::Branch(node) => match node.children[child_index].as_ref() {
                     None => Ok(None),
-                    Some(Child::Node(child)) => get_helper(nodestore, child, remaining_key),
-                    Some(Child::AddressWithHash(addr, _)) => {
-                        let child = nodestore.read_node(*addr)?;
-                        get_helper(nodestore, &child, remaining_key)
-                    }
-                    Some(Child::MaybePersisted(maybe_persisted, _)) => {
-                        let child = maybe_persisted.as_shared_node(nodestore)?;
+                    Some(child) => {
+                        let child = child.as_shared_node(nodestore)?;
                         get_helper(nodestore, &child, remaining_key)
                     }
                 },
@@ -303,7 +301,7 @@ impl<T: TrieReader> Merkle<T> {
     pub(crate) fn path_iter<'a>(
         &self,
         key: &'a [u8],
-    ) -> Result<PathIterator<'_, 'a, T>, FileIoError> {
+    ) -> Result<PathIterator<'_, 'a, T>, NodeError> {
         PathIterator::new(&self.nodestore, key)
     }
 
@@ -416,7 +414,7 @@ impl<T: TrieReader> Merkle<T> {
         let key_values = iter
             .by_ref()
             .take(limit.map_or(usize::MAX, NonZeroUsize::get))
-            .collect::<Result<Box<_>, FileIoError>>()?;
+            .collect::<Result<Box<_>, NodeError>>()?;
 
         if key_values.is_empty() && start_key.is_none() && end_key.is_none() {
             // unbounded range proof yielded no key-values, so the trie must be empty
@@ -442,14 +440,14 @@ impl<T: TrieReader> Merkle<T> {
         Ok(RangeProof::new(start_proof, end_proof, key_values))
     }
 
-    pub(crate) fn get_value(&self, key: &[u8]) -> Result<Option<Value>, FileIoError> {
+    pub(crate) fn get_value(&self, key: &[u8]) -> Result<Option<Value>, NodeError> {
         let Some(node) = self.get_node(key)? else {
             return Ok(None);
         };
         Ok(node.value().map(|v| v.to_vec().into_boxed_slice()))
     }
 
-    pub(crate) fn get_node(&self, key: &[u8]) -> Result<Option<SharedNode>, FileIoError> {
+    pub(crate) fn get_node(&self, key: &[u8]) -> Result<Option<SharedNode>, NodeError> {
         let Some(root) = self.root() else {
             return Ok(None);
         };
@@ -520,7 +518,7 @@ impl<T: HashedNodeReader> Merkle<T> {
         let batch_ops = iter
             .by_ref()
             .take(limit.map_or(usize::MAX, NonZeroUsize::get))
-            .collect::<Result<Box<_>, FileIoError>>()?;
+            .collect::<Result<Box<_>, NodeError>>()?;
 
         let end_proof = if let Some(limit) = limit
             && limit.get() <= batch_ops.len()
@@ -548,31 +546,41 @@ impl<T: HashedNodeReader> Merkle<T> {
         hash: Option<&HashType>,
         seen: &mut HashSet<String>,
         writer: &mut W,
-    ) -> Result<(), FileIoError> {
+    ) -> Result<(), NodeError> {
         writeln!(writer, "  {node}[label=\"{node}")
             .map_err(Error::other)
-            .map_err(|e| FileIoError::new(e, None, 0, None))?;
+            .map_err(|e| NodeError::from(FileIoError::new(e, None, 0, None)))?;
         if let Some(hash) = hash {
             write!(writer, " H={hash:.6?}")
                 .map_err(Error::other)
-                .map_err(|e| FileIoError::new(e, None, 0, None))?;
+                .map_err(|e| NodeError::from(FileIoError::new(e, None, 0, None)))?;
         }
 
         match &*node.as_shared_node(&self.nodestore)? {
             Node::Branch(b) => {
                 write_attributes!(writer, b, &b.value.clone().unwrap_or(Box::from([])));
-                writeln!(writer, "\"]")
-                    .map_err(|e| FileIoError::from_generic_no_file(e, "write branch"))?;
+                writeln!(writer, "\"]").map_err(|e| {
+                    NodeError::from(FileIoError::from_generic_no_file(e, "write branch"))
+                })?;
                 for (childidx, child) in &b.children {
                     let (child, child_hash) = match child {
                         None => continue,
-                        Some(node) => (node.as_maybe_persisted_node(), node.hash()),
+                        Some(node) => match node.try_as_maybe_persisted_node() {
+                            Ok(mp) => (mp, node.hash()),
+                            Err(_) => continue,
+                        },
                     };
 
                     let inserted = seen.insert(format!("{child}"));
                     if inserted {
-                        writeln!(writer, "  {node} -> {child}[label=\"{childidx:x}\"]")
-                            .map_err(|e| FileIoError::from_generic_no_file(e, "write branch"))?;
+                        writeln!(writer, "  {node} -> {child}[label=\"{childidx:x}\"]").map_err(
+                            |e| {
+                                NodeError::from(FileIoError::from_generic_no_file(
+                                    e,
+                                    "write branch",
+                                ))
+                            },
+                        )?;
                         self.dump_node(&child, child_hash, seen, writer)?;
                     } else {
                         // We have already seen this child, which shouldn't happen.
@@ -581,14 +589,17 @@ impl<T: HashedNodeReader> Merkle<T> {
                             writer,
                             "  {node} -> {child}[label=\"{childidx:x} (dup)\" color=red]"
                         )
-                        .map_err(|e| FileIoError::from_generic_no_file(e, "write branch"))?;
+                        .map_err(|e| {
+                            NodeError::from(FileIoError::from_generic_no_file(e, "write branch"))
+                        })?;
                     }
                 }
             }
             Node::Leaf(l) => {
                 write_attributes!(writer, l, &l.value);
-                writeln!(writer, "\" shape=rect]")
-                    .map_err(|e| FileIoError::from_generic_no_file(e, "write leaf"))?;
+                writeln!(writer, "\" shape=rect]").map_err(|e| {
+                    NodeError::from(FileIoError::from_generic_no_file(e, "write leaf"))
+                })?;
             }
         }
         Ok(())
@@ -605,7 +616,7 @@ impl<T: HashedNodeReader> Merkle<T> {
     ///
     /// Returns an error if writing to the output writer fails.
     pub(crate) fn dump<W: std::io::Write + ?Sized>(&self, writer: &mut W) -> Result<(), Error> {
-        let root = self.nodestore.root_as_maybe_persisted_node();
+        let root = self.nodestore.root_as_maybe_persisted_node().ok().flatten();
 
         writeln!(writer, "digraph Merkle {{\n  rankdir=LR;").map_err(Error::other)?;
         if let (Some(root), Some(root_hash)) = (root, self.nodestore.root_hash()) {
@@ -652,7 +663,7 @@ impl<F: Parentable, S: ReadableStorage> Merkle<NodeStore<F, S>> {
 impl<S: ReadableStorage> TryFrom<Merkle<NodeStore<MutableProposal, S>>>
     for Merkle<NodeStore<Arc<ImmutableProposal>, S>>
 {
-    type Error = FileIoError;
+    type Error = NodeError;
     fn try_from(m: Merkle<NodeStore<MutableProposal, S>>) -> Result<Self, Self::Error> {
         Ok(Merkle {
             nodestore: m.nodestore.try_into()?,
@@ -674,17 +685,17 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
         self.try_into().expect("failed to convert")
     }
 
-    fn read_for_update(&mut self, child: Child) -> Result<Node, FileIoError> {
-        match child {
-            Child::Node(node) => Ok(node),
-            Child::AddressWithHash(addr, _) => self.nodestore.read_for_update(addr.into()),
-            Child::MaybePersisted(node, _) => self.nodestore.read_for_update(node),
-        }
+    fn read_for_update(&mut self, child: Child) -> Result<Node, NodeError> {
+        Ok(match child {
+            Child::Node(node) => node,
+            Child::AddressWithHash(addr, _) => self.nodestore.read_for_update(addr.into())?,
+            Child::MaybePersisted(node, _) => self.nodestore.read_for_update(node)?,
+        })
     }
 
     /// Map `key` to `value` in the trie.
     /// Each element of key is 2 nibbles.
-    pub fn insert(&mut self, key: &[u8], value: Value) -> Result<(), FileIoError> {
+    pub fn insert(&mut self, key: &[u8], value: Value) -> Result<(), NodeError> {
         self.insert_from_iter(NibblesIterator::new(key), value)
     }
 
@@ -693,7 +704,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
         &mut self,
         key: NibblesIterator<'_>,
         value: Value,
-    ) -> Result<(), FileIoError> {
+    ) -> Result<(), NodeError> {
         let key = Path::from_nibbles_iterator(key);
         let root = self.nodestore.root_mut();
         let Some(root_node) = std::mem::take(root) else {
@@ -721,7 +732,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
         mut node: Node,
         key: &[u8],
         value: Value,
-    ) -> Result<Node, FileIoError> {
+    ) -> Result<Node, NodeError> {
         // 4 possibilities for the position of the `key` relative to `node`:
         // 1. The node is at `key`
         // 2. The key is above the node (i.e. its ancestor)
@@ -849,7 +860,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
     /// Returns the value that was removed, if any.
     /// Otherwise returns `None`.
     /// Each element of `key` is 2 nibbles.
-    pub fn remove(&mut self, key: &[u8]) -> Result<Option<Value>, FileIoError> {
+    pub fn remove(&mut self, key: &[u8]) -> Result<Option<Value>, NodeError> {
         self.remove_from_iter(NibblesIterator::new(key))
     }
 
@@ -860,7 +871,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
     pub fn remove_from_iter(
         &mut self,
         key: NibblesIterator<'_>,
-    ) -> Result<Option<Value>, FileIoError> {
+    ) -> Result<Option<Value>, NodeError> {
         let key = Path::from_nibbles_iterator(key);
         let root = self.nodestore.root_mut();
         let Some(root_node) = std::mem::take(root) else {
@@ -886,7 +897,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
         &mut self,
         node: Node,
         key: &[u8],
-    ) -> Result<(Option<Node>, Option<Value>), FileIoError> {
+    ) -> Result<(Option<Node>, Option<Value>), NodeError> {
         // 4 possibilities for the position of the `key` relative to `node`:
         // 1. The node is at `key`
         // 2. The key is above the node (i.e. its ancestor)
@@ -948,7 +959,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
 
     /// Removes any key-value pairs with keys that have the given `prefix`.
     /// Returns the number of key-value pairs removed.
-    pub fn remove_prefix(&mut self, prefix: &[u8]) -> Result<usize, FileIoError> {
+    pub fn remove_prefix(&mut self, prefix: &[u8]) -> Result<usize, NodeError> {
         self.remove_prefix_from_iter(NibblesIterator::new(prefix))
     }
 
@@ -957,7 +968,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
     pub fn remove_prefix_from_iter(
         &mut self,
         prefix: NibblesIterator<'_>,
-    ) -> Result<usize, FileIoError> {
+    ) -> Result<usize, NodeError> {
         let prefix = Path::from_nibbles_iterator(prefix);
         let root = self.nodestore.root_mut();
         let Some(root_node) = std::mem::take(root) else {
@@ -978,7 +989,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
         node: Node,
         key: &[u8],
         deleted: &mut usize,
-    ) -> Result<Option<Node>, FileIoError> {
+    ) -> Result<Option<Node>, NodeError> {
         // 4 possibilities for the position of the `key` relative to `node`:
         // 1. The node is at `key`, in which case we need to delete this node and all its children.
         // 2. The key is above the node (i.e. its ancestor), so the parent needs to be restructured (TODO).
@@ -1045,7 +1056,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
         &mut self,
         mut branch: Box<BranchNode>,
         deleted: &mut usize,
-    ) -> Result<(), FileIoError> {
+    ) -> Result<(), NodeError> {
         if branch.value.is_some() {
             // a KV pair was in the branch itself
             *deleted = deleted.saturating_add(1);
@@ -1078,7 +1089,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
     fn flatten_branch(
         &mut self,
         mut branch_node: Box<BranchNode>,
-    ) -> Result<Option<Node>, FileIoError> {
+    ) -> Result<Option<Node>, NodeError> {
         let mut children_iter = branch_node.children.each_mut().into_iter();
 
         let (child_index, child) = loop {

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -8,8 +8,8 @@ use firewood_metrics::{current_metrics_context, set_metrics_context};
 use firewood_storage::logger::error;
 use firewood_storage::{
     BranchNode, Child, Children, FileBacked, FileIoError, ImmutableProposal, LeafNode,
-    MaybePersistedNode, MutableProposal, NibblesIterator, Node, NodeStore, Parentable, Path,
-    PathComponent,
+    MaybePersistedNode, MutableProposal, NibblesIterator, Node, NodeError, NodeStore, Parentable,
+    Path, PathComponent,
 };
 use rayon::ThreadPool;
 use std::iter::once;
@@ -38,14 +38,20 @@ struct Response {
 
 #[derive(Debug)]
 pub enum CreateProposalError {
-    FileIoError(FileIoError),
+    NodeError(NodeError),
     SendError,
     InvalidConversionToPathComponent,
 }
 
+impl From<NodeError> for CreateProposalError {
+    fn from(err: NodeError) -> Self {
+        CreateProposalError::NodeError(err)
+    }
+}
+
 impl From<FileIoError> for CreateProposalError {
     fn from(err: FileIoError) -> Self {
-        CreateProposalError::FileIoError(err)
+        CreateProposalError::NodeError(NodeError::from(err))
     }
 }
 
@@ -116,7 +122,7 @@ impl ParallelMerkle {
         &self,
         nodestore: &mut NodeStore<MutableProposal, FileBacked>,
         mut branch: Box<BranchNode>,
-    ) -> Result<Option<Node>, FileIoError> {
+    ) -> Result<Option<Node>, NodeError> {
         let mut children_iter = branch
             .children
             .iter_mut()
@@ -169,8 +175,8 @@ impl ParallelMerkle {
         mut merkle: Merkle<NodeStore<MutableProposal, FileBacked>>,
         first_path_component: PathComponent,
         child_receiver: Receiver<BatchOp<Key, Value>>,
-        response_sender: Sender<Result<Response, FileIoError>>,
-    ) -> Result<(), Box<SendError<Result<Response, FileIoError>>>> {
+        response_sender: Sender<Result<Response, NodeError>>,
+    ) -> Result<(), Box<SendError<Result<Response, NodeError>>>> {
         // Wait for a message on the receiver child channel. Break out of loop when the sender has
         // closed the child sender.
         while let Ok(request) = child_receiver.recv() {
@@ -230,8 +236,8 @@ impl ParallelMerkle {
         proposal: &mut NodeStore<MutableProposal, FileBacked>,
         root_branch: &mut BranchNode,
         first_path_component: PathComponent,
-        response_sender: Sender<Result<Response, FileIoError>>,
-    ) -> Result<WorkerSender, FileIoError> {
+        response_sender: Sender<Result<Response, NodeError>>,
+    ) -> Result<WorkerSender, NodeError> {
         // Create a channel for the coordinator (main thread) to send messages to this worker.
         let (child_sender, child_receiver) = mpsc::channel();
 
@@ -239,7 +245,7 @@ impl ParallelMerkle {
             .children
             .get_mut(first_path_component)
             .take()
-            .map(|child| -> Result<_, FileIoError> {
+            .map(|child| -> Result<_, NodeError> {
                 match child {
                     Child::Node(node) => Ok(node),
                     Child::AddressWithHash(address, _) => {
@@ -277,10 +283,10 @@ impl ParallelMerkle {
     // root node of the main trie.
     fn merge_children(
         &mut self,
-        response_channel: Receiver<Result<Response, FileIoError>>,
+        response_channel: Receiver<Result<Response, NodeError>>,
         proposal: &mut NodeStore<MutableProposal, FileBacked>,
         root_branch: &mut BranchNode,
-    ) -> Result<(), FileIoError> {
+    ) -> Result<(), NodeError> {
         while let Ok(response) = response_channel.recv() {
             match response {
                 Ok(response) => {
@@ -306,8 +312,8 @@ impl ParallelMerkle {
         proposal: &mut NodeStore<MutableProposal, FileBacked>,
         root_branch: &mut BranchNode,
         first_path_component: PathComponent,
-        response_sender: Sender<Result<Response, FileIoError>>,
-    ) -> Result<&mut WorkerSender, FileIoError> {
+        response_sender: Sender<Result<Response, NodeError>>,
+    ) -> Result<&mut WorkerSender, NodeError> {
         // Find the worker's state corresponding to the first nibble which is stored in an array.
         let worker_option = self.workers.get_mut(first_path_component);
 
@@ -346,17 +352,17 @@ impl ParallelMerkle {
     }
 
     /// The parent thread may receive a `SendError` if the worker that it is sending to has
-    /// returned to the threadpool after encountering a `FileIoError`. This function should
-    /// be called after receiving a `SendError` to find and propagate the `FileIoError`.
-    fn find_fileio_error(
-        response_receiver: &Receiver<Result<Response, FileIoError>>,
-    ) -> Result<(), FileIoError> {
+    /// returned to the threadpool after encountering a `NodeError`. This function should
+    /// be called after receiving a `SendError` to find and propagate the `NodeError`.
+    fn find_node_error(
+        response_receiver: &Receiver<Result<Response, NodeError>>,
+    ) -> Result<(), NodeError> {
         // Go through the messages in the response channel without blocking to see if we can
-        // find the FileIoError that caused the worker to close the channel, resulting in a
-        // send error. If we can find it, then we propagate the FileIoError. Note that
-        // successful responses can be in the response channel ahead of the FileIoError.
+        // find the NodeError that caused the worker to close the channel, resulting in a
+        // send error. If we can find it, then we propagate the NodeError. Note that
+        // successful responses can be in the response channel ahead of the NodeError.
         // These are sent from workers that completed their requests without encountering
-        // a FileIoError.
+        // a NodeError.
         for result in response_receiver.try_iter() {
             let _ = result?; // explicitly ignore the successful Response
         }
@@ -372,7 +378,7 @@ impl ParallelMerkle {
     ///
     /// # Errors
     ///
-    /// Returns a `CreateProposalError::FileIoError` if it encounters an error fetching nodes
+    /// Returns a `CreateProposalError::NodeError` if it encounters an error fetching nodes
     /// from storage, a `CreateProposalError::SendError` if it is unable to send messages to
     /// the workers, and a `CreateProposalError::InvalidConversionToPathComponent` if it is
     /// unable to convert a u8 index into a path component.
@@ -425,7 +431,7 @@ impl ParallelMerkle {
                             // A send error is most likely due to a worker returning to the thread pool
                             // after it encountered a FileIoError. Try to find the FileIoError in the
                             // response channel and return that instead.
-                            ParallelMerkle::find_fileio_error(&response_receiver)?;
+                            ParallelMerkle::find_node_error(&response_receiver)?;
                             return Err(err.into());
                         }
                     }
@@ -467,7 +473,7 @@ impl ParallelMerkle {
                 // A send error is most likely due to a worker returning to the thread pool
                 // after it encountered a FileIoError. Try to find the FileIoError in the
                 // response channel and return that instead.
-                ParallelMerkle::find_fileio_error(&response_receiver)?;
+                ParallelMerkle::find_node_error(&response_receiver)?;
                 return Err(err.into());
             }
         }

--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -57,7 +57,7 @@ use std::{
 };
 
 use firewood_storage::{
-    Committed, FileBacked, FileIoError, HashedNodeReader, LinearAddress, NodeStore,
+    Committed, FileBacked, FileIoError, HashedNodeReader, LinearAddress, NodeError, NodeStore,
     NodeStoreHeader, TrieHash,
 };
 use parking_lot::{Condvar, Mutex, MutexGuard};
@@ -71,6 +71,8 @@ use firewood_storage::logger::error;
 pub enum PersistError {
     #[error("IO error during persistence: {0}")]
     FileIo(#[from] Arc<FileIoError>),
+    #[error("Node error during persistence: {0:?}")]
+    NodeError(Arc<NodeError>),
     #[error("RootStore error during persistence: {0}")]
     RootStore(#[source] Arc<dyn std::error::Error + Send + Sync>),
     #[error("Persist worker has shut down")]
@@ -495,8 +497,8 @@ impl PersistLoop {
     fn persist_to_disk(&self, revision: &CommittedRevision) -> Result<(), PersistError> {
         let mut header = self.shared.header.lock();
         revision.persist(&mut header).map_err(|e| {
-            error!("Failed to persist revision: {e}");
-            PersistError::FileIo(Arc::new(e))
+            error!("Failed to persist revision: {e:?}");
+            PersistError::NodeError(Arc::new(e))
         })
     }
 

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -48,8 +48,9 @@
 )]
 
 use firewood_storage::{
-    Children, FileIoError, HashType, Hashable, IntoHashType, IntoSplitPath, NibblesIterator, Path,
-    PathBuf, PathComponent, PathIterItem, Preimage, SplitPath, TrieHash, TriePath, ValueDigest,
+    Children, FileIoError, HashType, Hashable, IntoHashType, IntoSplitPath, NibblesIterator,
+    NodeError, Path, PathBuf, PathComponent, PathIterItem, Preimage, SplitPath, TrieHash, TriePath,
+    ValueDigest,
 };
 use thiserror::Error;
 
@@ -105,7 +106,11 @@ pub enum ProofError {
 
     /// Error from the merkle package
     #[error("{0:?}")]
-    IO(#[from] FileIoError),
+    IO(FileIoError),
+
+    /// Error from node operations
+    #[error("{0:?}")]
+    NodeError(#[from] NodeError),
 
     /// Error deserializing a proof
     #[error("error deserializing a proof: {0}")]
@@ -143,6 +148,12 @@ pub enum ProofError {
 
     #[error("the proposal for a change proof is None as it has been consumed")]
     ProposalIsNone,
+}
+
+impl From<FileIoError> for ProofError {
+    fn from(err: FileIoError) -> Self {
+        ProofError::IO(err)
+    }
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -6,7 +6,7 @@ use crate::merkle::parallel::CreateProposalError;
 use crate::merkle::{Key, Value};
 use crate::persist_worker::PersistError;
 use crate::{Proof, ProofError, ProofNode, RangeProof};
-use firewood_storage::{FileIoError, TrieHash};
+use firewood_storage::{FileIoError, NodeError, TrieHash};
 use std::fmt::Debug;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -145,7 +145,7 @@ pub enum Error {
 
     #[error("File IO error: {0}")]
     /// A file I/O error occurred
-    FileIO(#[from] FileIoError),
+    FileIO(FileIoError),
 
     #[error("RootStore error: {0}")]
     /// A `RootStore` error occurred
@@ -212,10 +212,25 @@ impl From<std::convert::Infallible> for Error {
     }
 }
 
+impl From<FileIoError> for Error {
+    fn from(err: FileIoError) -> Self {
+        Error::FileIO(err)
+    }
+}
+
+impl From<NodeError> for Error {
+    fn from(err: NodeError) -> Self {
+        match err {
+            NodeError::Io(io_err) => Error::FileIO(io_err),
+            other @ NodeError::Proxy(_) => Error::InternalError(Box::new(other)),
+        }
+    }
+}
+
 impl From<RevisionManagerError> for Error {
     fn from(err: RevisionManagerError) -> Self {
         use RevisionManagerError::{
-            FileIoError, IOError, NotLatest, PersistError, RevisionNotFound,
+            FileIoError, IOError, NodeError, NotLatest, PersistError, RevisionNotFound,
             RevisionWithoutAddress, RootStoreError,
         };
         match err {
@@ -225,6 +240,7 @@ impl From<RevisionManagerError> for Error {
             },
             RevisionWithoutAddress { provided } => Self::RevisionWithoutAddress { provided },
             FileIoError(io_err) => Self::FileIO(io_err),
+            NodeError(err) => Self::from(err),
             IOError(err) => Self::IO(err),
             RootStoreError(err) => Self::RootStoreError(err),
             PersistError(err) => Self::DeferredPersistenceError(err),
@@ -243,7 +259,7 @@ impl From<crate::db::DbError> for Error {
 impl From<CreateProposalError> for Error {
     fn from(value: CreateProposalError) -> Self {
         match value {
-            CreateProposalError::FileIoError(err) => Error::FileIO(err),
+            CreateProposalError::NodeError(err) => Error::from(err),
             CreateProposalError::SendError => Error::SendErrorToWorker,
             CreateProposalError::InvalidConversionToPathComponent => {
                 Error::InvalidConversionToPathComponent
@@ -304,7 +320,7 @@ pub trait Db {
 /// 3. From [`Proposal::propose`] which is a view on top of another proposal.
 pub trait DbView {
     /// The type of a stream of key/value pairs
-    type Iter<'view>: Iterator<Item = Result<(Key, Value), FileIoError>>
+    type Iter<'view>: Iterator<Item = Result<(Key, Value), NodeError>>
     where
         Self: 'view;
 
@@ -374,8 +390,7 @@ pub trait DbView {
 }
 
 /// A boxed iterator over key/value pairs.
-pub type BoxKeyValueIter<'view> =
-    Box<dyn Iterator<Item = Result<(Key, Value), FileIoError>> + 'view>;
+pub type BoxKeyValueIter<'view> = Box<dyn Iterator<Item = Result<(Key, Value), NodeError>> + 'view>;
 
 /// A dynamic dyspatch version of [`DbView`] that can be shared.
 pub type ArcDynDbView = Arc<dyn DynDbView>;

--- a/firewood/src/v2/batch_op.rs
+++ b/firewood/src/v2/batch_op.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use firewood_storage::FileIoError;
+use firewood_storage::NodeError;
 
 use crate::v2::api::{KeyType, ValueType};
 
@@ -147,7 +147,7 @@ impl<K: KeyType, V: ValueType> KeyValuePair for &(K, V) {
     }
 }
 
-impl<T: KeyValuePair<Error = std::convert::Infallible>, E: Into<FileIoError>> KeyValuePair
+impl<T: KeyValuePair<Error = std::convert::Infallible>, E: Into<NodeError>> KeyValuePair
     for Result<T, E>
 {
     fn try_into_tuple(self) -> Result<(Self::Key, Self::Value), Self::Error> {
@@ -167,13 +167,13 @@ pub trait TryIntoBatch {
     type Value: ValueType;
 
     /// The error type. It is preferable to use an error that is convertible into
-    /// [`FileIoError`] instead of the type directly to allow for better compiler
+    /// [`NodeError`] instead of the type directly to allow for better compiler
     /// optimizations.
     ///
-    /// E.g., [`std::convert::Infallible`] is preferred over [`FileIoError`] when
+    /// E.g., [`std::convert::Infallible`] is preferred over [`NodeError`] when
     /// there is no possibility of error so that the compiler can optimize away
     /// error handling.
-    type Error: Into<FileIoError>;
+    type Error: Into<NodeError>;
 
     /// Convert this key-value pair into a [`BatchOp`].
     ///
@@ -236,7 +236,7 @@ impl<'a, K: KeyType, V: ValueType> TryIntoBatch for &'a BatchOp<K, V> {
 impl<T, E> TryIntoBatch for Result<T, E>
 where
     T: TryIntoBatch<Error = std::convert::Infallible>,
-    E: Into<FileIoError>,
+    E: Into<NodeError>,
 {
     type Key = T::Key;
     type Value = T::Value;
@@ -267,7 +267,7 @@ pub trait BatchIter:
     /// An associated type for the iterator item's error type. This is a convenience
     /// requirement to avoid needing to build up nested generic associated types.
     /// E.g., `<<Self as Iterator>::Item as KeyValuePair>::Error`
-    type Error: Into<FileIoError>;
+    type Error: Into<NodeError>;
 }
 
 impl<I: Iterator<Item: TryIntoBatch>> BatchIter for I {
@@ -292,11 +292,11 @@ pub trait IntoBatchIter: IntoIterator<IntoIter: BatchIter> {
     fn into_batch_iter<E>(self) -> std::iter::Map<Self::IntoIter, MapIntoBatchFn<Self::Item, E>>
     where
         Self: Sized,
-        FileIoError: Into<E>,
+        NodeError: Into<E>,
     {
         self.into_iter().map(|item| {
             item.try_into_batch()
-                .map_err(Into::<FileIoError>::into)
+                .map_err(Into::<NodeError>::into)
                 .map_err(Into::<E>::into)
         })
     }

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -5,7 +5,7 @@ use firewood::db::{Db, DbConfig};
 use firewood::iter::MerkleKeyValueIter;
 use firewood::merkle::{Key, Value};
 use firewood::v2::api::{self, Db as _};
-use firewood_storage::FileIoError;
+use firewood_storage::NodeError;
 use std::borrow::Cow;
 use std::error::Error;
 use std::fs::File;
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 
 use crate::DatabasePath;
 
-type KeyFromStream = Option<Result<(Key, Value), FileIoError>>;
+type KeyFromStream = Option<Result<(Key, Value), NodeError>>;
 
 #[derive(Debug, clap::ValueEnum, Clone, PartialEq)]
 pub enum OutputFormat {

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -199,6 +199,8 @@ where
         }
         let trie_stats = self
             .root_as_maybe_persisted_node()
+            .ok()
+            .flatten()
             .and_then(|node| self.root_hash().map(|root_hash| (node, root_hash)))
             .and_then(|(root, root_hash)| {
                 if let Some(root_address) = root.as_linear_address() {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -52,6 +52,7 @@ pub use hashednode::{Hashable, Preimage, ValueDigest, hash_node, hash_preimage};
 pub use hashedshunt::HashableShunt;
 pub use hashtype::{HashType, IntoHashType, InvalidTrieHashLength, TrieHash};
 pub use linear::{FileIoError, ReadableStorage, WritableStorage};
+pub use node::branch::NodeError;
 pub use node::path::{NibblesIterator, Path};
 pub use node::{BranchNode, Child, Children, ChildrenSlots, LeafNode, Node, PathIterItem};
 pub use nodestore::{

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -1,11 +1,6 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![expect(
-    clippy::match_same_arms,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-
 use crate::node::ExtendableBytes;
 use crate::node::children::Children;
 use crate::{
@@ -14,6 +9,53 @@ use crate::{
 };
 use std::fmt::{Debug, Formatter};
 use std::io::Read;
+
+/// Error type for trie node operations.
+///
+/// This distinguishes between storage I/O errors and logical trie errors
+/// (e.g., encountering a `Child::Proxy` that requires remote lookup).
+#[derive(Debug)]
+pub enum NodeError {
+    /// An I/O error from the storage layer.
+    Io(FileIoError),
+    /// A Proxy child was encountered that requires remote lookup.
+    Proxy(HashType),
+}
+
+impl From<FileIoError> for NodeError {
+    fn from(e: FileIoError) -> Self {
+        NodeError::Io(e)
+    }
+}
+
+impl From<std::convert::Infallible> for NodeError {
+    fn from(e: std::convert::Infallible) -> Self {
+        match e {}
+    }
+}
+
+impl std::fmt::Display for NodeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NodeError::Io(e) => write!(f, "node I/O error: {e}"),
+            NodeError::Proxy(hash) => {
+                write!(
+                    f,
+                    "proxy child encountered (hash={hash}): requires remote lookup"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for NodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            NodeError::Io(e) => Some(e),
+            NodeError::Proxy(_) => None,
+        }
+    }
+}
 
 pub(crate) trait Serializable {
     fn write_to<W: ExtendableBytes>(&self, vec: &mut W);
@@ -72,9 +114,8 @@ impl lru_mem::HeapSize for Child {
     fn heap_size(&self) -> usize {
         match self {
             Child::Node(node) => node.heap_size(),
-            Child::AddressWithHash(_, _) => 0,
-            // MaybePersisted contains Arc<Mutex>, we don't count shared data
-            Child::MaybePersisted(_, _) => 0,
+            // AddressWithHash and MaybePersisted contain Arc<Mutex>, we don't count shared data
+            Child::AddressWithHash(_, _) | Child::MaybePersisted(_, _) => 0,
         }
     }
 }
@@ -86,7 +127,7 @@ impl Child {
     pub const fn as_mut_node(&mut self) -> Option<&mut Node> {
         match self {
             Child::Node(node) => Some(node),
-            _ => None,
+            Child::AddressWithHash(..) | Child::MaybePersisted(..) => None,
         }
     }
 
@@ -104,19 +145,18 @@ impl Child {
     /// variant, otherwise None.
     #[must_use]
     pub fn unpersisted(&self) -> Option<&MaybePersistedNode> {
-        if let Child::MaybePersisted(maybe_persisted, _) = self {
-            maybe_persisted.unpersisted()
-        } else {
-            None
+        match self {
+            Child::MaybePersisted(maybe_persisted, _) => maybe_persisted.unpersisted(),
+            Child::Node(_) | Child::AddressWithHash(..) => None,
         }
     }
 
-    /// Return the hash of the child if it is a [`Child::AddressWithHash`] or [`Child::MaybePersisted`] variant, otherwise None.
+    /// Return the hash of the child if it has been hashed. Returns `None` only
+    /// for [`Child::Node`] variants which have not yet been hashed.
     #[must_use]
     pub const fn hash(&self) -> Option<&HashType> {
         match self {
-            Child::AddressWithHash(_, hash) => Some(hash),
-            Child::MaybePersisted(_, hash) => Some(hash),
+            Child::AddressWithHash(_, hash) | Child::MaybePersisted(_, hash) => Some(hash),
             Child::Node(_) => None,
         }
     }
@@ -145,12 +185,15 @@ impl Child {
     ///
     /// This is used in the dump utility, but otherwise should be avoided,
     /// as it may create an unnecessary `MaybePersistedNode`
-    #[must_use]
-    pub fn as_maybe_persisted_node(&self) -> MaybePersistedNode {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError`] if conversion is not possible.
+    pub fn try_as_maybe_persisted_node(&self) -> Result<MaybePersistedNode, NodeError> {
         match self {
-            Child::Node(node) => MaybePersistedNode::from(SharedNode::from(node.clone())),
-            Child::AddressWithHash(addr, _) => MaybePersistedNode::from(*addr),
-            Child::MaybePersisted(maybe_persisted, _) => maybe_persisted.clone(),
+            Child::Node(node) => Ok(MaybePersistedNode::from(SharedNode::from(node.clone()))),
+            Child::AddressWithHash(addr, _) => Ok(MaybePersistedNode::from(*addr)),
+            Child::MaybePersisted(maybe_persisted, _) => Ok(maybe_persisted.clone()),
         }
     }
 
@@ -162,14 +205,20 @@ impl Child {
     ///
     /// # Returns
     ///
-    /// Returns a `Result<SharedNode, FileIoError>` where:
+    /// Returns a `Result<SharedNode, NodeError>` where:
     /// - `Ok(SharedNode)` contains the node if successfully read
-    /// - `Err(FileIoError)` if there was an error reading from storage
-    pub fn as_shared_node<S: NodeReader>(&self, storage: &S) -> Result<SharedNode, FileIoError> {
+    /// - `Err(NodeError::Io)` if there was an error reading from storage
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError::Io`] if there was an error reading from storage.
+    pub fn as_shared_node<S: NodeReader>(&self, storage: &S) -> Result<SharedNode, NodeError> {
         match self {
             Child::Node(node) => Ok(node.clone().into()),
-            Child::AddressWithHash(addr, _) => storage.read_node(*addr),
-            Child::MaybePersisted(maybe_persisted, _) => maybe_persisted.as_shared_node(storage),
+            Child::AddressWithHash(addr, _) => Ok(storage.read_node(*addr)?),
+            Child::MaybePersisted(maybe_persisted, _) => {
+                Ok(maybe_persisted.as_shared_node(storage)?)
+            }
         }
     }
 }
@@ -213,8 +262,7 @@ impl Debug for BranchNode {
 
         for (i, c) in &self.children {
             match c {
-                None => {}
-                Some(Child::Node(_)) => {} //TODO
+                None | Some(Child::Node(_)) => {} //TODO
                 Some(Child::AddressWithHash(addr, hash)) => {
                     write!(f, "({i:?}: address={addr:?} hash={hash})")?;
                 }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -91,7 +91,8 @@ use crate::hashednode::hash_node;
 use crate::node::Node;
 use crate::node::persist::MaybePersistedNode;
 use crate::{
-    CacheReadStrategy, Child, FileIoError, HashType, Path, ReadableStorage, SharedNode, TrieHash,
+    CacheReadStrategy, Child, FileIoError, HashType, NodeError, Path, ReadableStorage, SharedNode,
+    TrieHash,
 };
 
 use super::linear::WritableStorage;
@@ -218,7 +219,9 @@ impl Parentable for Arc<ImmutableProposal> {
             .and_then(|root| root.hash().cloned().map(HashType::into_triehash))
     }
     fn root(&self) -> Option<MaybePersistedNode> {
-        self.root.as_ref().map(Child::as_maybe_persisted_node)
+        self.root
+            .as_ref()
+            .and_then(|c| c.try_as_maybe_persisted_node().ok())
     }
     fn root_address(&self) -> Option<LinearAddress> {
         self.root.as_ref().and_then(Child::persisted_address)
@@ -247,7 +250,9 @@ impl Parentable for Committed {
             .and_then(|root| root.hash().cloned().map(HashType::into_triehash))
     }
     fn root(&self) -> Option<MaybePersistedNode> {
-        self.root.as_ref().map(Child::as_maybe_persisted_node)
+        self.root
+            .as_ref()
+            .and_then(|c| c.try_as_maybe_persisted_node().ok())
     }
     fn root_address(&self) -> Option<LinearAddress> {
         self.root.as_ref().and_then(Child::persisted_address)
@@ -393,7 +398,7 @@ where
     fn root_node(&self) -> Option<SharedNode> {
         self.deref().root_node()
     }
-    fn root_as_maybe_persisted_node(&self) -> Option<MaybePersistedNode> {
+    fn root_as_maybe_persisted_node(&self) -> Result<Option<MaybePersistedNode>, NodeError> {
         self.deref().root_as_maybe_persisted_node()
     }
 }
@@ -409,7 +414,11 @@ pub trait RootReader {
     /// Returns the root of the trie as a `MaybePersistedNode`.
     /// Callers that might want to modify the root or know how it is stored
     /// should use this function.
-    fn root_as_maybe_persisted_node(&self) -> Option<MaybePersistedNode>;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError`] if the root cannot be converted.
+    fn root_as_maybe_persisted_node(&self) -> Result<Option<MaybePersistedNode>, NodeError>;
 }
 
 /// A committed revision of a merkle trie.
@@ -608,11 +617,12 @@ impl<S: ReadableStorage> RootReader for NodeStore<MutableProposal, S> {
     fn root_node(&self) -> Option<SharedNode> {
         self.kind.root.as_ref().map(|node| node.clone().into())
     }
-    fn root_as_maybe_persisted_node(&self) -> Option<MaybePersistedNode> {
-        self.kind
+    fn root_as_maybe_persisted_node(&self) -> Result<Option<MaybePersistedNode>, NodeError> {
+        Ok(self
+            .kind
             .root
             .as_ref()
-            .map(|node| SharedNode::new(node.clone()).into())
+            .map(|node| SharedNode::new(node.clone()).into()))
     }
 }
 
@@ -622,11 +632,15 @@ impl<S: ReadableStorage> RootReader for NodeStore<Committed, S> {
         self.kind
             .root
             .as_ref()
-            .map(Child::as_maybe_persisted_node)
+            .and_then(|c| c.try_as_maybe_persisted_node().ok())
             .and_then(|node| node.as_shared_node(self).ok())
     }
-    fn root_as_maybe_persisted_node(&self) -> Option<MaybePersistedNode> {
-        self.kind.root.as_ref().map(Child::as_maybe_persisted_node)
+    fn root_as_maybe_persisted_node(&self) -> Result<Option<MaybePersistedNode>, NodeError> {
+        self.kind
+            .root
+            .as_ref()
+            .map(Child::try_as_maybe_persisted_node)
+            .transpose()
     }
 }
 
@@ -636,11 +650,15 @@ impl<S: ReadableStorage> RootReader for NodeStore<Arc<ImmutableProposal>, S> {
         self.kind
             .root
             .as_ref()
-            .map(Child::as_maybe_persisted_node)
+            .and_then(|c| c.try_as_maybe_persisted_node().ok())
             .and_then(|node| node.as_shared_node(self).ok())
     }
-    fn root_as_maybe_persisted_node(&self) -> Option<MaybePersistedNode> {
-        self.kind.root.as_ref().map(Child::as_maybe_persisted_node)
+    fn root_as_maybe_persisted_node(&self) -> Result<Option<MaybePersistedNode>, NodeError> {
+        self.kind
+            .root
+            .as_ref()
+            .map(Child::try_as_maybe_persisted_node)
+            .transpose()
     }
 }
 
@@ -947,7 +965,10 @@ mod tests {
 
         let node_store = node_store.as_committed();
 
-        let err = node_store.persist(&mut header).unwrap_err();
+        let node_err = node_store.persist(&mut header).unwrap_err();
+        let crate::NodeError::Io(err) = node_err else {
+            panic!("expected NodeError::Io, got {node_err:?}");
+        };
         let err_ctx = err.context();
         assert!(err_ctx == Some("allocate_node"));
 

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -30,6 +30,7 @@
 use bumpalo::Bump;
 use std::iter::FusedIterator;
 
+use crate::NodeError;
 use crate::linear::FileIoError;
 use coarsetime::Instant;
 use firewood_metrics::firewood_increment;
@@ -74,8 +75,8 @@ impl<N: NodeReader + RootReader> FusedIterator for UnPersistedNodeIterator<'_, N
 
 impl<'a, N: NodeReader + RootReader> UnPersistedNodeIterator<'a, N> {
     /// Creates a new iterator over unpersisted nodes in depth-first order.
-    fn new(store: &'a N) -> Self {
-        let root = store.root_as_maybe_persisted_node();
+    fn new(store: &'a N) -> Result<Self, NodeError> {
+        let root = store.root_as_maybe_persisted_node()?;
 
         // we must have an unpersisted root node to use this iterator
         // It's hard to tell at compile time if this is the case, so we assert it here
@@ -107,11 +108,11 @@ impl<'a, N: NodeReader + RootReader> UnPersistedNodeIterator<'a, N> {
             (vec![], vec![])
         };
 
-        Self {
+        Ok(Self {
             store,
             stack,
             child_iter_stack,
-        }
+        })
     }
 }
 
@@ -181,9 +182,9 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
     ///
     /// # Errors
     ///
-    /// Returns a [`FileIoError`] if any node cannot be written to storage.
+    /// Returns a [`NodeError`] if any node cannot be written to storage.
     #[fastrace::trace(short_name = true)]
-    pub fn flush_nodes(&self, header: &mut NodeStoreHeader) -> Result<(), FileIoError> {
+    pub fn flush_nodes(&self, header: &mut NodeStoreHeader) -> Result<(), NodeError> {
         let flush_start = Instant::now();
 
         let mut node_allocator = NodeAllocator::new(self.storage.as_ref(), header);
@@ -204,18 +205,18 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
     ///
     /// # Errors
     ///
-    /// Returns a [`FileIoError`] if any node cannot be serialized, allocated, or written to storage.
+    /// Returns a [`NodeError`] if any node cannot be serialized, allocated, or written to storage.
     fn process_unpersisted_nodes(
         &self,
         bump: &mut bumpalo::Bump,
         node_allocator: &mut NodeAllocator<'_, S>,
         bump_size_limit: usize,
-    ) -> Result<(), FileIoError> {
+    ) -> Result<(), NodeError> {
         let mut allocated_objects = Vec::new();
         let mut allocated_len = 0_usize;
 
         // Process each unpersisted node directly from the iterator
-        for node in UnPersistedNodeIterator::new(self) {
+        for node in UnPersistedNodeIterator::new(self)? {
             let shared_node = node.as_shared_node(self).expect("in memory, so no IO");
 
             // Serialize the node into the bump allocator
@@ -281,9 +282,9 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
     ///
     /// # Errors
     ///
-    /// Returns a [`FileIoError`] if any of the persistence operations fail.
+    /// Returns a [`NodeError`] if any of the persistence operations fail.
     #[fastrace::trace(short_name = true)]
-    pub fn persist(&self, header: &mut NodeStoreHeader) -> Result<(), FileIoError> {
+    pub fn persist(&self, header: &mut NodeStoreHeader) -> Result<(), NodeError> {
         // First persist all the nodes
         self.flush_nodes(header)?;
 
@@ -365,7 +366,7 @@ mod tests {
     fn test_empty_nodestore() {
         let mem_store = MemStore::default().into();
         let store = NodeStore::new_empty_proposal(mem_store);
-        let mut iter = UnPersistedNodeIterator::new(&store);
+        let mut iter = UnPersistedNodeIterator::new(&store).unwrap();
 
         assert!(iter.next().is_none());
     }
@@ -374,8 +375,9 @@ mod tests {
     fn test_single_leaf_node() {
         let leaf = create_leaf(&[1, 2, 3], &[4, 5, 6]);
         let store = create_test_store_with_root(leaf.clone());
-        let mut iter =
-            UnPersistedNodeIterator::new(&store).map(|node| node.as_shared_node(&store).unwrap());
+        let mut iter = UnPersistedNodeIterator::new(&store)
+            .unwrap()
+            .map(|node| node.as_shared_node(&store).unwrap());
 
         // Should return the leaf node
         let node = iter.next().unwrap();
@@ -394,8 +396,9 @@ mod tests {
             vec![(PathComponent::ALL[5], leaf.clone())],
         );
         let store = create_test_store_with_root(branch.clone());
-        let mut iter =
-            UnPersistedNodeIterator::new(&store).map(|node| node.as_shared_node(&store).unwrap());
+        let mut iter = UnPersistedNodeIterator::new(&store)
+            .unwrap()
+            .map(|node| node.as_shared_node(&store).unwrap());
 
         // Should return child first (depth-first)
         let node = iter.next().unwrap();
@@ -431,6 +434,7 @@ mod tests {
 
         // Collect all nodes
         let nodes: Vec<_> = UnPersistedNodeIterator::new(&store)
+            .unwrap()
             .map(|node| node.as_shared_node(&store).unwrap())
             .collect();
 
@@ -503,6 +507,7 @@ mod tests {
 
         // Collect all nodes
         let nodes: Vec<_> = UnPersistedNodeIterator::new(&store)
+            .unwrap()
             .map(|node| node.as_shared_node(&store).unwrap())
             .collect();
 
@@ -556,7 +561,7 @@ mod tests {
 
         // Verify the committed store has the expected values
         let root = committed_store.kind.root.as_ref().unwrap();
-        let root_maybe_persisted = root.as_maybe_persisted_node();
+        let root_maybe_persisted = root.try_as_maybe_persisted_node().unwrap();
         let root_node = root_maybe_persisted
             .as_shared_node(&committed_store)
             .unwrap();
@@ -569,7 +574,7 @@ mod tests {
         let child1 = root_branch.children[PathComponent::ALL[1]]
             .as_ref()
             .unwrap();
-        let child1_maybe_persisted = child1.as_maybe_persisted_node();
+        let child1_maybe_persisted = child1.try_as_maybe_persisted_node().unwrap();
         let child1_node = child1_maybe_persisted
             .as_shared_node(&committed_store)
             .unwrap();
@@ -579,7 +584,7 @@ mod tests {
         let child2 = root_branch.children[PathComponent::ALL[2]]
             .as_ref()
             .unwrap();
-        let child2_maybe_persisted = child2.as_maybe_persisted_node();
+        let child2_maybe_persisted = child2.try_as_maybe_persisted_node().unwrap();
         let child2_node = child2_maybe_persisted
             .as_shared_node(&committed_store)
             .unwrap();


### PR DESCRIPTION
 ## Why this should be merged

 Remote storage support (coming in subsequent PRs) requires Firewood to
 distinguish between real I/O errors and logical "this node lives on a remote
 server" signals. Today, all trie operations return `FileIoError`, which cannot
 express "need remote lookup." This PR introduces `NodeError` — a wrapper enum
 with `Io(FileIoError)` for storage errors and `Proxy(HashType)` for remote
 lookups — and propagates it through all trie operation signatures. This is the
 foundation that the entire remote storage feature stack builds on.

 ## How this works

 - Adds `NodeError` enum to `storage/src/node/branch.rs` with `From<FileIoError>`
   conversion so existing `?` chains keep working.
 - Renames every `Result<T, FileIoError>` → `Result<T, NodeError>` across
   `merkle/mod.rs`, `iter.rs`, `merkle/parallel.rs`, `nodestore/mod.rs`,
   `nodestore/persist.rs`, `persist_worker.rs`, `changes.rs`, `merge.rs`,
   `batch_op.rs`, `proofs/types.rs`, `manager.rs`, `api.rs`, and
   `fwdctl/dump.rs`.
 - Renames `as_maybe_persisted_node()` → `try_as_maybe_persisted_node()`
   (now fallible), `find_fileio_error()` → `find_node_error()`, and
   `CreateProposalError::FileIoError` → `CreateProposalError::NodeError`.
 - Simplifies iterator match arms to use `child.as_shared_node()` (which now
   returns `NodeError`), collapsing 3-arm matches into single calls. This is
   safe because `Child::as_shared_node()` internally dispatches to the same
   code each arm was doing manually (`node.clone().into()`,
   `storage.read_node(addr)`, `maybe_persisted.as_shared_node(storage)`).
 - Converts wildcard matches (`_ =>`) to explicit variant lists for future
   exhaustiveness when `Child::Proxy` is added.
 - Uses `.ok().flatten()` on `root_as_maybe_persisted_node()` in
   `revision_persist_status()` — safe because committed revisions never have
   `Proxy` roots, and if they did, treating it as "not persisted" is the
   correct conservative answer.
 - Adds `NodeError` variant to `ProofError`, `RevisionManagerError`, and
   `PersistError` so errors propagate through the proof, revision management,
   and persistence layers.

 ## How this was tested

 - CI

 ## Breaking Changes

 - [ ] firewood — public API return types change from `FileIoError` to
   `NodeError` (callers using `?` with `FileIoError` need to handle `NodeError`
   instead; `From<FileIoError>` impl makes most transitions automatic)
 - [ ] firewood-storage — `Child::as_shared_node()` returns `NodeError`;
   `RootReader::root_as_maybe_persisted_node()` returns `Result`;
   `as_maybe_persisted_node()` renamed to `try_as_maybe_persisted_node()`
 - [ ] firewood-ffi (C api)
 - [ ] firewood-go (Go api)
 - [ ] fwdctl