### PR TITLE
chore(deps): Update rustls-webpkio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3968,7 +3968,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -4006,9 +4006,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Why this should be merged

Resolves https://github.com/ava-labs/firewood/security/dependabot/24

## How this works

```
cargo update rustls-webpki@0.103.9
    Updating crates.io index
     Locking 1 package to latest compatible version
    Updating rustls-webpki v0.103.9 -> v0.103.10
````

## How this was tested

CI

## Breaking Changes

None