### PR TITLE
chore(docs): render mermaid graphs with aquamarine

### DIFF
--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -70,6 +70,7 @@ pub enum PersistError {
 ///
 /// Below is an example when `commit_count` is set to 10:
 ///
+#[cfg_attr(doc, aquamarine::aquamarine)]
 /// ```mermaid
 /// sequenceDiagram
 ///     participant Caller
@@ -106,7 +107,6 @@ pub enum PersistError {
 ///     BG->>Disk: persist last committed revision
 ///     Note right of Disk: Latest committed revision is persisted
 /// ```
-#[cfg_attr(doc, aquamarine::aquamarine)]
 #[derive(Debug)]
 pub(crate) struct PersistWorker {
     /// The background thread responsible for persisting commits async.

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -1,18 +1,8 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-//! A `LinearStore` provides a view of a set of bytes at
-//! a given time. A `LinearStore` has three different types,
-//! which refer to another base type, as follows:
-//! ```mermaid
-//! stateDiagram-v2
-//!     R1(Committed) --> R2(Committed)
-//!     R2(Committed) --> R3(FileBacked)
-//!     P1(Proposed) --> R3(FileBacked)
-//!     P2(Proposed) --> P1(Proposed)
-//! ```
-//!
-//! Each type is described in more detail below.
+//! This module provides the [`ReadableStorage`] and [`WritableStorage`] traits,
+//! which define the interface for reading and writing to a linear store.
 
 #![expect(
     clippy::missing_errors_doc,

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -61,28 +61,6 @@ pub use primitives::{AreaIndex, LinearAddress};
 // Re-export types from header module
 pub use header::NodeStoreHeader;
 
-/// The [`NodeStore`] handles the serialization of nodes and
-/// free space management of nodes in the page store. It lays out the format
-/// of the [`PageStore`]. More specifically, it places a [`FileIdentifyingMagic`]
-/// and a [`FreeSpaceHeader`] at the beginning
-///
-/// Nodestores represent a revision of the trie. There are three types of nodestores:
-/// - Committed: A committed revision of the trie. It has no in-memory changes.
-/// - `MutableProposal`: A proposal that is still being modified. It has some nodes in memory.
-/// - `ImmutableProposal`: A proposal that has been hashed and assigned addresses. It has no in-memory changes.
-///
-/// The general lifecycle of nodestores is as follows:
-/// ```mermaid
-/// flowchart TD
-/// subgraph subgraph["Committed Revisions"]
-/// L("Latest Nodestore&lt;Committed, S&gt;") --- |...|O("Oldest NodeStore&lt;Committed, S&gt;")
-/// end
-/// O --> E("Expire")
-/// L --> |start propose|M("NodeStore&lt;ProposedMutable, S&gt;")
-/// M --> |finish propose + hash|I("NodeStore&lt;ProposedImmutable, S&gt;")
-/// I --> |commit|N("New commit NodeStore&lt;Committed, S&gt;")
-/// style E color:#FFFFFF, fill:#AA00FF, stroke:#AA00FF
-/// ```
 use std::mem::take;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -482,7 +460,20 @@ impl ImmutableProposal {
 /// 3. Create a new mutable proposal from either a [Committed] or [`ImmutableProposal`] [`NodeStore`] using [`NodeStore::new`].
 /// 4. Convert a mutable proposal to an immutable proposal using [`std::convert::TryInto`], which hashes the nodes and assigns addresses
 /// 5. Convert an immutable proposal to a committed revision using [`std::convert::TryInto`], which writes the nodes to disk.
-
+///
+/// The general lifecycle of nodestores is as follows:
+#[cfg_attr(doc, aquamarine::aquamarine)]
+/// ```mermaid
+/// flowchart TD
+/// subgraph subgraph["Committed Revisions"]
+/// L("Latest Nodestore&lt;Committed, S&gt;") --- |...|O("Oldest NodeStore&lt;Committed, S&gt;")
+/// end
+/// O --> E("Expire")
+/// L --> |start propose|M("NodeStore&lt;ProposedMutable, S&gt;")
+/// M --> |finish propose + hash|I("NodeStore&lt;ProposedImmutable, S&gt;")
+/// I --> |commit|N("New commit NodeStore&lt;Committed, S&gt;")
+/// style E color:#FFFFFF, fill:#AA00FF, stroke:#AA00FF
+/// ```
 #[derive(Debug)]
 pub struct NodeStore<T, S> {
     /// This is one of [Committed], [`ImmutableProposal`], or [`MutableProposal`].


### PR DESCRIPTION
## Why this should be merged

Closes: #1717

## How this works

We already had aquamarine imported and use it for one graph. However, other graphs were missing the annotation.

Using this annotation on the mod-level comment is not yet supported by `cargo doc`. However, the diagram where this was a problem was incorrect and stale, so I removed it instead of relocating.

This however means we must remove `--no-deps` from the `cargo doc` invocation. This is because `--no-deps` will cause the build of the documentation to not include the necessary static assets for rendering.

## How this was tested

<img width="1030" height="558" alt="image" src="https://github.com/user-attachments/assets/1cdc2147-b2e3-47f7-981b-92b914136def" />

## Breaking Changes

n/a
