### PR TITLE
refactor: read node mode

### DIFF
--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -30,6 +30,7 @@ use firewood_metrics::{firewood_increment, firewood_set};
 use lru::LruCache as EntryLruCache;
 use lru_mem::LruCache as MemLruCache;
 
+use crate::linear::ReadableNodeMode;
 use crate::{CacheReadStrategy, CachedNode, LinearAddress, MaybePersistedNode, SharedNode};
 
 use super::{FileIoError, OffsetReader, ReadableStorage, WritableStorage};
@@ -131,10 +132,10 @@ impl ReadableStorage for FileBacked {
             .len())
     }
 
-    fn read_cached_node(&self, addr: LinearAddress, mode: &'static str) -> Option<SharedNode> {
+    fn read_cached_node(&self, addr: LinearAddress, mode: ReadableNodeMode) -> Option<SharedNode> {
         let mut guard = self.cache.lock();
         let cached = guard.get(&addr).map(|cached_node| cached_node.0.clone());
-        firewood_increment!(crate::registry::CACHE_NODE, 1, "mode" => mode, "type" => if cached.is_some() { "hit" } else { "miss" });
+        firewood_increment!(crate::registry::CACHE_NODE, 1, "mode" => mode.as_str(), "type" => if cached.is_some() { "hit" } else { "miss" });
         cached
     }
 

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -115,6 +115,23 @@ impl Deref for FileIoError {
     }
 }
 
+#[derive(Debug)]
+pub enum ReadableNodeMode {
+    Open,
+    Read,
+    Write,
+}
+
+impl ReadableNodeMode {
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            ReadableNodeMode::Open => "open",
+            ReadableNodeMode::Read => "read",
+            ReadableNodeMode::Write => "write",
+        }
+    }
+}
+
 /// Trait for readable storage.
 pub trait ReadableStorage: Debug + Sync + Send {
     /// The node hash algorithm used by this storage.
@@ -135,7 +152,11 @@ pub trait ReadableStorage: Debug + Sync + Send {
     fn size(&self) -> Result<u64, FileIoError>;
 
     /// Read a node from the cache (if any)
-    fn read_cached_node(&self, _addr: LinearAddress, _mode: &'static str) -> Option<SharedNode> {
+    fn read_cached_node(
+        &self,
+        _addr: LinearAddress,
+        _mode: ReadableNodeMode,
+    ) -> Option<SharedNode> {
         None
     }
 

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -46,7 +46,7 @@ pub(crate) mod persist;
 pub(crate) mod primitives;
 
 use crate::IntoHashType;
-use crate::linear::OffsetReader;
+use crate::linear::{OffsetReader, ReadableNodeMode};
 use crate::logger::{debug, trace};
 use crate::node::branch::ReadSerializable as _;
 use firewood_metrics::firewood_increment;
@@ -125,7 +125,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
             } else {
                 debug!("No root hash in header; computing from disk");
                 nodestore
-                    .read_node_from_disk(root_address, "open")
+                    .read_node_from_disk(root_address, ReadableNodeMode::Open)
                     .map(|n| hash_node(&n, &Path(SmallVec::default())))?
             };
 
@@ -669,13 +669,13 @@ impl<S: ReadableStorage> From<NodeStore<Arc<ImmutableProposal>, S>>
 
 impl<T, S: ReadableStorage> NodeReader for NodeStore<Mutable<T>, S> {
     fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
-        self.read_node_from_disk(addr, "write")
+        self.read_node_from_disk(addr, ReadableNodeMode::Write)
     }
 }
 
 impl<T: Parentable, S: ReadableStorage> NodeReader for NodeStore<T, S> {
     fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
-        self.read_node_from_disk(addr, "read")
+        self.read_node_from_disk(addr, ReadableNodeMode::Read)
     }
 }
 
@@ -781,7 +781,7 @@ impl<T, S: ReadableStorage> NodeStore<T, S> {
     pub fn read_node_from_disk(
         &self,
         addr: LinearAddress,
-        mode: &'static str,
+        mode: ReadableNodeMode,
     ) -> Result<SharedNode, FileIoError> {
         if let Some(node) = self.storage.read_cached_node(addr, mode) {
             return Ok(node);


### PR DESCRIPTION
## Why this should be merged

Reading through #1785, I noticed that we pass in the `read_cached_node()` `mode` argument as a string. Since we know which modes we want at build-time, it's easier (and less error-prone) if we use an `enum` here.

## How this works

Adds `ReadableNodeMode` enum

## How this was tested

CI

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
