### PR TITLE
refactor!: remove v2 module

### DIFF
--- a/benchmark/src/create.rs
+++ b/benchmark/src/create.rs
@@ -11,8 +11,8 @@ use std::time::Instant;
 
 use fastrace::prelude::SpanContext;
 use fastrace::{Span, func_path};
+use firewood::api::{Db as _, Proposal as _};
 use firewood::db::Db;
-use firewood::v2::api::{Db as _, Proposal as _};
 use log::info;
 
 use pretty_duration::pretty_duration;

--- a/benchmark/src/single.rs
+++ b/benchmark/src/single.rs
@@ -11,8 +11,8 @@
 )]
 
 use crate::TestRunner;
+use firewood::api::{Db as _, Proposal as _};
 use firewood::db::{BatchOp, Db};
-use firewood::v2::api::{Db as _, Proposal as _};
 use log::debug;
 use pretty_duration::pretty_duration;
 use sha2::{Digest, Sha256};

--- a/benchmark/src/tenkrandom.rs
+++ b/benchmark/src/tenkrandom.rs
@@ -9,9 +9,9 @@
 use std::error::Error;
 use std::time::Instant;
 
+use firewood::api::{Db as _, Proposal as _};
 use firewood::db::{BatchOp, Db};
 use firewood::logger::debug;
-use firewood::v2::api::{Db as _, Proposal as _};
 
 use crate::{Args, TestRunner};
 use sha2::{Digest, Sha256};

--- a/benchmark/src/zipf.rs
+++ b/benchmark/src/zipf.rs
@@ -19,8 +19,8 @@
 )]
 
 use crate::TestRunner;
+use firewood::api::{Db as _, Proposal as _};
 use firewood::db::{BatchOp, Db};
