### PR TITLE
refactor: parallel execution helpers

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -30,8 +30,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use typed_builder::TypedBuilder;
 
-use crate::merkle::parallel::ParallelMerkle;
-
 #[derive(Error, Debug)]
 #[non_exhaustive]
 /// Represents the different types of errors that can occur in the database.
@@ -246,41 +244,12 @@ impl Db {
     ) -> Result<Proposal<'_>, api::Error> {
         // Return immediately if the background thread is no longer running.
         self.manager.check_persist_error()?;
-        // If use_parallel is BatchSize, then perform parallel proposal creation if the batch
-        // size is >= BatchSize.
-        let batch = batch.into_iter();
-        let use_parallel = match self.use_parallel {
-            UseParallel::Never => false,
-            UseParallel::Always => true,
-            UseParallel::BatchSize(required_size) => batch.size_hint().0 >= required_size,
-        };
-        let immutable = if use_parallel {
-            let mut parallel_merkle = ParallelMerkle::default();
-            let _span = fastrace::Span::enter_with_local_parent("parallel_merkle");
-            parallel_merkle.create_proposal(parent, batch, self.manager.threadpool())?
-        } else {
-            let proposal = NodeStore::new(parent)?;
-            let mut merkle = Merkle::from(proposal);
-            let span = fastrace::Span::enter_with_local_parent("merkleops");
-            for res in batch.into_batch_iter::<api::Error>() {
-                match res? {
-                    BatchOp::Put { key, value } => {
-                        merkle.insert(key.as_ref(), value.as_ref().into())?;
-                    }
-                    BatchOp::Delete { key } => {
-                        merkle.remove(key.as_ref())?;
-                    }
-                    BatchOp::DeleteRange { prefix } => {
-                        merkle.remove_prefix(prefix.as_ref())?;
-                    }
-                }
-            }
-
-            drop(span);
-            let _span = fastrace::Span::enter_with_local_parent("freeze");
-            let nodestore = merkle.into_inner();
-            Arc::new(nodestore.try_into()?)
-        };
+        let proposal = NodeStore::new(parent)?;
+        let mutable_nodestore = self
+            .manager
+            .apply_batch(&self.use_parallel, proposal, batch)?;
+        let immutable: Arc<NodeStore<Arc<ImmutableProposal>, FileBacked>> =
+            Arc::new(mutable_nodestore.try_into()?);
         self.manager.add_proposal(immutable.clone());
 
         self.metrics.proposals.increment(1);

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -18,16 +18,19 @@ use firewood_storage::logger::{trace, warn};
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use typed_builder::TypedBuilder;
 
+use crate::db::UseParallel;
 use crate::merkle::Merkle;
+use crate::merkle::parallel::ParallelMerkle;
 use crate::persist_worker::{PersistError, PersistWorker};
 use crate::root_store::RootStore;
+use crate::v2::api::{self, BatchOp, IntoBatchIter};
 use crate::v2::api::{ArcDynDbView, HashKey, OptionalHashKeyExt};
 
 use firewood_metrics::{firewood_increment, firewood_set};
 pub use firewood_storage::CacheReadStrategy;
 use firewood_storage::{
     BranchNode, Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal,
-    NodeHashAlgorithm, NodeStore, NodeStoreHeader, TrieHash,
+    MutableProposal, NodeHashAlgorithm, NodeStore, NodeStoreHeader, TrieHash,
 };
 
 pub(crate) const DB_FILE_NAME: &str = "firewood.db";
@@ -474,6 +477,50 @@ impl RevisionManager {
                 .build()
                 .expect("Error in creating threadpool")
         })
+    }
+
+    /// Returns whether a batch should use parallel application based on configuration.
+    #[inline]
+    fn should_parallelize<I>(use_parallel: &UseParallel, batch_iter: &I) -> bool
+    where
+        I: Iterator,
+    {
+        let batch_size_lower_bound = batch_iter.size_hint().0;
+        match use_parallel {
+            UseParallel::Never => false,
+            UseParallel::Always => true,
+            UseParallel::BatchSize(required_size) => batch_size_lower_bound >= *required_size,
+        }
+    }
+
+    /// Applies a batch to a mutable nodestore using the configured parallel policy.
+    pub fn apply_batch(
+        &self,
+        use_parallel: &UseParallel,
+        mutable_nodestore: NodeStore<MutableProposal, FileBacked>,
+        batch: impl IntoBatchIter,
+    ) -> Result<NodeStore<MutableProposal, FileBacked>, api::Error> {
+        let batch = batch.into_iter();
+        if Self::should_parallelize(use_parallel, &batch) {
+            let mut parallel_merkle = ParallelMerkle::default();
+            Ok(parallel_merkle.apply(mutable_nodestore, batch, self.threadpool())?)
+        } else {
+            let mut merkle = Merkle::from(mutable_nodestore);
+            for res in batch.into_batch_iter::<api::Error>() {
+                match res? {
+                    BatchOp::Put { key, value } => {
+                        merkle.insert(key.as_ref(), value.as_ref().into())?;
+                    }
+                    BatchOp::Delete { key } => {
+                        merkle.remove(key.as_ref())?;
+                    }
+                    BatchOp::DeleteRange { prefix } => {
+                        merkle.remove_prefix(prefix.as_ref())?;
+                    }
+                }
+            }
+            Ok(merkle.into_inner())
+        }
     }
 
     /// Checks if the `PersistWorker` has errored.

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -363,12 +363,8 @@ impl ParallelMerkle {
         Ok(())
     }
 
