### PR TITLE
chore(ci): Add Amin as codeowner for fwdctl

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 # Note: more specific rules overrule wildcard
 *        @rkuris @demosdemon @RodrigoVillar @bernard-avalabs
 /ffi     @rkuris @demosdemon @alarso16 @RodrigoVillar @bernard-avalabs
+/fwdctl  @rkuris @demosdemon @RodrigoVillar @bernard-avalabs @aminR443


### PR DESCRIPTION
## Why this should be merged

Amin did a lot of work on fwdctl and should be considered the domain expert there.

## Breaking Changes

None