### PR TITLE
refactor(reconstruct): rename MutableProposal to Mutable<Propose>

### DIFF
--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -622,7 +622,7 @@ impl<I: Iterator<Item = T>, T: KeyValuePair, K: KeyType> Iterator for FilteredKe
 mod tests {
     use super::*;
     use crate::merkle::Merkle;
-    use firewood_storage::{ImmutableProposal, MemStore, MutableProposal, NodeStore};
+    use firewood_storage::{ImmutableProposal, MemStore, Mutable, NodeStore, Propose};
     use std::sync::Arc;
     use test_case::test_case;
 
@@ -636,7 +636,7 @@ mod tests {
         };
     }
 
-    pub(super) fn create_test_merkle() -> Merkle<NodeStore<MutableProposal, MemStore>> {
+    pub(super) fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
         let memstore = MemStore::default();
         let memstore = Arc::new(memstore);
         let nodestore = NodeStore::new_empty_proposal(memstore);
@@ -805,7 +805,7 @@ mod tests {
     ///  1   F
     ///
     /// The number next to each branch is the position of the child in the branch's children array.
-    fn created_populated_merkle() -> Merkle<NodeStore<MutableProposal, MemStore>> {
+    fn created_populated_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
         let mut merkle = create_test_merkle();
 
         merkle

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -69,7 +69,7 @@
 //!   There are three states for a nodestore:
 //!    - [`firewood_storage::Committed`] for revisions that are committed
 //!    - [`firewood_storage::ImmutableProposal`] for revisions that are proposals against committed versions
-//!    - [`firewood_storage::MutableProposal`] for revisions where nodes are still being added.
+//!    - [`firewood_storage::Mutable<firewood_storage::Propose>`] for revisions where nodes are still being added.
 //!
 //!  For more information on these node states, see their associated documentation.
 //!
@@ -85,17 +85,17 @@
 //!
 //! In short, a Read-Modify-Write (RMW) style normal operation flow is as follows in Firewood:
 //!
-//! - Create a [`firewood_storage::MutableProposal`] [`firewood_storage::NodeStore`] from the most recent [`firewood_storage::Committed`] one.
+//! - Create a [`firewood_storage::NodeStore`]`<`[`firewood_storage::Mutable`]`<`[`firewood_storage::Propose`]`>, _>` from the most recent [`firewood_storage::Committed`] one.
 //! - Traverse the trie, starting at the root. Make a new root node by duplicating the existing
 //!   root from the committed one and save that in memory. As you continue traversing, make copies
 //!   of each node accessed if they are not already in memory.
 //!
 //! - Make changes to the trie, in memory. Each node you've accessed is currently in memory and is
-//!   owned by the [`firewood_storage::MutableProposal`]. Adding a node simply means adding a reference to it.
+//!   owned by the [`firewood_storage::Mutable`]`<`[`firewood_storage::Propose`]`>` nodestore. Adding a node simply means adding a reference to it.
 //!
 //! - If you delete a node, mark it as deleted in the proposal and remove the child reference to it.
 //!
-//! - After making all mutations, convert the [`firewood_storage::MutableProposal`] to an [`firewood_storage::ImmutableProposal`]. This
+//! - After making all mutations, convert the `Mutable<Propose>` nodestore to an [`firewood_storage::ImmutableProposal`]. This
 //!   involves walking the in-memory trie and converting them to a [`firewood_storage::SharedNode`].
 //!
 //! - Since the root is guaranteed to be new, the new root will reference all of the new revision.

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -27,8 +27,8 @@ use crate::root_store::RootStore;
 use firewood_metrics::{firewood_increment, firewood_set};
 pub use firewood_storage::CacheReadStrategy;
 use firewood_storage::{
-    BranchNode, Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal,
-    MutableProposal, NodeHashAlgorithm, NodeStore, NodeStoreHeader, TrieHash,
+    BranchNode, Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal, Mutable,
+    MutableKind, NodeHashAlgorithm, NodeStore, NodeStoreHeader, Propose, TrieHash,
 };
 
 pub(crate) const DB_FILE_NAME: &str = "firewood.db";
@@ -495,30 +495,38 @@ impl RevisionManager {
     pub fn apply_batch(
         &self,
         use_parallel: &UseParallel,
-        mutable_nodestore: NodeStore<MutableProposal, FileBacked>,
+        mutable_nodestore: NodeStore<Mutable<Propose>, FileBacked>,
         batch: impl IntoBatchIter,
-    ) -> Result<NodeStore<MutableProposal, FileBacked>, api::Error> {
+    ) -> Result<NodeStore<Mutable<Propose>, FileBacked>, api::Error> {
         let batch = batch.into_iter();
         if Self::should_parallelize(use_parallel, &batch) {
             let mut parallel_merkle = ParallelMerkle::default();
             Ok(parallel_merkle.apply(mutable_nodestore, batch, self.threadpool())?)
         } else {
-            let mut merkle = Merkle::from(mutable_nodestore);
-            for res in batch.into_batch_iter::<api::Error>() {
-                match res? {
-                    BatchOp::Put { key, value } => {
-                        merkle.insert(key.as_ref(), value.as_ref().into())?;
-                    }
-                    BatchOp::Delete { key } => {
-                        merkle.remove(key.as_ref())?;
-                    }
-                    BatchOp::DeleteRange { prefix } => {
-                        merkle.remove_prefix(prefix.as_ref())?;
-                    }
+            Self::apply_batch_serial(mutable_nodestore, batch)
+        }
+    }
+
+    /// Serial batch application shared by [`apply_batch`][Self::apply_batch].
+    fn apply_batch_serial<K: MutableKind>(
+        mutable_nodestore: NodeStore<Mutable<K>, FileBacked>,
+        batch: impl IntoBatchIter,
+    ) -> Result<NodeStore<Mutable<K>, FileBacked>, api::Error> {
+        let mut merkle = Merkle::from(mutable_nodestore);
+        for res in batch.into_batch_iter::<api::Error>() {
+            match res? {
+                BatchOp::Put { key, value } => {
+                    merkle.insert(key.as_ref(), value.as_ref().into())?;
+                }
+                BatchOp::Delete { key } => {
+                    merkle.remove(key.as_ref())?;
+                }
+                BatchOp::DeleteRange { prefix } => {
+                    merkle.remove_prefix(prefix.as_ref())?;
                 }
             }
-            Ok(merkle.into_inner())
         }
+        Ok(merkle.into_inner())
     }
 
     /// Checks if the `PersistWorker` has errored.

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -698,8 +698,8 @@ mod tests {
     };
 
     use firewood_storage::{
-        Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal, MemStore,
-        MutableProposal, NodeStore, SeededRng, TestRecorder, TrieReader,
+        Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal, MemStore, Mutable,
+        NodeStore, Propose, SeededRng, TestRecorder, TrieReader,
     };
     use lender::Lender;
     use std::{collections::HashSet, ops::Deref, path::PathBuf, sync::Arc};
@@ -743,14 +743,14 @@ mod tests {
         DiffMerkleNodeStream::new(tree_left.nodestore(), tree_right.nodestore(), start_key)
     }
 
-    fn create_test_merkle() -> Merkle<NodeStore<MutableProposal, MemStore>> {
+    fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
         let memstore = MemStore::default();
         let nodestore = NodeStore::new_empty_proposal(Arc::new(memstore));
         Merkle::from(nodestore)
     }
 
     fn populate_merkle(
-        mut merkle: Merkle<NodeStore<MutableProposal, MemStore>>,
+        mut merkle: Merkle<NodeStore<Mutable<Propose>, MemStore>>,
         items: &[(&[u8], &[u8])],
     ) -> Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>> {
         for (key, value) in items {

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -18,9 +18,9 @@ use crate::{Proof, ProofCollection, ProofError, ProofNode, RangeProof};
 use firewood_metrics::firewood_increment;
 use firewood_storage::{
     BranchNode, Child, Children, FileIoError, HashType, HashedNodeReader, ImmutableProposal,
-    IntoHashType, LeafNode, MaybePersistedNode, MutableProposal, NibblesIterator, Node, NodeStore,
-    Parentable, Path, PathComponent, ReadableStorage, SharedNode, TrieHash, TrieReader,
-    ValueDigest,
+    IntoHashType, LeafNode, MaybePersistedNode, Mutable, MutableKind, NibblesIterator, Node,
+    NodeStore, Parentable, Path, PathComponent, Propose, ReadableStorage, SharedNode, TrieHash,
+    TrieReader, ValueDigest,
 };
 use std::collections::HashSet;
 use std::fmt::Debug;
@@ -644,25 +644,24 @@ impl<F: Parentable, S: ReadableStorage> Merkle<NodeStore<F, S>> {
     /// ## Errors
     ///
     /// Returns an error if the nodestore cannot be created. See [`NodeStore::new`].
-    pub fn fork(&self) -> Result<Merkle<NodeStore<MutableProposal, S>>, FileIoError> {
+    pub fn fork(&self) -> Result<Merkle<NodeStore<Mutable<Propose>, S>>, FileIoError> {
         NodeStore::new(&self.nodestore).map(Into::into)
     }
 }
 
-impl<S: ReadableStorage> TryFrom<Merkle<NodeStore<MutableProposal, S>>>
+impl<S: ReadableStorage> TryFrom<Merkle<NodeStore<Mutable<Propose>, S>>>
     for Merkle<NodeStore<Arc<ImmutableProposal>, S>>
 {
     type Error = FileIoError;
-    fn try_from(m: Merkle<NodeStore<MutableProposal, S>>) -> Result<Self, Self::Error> {
+    fn try_from(m: Merkle<NodeStore<Mutable<Propose>, S>>) -> Result<Self, Self::Error> {
         Ok(Merkle {
             nodestore: m.nodestore.try_into()?,
         })
     }
 }
 
-#[expect(clippy::missing_errors_doc)]
-impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
-    /// Convert a merkle backed by an `MutableProposal` into an `ImmutableProposal`
+impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
+    /// Convert a merkle backed by an `Mutable<Propose>` into an `ImmutableProposal`
     ///
     /// This function is only used in benchmarks and tests
     ///
@@ -673,7 +672,10 @@ impl<S: ReadableStorage> Merkle<NodeStore<MutableProposal, S>> {
     pub fn hash(self) -> Merkle<NodeStore<Arc<ImmutableProposal>, S>> {
         self.try_into().expect("failed to convert")
     }
+}
 
+#[expect(clippy::missing_errors_doc)]
+impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
     fn read_for_update(&mut self, child: Child) -> Result<Node, FileIoError> {
         match child {
             Child::Node(node) => Ok(node),

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -8,8 +8,8 @@ use firewood_metrics::{current_metrics_context, set_metrics_context};
 use firewood_storage::logger::error;
 use firewood_storage::{
     BranchNode, Child, Children, FileBacked, FileIoError, ImmutableProposal, LeafNode,
-    MaybePersistedNode, MutableProposal, NibblesIterator, Node, NodeStore, Parentable, Path,
-    PathComponent,
+    MaybePersistedNode, Mutable, NibblesIterator, Node, NodeStore, Parentable, Path, PathComponent,
+    Propose,
 };
 use rayon::ThreadPool;
 use std::iter::once;
@@ -69,7 +69,7 @@ impl ParallelMerkle {
     /// by the worker threads.
     fn force_root(
         &self,
-        proposal: &mut NodeStore<MutableProposal, FileBacked>,
+        proposal: &mut NodeStore<Mutable<Propose>, FileBacked>,
     ) -> Result<Box<BranchNode>, CreateProposalError> {
         // There are 3 different cases to handle depending on the value of the root node.
         //
@@ -114,7 +114,7 @@ impl ParallelMerkle {
     /// In all other cases, the root is already correct.
     fn postprocess_trie(
         &self,
-        nodestore: &mut NodeStore<MutableProposal, FileBacked>,
+        nodestore: &mut NodeStore<Mutable<Propose>, FileBacked>,
         mut branch: Box<BranchNode>,
     ) -> Result<Option<Node>, FileIoError> {
         let mut children_iter = branch
@@ -166,7 +166,7 @@ impl ParallelMerkle {
     /// Call by a worker to processes requests from `child_receiver` and send back a response on
     /// `response_sender` once the main thread closes the child sender.
     fn worker_event_loop(
-        mut merkle: Merkle<NodeStore<MutableProposal, FileBacked>>,
+        mut merkle: Merkle<NodeStore<Mutable<Propose>, FileBacked>>,
         first_path_component: PathComponent,
         child_receiver: Receiver<BatchOp<Key, Value>>,
         response_sender: Sender<Result<Response, FileIoError>>,
@@ -204,10 +204,11 @@ impl ParallelMerkle {
             .take()
             .map(|root| {
                 #[cfg(not(feature = "ethhash"))]
-                let (root_node, root_hash) = NodeStore::<MutableProposal, FileBacked>::hash_helper(
-                    root,
-                    Path::from(&[first_path_component.as_u8()]),
-                )?;
+                let (root_node, root_hash) =
+                    NodeStore::<Mutable<Propose>, FileBacked>::hash_helper(
+                        root,
+                        Path::from(&[first_path_component.as_u8()]),
+                    )?;
                 #[cfg(feature = "ethhash")]
                 let (root_node, root_hash) =
                     nodestore.hash_helper(root, Path::from(&[first_path_component.as_u8()]))?;
@@ -227,7 +228,7 @@ impl ParallelMerkle {
     /// by the value of the `first_path_component`.
     fn create_worker(
         pool: &ThreadPool,
-        proposal: &mut NodeStore<MutableProposal, FileBacked>,
+        proposal: &mut NodeStore<Mutable<Propose>, FileBacked>,
         root_branch: &mut BranchNode,
         first_path_component: PathComponent,
         response_sender: Sender<Result<Response, FileIoError>>,
@@ -278,7 +279,7 @@ impl ParallelMerkle {
     fn merge_children(
         &mut self,
         response_channel: Receiver<Result<Response, FileIoError>>,
-        proposal: &mut NodeStore<MutableProposal, FileBacked>,
+        proposal: &mut NodeStore<Mutable<Propose>, FileBacked>,
         root_branch: &mut BranchNode,
     ) -> Result<(), FileIoError> {
         while let Ok(response) = response_channel.recv() {
@@ -303,7 +304,7 @@ impl ParallelMerkle {
     fn worker(
         &mut self,
         pool: &ThreadPool,
-        proposal: &mut NodeStore<MutableProposal, FileBacked>,
+        proposal: &mut NodeStore<Mutable<Propose>, FileBacked>,
         root_branch: &mut BranchNode,
         first_path_component: PathComponent,
         response_sender: Sender<Result<Response, FileIoError>>,
@@ -330,7 +331,7 @@ impl ParallelMerkle {
     fn remove_all_entries(
         &mut self,
         pool: &ThreadPool,
-        proposal: &mut NodeStore<MutableProposal, FileBacked>,
+        proposal: &mut NodeStore<Mutable<Propose>, FileBacked>,
         root_branch: &mut BranchNode,
         response_sender: &Sender<Result<Response, FileIoError>>,
     ) -> Result<(), CreateProposalError> {
@@ -380,10 +381,10 @@ impl ParallelMerkle {
     /// unable to convert a u8 index into a path component.
     pub fn apply(
         &mut self,
-        mut mutable_nodestore: NodeStore<MutableProposal, FileBacked>,
+        mut mutable_nodestore: NodeStore<Mutable<Propose>, FileBacked>,
         batch: impl IntoBatchIter,
         pool: &ThreadPool,
-    ) -> Result<NodeStore<MutableProposal, FileBacked>, CreateProposalError> {
+    ) -> Result<NodeStore<Mutable<Propose>, FileBacked>, CreateProposalError> {
         // Prepare step: Force the root into a branch with no partial path in preparation for
         // performing parallel modifications to the trie.
         let mut root_branch = self.force_root(&mut mutable_nodestore)?;

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -16,7 +16,7 @@ use std::fmt::Write;
 
 use super::*;
 use firewood_storage::{
-    Committed, MemStore, MutableProposal, NodeHashAlgorithm, NodeStore, NodeStoreHeader,
+    Committed, MemStore, Mutable, NodeHashAlgorithm, NodeStore, NodeStoreHeader, Propose,
     RootReader, TrieHash,
 };
 
@@ -182,7 +182,7 @@ fn insert_one() {
     merkle.insert(b"abc", Box::new([])).unwrap();
 }
 
-fn create_in_memory_merkle() -> Merkle<NodeStore<MutableProposal, MemStore>> {
+fn create_in_memory_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
     let memstore = MemStore::default();
 
     let nodestore = NodeStore::new_empty_proposal(memstore.into());
@@ -312,7 +312,7 @@ fn remove_prefix_exact() {
     }
 }
 
-fn two_byte_all_keys() -> Merkle<NodeStore<MutableProposal, MemStore>> {
+fn two_byte_all_keys() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
     let mut merkle = create_in_memory_merkle();
     for key_val in u8::MIN..=u8::MAX {
         let key = [key_val, key_val];

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -9,7 +9,7 @@ use crate::nodestore::alloc::FreeAreaWithMetadata;
 use crate::nodestore::primitives::{AreaIndex, area_size_iter};
 use crate::{
     CheckerError, Committed, FileIoError, HashType, HashedNodeReader, IntoHashType, LinearAddress,
-    MutableProposal, Node, NodeReader, NodeStore, Path, ReadableStorage, RootReader,
+    Mutable, Node, NodeReader, NodeStore, Path, Propose, ReadableStorage, RootReader,
     StoredAreaParent, TrieNodeParent, WritableStorage, nodestore::NodeStoreHeader,
 };
 
@@ -588,13 +588,13 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
         header: &mut NodeStoreHeader,
         check_report: CheckerReport,
     ) -> Result<FixReport, FileIoError> {
-        let mut proposal = NodeStore::<MutableProposal, S>::new(self)?;
+        let mut proposal = NodeStore::<Mutable<Propose>, S>::new(self)?;
 
         Ok(proposal.fix(header, check_report))
     }
 }
 
-impl<S: WritableStorage> NodeStore<MutableProposal, S> {
+impl<S: WritableStorage> NodeStore<Mutable<Propose>, S> {
     fn fix(&mut self, header: &mut NodeStoreHeader, check_report: CheckerReport) -> FixReport {
         let mut fixed = Vec::new();
         let mut unfixable = Vec::new();
@@ -1168,7 +1168,7 @@ mod test {
         let expected_error_num = errors.len();
 
         // fix the freelist
-        let mut proposal = NodeStore::<MutableProposal, _>::new(&nodestore).unwrap();
+        let mut proposal = NodeStore::<Mutable<Propose>, _>::new(&nodestore).unwrap();
         let fix_report = proposal.fix(
             &mut header,
             CheckerReport {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -55,9 +55,9 @@ pub use linear::{FileIoError, ReadableStorage, WritableStorage};
 pub use node::path::{NibblesIterator, Path};
 pub use node::{BranchNode, Child, Children, ChildrenSlots, LeafNode, Node, PathIterItem};
 pub use nodestore::{
-    AreaIndex, Committed, HashedNodeReader, ImmutableProposal, LinearAddress, MutableProposal,
+    AreaIndex, Committed, HashedNodeReader, ImmutableProposal, LinearAddress, Mutable, MutableKind,
     NodeHashAlgorithm, NodeHashAlgorithmTryFromIntError, NodeReader, NodeStore, NodeStoreHeader,
-    Parentable, RootReader, TrieReader,
+    Parentable, Propose, RootReader, TrieReader,
 };
 pub use path::{
     ComponentIter, IntoSplitPath, JoinedPath, PackedBytes, PackedPathComponents, PackedPathRef,

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -23,12 +23,12 @@
 //!
 //! `T` is one of the following state types:
 //! - [`Committed`] - For a committed revision with no in-memory changes
-//! - [`MutableProposal`] - For a proposal being actively modified with in-memory nodes
+//! - [`Mutable<Propose>`] - For a proposal being actively modified with in-memory nodes
 //! - [`ImmutableProposal`] - For a proposal that has been hashed and assigned addresses
 //!
 //! The nodestore follows a lifecycle pattern:
 //! ```text
-//! Committed -> MutableProposal -> ImmutableProposal -> Committed
+//! Committed -> Mutable<Propose> -> ImmutableProposal -> Committed
 //! ```
 //!
 //! ## Traits
@@ -61,6 +61,28 @@ pub use primitives::{AreaIndex, LinearAddress};
 // Re-export types from header module
 pub use header::NodeStoreHeader;
 
+/// The [`NodeStore`] handles the serialization of nodes and
+/// free space management of nodes in the page store. It lays out the format
+/// of the [`PageStore`]. More specifically, it places a [`FileIdentifyingMagic`]
+/// and a [`FreeSpaceHeader`] at the beginning
+///
+/// Nodestores represent a revision of the trie. There are three types of nodestores:
+/// - `Committed`: A committed revision of the trie. It has no in-memory changes.
+/// - `Mutable<Propose>`: A proposal that is still being modified. It has some nodes in memory, a delete list, and a parent.
+/// - `ImmutableProposal`: A proposal that has been hashed and assigned addresses. It has no in-memory changes.
+///
+/// The general lifecycle of nodestores is as follows:
+/// ```mermaid
+/// flowchart TD
+/// subgraph subgraph["Committed Revisions"]
+/// L("Latest Nodestore&lt;Committed, S&gt;") --- |...|O("Oldest NodeStore&lt;Committed, S&gt;")
+/// end
+/// O --> E("Expire")
+/// L --> |start propose|M("NodeStore&lt;Mutable&lt;Propose&gt;, S&gt;")
+/// M --> |finish propose + hash|I("NodeStore&lt;ProposedImmutable, S&gt;")
+/// I --> |commit|N("New commit NodeStore&lt;Committed, S&gt;")
+/// style E color:#FFFFFF, fill:#AA00FF, stroke:#AA00FF
+/// ```
 use std::mem::take;
 use std::ops::Deref;
 use std::sync::Arc;
@@ -173,7 +195,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
 ///
 /// This means that the nodestore can have children.
 /// Only [`ImmutableProposal`] and [Committed] implement this trait.
-/// [`MutableProposal`] does not implement this trait because it is not a valid parent.
+/// [`Mutable<Propose>`] does not implement this trait because it is not a valid parent.
 /// TODO: Maybe this can be renamed to `ImmutableNodestore`
 pub trait Parentable {
     /// Returns the parent of this nodestore.
@@ -232,8 +254,8 @@ impl Parentable for Committed {
     }
 }
 
-impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
-    /// Create a new `MutableProposal` [`NodeStore`] from a parent [`NodeStore`]
+impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
+    /// Create a new proposal [`NodeStore`] from a parent [`NodeStore`].
     ///
     /// # Errors
     ///
@@ -242,15 +264,17 @@ impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
         let mut deleted = Vec::default();
         let root = if let Some(ref root) = parent.kind.root() {
             deleted.push(root.clone());
-            let root = root.as_shared_node(parent)?.deref().clone();
+            let root = triomphe::Arc::unwrap_or_clone(root.as_shared_node(parent)?);
             Some(root)
         } else {
             None
         };
-        let kind = MutableProposal {
+        let kind = Mutable {
             root,
-            deleted,
-            parent: parent.kind.as_nodestore_parent(),
+            inner: Propose {
+                deleted,
+                parent: parent.kind.as_nodestore_parent(),
+            },
         };
         Ok(NodeStore {
             kind,
@@ -261,69 +285,77 @@ impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
     /// Marks the node at `addr` as deleted in this proposal.
     pub fn delete_node(&mut self, node: MaybePersistedNode) {
         trace!("Pending delete at {node:?}");
-        self.kind.deleted.push(node);
+        self.kind.inner.deleted.push(node);
     }
 
     /// Take the nodes that have been marked as deleted in this proposal.
     pub fn take_deleted_nodes(&mut self) -> Vec<MaybePersistedNode> {
-        take(&mut self.kind.deleted)
+        take(&mut self.kind.inner.deleted)
     }
 
     /// Adds to the nodes deleted in this proposal.
     pub fn delete_nodes(&mut self, nodes: &[MaybePersistedNode]) {
-        self.kind.deleted.extend_from_slice(nodes);
+        self.kind.inner.deleted.extend_from_slice(nodes);
     }
 
-    /// Reads a node for update, marking it as deleted in this proposal.
-    /// We get an arc from cache (reading it from disk if necessary) then
-    /// copy/clone the node and return it.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`FileIoError`] if the node cannot be read.
-    pub fn read_for_update(&mut self, node: MaybePersistedNode) -> Result<Node, FileIoError> {
-        let arc_wrapped_node = node.as_shared_node(self)?;
-        self.delete_node(node);
-        Ok((*arc_wrapped_node).clone())
-    }
-
-    /// Returns the root of this proposal.
-    pub const fn root_mut(&mut self) -> &mut Option<Node> {
-        &mut self.kind.root
-    }
-}
-
-impl<S: ReadableStorage> NodeStore<MutableProposal, S> {
-    /// Creates a new [`NodeStore`] from a root node.
+    /// Creates a new [`NodeStore`] from a root node, inheriting the parent from another proposal.
     #[must_use]
-    pub fn from_root(parent: &NodeStore<MutableProposal, S>, root: Option<Node>) -> Self {
+    pub fn from_root(parent: &NodeStore<Mutable<Propose>, S>, root: Option<Node>) -> Self {
         NodeStore {
-            kind: MutableProposal {
+            kind: Mutable {
                 root,
-                deleted: Vec::default(),
-                parent: parent.kind.parent.clone(),
+                inner: Propose {
+                    deleted: Vec::default(),
+                    parent: parent.kind.inner.parent.clone(),
+                },
             },
             storage: parent.storage.clone(),
         }
     }
+}
 
-    /// Consumes the `NodeStore` and returns the root of the trie
+impl<K: MutableKind, S: ReadableStorage> NodeStore<Mutable<K>, S> {
+    /// Reads a node for update, marking it as replaced (logically deleted).
+    ///
+    /// Reads the node from cache or disk, then calls [`MutableKind::track_deleted`] on the
+    /// kind-specific inner state. For [`Propose`] this records the node in the delete list;
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`FileIoError`] if the node cannot be read.
+    #[inline]
+    pub fn read_for_update(&mut self, node: MaybePersistedNode) -> Result<Node, FileIoError> {
+        let arc_wrapped_node = node.as_shared_node(self)?;
+        self.kind.inner.track_deleted(node);
+        Ok(triomphe::Arc::unwrap_or_clone(arc_wrapped_node))
+    }
+}
+
+impl<T, S> NodeStore<Mutable<T>, S> {
+    /// Returns the root of this mutable nodestore.
+    pub const fn root_mut(&mut self) -> &mut Option<Node> {
+        &mut self.kind.root
+    }
+
+    /// Consumes the `NodeStore` and returns the root of the trie.
     #[must_use]
     pub fn into_root(self) -> Option<Node> {
         self.kind.root
     }
 }
 
-impl<S: WritableStorage> NodeStore<MutableProposal, S> {
+impl<S: WritableStorage> NodeStore<Mutable<Propose>, S> {
     /// Creates a new, empty, [`NodeStore`].
     /// This is used during testing and during the creation of an in-memory merkle for proofs.
     #[cfg(any(test, feature = "test_utils"))]
     pub fn new_empty_proposal(storage: Arc<S>) -> Self {
         NodeStore {
-            kind: MutableProposal {
+            kind: Mutable {
                 root: None,
-                deleted: Vec::default(),
-                parent: NodeStoreParent::Committed(None),
+                inner: Propose {
+                    deleted: Vec::default(),
+                    parent: NodeStoreParent::Committed(None),
+                },
             },
             storage,
         }
@@ -469,42 +501,58 @@ impl ImmutableProposal {
 /// L("Latest Nodestore&lt;Committed, S&gt;") --- |...|O("Oldest NodeStore&lt;Committed, S&gt;")
 /// end
 /// O --> E("Expire")
-/// L --> |start propose|M("NodeStore&lt;ProposedMutable, S&gt;")
+/// L --> |start propose|M("NodeStore&lt;Mutable&lt;Propose&gt;, S&gt;")
 /// M --> |finish propose + hash|I("NodeStore&lt;ProposedImmutable, S&gt;")
 /// I --> |commit|N("New commit NodeStore&lt;Committed, S&gt;")
 /// style E color:#FFFFFF, fill:#AA00FF, stroke:#AA00FF
 /// ```
+
 #[derive(Debug)]
 pub struct NodeStore<T, S> {
-    /// This is one of [Committed], [`ImmutableProposal`], or [`MutableProposal`].
+    /// This is one of [Committed], [`ImmutableProposal`], or [`Mutable<Propose>`].
     kind: T,
     /// Persisted storage to read nodes from.
     storage: Arc<S>,
 }
 
-/// Contains the state of a proposal that is still being modified.
+/// Proposal-specific fields for a mutable nodestore.
 #[derive(Debug)]
-pub struct MutableProposal {
-    /// The root of the trie in this proposal.
-    root: Option<Node>,
+pub struct Propose {
     /// Nodes that have been deleted in this proposal.
-    deleted: Vec<MaybePersistedNode>,
-    parent: NodeStoreParent,
+    pub(crate) deleted: Vec<MaybePersistedNode>,
+    pub(crate) parent: NodeStoreParent,
 }
 
-impl<T: Into<NodeStoreParent>, S: ReadableStorage> From<NodeStore<T, S>>
-    for NodeStore<MutableProposal, S>
-{
-    fn from(val: NodeStore<T, S>) -> Self {
-        NodeStore {
-            kind: MutableProposal {
-                root: None,
-                deleted: Vec::default(),
-                parent: val.kind.into(),
-            },
-            storage: val.storage,
-        }
+/// Behaviour that differs between proposal mutable nodestores.
+///
+/// Types that implement this trait can be used as the `Kind` parameter of [`Mutable`],
+/// allowing [`NodeStore`] operations such as [`NodeStore::read_for_update`] and
+/// `Merkle` insert/remove to work generically.
+pub trait MutableKind: std::fmt::Debug {
+    /// Record that `node` is being replaced (i.e. logically deleted).
+    ///
+    /// For [`Propose`] this appends the node to the delete list so that its
+    /// storage can be reclaimed when the proposal is committed.
+    fn track_deleted(&mut self, node: MaybePersistedNode);
+}
+
+impl MutableKind for Propose {
+    #[inline]
+    fn track_deleted(&mut self, node: MaybePersistedNode) {
+        trace!("Pending delete at {node:?}");
+        self.deleted.push(node);
     }
+}
+
+/// Contains the state of a nodestore that is still being modified.
+///
+/// The type parameter `Kind` is [`Propose`] (for building proposals,
+/// with a delete list and parent).
+#[derive(Debug)]
+pub struct Mutable<Kind> {
+    /// The root of the trie in this mutable nodestore.
+    pub(crate) root: Option<Node>,
+    pub(crate) inner: Kind,
 }
 
 /// Commit a proposal to a new revision of the trie
@@ -543,24 +591,28 @@ impl<S: WritableStorage> NodeStore<Arc<ImmutableProposal>, S> {
     }
 }
 
-impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
+impl<S: ReadableStorage> TryFrom<NodeStore<Mutable<Propose>, S>>
     for NodeStore<Arc<ImmutableProposal>, S>
 {
     type Error = FileIoError;
 
-    fn try_from(val: NodeStore<MutableProposal, S>) -> Result<Self, Self::Error> {
+    fn try_from(val: NodeStore<Mutable<Propose>, S>) -> Result<Self, Self::Error> {
         let NodeStore { kind, storage } = val;
+        let Mutable {
+            root,
+            inner: Propose { deleted, parent },
+        } = kind;
 
         let mut nodestore = NodeStore {
             kind: Arc::new(ImmutableProposal {
-                deleted: kind.deleted.into(),
-                parent: Arc::new(parking_lot::Mutex::new(kind.parent)),
+                deleted: deleted.into(),
+                parent: Arc::new(parking_lot::Mutex::new(parent)),
                 root: None,
             }),
             storage,
         };
 
-        let Some(root) = kind.root else {
+        let Some(root) = root else {
             // This trie is now empty. Root address will be set to None during persist.
             return Ok(nodestore);
         };
@@ -569,13 +621,13 @@ impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
         #[cfg(feature = "ethhash")]
         let (root, root_hash) = nodestore.hash_helper(root, Path::new())?;
         #[cfg(not(feature = "ethhash"))]
-        let (root, root_hash) = NodeStore::<MutableProposal, S>::hash_helper(root, Path::new())?;
+        let (root, root_hash) = NodeStore::<Mutable<Propose>, S>::hash_helper(root, Path::new())?;
 
         let immutable_proposal =
             Arc::into_inner(nodestore.kind).expect("no other references to the proposal");
         nodestore.kind = Arc::new(ImmutableProposal {
-            deleted: immutable_proposal.deleted.clone(),
-            parent: immutable_proposal.parent.clone(),
+            deleted: immutable_proposal.deleted,
+            parent: immutable_proposal.parent,
             root: Some(Child::MaybePersisted(root, root_hash)),
         });
 
@@ -583,7 +635,32 @@ impl<S: ReadableStorage> TryFrom<NodeStore<MutableProposal, S>>
     }
 }
 
-impl<S: ReadableStorage> NodeReader for NodeStore<MutableProposal, S> {
+impl<S: ReadableStorage> From<NodeStore<Arc<ImmutableProposal>, S>>
+    for NodeStore<Mutable<Propose>, S>
+{
+    fn from(val: NodeStore<Arc<ImmutableProposal>, S>) -> Self {
+        let parent = val.kind.as_nodestore_parent();
+        let root = val
+            .kind
+            .root
+            .as_ref()
+            .map(Child::as_maybe_persisted_node)
+            .and_then(|node| node.as_shared_node(&val).ok())
+            .map(triomphe::Arc::unwrap_or_clone);
+        NodeStore {
+            kind: Mutable {
+                root,
+                inner: Propose {
+                    deleted: Vec::default(),
+                    parent,
+                },
+            },
+            storage: val.storage,
+        }
+    }
+}
+
+impl<T, S: ReadableStorage> NodeReader for NodeStore<Mutable<T>, S> {
     fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
         self.read_node_from_disk(addr, "write")
     }
@@ -595,7 +672,7 @@ impl<T: Parentable, S: ReadableStorage> NodeReader for NodeStore<T, S> {
     }
 }
 
-impl<S: ReadableStorage> RootReader for NodeStore<MutableProposal, S> {
+impl<T, S: ReadableStorage> RootReader for NodeStore<Mutable<T>, S> {
     fn root_node(&self) -> Option<SharedNode> {
         self.kind.root.as_ref().map(|node| node.clone().into())
     }
@@ -897,7 +974,7 @@ mod tests {
         }
 
         // create an empty r2, check that it's parent is the proposed version r1
-        let r2: NodeStore<MutableProposal, _> = NodeStore::new(&r1).unwrap();
+        let r2: NodeStore<Mutable<Propose>, _> = NodeStore::new(&r1).unwrap();
         let r2: NodeStore<Arc<ImmutableProposal>, _> = r2.try_into().unwrap();
         {
             let parent = r2.kind.parent.lock();

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -310,7 +310,7 @@ mod tests {
         NodeStoreHeader, Path, PathComponent, SharedNode,
         linear::memory::MemStore,
         node::{BranchNode, LeafNode, Node},
-        nodestore::MutableProposal,
+        nodestore::{Mutable, Propose},
     };
     use std::sync::Arc;
 
@@ -324,7 +324,7 @@ mod tests {
     }
 
     /// Helper to create a test node store with a specific root
-    fn create_test_store_with_root(root: Node) -> NodeStore<MutableProposal, MemStore> {
+    fn create_test_store_with_root(root: Node) -> NodeStore<Mutable<Propose>, MemStore> {
         let mem_store = MemStore::default().into();
         let mut store = NodeStore::new_empty_proposal(mem_store);
         store.root_mut().replace(root);


### PR DESCRIPTION
## Why this should be merged

Replace the flat `MutableProposal` struct with a two-level design: `Mutable<Kind>` holds `root: Option<Node>` and `inner: Kind`, where `Kind` implements the new `MutableKind` trait.

The only `MutableKind` implementor introduced here is `Propose`, which carries the delete list and parent pointer that `MutableProposal` held directly. A second implementor (`Recon`) is introduced in the next commit to support reconstruction chains, which do not track parents or delete lists; the trait exists now so that proposal-path code (`read_for_update`, `Merkle` insert/remove) can be written generically over both workflows without duplicating logic.

No behaviour change; this is a pure rename/refactor.

## How this works

`read_for_update` now delegates node tracking to `kind.inner.track_deleted` instead of calling `delete_node` directly; for `Propose` this pushes the node onto the delete list (unchanged behaviour).

## How this was tested

Unit tests

## Breaking Changes

None