### PR TITLE
chore: add metric for committed revision delete list

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -23,7 +23,7 @@ use crate::persist_worker::{PersistError, PersistWorker};
 use crate::root_store::RootStore;
 use crate::v2::api::{ArcDynDbView, HashKey, OptionalHashKeyExt};
 
-use firewood_metrics::{firewood_increment, firewood_set};
+use firewood_metrics::{firewood_increment, firewood_record, firewood_set};
 pub use firewood_storage::CacheReadStrategy;
 use firewood_storage::{
     BranchNode, Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal,
@@ -298,6 +298,13 @@ impl RevisionManager {
         }
 
         let committed = proposal.as_committed();
+
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "deleted list length will never exceed 2^52"
+        )]
+        let deleted_list_len = committed.deleted_len() as f64;
+        firewood_record!(crate::registry::DELETED_LIST_LEN, deleted_list_len);
 
         // 3. Revision reaping
         // When we exceed max_revisions, remove the oldest revision from memory

--- a/firewood/src/registry.rs
+++ b/firewood/src/registry.rs
@@ -3,7 +3,7 @@
 
 //! Firewood layer metric definitions.
 
-use metrics::{describe_counter, describe_gauge};
+use metrics::{describe_counter, describe_gauge, describe_histogram};
 
 /// Number of proposals created.
 pub const PROPOSALS: &str = "proposals";
@@ -35,6 +35,9 @@ pub const ACTIVE_REVISIONS: &str = "active_revisions";
 /// Maximum number of revisions configured.
 pub const MAX_REVISIONS: &str = "max_revisions";
 
+/// Length of the deleted list for committed revisions.
+pub const DELETED_LIST_LEN: &str = "deleted_list_len";
+
 /// Registers all firewood metric descriptions.
 pub fn register() {
     describe_counter!(PROPOSALS, "Number of proposals created");
@@ -59,4 +62,8 @@ pub fn register() {
     describe_counter!(COMMIT_LATENCY_MS, "Commit latency (ms)");
     describe_gauge!(ACTIVE_REVISIONS, "Current number of active revisions");
     describe_gauge!(MAX_REVISIONS, "Maximum number of revisions configured");
+    describe_histogram!(
+        DELETED_LIST_LEN,
+        "Length of deleted list for committed revisions"
+    );
 }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -158,6 +158,12 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
 
         nodestore
     }
+
+    /// Returns the length of the deleted list for this `NodeStore`.
+    #[must_use]
+    pub fn deleted_len(&self) -> usize {
+        self.kind.deleted.len()
+    }
 }
 
 impl<S: ReadableStorage> NodeStore<Committed, S> {


### PR DESCRIPTION
## Why this should be merged

As discussed during the conversation about the delete log, we should track the length of the deleted list of committed revisions.

## How this works

- During `commit()`, we record the length of the deleted list of the committed nodestore.
- Adds `deleted_len()` method to committed nodestores.

## How this was tested

CI

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
