### PR TITLE
feat(remote-storage): Add DeleteRange expansion for witness generation

### DIFF
--- a/firewood/src/remote/witness.rs
+++ b/firewood/src/remote/witness.rs
@@ -145,7 +145,8 @@ impl From<ClientOp> for OwnedBatchOp {
 ///
 /// # Arguments
 ///
-/// * `view` - The committed revision to scan for existing keys
+/// * `view` - The parent revision to scan for existing keys (typically the
+///   pre-batch state, e.g. an `ImmutableProposal` or committed revision)
 /// * `ops` - Core batch operations that may contain `DeleteRange`
 ///
 /// # Errors
@@ -626,9 +627,7 @@ fn validate_witness_ops(
 ///
 /// A key survives only if it is `Put` AFTER the `DeleteRange` and not
 /// subsequently deleted by a `Delete` or covered by another `DeleteRange`.
-fn allowed_surviving_keys(
-    expected_ops: &[OwnedBatchOp],
-) -> Vec<(&[u8], HashSet<&[u8]>)> {
+fn allowed_surviving_keys(expected_ops: &[OwnedBatchOp]) -> Vec<(&[u8], HashSet<&[u8]>)> {
     let mut result = Vec::new();
     for (i, op) in expected_ops.iter().enumerate() {
         let BatchOp::DeleteRange { prefix } = op else {


### PR DESCRIPTION
## Why this should be merged                                                                                                                                                                                                                         
                                                            
  This is part of the remote storage series (follows https://github.com/ava-labs/firewood/pull/1750). The core                                                                                                                                                                                      
  v2::api::BatchOp supports DeleteRange { prefix }, but the witness protocol
  operates on individual key-level operations (ClientOp::Put /
  ClientOp::Delete). This PR adds the server-side expansion step that bridges
  the two: before generating a witness, the server scans the committed revision
  for keys matching each DeleteRange prefix and emits individual Delete
  operations. It also adds the order-aware completeness check
  (allowed_surviving_keys) that prevents two classes of ordering attacks where
  a malicious server could silently drop deletes.

## How this works

  - Adds expand_delete_ranges() to witness.rs:
  - Takes a `DynDbView` (the parent revision, e.g. an `ImmutableProposal`)
and a slice of `OwnedBatchOp` (core batch ops with owned data)
    - Iterates through ops: Put and Delete pass through as ClientOp
  equivalents; DeleteRange triggers a prefix scan
    - For each DeleteRange, uses view.iter_from(prefix) to find matching keys
  in the parent revision, plus checks intra-batch Put keys that also match
  the prefix (handles Put-then-DeleteRange within the same batch)
    - Tracks added_keys (from Puts) and deleted_keys (from Deletes) to avoid
  redundant deletes when a Delete precedes a DeleteRange for the same key
    - Returns Vec<ClientOp> ready for generate_witness()
  - Adds allowed_surviving_keys() for order-aware DeleteRange completeness:
    - For each DeleteRange(prefix) in the client's original ops, walks all
  subsequent ops to compute the exact set of keys that may legitimately
  survive in the post-execution trie
    - A key survives only if it is Put after the DeleteRange and not
  subsequently deleted by a Delete or covered by another DeleteRange
    - Used in step 6 of verify_witness to replace the naive "no keys may
  survive" check, which incorrectly rejected [DR, Put] patterns
  - Adds OwnedBatchOp type alias (BatchOp<Box<[u8]>, Box<[u8]>>)
  - Adds WitnessError::ApiError(ApiError) variant for iterator failures

## Why allowed_surviving_keys

  The naive completeness check ("no keys with the prefix may survive after a
  DeleteRange") rejects legitimate batches. Two attacks motivate the
  order-aware check:

  - Attack 1: [Put("a/1"), DR("a/")] — a/1 was Put before the
  DeleteRange, so the DR must delete it. A malicious server that omits the
  delete would leave a/1 in the trie. The naive check catches this, but
  allowed_surviving_keys also catches it: since a/1 was Put before the
  DR, not after, it is not in the allowed set.
  - Attack 2: [DR("a/"), Put("a/1"), DR("a/")] — the second DR deletes
  the sandwiched Put. A server that only expands the first DR and keeps
  a/1 alive would pass the naive check (the first DR's prefix has no
  surviving keys except the Put). allowed_surviving_keys walks past the
  second DR and removes a/1 from the allowed set for that prefix.

## How this was tested

  - 12 unit tests in witness.rs:
    - No DeleteRange — passthrough of Put + Delete unchanged
    - Basic DeleteRange — prefix scan expands to individual Deletes
    - Intra-batch Put then DeleteRange — Put key also gets a Delete
    - Empty prefix match — no keys match, no Deletes emitted
    - Empty trie — DeleteRange on empty trie produces nothing
    - DeleteRange witness roundtrip — end-to-end expand → generate → verify
    - Mixed ops with DeleteRange — Put + DeleteRange + Put in one batch
    - Delete before DeleteRange — no redundant Delete for already-deleted key
    - verify_witness with DeleteRange — end-to-end with OwnedBatchOp
    - Attack 1 regression (pre_dr_put_must_not_survive) — [Put, DR] catches
  omitted delete via OpsMismatch
    - Attack 2 regression (put_between_two_drs_must_not_survive) — [DR, Put, DR] catches omitted second DR's delete via OpsMismatch
    - Positive case (post_dr_put_survives) — [DR, Put] correctly allows the
  post-DR Put to survive
  - cargo test --workspace --features ethhash,logger --all-targets
  - cargo test --workspace --all-targets
  - cargo clippy --workspace --features ethhash,logger --all-targets
  - cargo fmt -- --check

## Breaking Changes

  - firewood — adds expand_delete_ranges, OwnedBatchOp to public
  API; adds WitnessError::ApiError variant
  - firewood-storage
  - firewood-ffi (C api)
  - firewood-go (Go api)
  - fwdctl