### PR TITLE
fix!: enforce `max_revisions` > `commit_count`

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -105,7 +105,7 @@ type config struct {
 	// revisions is the maximum number of historical revisions to keep in memory.
 	// If rootStoreDir is set, then any revisions removed from memory will still be kept on disk.
 	// Otherwise, any revisions removed from memory will no longer be kept on disk.
-	// Must be >= 2.
+	// Must be >= 2 and > deferredPersistenceCommitCount.
 	revisions uint
 	// readCacheStrategy is the caching strategy used for the node cache.
 	readCacheStrategy CacheStrategy
@@ -115,6 +115,7 @@ type config struct {
 	expensiveMetricsEnabled bool
 	// deferredPersistenceCommitCount determines the maximum number of unpersisted
 	// revisions that can exist at a given time.
+	// Note: revisions must be > deferredPersistenceCommitCount
 	deferredPersistenceCommitCount uint64
 }
 
@@ -161,7 +162,7 @@ func WithFreeListCacheEntries(entries uint) Option {
 // WithRevisions sets the maximum number of historical revisions to keep in memory.
 // If RootStoreDir is set, then any revisions removed from memory will still be kept on disk.
 // Otherwise, any revisions removed from memory will no longer be kept on disk.
-// Must be >= 2.
+// Must be >= 2 and > WithDeferredPersistenceCommitCount.
 // Default: 100
 func WithRevisions(revisions uint) Option {
 	return func(c *config) {
@@ -197,7 +198,8 @@ func WithExpensiveMetrics() Option {
 }
 
 // WithDeferredPersistenceCommitCount sets the maximum number of unpersisted revisions
-// that can exist at a time. Note: `commitCount` must be greater than 0.
+// that can exist at a time. Note: `commitCount` must be greater than 0 and WithRevisions
+// must be greater than `commitCount`.
 // Default: 1
 func WithDeferredPersistenceCommitCount(commitCount uint64) Option {
 	return func(c *config) {

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1035,6 +1035,8 @@ typedef struct DatabaseHandleArgs {
   size_t free_list_cache_size;
   /**
    * The maximum number of revisions to keep.
+   *
+   * Must be > `deferred_persistence_commit_count`.
    */
   size_t revisions;
   /**
@@ -1071,6 +1073,8 @@ typedef struct DatabaseHandleArgs {
   enum NodeHashAlgorithm node_hash_algorithm;
   /**
    * The maximum number of unpersisted revisions that can exist at a given time.
+   *
+   * Note: `revisions` must be > `deferred_persistence_commit_count`.
    */
   uint64_t deferred_persistence_commit_count;
 } DatabaseHandleArgs;

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -71,6 +71,8 @@ pub struct DatabaseHandleArgs<'a> {
     pub free_list_cache_size: usize,
 
     /// The maximum number of revisions to keep.
+    ///
+    /// Must be > `deferred_persistence_commit_count`.
     pub revisions: usize,
 
     /// The cache read strategy to use.
@@ -102,6 +104,8 @@ pub struct DatabaseHandleArgs<'a> {
     pub node_hash_algorithm: NodeHashAlgorithm,
 
     /// The maximum number of unpersisted revisions that can exist at a given time.
+    ///
+    /// Note: `revisions` must be > `deferred_persistence_commit_count`.
     pub deferred_persistence_commit_count: u64,
 }
 
@@ -115,6 +119,8 @@ impl DatabaseHandleArgs<'_> {
         };
         let free_list_cache_size = NonZeroUsize::new(self.free_list_cache_size)
             .ok_or_else(|| invalid_data("free list cache size should be non-zero"))?;
+        let commit_count = NonZeroU64::new(self.deferred_persistence_commit_count)
+            .ok_or(api::Error::ZeroCommitCount)?;
 
         let memory_limit = NonZeroUsize::new(self.node_cache_memory_limit);
 
@@ -122,7 +128,8 @@ impl DatabaseHandleArgs<'_> {
             let builder = RevisionManagerConfig::builder()
                 .max_revisions(self.revisions)
                 .cache_read_strategy(cache_read_strategy)
-                .free_list_cache_size(free_list_cache_size);
+                .free_list_cache_size(free_list_cache_size)
+                .deferred_persistence_commit_count(commit_count);
 
             if let Some(memory_limit) = memory_limit {
                 builder.node_cache_memory_limit(memory_limit).build()
@@ -159,15 +166,12 @@ impl DatabaseHandle {
     /// If the path is empty, or if the configuration is invalid, this will return an error.
     pub fn new(args: DatabaseHandleArgs<'_>) -> Result<Self, api::Error> {
         let metrics_context = MetricsContext::new(args.expensive_metrics);
-        let commit_count = NonZeroU64::new(args.deferred_persistence_commit_count)
-            .ok_or(api::Error::ZeroCommitCount)?;
 
         let cfg = DbConfig::builder()
             .node_hash_algorithm(args.node_hash_algorithm.into())
             .truncate(args.truncate)
             .manager(args.as_rev_manager_config()?)
             .root_store(args.root_store)
-            .deferred_persistence_commit_count(commit_count)
             .build();
 
         let path = args

--- a/firewood/benches/defer_persist.rs
+++ b/firewood/benches/defer_persist.rs
@@ -3,6 +3,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use firewood::db::{BatchOp, Db, DbConfig};
+use firewood::manager::RevisionManagerConfig;
 use firewood::v2::api::{Db as _, Proposal as _};
 use firewood_storage::NodeHashAlgorithm;
 use rand::{RngExt, distr::Alphanumeric};
@@ -14,6 +15,7 @@ fn bench_deferred_persistence<const N: usize, const COMMIT_COUNT: u64>(criterion
     const KEY_LEN: usize = 4;
     let rng = &firewood_storage::SeededRng::from_option(Some(1234));
     let commit_count = NonZeroU64::new(COMMIT_COUNT).unwrap();
+    let max_revisions = commit_count.get().wrapping_add(1) as usize;
 
     criterion
         .benchmark_group("deferred_persistence")
@@ -35,7 +37,12 @@ fn bench_deferred_persistence<const N: usize, const COMMIT_COUNT: u64>(criterion
                     let tmpdir = tempfile::tempdir().unwrap();
                     let dbcfg = DbConfig::builder()
                         .node_hash_algorithm(NodeHashAlgorithm::compile_option())
-                        .deferred_persistence_commit_count(commit_count)
+                        .manager(
+                            RevisionManagerConfig::builder()
+                                .max_revisions(max_revisions)
+                                .deferred_persistence_commit_count(commit_count)
+                                .build(),
+                        )
                         .build();
                     let db = Db::new(tmpdir, dbcfg).unwrap();
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -23,9 +23,8 @@ use firewood_storage::{
     CheckOpt, CheckerReport, Committed, FileBacked, FileIoError, HashedNodeReader,
     ImmutableProposal, NodeHashAlgorithm, NodeStore, Parentable, ReadableStorage, TrieReader,
 };
-use nonzero_ext::nonzero;
 use std::io::Write;
-use std::num::{NonZeroU64, NonZeroUsize};
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
 use thiserror::Error;
@@ -136,9 +135,6 @@ pub struct DbConfig {
     /// Whether to enable `RootStore`.
     #[builder(default = false)]
     pub root_store: bool,
-    /// The maximum number of unpersisted revisions that can exist at a given time.
-    #[builder(default = nonzero!(1u64))]
-    pub deferred_persistence_commit_count: NonZeroU64,
 }
 
 /// A database instance.
@@ -190,7 +186,6 @@ impl Db {
             .create(cfg.create_if_missing)
             .truncate(cfg.truncate)
             .root_store(cfg.root_store)
-            .deferred_persistence_commit_count(cfg.deferred_persistence_commit_count)
             .manager(cfg.manager)
             .build();
         let manager = RevisionManager::new(config_manager)?;
@@ -1418,11 +1413,17 @@ mod test {
     #[test]
     fn test_deferred_persist_close_with_high_commit_count() {
         const HIGH_COMMIT_COUNT: NonZeroU64 = nonzero!(1_000_000u64);
+        const MAX_REVISIONS: usize = HIGH_COMMIT_COUNT.get() as usize + 1;
 
         // Set commit count to an arbitrarily high number so persist happens
         // only on shutdown
         let dbcfg = DbConfig::builder()
-            .deferred_persistence_commit_count(HIGH_COMMIT_COUNT)
+            .manager(
+                RevisionManagerConfig::builder()
+                    .max_revisions(MAX_REVISIONS)
+                    .deferred_persistence_commit_count(HIGH_COMMIT_COUNT)
+                    .build(),
+            )
             .build();
 
         let db = TestDb::new_with_config(dbcfg);
@@ -1449,7 +1450,11 @@ mod test {
         const NUM_REVISIONS: u64 = COMMIT_COUNT.get() + 1;
 
         let dbcfg = DbConfig::builder()
-            .deferred_persistence_commit_count(COMMIT_COUNT)
+            .manager(
+                RevisionManagerConfig::builder()
+                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .build(),
+            )
             .build();
 
         let db = TestDb::new_with_config(dbcfg);
@@ -1487,7 +1492,11 @@ mod test {
         const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
 
         let dbcfg = DbConfig::builder()
-            .deferred_persistence_commit_count(COMMIT_COUNT)
+            .manager(
+                RevisionManagerConfig::builder()
+                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .build(),
+            )
             .build();
 
         let db = TestDb::new_with_config(dbcfg);
@@ -1518,15 +1527,15 @@ mod test {
     fn test_deferred_persistence_root_store() {
         const NUM_COMMITS: usize = 20;
         const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
-        const MAX_IN_MEMORY_REVISIONS: usize = 2;
+        const MAX_REVISIONS: usize = COMMIT_COUNT.get() as usize + 1;
 
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
-                    .max_revisions(MAX_IN_MEMORY_REVISIONS)
+                    .max_revisions(MAX_REVISIONS)
+                    .deferred_persistence_commit_count(COMMIT_COUNT)
                     .build(),
             )
-            .deferred_persistence_commit_count(COMMIT_COUNT)
             .root_store(true)
             .build();
 
@@ -1583,7 +1592,11 @@ mod test {
         const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
 
         let dbcfg = DbConfig::builder()
-            .deferred_persistence_commit_count(COMMIT_COUNT)
+            .manager(
+                RevisionManagerConfig::builder()
+                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .build(),
+            )
             .root_store(true)
             .build();
 

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -36,6 +36,8 @@ pub(crate) const DB_FILE_NAME: &str = "firewood.db";
 /// Revision manager configuratoin
 pub struct RevisionManagerConfig {
     /// The number of committed revisions to keep in memory.
+    ///
+    /// Must be > `deferred_persistence_commit_count`.
     #[builder(default = 128)]
     max_revisions: usize,
 
@@ -60,6 +62,12 @@ pub struct RevisionManagerConfig {
 
     #[builder(default = CacheReadStrategy::WritesOnly)]
     cache_read_strategy: CacheReadStrategy,
+
+    /// The maximum number of unpersisted revisions that can exist at a given time.
+    ///
+    /// Must be < `max_revisions`.
+    #[builder(default = nonzero!(1u64))]
+    deferred_persistence_commit_count: NonZeroU64,
 }
 
 impl RevisionManagerConfig {
@@ -113,9 +121,6 @@ pub struct ConfigManager {
     /// Whether to enable `RootStore`.
     #[builder(default = false)]
     pub root_store: bool,
-    /// The maximum number of unpersisted revisions that can exist at a given time.
-    #[builder(default = nonzero!(1u64))]
-    pub deferred_persistence_commit_count: NonZeroU64,
     /// Revision manager configuration.
     #[builder(default = RevisionManagerConfig::builder().build())]
     pub manager: RevisionManagerConfig,
@@ -183,10 +188,25 @@ pub(crate) enum RevisionManagerError {
     RootStoreError(#[source] Box<dyn std::error::Error + Send + Sync>),
     #[error("A deferred persistence error occurred: {0}")]
     PersistError(#[source] PersistError),
+    #[error(
+        "max_revisions ({max_revisions}) must be > deferred_persistence_commit_count ({commit_count})"
+    )]
+    InsufficientRevisions {
+        max_revisions: usize,
+        commit_count: u64,
+    },
 }
 
 impl RevisionManager {
     pub fn new(config: ConfigManager) -> Result<Self, RevisionManagerError> {
+        let commit_count = config.manager.deferred_persistence_commit_count.get();
+        if (config.manager.max_revisions as u64) <= commit_count {
+            return Err(RevisionManagerError::InsufficientRevisions {
+                max_revisions: config.manager.max_revisions,
+                commit_count,
+            });
+        }
+
         if config.create {
             std::fs::create_dir_all(&config.root_dir).map_err(RevisionManagerError::IOError)?;
         }
@@ -247,7 +267,7 @@ impl RevisionManager {
         }
 
         let persist_worker = PersistWorker::new(
-            config.deferred_persistence_commit_count,
+            config.manager.deferred_persistence_commit_count,
             header,
             root_store.clone(),
         );
@@ -893,5 +913,58 @@ mod tests {
         let memory_limit = config.compute_node_cache_memory_limit().unwrap();
 
         assert_eq!(memory_limit.get(), 256_000_000);
+    }
+
+    #[test]
+    fn test_revision_count() {
+        let db_dir = tempfile::tempdir().unwrap();
+        let commit_count = nonzero!(10u64);
+
+        // `max_revisions` < `commit_count`
+        let config = ConfigManager::builder()
+            .root_dir(db_dir.as_ref().to_path_buf())
+            .node_hash_algorithm(NodeHashAlgorithm::compile_option())
+            .create(true)
+            .manager(
+                RevisionManagerConfig::builder()
+                    .max_revisions(5)
+                    .deferred_persistence_commit_count(commit_count)
+                    .build(),
+            )
+            .build();
+
+        let result = RevisionManager::new(config);
+        assert!(result.is_err());
+
+        // `max_revisions` == `commit_count`
+        let config = ConfigManager::builder()
+            .root_dir(db_dir.as_ref().to_path_buf())
+            .node_hash_algorithm(NodeHashAlgorithm::compile_option())
+            .manager(
+                RevisionManagerConfig::builder()
+                    .max_revisions(commit_count.get() as usize)
+                    .deferred_persistence_commit_count(commit_count)
+                    .build(),
+            )
+            .build();
+
+        let result = RevisionManager::new(config);
+        assert!(result.is_err());
+
+        // `max_revisions` > `commit_count`
+        let max_revisions = commit_count.get().wrapping_add(1) as usize;
+        let config = ConfigManager::builder()
+            .root_dir(db_dir.as_ref().to_path_buf())
+            .node_hash_algorithm(NodeHashAlgorithm::compile_option())
+            .manager(
+                RevisionManagerConfig::builder()
+                    .max_revisions(max_revisions)
+                    .deferred_persistence_commit_count(commit_count)
+                    .build(),
+            )
+            .build();
+
+        let result = RevisionManager::new(config);
+        assert!(result.is_ok());
     }
 }

--- a/firewood/src/v2/api.rs
+++ b/firewood/src/v2/api.rs
@@ -204,6 +204,14 @@ pub enum Error {
 
     #[error("commit count must be positive")]
     ZeroCommitCount,
+
+    #[error(
+        "max_revisions ({max_revisions}) must be > deferred_persistence_commit_count ({commit_count})"
+    )]
+    InsufficientRevisions {
+        max_revisions: usize,
+        commit_count: u64,
+    },
 }
 
 impl From<std::convert::Infallible> for Error {
@@ -215,7 +223,7 @@ impl From<std::convert::Infallible> for Error {
 impl From<RevisionManagerError> for Error {
     fn from(err: RevisionManagerError) -> Self {
         use RevisionManagerError::{
-            FileIoError, IOError, NotLatest, PersistError, RevisionNotFound,
+            FileIoError, IOError, InsufficientRevisions, NotLatest, PersistError, RevisionNotFound,
             RevisionWithoutAddress, RootStoreError,
         };
         match err {
@@ -228,6 +236,13 @@ impl From<RevisionManagerError> for Error {
             IOError(err) => Self::IO(err),
             RootStoreError(err) => Self::RootStoreError(err),
             PersistError(err) => Self::DeferredPersistenceError(err),
+            InsufficientRevisions {
+                max_revisions,
+                commit_count,
+            } => Self::InsufficientRevisions {
+                max_revisions,
+                commit_count,
+            },
         }
     }
 }


### PR DESCRIPTION
## Why this should be merged

During review of #1739, it was noted that we could prevent the last persisted revision from being persisted if we set `max_revisions > commit_count`. This is because if `max_revisions > commit_count`, then once the oldest revision is marked for reaping, then there has been at least a newer revision persisted as `commit_count` revisions have been committed.

## How this works

- During initialization, enforces that `max_revisions > commit_count`
- Moves `commit_count` from `ConfigManager` to `RevisionManagerConfig`
    - Having an invariant be linked between two different data structures seems incredibly fragile to me, so I decided to move `commit_count` to reduce any confusion.
- Updates Go + Rust docs to make this new invariant clear 

## How this was tested

CI + added UT

## Breaking Changes

- [x] firewood
- [ ] firewood-storage
- [x] firewood-ffi (C api)
- [x] firewood-go (Go api)
- [ ] fwdctl
