### PR TITLE
chore(fwdctl): add block height 77m

### DIFF
--- a/fwdctl/src/launch/mod.rs
+++ b/fwdctl/src/launch/mod.rs
@@ -137,6 +137,8 @@ pub enum NBlocks {
     OneM = 1_000_000,
     #[value(name = "50m")]
     FiftyM = 50_000_000,
+    #[value(name = "77m")]
+    SeventySevenM = 77_000_000,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
@@ -159,6 +161,7 @@ impl NBlocks {
             Self::TenK => "10k",
             Self::OneM => "1m",
             Self::FiftyM => "50m",
+            Self::SeventySevenM => "77m",
         }
     }
 }


### PR DESCRIPTION
## Why this should be merged

For bootstrap benchmarking, it would be great to test from genesis to as close to the tip of the C-Chain as possible. The farthest block we have indexed is block height `77m`.

## How this works

Adds an option to run the bootstrapping benchmark with `--nblocks 77m`.

## How this was tested

Ran `fwdctl launch deploy --nblocks 77m`

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
