### PR TITLE
refactor(merkle): 3/6 fix dup detection in dump_node with keep_alive vec

### DIFF
--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -605,12 +605,17 @@ impl<T: HashedNodeReader> Merkle<T> {
         Ok(ChangeProof::new(start_proof, end_proof, batch_ops))
     }
 
-    /// Dump a node, recursively, to a dot file
+    /// Dump a node, recursively, to a dot file.
+    ///
+    /// The `keep_alive` vec holds references to all `MaybePersistedNode`s
+    /// created during the dump so their addresses remain stable for dup
+    /// detection in `seen`.
     pub(crate) fn dump_node<W: std::io::Write + ?Sized>(
         &self,
         node: &MaybePersistedNode,
         hash: Option<&HashType>,
         seen: &mut HashSet<String>,
+        keep_alive: &mut Vec<MaybePersistedNode>,
         writer: &mut W,
     ) -> Result<(), FileIoError> {
         writeln!(writer, "  {node}[label=\"{node}")
@@ -634,10 +639,11 @@ impl<T: HashedNodeReader> Merkle<T> {
                     };
 
                     let inserted = seen.insert(format!("{child}"));
+                    keep_alive.push(child.clone());
                     if inserted {
                         writeln!(writer, "  {node} -> {child}[label=\"{childidx:x}\"]")
                             .map_err(|e| FileIoError::from_generic_no_file(e, "write branch"))?;
-                        self.dump_node(&child, child_hash, seen, writer)?;
+                        self.dump_node(&child, child_hash, seen, keep_alive, writer)?;
                     } else {
                         // We have already seen this child, which shouldn't happen.
                         // Indicate this with a red edge.
@@ -678,8 +684,15 @@ impl<T: HashedNodeReader> Merkle<T> {
                 .map_err(|e| FileIoError::new(e, None, 0, None))
                 .map_err(Error::other)?;
             let mut seen = HashSet::new();
-            self.dump_node(&root, Some(&root_hash.into_hash_type()), &mut seen, writer)
-                .map_err(Error::other)?;
+            let mut keep_alive = Vec::new();
+            self.dump_node(
+                &root,
+                Some(&root_hash.into_hash_type()),
+                &mut seen,
+                &mut keep_alive,
+                writer,
+            )
+            .map_err(Error::other)?;
         }
         writeln!(writer, "}}")
             .map_err(Error::other)


### PR DESCRIPTION
## Why this should be merged

Discovered this problem while debugging merkle tries. Now that reconstructed revisions often contain Node types, the address of the Node Arc is used as a unique identifier. Unfortunately, these are reused while walking a reconstructed node, leading to false "dup" reports and not actually traversing the children (to avoid infinite loops).

## How this works

Keep created nodes around to give them unique addresses. This uses more memory but we typically never dump anything too big.

## How this was tested

Used during debugging and it seems to work. I'm not sure I want a test around this because it's primarily a debugging tool, but if you feel strongly that we should test it speak up.

## Breaking Changes

None