### PR TITLE
chore: bump go to 1.25.8

### DIFF
--- a/ffi/flake.lock
+++ b/ffi/flake.lock
@@ -39,17 +39,17 @@
       },
       "locked": {
         "dir": "nix/go",
-        "lastModified": 1771869261,
-        "narHash": "sha256-2B5tyF6GihyZtj0133MWiu3rD1stmtK/eZ7onNx23Rs=",
+        "lastModified": 1773256574,
+        "narHash": "sha256-bZiyC/Y4LIBdp9RR93rJYqh3Ls+VZap5L0KNyjGo308=",
         "owner": "ava-labs",
         "repo": "avalanchego",
-        "rev": "4aa7f05e07636567e956d2c0f0d6146bf8b5d144",
+        "rev": "50585cbbdfe1af02a2c11bdc9fa77fca26e6b838",
         "type": "github"
       },
       "original": {
         "dir": "nix/go",
         "owner": "ava-labs",
-        "ref": "4aa7f05e07636567e956d2c0f0d6146bf8b5d144",
+        "ref": "50585cbbdfe1af02a2c11bdc9fa77fca26e6b838",
         "repo": "avalanchego",
         "type": "github"
       }

--- a/ffi/flake.nix
+++ b/ffi/flake.nix
@@ -12,7 +12,7 @@
     rust-overlay.url = "github:oxalica/rust-overlay";
     crane.url = "github:ipetkov/crane";
     flake-utils.url = "github:numtide/flake-utils";
-    golang.url = "github:ava-labs/avalanchego?dir=nix/go&ref=4aa7f05e07636567e956d2c0f0d6146bf8b5d144";
+    golang.url = "github:ava-labs/avalanchego?dir=nix/go&ref=50585cbbdfe1af02a2c11bdc9fa77fca26e6b838";
   };
 
   outputs = { self, nixpkgs, rust-overlay, crane, flake-utils, golang }:

--- a/ffi/go.mod
+++ b/ffi/go.mod
@@ -8,7 +8,7 @@ go 1.25
 //   - ffi/tests/eth/go.mod
 //   - ffi/tests/firewood/go.mod
 // `just check-golang-version` validates that these versions are in sync and will run in CI as part of the ffi-nix job.
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/prometheus/client_golang v1.22.0

--- a/ffi/tests/eth/go.mod
+++ b/ffi/tests/eth/go.mod
@@ -2,7 +2,7 @@ module github.com/ava-labs/firewood/ffi/tests/eth
 
 go 1.25
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.0 // this is replaced to use the parent folder

--- a/ffi/tests/firewood/go.mod
+++ b/ffi/tests/firewood/go.mod
@@ -2,7 +2,7 @@ module github.com/ava-labs/firewood/ffi/tests/firewood
 
 go 1.25
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/ava-labs/firewood-go/ffi v0.0.0 // this is replaced to use the parent folder


### PR DESCRIPTION
## Why this should be merged

Matches AvalancheGo's version of Go.

## How this works

Bumps Go from 1.25.7 to 1.25.8

## How this was tested

CI

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
