### PR TITLE
chore: reduce visibility of flush_nodes()

### DIFF
--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -183,7 +183,7 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
     ///
     /// Returns a [`FileIoError`] if any node cannot be written to storage.
     #[fastrace::trace(short_name = true)]
-    pub fn flush_nodes(&self, header: &mut NodeStoreHeader) -> Result<(), FileIoError> {
+    fn flush_nodes(&self, header: &mut NodeStoreHeader) -> Result<(), FileIoError> {
         let flush_start = Instant::now();
 
         let mut node_allocator = NodeAllocator::new(self.storage.as_ref(), header);


### PR DESCRIPTION
## Why this should be merged

Closes #1389.

## How this works

Reduces visibility of `flush_nodes()` from public to private.

## How this was tested

CI

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
