### PR TITLE
fix(range-proof): manual audit bug fixes

### DIFF
--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -139,8 +139,9 @@ impl<T> From<T> for Merkle<T> {
 
 /// Verify one edge (left or right) of a range proof.
 ///
-/// Checks that the requested bound is consistent with the edge key-value pair,
-/// then verifies the proof against the root hash.
+/// Empty proofs are accepted without verification. Otherwise, checks that the
+/// requested bound is consistent with the edge key-value pair, then verifies
+/// the proof against the root hash.
 fn verify_edge<H: ProofCollection + ?Sized>(
     requested_bound: Option<&[u8]>,
     edge_kv: Option<(&[u8], &[u8])>,
@@ -148,6 +149,10 @@ fn verify_edge<H: ProofCollection + ?Sized>(
     root_hash: &TrieHash,
     bound_is_lower: bool,
 ) -> Result<(), api::Error> {
+    if edge_proof.is_empty() {
+        return Ok(());
+    }
+
     // Validate bound vs edge key ordering
     if let (Some(bound), Some((edge_key, _))) = (requested_bound, edge_kv) {
         let out_of_order = if bound_is_lower {
@@ -278,7 +283,7 @@ fn mark_outside(
     on_path_nibble: u8,
     is_left_edge: bool,
 ) {
-    let entry = map.entry(key).or_insert([false; 16]);
+    let entry = map.entry(key).or_default();
     if is_left_edge {
         for nibble in 0..on_path_nibble {
             entry[nibble as usize] = true;
@@ -384,6 +389,7 @@ fn compute_root_hash_with_proofs(
 /// Returns [`api::Error::ProofError`] if the proof is structurally invalid,
 /// keys are outside the requested range, boundary proofs fail verification,
 /// or the reconstructed root hash doesn't match.
+#[allow(clippy::too_many_lines)]
 pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     first_key: Option<impl KeyType>,
     last_key: Option<impl KeyType>,
@@ -392,6 +398,13 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
 ) -> Result<(), api::Error> {
     let first_key_bytes: Option<&[u8]> = first_key.as_ref().map(AsRef::as_ref);
     let last_key_bytes: Option<&[u8]> = last_key.as_ref().map(AsRef::as_ref);
+
+    // Reject invalid range where start > end
+    if let (Some(start), Some(end)) = (first_key_bytes, last_key_bytes)
+        && start > end
+    {
+        return Err(api::Error::ProofError(ProofError::StartAfterEnd));
+    }
 
     // check that the keys are in ascending order and within the requested range
     let key_values = proof.key_values();
@@ -454,6 +467,45 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
         )?;
     }
 
+    let all_proof_nodes: Box<[&ProofNode]> = proof
+        .start_proof()
+        .as_ref()
+        .iter()
+        .chain(proof.end_proof().as_ref())
+        .collect();
+
+    // Verify that proof nodes with values within the range are included in key_values.
+    // Without this check, an attacker could hide key-value pairs that exist on an edge
+    // proof path by omitting them from key_values while reconciliation silently inserts
+    // them, making the root hash correct.
+    for proof_node in &all_proof_nodes {
+        // Only even-nibble-length keys correspond to byte keys with values
+        if !proof_node.key.len().is_multiple_of(2) {
+            continue;
+        }
+        // Only check nodes that have values
+        if !matches!(proof_node.value_digest, Some(ValueDigest::Value(_))) {
+            continue;
+        }
+        let key_nibbles: Vec<u8> = proof_node
+            .key
+            .iter()
+            .map(|component| component.as_u8())
+            .collect();
+        let node_key_bytes: Vec<u8> = Path::from(key_nibbles.as_slice()).bytes_iter().collect();
+        let in_range = first_key_bytes.is_none_or(|start| node_key_bytes.as_slice() >= start)
+            && last_key_bytes.is_none_or(|end| node_key_bytes.as_slice() <= end);
+        if in_range
+            && key_values
+                .binary_search_by(|(k, _)| k.as_ref().cmp(node_key_bytes.as_slice()))
+                .is_err()
+        {
+            return Err(api::Error::ProofError(
+                ProofError::ProofNodeHasUnincludedValue,
+            ));
+        }
+    }
+
     // Build in-memory merkle from key-value pairs
     let memstore = MemStore::default();
     let nodestore = NodeStore::new_empty_proposal(memstore.into());
@@ -495,7 +547,7 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
         compute_outside_children(proof.start_proof().as_ref(), first_key_bytes, true)?;
     for (key, flags) in compute_outside_children(proof.end_proof().as_ref(), last_key_bytes, false)?
     {
-        let entry = outside_children.entry(key).or_insert([false; 16]);
+        let entry = outside_children.entry(key).or_default();
         for (e, flag) in entry.iter_mut().zip(flags.iter()) {
             *e |= flag;
         }

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -1228,3 +1228,248 @@ fn test_range_proof_fuzz() {
         }
     }
 }
+
+#[test]
+// Rejects a range proof where the end proof has been truncated (missing last node).
+fn test_bad_range_proof_truncated_end_proof() {
+    let items = [("aa", "v1"), ("bb", "v2"), ("cc", "v3")];
+    let merkle = init_merkle(items);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let start_proof = merkle.prove(b"aa").unwrap();
+    let end_proof = merkle.prove(b"cc").unwrap();
+
+    // Truncate the end proof by removing the last node
+    let mut truncated_end = end_proof.into_mutable();
+    truncated_end.pop();
+    let truncated_end = truncated_end.into_immutable();
+
+    let key_values: KeyValuePairs = items
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_bytes().to_vec().into_boxed_slice(),
+                v.as_bytes().to_vec().into_boxed_slice(),
+            )
+        })
+        .collect();
+
+    let range_proof = RangeProof::new(start_proof, truncated_end, key_values.into_boxed_slice());
+
+    let result = verify_range_proof(
+        Some(b"aa".as_slice()),
+        Some(b"cc".as_slice()),
+        &root_hash,
+        &range_proof,
+    );
+    assert!(result.is_err(), "truncated end proof should be rejected");
+}
+
+#[test]
+// Rejects a range proof where the start proof has been truncated (missing last node).
+fn test_bad_range_proof_truncated_start_proof() {
+    let items = [("aa", "v1"), ("bb", "v2"), ("cc", "v3")];
+    let merkle = init_merkle(items);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let start_proof = merkle.prove(b"aa").unwrap();
+    let end_proof = merkle.prove(b"cc").unwrap();
+
+    // Truncate the start proof by removing the last node
+    let mut truncated_start = start_proof.into_mutable();
+    truncated_start.pop();
+    let truncated_start = truncated_start.into_immutable();
+
+    let key_values: KeyValuePairs = items
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_bytes().to_vec().into_boxed_slice(),
+                v.as_bytes().to_vec().into_boxed_slice(),
+            )
+        })
+        .collect();
+
+    let range_proof = RangeProof::new(truncated_start, end_proof, key_values.into_boxed_slice());
+
+    let result = verify_range_proof(
+        Some(b"aa".as_slice()),
+        Some(b"cc".as_slice()),
+        &root_hash,
+        &range_proof,
+    );
+    assert!(result.is_err(), "truncated start proof should be rejected");
+}
+
+#[test]
+// Rejects a range proof containing a proof node with a value at an odd nibble length.
+// The odd-nibble-with-value check is defense-in-depth: in practice, corrupting a proof
+// node to have an odd-nibble key breaks its hash, so UnexpectedHash is returned first.
+// This test verifies the corruption is detected regardless of which check fires.
+fn test_bad_range_proof_value_at_odd_nibble() {
+    let items = [("aa", "v1"), ("bb", "v2"), ("cc", "v3")];
+    let merkle = init_merkle(items);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let start_proof = merkle.prove(b"aa").unwrap();
+    let end_proof = merkle.prove(b"cc").unwrap();
+
+    // Corrupt the end proof: set a value on a node with an odd-length key.
+    let mut corrupt_end = end_proof.into_mutable();
+    if let Some(node) = corrupt_end.last_mut() {
+        // Extend the key by one nibble to make it odd length
+        node.key.push(firewood_storage::PathComponent::ALL[0]);
+        node.value_digest = Some(ValueDigest::Value(b"bad".to_vec().into()));
+    }
+    let corrupt_end = corrupt_end.into_immutable();
+
+    let key_values: KeyValuePairs = items
+        .iter()
+        .map(|(k, v)| {
+            (
+                k.as_bytes().to_vec().into_boxed_slice(),
+                v.as_bytes().to_vec().into_boxed_slice(),
+            )
+        })
+        .collect();
+
+    let range_proof = RangeProof::new(start_proof, corrupt_end, key_values.into_boxed_slice());
+
+    let result = verify_range_proof(
+        Some(b"aa".as_slice()),
+        Some(b"cc".as_slice()),
+        &root_hash,
+        &range_proof,
+    );
+    assert!(
+        result.is_err(),
+        "proof with value at odd nibble length should be rejected"
+    );
+}
+
+#[test]
+// Rejects a range proof that hides a key-value pair on an edge proof path by
+// omitting it from key_values.
+fn test_bad_range_proof_hidden_value_on_edge_path() {
+    // Create a trie where "b" is an intermediate branch on the path to "ba" and "bc".
+    // "b" has a value AND is on the edge proof path for "bc".
+    // The range ["a", "bc"] should include "b" and "ba", but we omit "b" from key_values.
+    let items = [("b", "v1"), ("ba", "v2"), ("bc", "v3")];
+    let merkle = init_merkle(items);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    // Use a non-existent start key so the start proof is an exclusion proof
+    let start_proof = merkle.prove(b"a").unwrap();
+    let end_proof = merkle.prove(b"bc").unwrap();
+
+    // Include "ba" and "bc" but omit "b" — "b" is on the end proof path
+    let key_values: KeyValuePairs = vec![
+        (
+            b"ba".to_vec().into_boxed_slice(),
+            b"v2".to_vec().into_boxed_slice(),
+        ),
+        (
+            b"bc".to_vec().into_boxed_slice(),
+            b"v3".to_vec().into_boxed_slice(),
+        ),
+    ];
+
+    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+
+    let result = verify_range_proof(
+        Some(b"a".as_slice()),
+        Some(b"bc".as_slice()),
+        &root_hash,
+        &range_proof,
+    );
+    assert!(
+        matches!(
+            result,
+            Err(crate::api::Error::ProofError(
+                ProofError::ProofNodeHasUnincludedValue
+            ))
+        ),
+        "expected ProofNodeHasUnincludedValue, got {result:?}"
+    );
+}
+
+#[test]
+// Rejects a range proof with a non-existent edge proof that has its final node removed.
+// This is the subtle case: since the bound doesn't match any key in key_values,
+// verify_edge passes the truncated proof as an exclusion proof (expected_value=None).
+// The corruption must be caught by the final root hash check.
+fn test_bad_range_proof_truncated_non_existent_edge() {
+    let items: Vec<([u8; 32], [u8; 32])> = (0..10_u32)
+        .map(|i| {
+            let mut key = [0u8; 32];
+            let mut value = [0u8; 32];
+            key[..4].copy_from_slice(&i.to_be_bytes());
+            value[..4].copy_from_slice(&(i + 100).to_be_bytes());
+            (key, value)
+        })
+        .collect();
+
+    let merkle = init_merkle(items.clone());
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    // Use a non-existent start key (before the first item)
+    let start_bound = {
+        let mut k = items[2].0;
+        k[31] = k[31].wrapping_sub(1);
+        k
+    };
+    let end_bound = items[7].0;
+
+    let start_proof = merkle.prove(&start_bound).unwrap();
+    let end_proof = merkle.prove(&end_bound).unwrap();
+
+    // Truncate the start proof (non-existent edge)
+    let mut truncated_start = start_proof.into_mutable();
+    truncated_start.pop();
+    let truncated_start = truncated_start.into_immutable();
+
+    let key_values: KeyValuePairs = items[2..=7]
+        .iter()
+        .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
+        .collect();
+
+    let range_proof = RangeProof::new(truncated_start, end_proof, key_values.into_boxed_slice());
+
+    let result = verify_range_proof(
+        Some(start_bound.as_slice()),
+        Some(end_bound.as_slice()),
+        &root_hash,
+        &range_proof,
+    );
+    assert!(
+        result.is_err(),
+        "truncated non-existent edge proof should be rejected"
+    );
+}
+
+#[test]
+// Rejects a range proof when start key > end key during verification.
+fn test_bad_range_proof_start_after_end() {
+    let items = [("bb", "v1"), ("cc", "v2"), ("dd", "v3")];
+    let merkle = init_merkle(items);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let range_proof = merkle
+        .range_proof(Some(b"bb".as_slice()), Some(b"dd".as_slice()), None)
+        .unwrap();
+
+    // Verify with start > end
+    let result = verify_range_proof(
+        Some(b"dd".as_slice()),
+        Some(b"bb".as_slice()),
+        &root_hash,
+        &range_proof,
+    );
+    assert!(
+        matches!(
+            result,
+            Err(crate::api::Error::ProofError(ProofError::StartAfterEnd))
+        ),
+        "expected StartAfterEnd, got {result:?}"
+    );
+}

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -165,6 +165,14 @@ pub enum ProofError {
     #[error("conflicting proof nodes at the same key path")]
     ConflictingProofNodes,
 
+    /// Start key is after end key
+    #[error("start key is after end key")]
+    StartAfterEnd,
+
+    /// A proof node within the range has a value not present in the key-value pairs
+    #[error("proof node has a value not included in key-value pairs")]
+    ProofNodeHasUnincludedValue,
+
     #[error("the proposal for a change proof is None as it has been consumed")]
     ProposalIsNone,
 }


### PR DESCRIPTION
## Why this should be merged

A code walkthrough resulted some fixes and code cleanup.

Proofs did not verify that the value provided on the edge matched what was in the proof. 

## How this works

Verifying the value wasn't too difficult.

Added a check for start > end with a new StartAfterend error.

Slight improvements to empty edge proof handling

## How this was tested

Added a test that fails without the fix.

- test_bad_range_proof_hidden_value_on_edge_path

More tests, mostly used to attempt to find problems
- test_bad_range_proof_truncated_{start,end}_proof
- test_bad_range_proof_value_at_odd_nibble
- test_bad_range_proof_truncated_non_existent_edge
- test_bad_range_proof_start_after_end

## Breaking Changes

None