### PR TITLE
chore: add additional metrics for `v0.3.0`

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -24,7 +24,7 @@ use crate::merkle::Merkle;
 use crate::merkle::parallel::ParallelMerkle;
 use crate::persist_worker::{PersistError, PersistWorker};
 use crate::root_store::RootStore;
-use firewood_metrics::{firewood_increment, firewood_record, firewood_set};
+use firewood_metrics::{firewood_increment, firewood_set};
 pub use firewood_storage::CacheReadStrategy;
 use firewood_storage::{
     BranchNode, Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal, Mutable,
@@ -300,12 +300,7 @@ impl RevisionManager {
 
         let committed = proposal.as_committed();
 
-        #[expect(
-            clippy::cast_precision_loss,
-            reason = "deleted list length will never exceed 2^52"
-        )]
-        let deleted_list_len = committed.deleted_len() as f64;
-        firewood_record!(crate::registry::DELETED_LIST_LEN, deleted_list_len);
+        firewood_set!(crate::registry::DELETED_LIST_LEN, committed.deleted_len());
 
         // 3. Revision reaping
         // When we exceed max_revisions, remove the oldest revision from memory

--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -43,6 +43,7 @@ use std::{
     thread::{self, JoinHandle},
 };
 
+use firewood_metrics::{firewood_increment, firewood_set};
 use firewood_storage::{
     Committed, FileBacked, FileIoError, HashedNodeReader, LinearAddress, NodeStore,
     NodeStoreHeader, TrieHash,
@@ -262,7 +263,10 @@ struct PersistChannel {
 }
 
 impl PersistChannel {
-    const fn new(max_permits: NonZeroU64, persist_threshold: u64) -> Self {
+    fn new(max_permits: NonZeroU64, persist_threshold: u64) -> Self {
+        // Emit once at construction since `max_permits` is constant.
+        firewood_set!(crate::registry::MAX_PERMITS, max_permits.get());
+
         Self {
             state: Mutex::new(PersistChannelState {
                 permits_available: max_permits.get(),
@@ -308,7 +312,10 @@ impl PersistChannel {
     /// Returns an error if the channel has been shut down.
     fn push(&self, revision: CommittedRevision) -> Result<(), PersistError> {
         let mut state = self.state.lock();
+        state.emit_permits();
+
         while state.permits_available == 0 && !state.shutdown {
+            firewood_increment!(crate::registry::COMMIT_BLOCKED, 1);
             self.commit_not_full.wait(&mut state);
         }
 
@@ -414,6 +421,13 @@ struct PersistChannelState {
     pending_reaps: Vec<NodeStore<Committed, FileBacked>>,
     /// The most recent committed revision, replaced on each push.
     latest_committed: Option<CommittedRevision>,
+}
+
+impl PersistChannelState {
+    /// Emits the current permit gauge.
+    fn emit_permits(&self) {
+        firewood_set!(crate::registry::PERMITS_AVAILABLE, self.permits_available);
+    }
 }
 
 /// RAII guard returned by [`PersistChannel::pop`] that carries the data for

--- a/firewood/src/registry.rs
+++ b/firewood/src/registry.rs
@@ -3,7 +3,7 @@
 
 //! Firewood layer metric definitions.
 
-use metrics::{describe_counter, describe_gauge, describe_histogram};
+use metrics::{describe_counter, describe_gauge};
 
 /// Number of proposals created.
 pub const PROPOSALS: &str = "proposals";
@@ -38,6 +38,15 @@ pub const MAX_REVISIONS: &str = "max_revisions";
 /// Length of the deleted list for committed revisions.
 pub const DELETED_LIST_LEN: &str = "deleted_list_len";
 
+/// Number of persist permits currently available.
+pub const PERMITS_AVAILABLE: &str = "persist.permits_available";
+
+/// Maximum number of persist permits.
+pub const MAX_PERMITS: &str = "persist.max_permits";
+
+/// Number of times commit was blocked.
+pub const COMMIT_BLOCKED: &str = "persist.commit_blocked";
+
 /// Registers all firewood metric descriptions.
 pub fn register() {
     describe_counter!(PROPOSALS, "Number of proposals created");
@@ -62,8 +71,14 @@ pub fn register() {
     describe_counter!(COMMIT_LATENCY_MS, "Commit latency (ms)");
     describe_gauge!(ACTIVE_REVISIONS, "Current number of active revisions");
     describe_gauge!(MAX_REVISIONS, "Maximum number of revisions configured");
-    describe_histogram!(
+    describe_gauge!(
         DELETED_LIST_LEN,
         "Length of deleted list for committed revisions"
     );
+    describe_gauge!(
+        PERMITS_AVAILABLE,
+        "Number of persist permits currently available"
+    );
+    describe_gauge!(MAX_PERMITS, "Maximum number of persist permits");
+    describe_counter!(COMMIT_BLOCKED, "Number of times commit was blocked");
 }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -53,6 +53,7 @@ use firewood_metrics::firewood_increment;
 use smallvec::SmallVec;
 use std::fmt::Debug;
 use std::io::{Error, ErrorKind};
+use std::time::Instant;
 
 // Re-export types from alloc module
 pub use alloc::NodeAllocator;
@@ -881,6 +882,8 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
     ///
     /// Returns a [`FileIoError`] if a node cannot be deleted.
     pub fn reap_deleted(mut self, header: &mut NodeStoreHeader) -> Result<(), FileIoError> {
+        let reap_start = Instant::now();
+
         self.storage
             .invalidate_cached_nodes(self.kind.deleted.iter());
         trace!("There are {} nodes to reap", self.kind.deleted.len());
@@ -888,6 +891,10 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
         for node in take(&mut self.kind.deleted) {
             allocator.delete_node(node)?;
         }
+
+        let reap_time = reap_start.elapsed().as_millis() as u64;
+        firewood_increment!(crate::registry::REAP_NODES, reap_time);
+
         Ok(())
     }
 }

--- a/storage/src/registry.rs
+++ b/storage/src/registry.rs
@@ -15,6 +15,8 @@ pub const SPACE_FREED: &str = "space.freed";
 pub const DELETE_NODE: &str = "delete_node";
 /// Time spent flushing nodes.
 pub const FLUSH_NODES: &str = "flush_nodes";
+/// Time spent reaping in milliseconds.
+pub const REAP_NODES: &str = "reap_nodes";
 
 /// Number of node reads.
 pub const READ_NODE: &str = "read_node";
@@ -59,6 +61,7 @@ pub fn register() {
     describe_counter!(SPACE_FREED, "Amount of space freed (bytes)");
     describe_counter!(DELETE_NODE, "Count of deleted nodes");
     describe_counter!(FLUSH_NODES, "Time spent flushing nodes (ms)");
+    describe_counter!(REAP_NODES, "Time spent reaping nodes (ms)");
 
     describe_counter!(READ_NODE, "Number of node reads");
     describe_counter!(CACHE_NODE, "Number of node cache operations");


### PR DESCRIPTION
## Why this should be merged

Adds exploratory metrics prior to `v0.3.0` related to deferred persistence and the upcoming delete list feature.

## How this works

- Adds `PERMITS_AVAILABLE` and `MAX_PERMITS` metrics for tracking the number of outstanding permits and the number of maximum permits, respectively.
- Adds `COMMIT_BLOCKED` metric for counting how many times we block.
- Adds metric for tracking how it takes to reap the deleted nodes of a revision.
- Adds metric for tracking the length of the deleted list for each committed revision.

## How this was tested

CI + Grafana dashboards

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