-    /// Creates a parallel proposal in 4 steps: Prepare, Split, Merge, and Post-process. In the
-    /// Prepare step, the trie is modified to ensure that the root is a branch node with no
-    /// partial path. In the split step, entries from the batch are sent to workers that
-    /// independently modify their sub-tries. In the merge step, the sub-tries are merged back
-    /// to the main trie. Finally, in the post-processing step, the trie is returned to its
-    /// canonical form.
+    /// Applies a batch of operations to an existing mutable nodestore using the parallel
+    /// proposal pipeline (prepare, split, merge, post-process).
     ///
     /// # Errors
     ///
@@ -376,15 +372,12 @@ impl ParallelMerkle {
     /// from storage, a `CreateProposalError::SendError` if it is unable to send messages to
     /// the workers, and a `CreateProposalError::InvalidConversionToPathComponent` if it is
     /// unable to convert a u8 index into a path component.
-    pub fn create_proposal<T: Parentable>(
+    pub fn apply(
         &mut self,
-        parent: &NodeStore<T, FileBacked>,
+        mut mutable_nodestore: NodeStore<MutableProposal, FileBacked>,
         batch: impl IntoBatchIter,
         pool: &ThreadPool,
-    ) -> Result<Arc<NodeStore<Arc<ImmutableProposal>, FileBacked>>, CreateProposalError> {
-        // Create a mutable nodestore from the parent
-        let mut mutable_nodestore = NodeStore::new(parent)?;
-
+    ) -> Result<NodeStore<MutableProposal, FileBacked>, CreateProposalError> {
         // Prepare step: Force the root into a branch with no partial path in preparation for
         // performing parallel modifications to the trie.
         let mut root_branch = self.force_root(&mut mutable_nodestore)?;
@@ -485,6 +478,32 @@ impl ParallelMerkle {
         // Post-process step: return the trie to its canonical form.
         *mutable_nodestore.root_mut() =
             self.postprocess_trie(&mut mutable_nodestore, root_branch)?;
+
+        Ok(mutable_nodestore)
+    }
+
+    /// Creates a parallel proposal in 4 steps: Prepare, Split, Merge, and Post-process. In the
+    /// Prepare step, the trie is modified to ensure that the root is a branch node with no
+    /// partial path. In the split step, entries from the batch are sent to workers that
+    /// independently modify their sub-tries. In the merge step, the sub-tries are merged back
+    /// to the main trie. Finally, in the post-processing step, the trie is returned to its
+    /// canonical form.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `CreateProposalError::FileIoError` if it encounters an error fetching nodes
+    /// from storage, a `CreateProposalError::SendError` if it is unable to send messages to
+    /// the workers, and a `CreateProposalError::InvalidConversionToPathComponent` if it is
+    /// unable to convert a u8 index into a path component.
+    pub fn create_proposal<T: Parentable>(
+        &mut self,
+        parent: &NodeStore<T, FileBacked>,
+        batch: impl IntoBatchIter,
+        pool: &ThreadPool,
+    ) -> Result<Arc<NodeStore<Arc<ImmutableProposal>, FileBacked>>, CreateProposalError> {
+        // Create a mutable nodestore from the parent
+        let mutable_nodestore = NodeStore::new(parent)?;
+        let mutable_nodestore = self.apply(mutable_nodestore, batch, pool)?;
 
         let immutable: Arc<NodeStore<Arc<ImmutableProposal>, FileBacked>> =
             Arc::new(mutable_nodestore.try_into()?);


### PR DESCRIPTION
## Why this should be merged

Created helpers for should_parallelize and apply_batch. The former decides whether parallel operations are allowed, and the latter applies a batch to a mutable merkle nodestore, either in parallel or serially.

Also moved them from Db to RevisionManager, which puts them closer to what they need. There's nothing in Db they depend on.

These functions were moved to make them accessible for callsites in a future diff. There are no functional changes in this diff.

## How this works

Code restructure only

## How this was tested

CI only

## Breaking Changes

None