### PR TITLE
fix: fwdctl vm config

### DIFF
--- a/fwdctl/src/launch/cloud_init.rs
+++ b/fwdctl/src/launch/cloud_init.rs
@@ -60,7 +60,7 @@ impl CloudInitContext {
             args: HashMap::from([
                 ("end_block".into(), end_block),
                 ("nblocks".into(), nblocks),
-                ("config".into(), opts.config.clone()),
+                ("config".into(), opts.config.as_str().to_owned()),
                 ("metrics_server".into(), opts.metrics_server.to_string()),
             ]),
             branches: opts

--- a/fwdctl/src/launch/mod.rs
+++ b/fwdctl/src/launch/mod.rs
@@ -139,6 +139,14 @@ pub enum NBlocks {
     FiftyM = 50_000_000,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
+pub enum Config {
+    Firewood,
+    FirewoodArchive,
+    Archive,
+    Default,
+}
+
 impl NBlocks {
     #[must_use]
     pub const fn end_block(self) -> u64 {
@@ -151,6 +159,18 @@ impl NBlocks {
             Self::TenK => "10k",
             Self::OneM => "1m",
             Self::FiftyM => "50m",
+        }
+    }
+}
+
+impl Config {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Firewood => "firewood",
+            Self::FirewoodArchive => "firewood-archive",
+            Self::Archive => "archive",
+            Self::Default => "default",
         }
     }
 }
@@ -270,9 +290,9 @@ pub struct DeployOptions {
     )]
     pub scenario: String,
 
-    /// VM reexecution config (firewood, hashdb, pathdb, etc.)
-    #[arg(long = "config", value_name = "CONFIG", default_value = "firewood")]
-    pub config: String,
+    /// VM reexecution config
+    #[arg(long = "config", value_name = "CONFIG", value_enum, default_value_t = Config::Firewood)]
+    pub config: Config,
 
     /// Override template variables (`KEY=VALUE`). Repeat the flag to set multiple values.
     #[arg(
@@ -728,7 +748,7 @@ fn log_launch_config(opts: &DeployOptions) {
     }
     info!("\t{:24}{}", "Scenario:", opts.scenario_name());
     info!("\t{:24}{}", "Blocks:", opts.nblocks.as_str());
-    info!("\t{:24}{}", "Config:", opts.config);
+    info!("\t{:24}{}", "Config:", opts.config.as_str());
     info!(
         "\t{:24}{}",
         "Variable overrides:",


### PR DESCRIPTION
## Why this should be merged

Previously, reading the documentation for the `config` flag in `./target/release/fwdctl launch deploy -h` would read:

```
VM reexecution config (firewood, hashdb, pathdb, etc.)
```

However, this is wrong as the reexecution test supports a different set of configs: 

https://github.com/ava-labs/avalanchego/blob/50585cbbdfe1af02a2c11bdc9fa77fca26e6b838/tests/reexecute/c/vm_reexecute.go#L65-L80

## How this works

- Created enum where variants represent valid VM configs
- Updated `config` field to use this new variant

## How this was tested

Running `./target/release/fwdctl launch deploy -h` now reads:

```
--config <CONFIG>              VM reexecution config [default: firewood] [possible values: firewood, firewood-archive, archive, default]
```

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
