### PR TITLE
chore(ci): Pedantically check all golang errors

### DIFF
--- a/.github/.golangci.yaml.patch
+++ b/.github/.golangci.yaml.patch
@@ -1,5 +1,5 @@
---- .github/.golangci.yaml	2026-02-20 16:14:53.739528860 +0000
-+++ ffi/.golangci.yaml	2026-02-20 16:00:50.182324273 +0000
+--- .github/.golangci.yaml	2026-03-19 15:26:49
++++ ffi/.golangci.yaml	2026-03-19 15:18:18
 @@ -40,7 +40,7 @@
          - standard
          - default
@@ -41,7 +41,13 @@
      - nolintlint
      - perfsprint
      - prealloc
-@@ -97,12 +97,10 @@
+@@ -93,12 +93,12 @@
+     - usestdlibvars
+     - whitespace
+   settings:
++    errcheck:
++      disable-default-exclusions: true
+     depguard:
        rules:
          packages:
            deny:
@@ -50,11 +56,7 @@
              - pkg: github.com/golang/mock/gomock
                desc: go.uber.org/mock/gomock should be used instead.
              # Note: testify/assert is checked separately by test_warn_testify_assert
-             # in lint.sh to produce warnings instead of errors.
-             - pkg: io/ioutil
-               desc: io/ioutil is deprecated. Use package io or os instead.
-     errorlint:
-@@ -113,33 +111,10 @@
+@@ -113,33 +113,10 @@
      forbidigo:
        # Forbid the following identifiers (list of regexp).
        forbid:
@@ -88,7 +90,7 @@
      revive:
        rules:
          # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
-@@ -203,17 +178,6 @@
+@@ -203,17 +180,6 @@
          # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
          - name: useless-break
            disabled: false

--- a/ffi/.golangci.yaml
+++ b/ffi/.golangci.yaml
@@ -93,6 +93,8 @@ linters:
     - usestdlibvars
     - whitespace
   settings:
+    errcheck:
+      disable-default-exclusions: true
     depguard:
       rules:
         packages:


### PR DESCRIPTION
## Why this should be merged

Lots of churn in https://github.com/ava-labs/firewood/pull/1814 over checking the return value of a function that cannot error.

This was flagged by:
 - github copilot's review https://github.com/ava-labs/firewood/pull/1814#discussion_r2961404379
 - @maru-ava https://github.com/ava-labs/firewood/pull/1814#discussion_r2961496332
 - @RodrigoVillar https://github.com/ava-labs/firewood/pull/1814#discussion_r2962086982

and required 3 changes to meet all reviewers concerns.

## How this works

This catches the error at lint time, and prohibits check-ins that don't check errors on everything in the exclude list. For the list of exclusions, that are no longer allowed, check out the source for errcheck here https://github.com/kisielk/errcheck/blob/master/errcheck/excludes.go or open the thingy below:

<details><summary>errcheck excludes</summary>
<code>
	// bytes
	"(*bytes.Buffer).Write",
	"(*bytes.Buffer).WriteByte",
	"(*bytes.Buffer).WriteRune",
	"(*bytes.Buffer).WriteString",

	// crypto
	"crypto/rand.Read", // https://github.com/golang/go/issues/66821

	// fmt
	"fmt.Print",
	"fmt.Printf",
	"fmt.Println",
	"fmt.Fprint(*bytes.Buffer)",
	"fmt.Fprintf(*bytes.Buffer)",
	"fmt.Fprintln(*bytes.Buffer)",
	"fmt.Fprint(*strings.Builder)",
	"fmt.Fprintf(*strings.Builder)",
	"fmt.Fprintln(*strings.Builder)",
	"fmt.Fprint(os.Stderr)",
	"fmt.Fprintf(os.Stderr)",
	"fmt.Fprintln(os.Stderr)",

	// io
	"(*io.PipeReader).CloseWithError",
	"(*io.PipeWriter).CloseWithError",

	// math/rand
	"math/rand.Read",
	"(*math/rand.Rand).Read",

	// strings
	"(*strings.Builder).Write",
	"(*strings.Builder).WriteByte",
	"(*strings.Builder).WriteRune",
	"(*strings.Builder).WriteString",

	// hash
	"(hash.Hash).Write",

	// hash/maphash
	"(*hash/maphash.Hash).Write",
	"(*hash/maphash.Hash).WriteByte",
	"(*hash/maphash.Hash).WriteString",
</code>
</details> 

## How this was tested

Changed the code to just call rng.Read and the linter failed

## Breaking Changes

None