-use firewood::v2::api::{Db as _, Proposal as _};
 use log::{debug, trace};
 use pretty_duration::pretty_duration;
 use rand::prelude::*;

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -4,13 +4,13 @@
 use std::num::{NonZeroU64, NonZeroUsize};
 
 use firewood::{
-    db::{Db, DbConfig},
-    manager::RevisionManagerConfig,
-    merkle::Merkle,
-    v2::api::{
+    api::{
         self, ArcDynDbView, Db as _, DbView, FrozenChangeProof, HashKey, HashKeyExt, IntoBatchIter,
         KeyType,
     },
+    db::{Db, DbConfig},
+    manager::RevisionManagerConfig,
+    merkle::Merkle,
 };
 
 use crate::{BatchOp, BorrowedBytes, CView, CreateProposalResult, arc_cache::ArcCache};

--- a/ffi/src/iterator.rs
+++ b/ffi/src/iterator.rs
@@ -3,8 +3,8 @@
 
 use std::fmt;
 
+use firewood::api::{self, ArcDynDbView, BoxKeyValueIter};
 use firewood::merkle;
-use firewood::v2::api::{self, ArcDynDbView, BoxKeyValueIter};
 use firewood_metrics::MetricsContext;
 use std::iter::FusedIterator;
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -35,7 +35,7 @@ mod replay;
 mod revision;
 mod value;
 
-use firewood::v2::api::DbView;
+use firewood::api::DbView;
 use firewood_metrics::set_metrics_context;
 
 pub use crate::handle::*;
@@ -836,7 +836,7 @@ pub extern "C" fn fwd_db_dump(db: Option<&DatabaseHandle>) -> ValueResult {
 ///   returned value.
 #[unsafe(no_mangle)]
 pub extern "C" fn fwd_revision_dump(revision: Option<&RevisionHandle>) -> ValueResult {
-    invoke_with_handle(revision, firewood::v2::api::DbView::dump_to_string)
+    invoke_with_handle(revision, firewood::api::DbView::dump_to_string)
 }
 
 /// Dumps the Trie structure of a proposal to a DOT (Graphviz) format string for debugging.
@@ -861,5 +861,5 @@ pub extern "C" fn fwd_revision_dump(revision: Option<&RevisionHandle>) -> ValueR
 ///   returned value.
 #[unsafe(no_mangle)]
 pub extern "C" fn fwd_proposal_dump(proposal: Option<&ProposalHandle>) -> ValueResult {
-    invoke_with_handle(proposal, firewood::v2::api::DbView::dump_to_string)
+    invoke_with_handle(proposal, firewood::api::DbView::dump_to_string)
 }

--- a/ffi/src/proofs/change.rs
+++ b/ffi/src/proofs/change.rs
@@ -12,8 +12,8 @@ use rlp::Rlp;
 
 use firewood::{
     ProofError,
+    api::{self, DbView as _, FrozenChangeProof},
     logger::warn,
-    v2::api::{self, DbView as _, FrozenChangeProof},
 };
 
 use std::cmp::Ordering;

--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -5,8 +5,8 @@ use std::num::NonZeroUsize;
 
 use firewood::{
     ProofError,
+    api::{self, DbView, FrozenRangeProof, HashKey},
     logger::warn,
-    v2::api::{self, DbView, FrozenRangeProof, HashKey},
 };
 use firewood_metrics::{MetricsContext, firewood_increment};
 

--- a/ffi/src/proposal.rs
+++ b/ffi/src/proposal.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use firewood::v2::api::{self, BoxKeyValueIter, DbView, HashKey, IntoBatchIter, Proposal as _};
+use firewood::api::{self, BoxKeyValueIter, DbView, HashKey, IntoBatchIter, Proposal as _};
 
 use crate::{IteratorHandle, iterator::CreateIteratorResult, metrics::MetricsContextExt};
 use firewood_metrics::{firewood_increment, firewood_record, fwd_expensive_timed_result};

--- a/ffi/src/replay.rs
+++ b/ffi/src/replay.rs
@@ -276,7 +276,7 @@ pub(crate) fn record_commit(
 
     let returned_hash_bytes = match result {
         crate::HashResult::Some(hash) => {
-            let api_hash: firewood::v2::api::HashKey = (*hash).into();
+            let api_hash: firewood::api::HashKey = (*hash).into();
             let bytes: [u8; 32] = api_hash.into();
             Some(bytes)
         }

--- a/ffi/src/revision.rs
+++ b/ffi/src/revision.rs
@@ -3,8 +3,8 @@
 
 use crate::metrics::MetricsContextExt;
 use crate::{CreateIteratorResult, IteratorHandle};
-use firewood::v2::api;
-use firewood::v2::api::{ArcDynDbView, BoxKeyValueIter, DbView, HashKey};
+use firewood::api;
+use firewood::api::{ArcDynDbView, BoxKeyValueIter, DbView, HashKey};
 use firewood_metrics::MetricsContext;
 
 #[derive(Debug)]

--- a/ffi/src/value/display_hex.rs
+++ b/ffi/src/value/display_hex.rs
@@ -55,7 +55,7 @@ mod tests {
     use super::*;
 
     #[cfg(feature = "ethhash")]
-    use firewood::v2::api::HashKeyExt;
+    use firewood::api::HashKeyExt;
     use test_case::test_case;
 
     #[test_case(&[], "", None; "empty slice")]

--- a/ffi/src/value/hash_key.rs
+++ b/ffi/src/value/hash_key.rs
@@ -25,13 +25,13 @@ impl fmt::Display for HashKey {
     }
 }
 
-impl From<firewood::v2::api::HashKey> for HashKey {
-    fn from(value: firewood::v2::api::HashKey) -> Self {
+impl From<firewood::api::HashKey> for HashKey {
+    fn from(value: firewood::api::HashKey) -> Self {
         Self(value.into())
     }
 }
 
-impl From<HashKey> for firewood::v2::api::HashKey {
+impl From<HashKey> for firewood::api::HashKey {
     fn from(value: HashKey) -> Self {
         value.0.into()
     }

--- a/ffi/src/value/kvp.rs
+++ b/ffi/src/value/kvp.rs
@@ -5,7 +5,7 @@ use std::fmt;
 
 use crate::value::BorrowedBytes;
 use crate::{OwnedBytes, OwnedSlice};
-use firewood::v2::api;
+use firewood::api;
 
 /// A type alias for a rust-owned byte slice.
 pub type OwnedKeyValueBatch = OwnedSlice<OwnedKeyValuePair>;

--- a/ffi/src/value/results.rs
+++ b/ffi/src/value/results.rs
@@ -1,8 +1,8 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use firewood::api;
 use firewood::merkle;
-use firewood::v2::api;
 use firewood_storage::TrieHash;
 use std::fmt;
 

--- a/firewood/benches/defer_persist.rs
+++ b/firewood/benches/defer_persist.rs
@@ -2,9 +2,9 @@
 // See the file LICENSE.md for licensing terms.
 
 use criterion::{Criterion, criterion_group, criterion_main};
+use firewood::api::{Db as _, Proposal as _};
 use firewood::db::{BatchOp, Db, DbConfig};
 use firewood::manager::RevisionManagerConfig;
-use firewood::v2::api::{Db as _, Proposal as _};
 use firewood_storage::NodeHashAlgorithm;
 use rand::{RngExt, distr::Alphanumeric};
 use std::iter::repeat_with;

--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -5,9 +5,9 @@
 
 use criterion::profiler::Profiler;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use firewood::api::{Db as _, Proposal as _};
 use firewood::db::{BatchOp, DbConfig};
 use firewood::merkle::Merkle;
-use firewood::v2::api::{Db as _, Proposal as _};
 use firewood_storage::{MemStore, NodeHashAlgorithm, NodeStore};
 use pprof::ProfilerGuard;
 use rand::{RngExt, distr::Alphanumeric};

--- a/firewood/examples/insert.rs
+++ b/firewood/examples/insert.rs
@@ -12,9 +12,9 @@ use std::num::NonZeroUsize;
 use std::ops::RangeInclusive;
 use std::time::Instant;
 
+use firewood::api::{Db as _, DbView, KeyType, Proposal as _, ValueType};
 use firewood::db::{BatchOp, Db, DbConfig};
 use firewood::manager::RevisionManagerConfig;
-use firewood::v2::api::{Db as _, DbView, KeyType, Proposal as _, ValueType};
 use rand::{RngExt, distr::Alphanumeric};
 
 #[derive(Parser, Debug)]
@@ -128,9 +128,9 @@ fn get_keys_to_verify<'a, K: KeyType + 'a, V: ValueType + 'a>(
 }
 
 fn verify_keys(
-    db: &impl firewood::v2::api::Db,
+    db: &impl firewood::api::Db,
     verify: HashMap<&[u8], &[u8]>,
-) -> Result<(), firewood::v2::api::Error> {
+) -> Result<(), firewood::api::Error> {
     if !verify.is_empty() {
         let hash = db.root_hash().expect("root hash should exist");
         let revision = db.revision(hash)?;

--- a/firewood/src/api.rs
+++ b/firewood/src/api.rs
@@ -11,8 +11,8 @@ use std::fmt::Debug;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+pub use crate::batch_op::{BatchIter, BatchOp, IntoBatchIter, KeyValuePair, TryIntoBatch};
 use crate::merkle::changes::ChangeProof;
-pub use crate::v2::batch_op::{BatchIter, BatchOp, IntoBatchIter, KeyValuePair, TryIntoBatch};
 
 /// A `KeyType` is something that can be xcast to a u8 reference,
 /// and can be sent and shared across threads. References with

--- a/firewood/src/batch_op.rs
+++ b/firewood/src/batch_op.rs
@@ -3,7 +3,7 @@
 
 use firewood_storage::FileIoError;
 
-use crate::v2::api::{KeyType, ValueType};
+use crate::api::{KeyType, ValueType};
 
 /// A key/value pair operation.
 ///

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -9,13 +9,13 @@
 #[cfg(test)]
 mod tests;
 
-use crate::iter::MerkleKeyValueIter;
-use crate::merkle::{Merkle, Value};
-pub use crate::v2::api::BatchOp;
-use crate::v2::api::{
+pub use crate::api::BatchOp;
+use crate::api::{
     self, ArcDynDbView, FrozenProof, FrozenRangeProof, HashKey, IntoBatchIter, KeyType,
     KeyValuePair, OptionalHashKeyExt,
 };
+use crate::iter::MerkleKeyValueIter;
+use crate::merkle::{Merkle, Value};
 
 use crate::manager::{ConfigManager, RevisionManager, RevisionManagerConfig};
 use firewood_metrics::firewood_counter;
@@ -419,9 +419,9 @@ mod test {
     };
     use nonzero_ext::nonzero;
 
+    use crate::api::{Db as _, DbView, HashKeyExt, Proposal as _};
     use crate::db::{Db, Proposal, UseParallel};
     use crate::manager::RevisionManagerConfig;
-    use crate::v2::api::{Db as _, DbView, HashKeyExt, Proposal as _};
 
     use super::{BatchOp, DbConfig};
 

--- a/firewood/src/db/tests/merge.rs
+++ b/firewood/src/db/tests/merge.rs
@@ -2,8 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 use crate::{
+    api::{Db, DbView, Proposal},
     db::BatchOp,
-    v2::api::{Db, DbView, Proposal},
 };
 
 use super::*;

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -1,8 +1,8 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use crate::api::{KeyType, KeyValuePair};
 use crate::merkle::{Key, Value};
-use crate::v2::api::{KeyType, KeyValuePair};
 
 use firewood_storage::{
     BranchNode, Child, FileIoError, NibblesIterator, Node, PathBuf, PathComponent, PathIterItem,

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -162,8 +162,11 @@ mod persist_worker;
 /// Root store module
 pub mod root_store;
 
-/// Version 2 API
-pub mod v2;
+/// The public API
+pub mod api;
+
+/// A batch operation and associated types
+mod batch_op;
 
 /// Expose the storage logger
 pub use firewood_storage::logger;

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -18,14 +18,12 @@ use firewood_storage::logger::{trace, warn};
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use typed_builder::TypedBuilder;
 
-use crate::db::UseParallel;
+use crate::api::{self, ArcDynDbView, HashKey, IntoBatchIter, OptionalHashKeyExt};
+use crate::db::{BatchOp, UseParallel};
 use crate::merkle::Merkle;
 use crate::merkle::parallel::ParallelMerkle;
 use crate::persist_worker::{PersistError, PersistWorker};
 use crate::root_store::RootStore;
-use crate::v2::api::{self, BatchOp, IntoBatchIter};
-use crate::v2::api::{ArcDynDbView, HashKey, OptionalHashKeyExt};
-
 use firewood_metrics::{firewood_increment, firewood_set};
 pub use firewood_storage::CacheReadStrategy;
 use firewood_storage::{

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -688,13 +688,13 @@ impl<'a, T: HashedNodeReader> PreOrderIterator<'a, T> {
 mod tests {
     use crate::{
         Proof,
+        api::{Db as _, DbView, Proposal as _},
         db::{BatchOp, Db, DbConfig},
         iter::{MerkleKeyValueIter, key_from_nibble_iter},
         merkle::{
             Key, Merkle, Value,
             changes::{ChangeProof, DiffMerkleNodeStream, PreOrderIterator},
         },
-        v2::api::{Db as _, DbView, Proposal as _},
     };
 
     use firewood_storage::{

--- a/firewood/src/merkle/merge.rs
+++ b/firewood/src/merkle/merge.rs
@@ -4,10 +4,10 @@
 use firewood_storage::{FileIoError, TrieReader};
 
 use crate::{
+    api::{BatchIter, KeyType, KeyValuePair},
     db::BatchOp,
     iter::{FilteredKeyRangeIter, MerkleKeyValueIter},
     merkle::Key,
-    v2::api::{BatchIter, KeyType, KeyValuePair},
 };
 
 /// Serializes a sequence of key-value pairs merged with the base merkle trie

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -9,11 +9,11 @@ mod merge;
 /// Parallel merkle
 pub mod parallel;
 
-use crate::iter::{MerkleKeyValueIter, PathIterator};
-use crate::merkle::changes::{ChangeProof, DiffMerkleNodeStream};
-use crate::v2::api::{
+use crate::api::{
     self, BatchIter, FrozenProof, FrozenRangeProof, KeyType, KeyValuePair, ValueType,
 };
+use crate::iter::{MerkleKeyValueIter, PathIterator};
+use crate::merkle::changes::{ChangeProof, DiffMerkleNodeStream};
 use crate::{Proof, ProofCollection, ProofError, ProofNode, RangeProof};
 use firewood_metrics::firewood_increment;
 use firewood_storage::{

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -1,9 +1,9 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use crate::api::IntoBatchIter;
 use crate::db::BatchOp;
 use crate::merkle::{Key, Merkle, Value};
-use crate::v2::api::IntoBatchIter;
 use firewood_metrics::{current_metrics_context, set_metrics_context};
 use firewood_storage::logger::error;
 use firewood_storage::{

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::v2::api::OptionalHashKeyExt;
+use crate::api::OptionalHashKeyExt;
 
 use super::*;
 use ethereum_types::H256;

--- a/firewood/src/proofs/de.rs
+++ b/firewood/src/proofs/de.rs
@@ -19,10 +19,10 @@ use super::{
     types::{Proof, ProofNode, ProofType},
 };
 use crate::{
+    api::{FrozenChangeProof, FrozenRangeProof},
     db::BatchOp,
     merkle::{Key, Value},
     proofs::magic::{BATCH_DELETE, BATCH_DELETE_RANGE, BATCH_PUT},
-    v2::api::{FrozenChangeProof, FrozenRangeProof},
 };
 
 impl FrozenRangeProof {

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -205,7 +205,7 @@ mod tests {
     #![expect(clippy::unwrap_used, reason = "Tests can use unwrap")]
     #![expect(clippy::indexing_slicing, reason = "Tests can use indexing")]
 
-    use crate::v2::api::TryIntoBatch;
+    use crate::api::TryIntoBatch;
 
     use super::*;
 
@@ -285,7 +285,7 @@ mod tests {
 
         assert_eq!(batches.len(), 1);
         // The batch should be a Put operation since value is non-empty
-        if let crate::v2::api::BatchOp::Put { key, value } = &batches[0] {
+        if let crate::api::BatchOp::Put { key, value } = &batches[0] {
             assert_eq!(key.as_ref() as &[u8], b"test");
             assert_eq!(value.as_ref() as &[u8], b"data");
         } else {

--- a/firewood/src/proofs/ser.rs
+++ b/firewood/src/proofs/ser.rs
@@ -16,10 +16,10 @@ use super::{
     types::{ProofNode, ProofType},
 };
 use crate::{
+    api::{FrozenChangeProof, FrozenRangeProof},
     db::BatchOp,
     merkle::{Key, Value},
     proofs::magic::{BATCH_DELETE, BATCH_DELETE_RANGE, BATCH_PUT},
-    v2::api::{FrozenChangeProof, FrozenRangeProof},
 };
 
 impl FrozenRangeProof {

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -7,7 +7,7 @@ use integer_encoding::VarInt;
 use test_case::test_case;
 
 use super::{header::InvalidHeader, magic, reader::ReadError, types::ProofType};
-use crate::v2::api::FrozenRangeProof;
+use crate::api::FrozenRangeProof;
 
 fn create_valid_range_proof() -> (FrozenRangeProof, Vec<u8>) {
     let merkle = crate::merkle::tests::init_merkle((0u8..=10).map(|k| ([k], [k])));

--- a/firewood/src/v2/mod.rs
+++ b/firewood/src/v2/mod.rs
@@ -1,8 +1,0 @@
-// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
-// See the file LICENSE.md for licensing terms.
-
-/// The public API
-pub mod api;
-
-/// A batch operation and associated types
-mod batch_op;

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use askama::Template;
 use clap::Args;
-use firewood::v2::api;
+use firewood::api;
 use firewood_storage::{
     CacheReadStrategy, CheckOpt, DBStats, FileBacked, NodeStore, NodeStoreHeader,
 };

--- a/fwdctl/src/create.rs
+++ b/fwdctl/src/create.rs
@@ -2,8 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 use clap::{Args, value_parser};
+use firewood::api;
 use firewood::db::{Db, DbConfig};
-use firewood::v2::api;
 
 use crate::DatabasePath;
 

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -2,8 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 use clap::Args;
+use firewood::api::{self, Db as _, Proposal as _};
 use firewood::db::{BatchOp, Db, DbConfig};
-use firewood::v2::api::{self, Db as _, Proposal as _};
 
 use crate::DatabasePath;
 

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -1,10 +1,10 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 use clap::Args;
+use firewood::api::{self, Db as _};
 use firewood::db::{Db, DbConfig};
 use firewood::iter::MerkleKeyValueIter;
 use firewood::merkle::{Key, Value};
-use firewood::v2::api::{self, Db as _};
 use firewood_storage::FileIoError;
 use std::borrow::Cow;
 use std::error::Error;

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -3,8 +3,8 @@
 
 use clap::Args;
 
+use firewood::api::{self, Db as _, DbView as _};
 use firewood::db::{Db, DbConfig};
-use firewood::v2::api::{self, Db as _, DbView as _};
 
 use crate::DatabasePath;
 

--- a/fwdctl/src/graph.rs
+++ b/fwdctl/src/graph.rs
@@ -2,8 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 use clap::Args;
+use firewood::api;
 use firewood::db::{Db, DbConfig};
-use firewood::v2::api;
 use std::io::stdout;
 
 use crate::DatabasePath;

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -2,8 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 use clap::Args;
+use firewood::api::{self, Db as _, Proposal as _};
 use firewood::db::{BatchOp, Db, DbConfig};
-use firewood::v2::api::{self, Db as _, Proposal as _};
 
 use crate::DatabasePath;
 

--- a/fwdctl/src/launch/mod.rs
+++ b/fwdctl/src/launch/mod.rs
@@ -12,7 +12,7 @@ use clap::{Args, Subcommand, ValueEnum};
 use log::{debug, info};
 use thiserror::Error;
 
-type FwdError = firewood::v2::api::Error;
+type FwdError = firewood::api::Error;
 
 #[derive(Debug, Error)]
 pub enum LaunchError {

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
-use firewood::v2::api;
+use firewood::api;
 
 pub mod check;
 pub mod create;

--- a/fwdctl/src/replay.rs
+++ b/fwdctl/src/replay.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use clap::Args;
+use firewood::api::{self, Db as DbApi};
 use firewood::db::{Db, DbConfig};
-use firewood::v2::api::{self, Db as DbApi};
 use firewood_replay::replay_from_file;
 
 use crate::DatabasePath;

--- a/fwdctl/src/root.rs
+++ b/fwdctl/src/root.rs
@@ -3,8 +3,8 @@
 
 use clap::Args;
 
+use firewood::api::{self, Db as _};
 use firewood::db::{Db, DbConfig};
-use firewood::v2::api::{self, Db as _};
 
 use crate::DatabasePath;
 

--- a/replay/src/lib.rs
+++ b/replay/src/lib.rs
@@ -23,8 +23,8 @@ use std::collections::HashMap;
 use std::io::{self, Read};
 use std::time::Instant;
 
+use firewood::api::{self, Db as DbApi, DbView as DbViewApi, Proposal as ProposalApi};
 use firewood::db::{BatchOp, Db, Proposal};
-use firewood::v2::api::{self, Db as DbApi, DbView as DbViewApi, Proposal as ProposalApi};
 use firewood_metrics::firewood_increment;
 use firewood_storage::InvalidTrieHashLength;
 


### PR DESCRIPTION
## Why this should be merged

Closes #1644.

## How this works

- Moves `api.rs` and `batch_ops.rs` up a directory.
- Deletes `v2` module.
- Updates all relevant import paths.

## How this was tested

CI

## Breaking Changes

- [x] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
