### PR TITLE
refactor(proofs): replace ChildMask [bool; 16] with u16 newtype

### DIFF
--- a/firewood/src/merkle/childmask.rs
+++ b/firewood/src/merkle/childmask.rs
@@ -1,0 +1,154 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use firewood_storage::U4;
+
+/// Bitmask indicating which of a branch node's 16 children are "outside" the
+/// proven range and should use the proof's original hashes instead of being
+/// recomputed from the proving trie.
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct ChildMask(u16);
+
+impl ChildMask {
+    /// A mask with all children marked as outside.
+    pub(super) const ALL: Self = Self(u16::MAX);
+
+    /// Marks all children with index less than `nibble` as outside.
+    pub(super) const fn mark_left_outside(mut self, nibble: U4) -> Self {
+        self.0 |= 1u16.wrapping_shl(nibble.as_u8() as u32).wrapping_sub(1);
+        self
+    }
+
+    /// Marks all children with index greater than `nibble` as outside.
+    pub(super) const fn mark_right_outside(mut self, nibble: U4) -> Self {
+        self.0 |= u16::MAX.wrapping_shl(nibble.as_u8() as u32).wrapping_shl(1);
+        self
+    }
+
+    /// Marks a single child as outside.
+    pub(super) const fn set_outside(mut self, nibble: U4) -> Self {
+        self.0 |= 1u16.wrapping_shl(nibble.as_u8() as u32);
+        self
+    }
+
+    /// Returns true if the child at `nibble` is outside the proven range.
+    pub(super) const fn is_outside(self, nibble: U4) -> bool {
+        self.0 & 1u16.wrapping_shl(nibble.as_u8() as u32) != 0
+    }
+
+    /// Merges another mask into this one (union of outside children).
+    pub(super) const fn merge(mut self, other: ChildMask) -> Self {
+        self.0 |= other.0;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const fn u4(v: u8) -> U4 {
+        U4::new_masked(v)
+    }
+
+    #[test]
+    fn child_mask_mark_left_outside() {
+        // mark_left_outside(n) should set bits 0..n (children < n)
+        let expected: [(U4, u16); 16] = [
+            (u4(0), 0b0000_0000_0000_0000),
+            (u4(1), 0b0000_0000_0000_0001),
+            (u4(2), 0b0000_0000_0000_0011),
+            (u4(3), 0b0000_0000_0000_0111),
+            (u4(4), 0b0000_0000_0000_1111),
+            (u4(5), 0b0000_0000_0001_1111),
+            (u4(6), 0b0000_0000_0011_1111),
+            (u4(7), 0b0000_0000_0111_1111),
+            (u4(8), 0b0000_0000_1111_1111),
+            (u4(9), 0b0000_0001_1111_1111),
+            (u4(10), 0b0000_0011_1111_1111),
+            (u4(11), 0b0000_0111_1111_1111),
+            (u4(12), 0b0000_1111_1111_1111),
+            (u4(13), 0b0001_1111_1111_1111),
+            (u4(14), 0b0011_1111_1111_1111),
+            (u4(15), 0b0111_1111_1111_1111),
+        ];
+        for (nibble, bits) in expected {
+            let mask = ChildMask::default().mark_left_outside(nibble);
+            assert_eq!(mask.0, bits, "mark_left_outside({nibble})");
+        }
+    }
+
+    #[test]
+    fn child_mask_mark_right_outside() {
+        // mark_right_outside(n) should set bits (n+1)..16 (children > n)
+        let expected: [(U4, u16); 16] = [
+            (u4(0), 0b1111_1111_1111_1110),
+            (u4(1), 0b1111_1111_1111_1100),
+            (u4(2), 0b1111_1111_1111_1000),
+            (u4(3), 0b1111_1111_1111_0000),
+            (u4(4), 0b1111_1111_1110_0000),
+            (u4(5), 0b1111_1111_1100_0000),
+            (u4(6), 0b1111_1111_1000_0000),
+            (u4(7), 0b1111_1111_0000_0000),
+            (u4(8), 0b1111_1110_0000_0000),
+            (u4(9), 0b1111_1100_0000_0000),
+            (u4(10), 0b1111_1000_0000_0000),
+            (u4(11), 0b1111_0000_0000_0000),
+            (u4(12), 0b1110_0000_0000_0000),
+            (u4(13), 0b1100_0000_0000_0000),
+            (u4(14), 0b1000_0000_0000_0000),
+            (u4(15), 0b0000_0000_0000_0000),
+        ];
+        for (nibble, bits) in expected {
+            let mask = ChildMask::default().mark_right_outside(nibble);
+            assert_eq!(mask.0, bits, "mark_right_outside({nibble})");
+        }
+    }
+
+    #[test]
+    fn child_mask_is_outside() {
+        // Mark children < 3 and children > 12 as outside
+        let mask = ChildMask::default()
+            .mark_left_outside(u4(3))
+            .mark_right_outside(u4(12));
+
+        for i in 0..16u8 {
+            let nibble = u4(i);
+            let expected = !(3..=12).contains(&i);
+            assert_eq!(mask.is_outside(nibble), expected, "is_outside({nibble})");
+        }
+    }
+
+    #[test]
+    fn child_mask_merge() {
+        let merged = ChildMask::default()
+            .mark_left_outside(u4(5)) // bits 0..5
+            .merge(ChildMask::default().mark_right_outside(u4(10))); // bits 11..16
+
+        for i in 0..16u8 {
+            let nibble = u4(i);
+            let expected = !(5..=10).contains(&i);
+            assert_eq!(
+                merged.is_outside(nibble),
+                expected,
+                "merged is_outside({nibble})"
+            );
+        }
+    }
+
+    #[test]
+    fn child_mask_default_is_empty() {
+        let mask = ChildMask::default();
+        for i in 0..16u8 {
+            assert!(!mask.is_outside(u4(i)), "default should have no bits set");
+        }
+    }
+
+    #[test]
+    fn child_mask_all_is_full() {
+        let mask = ChildMask::ALL;
+        for i in 0..16u8 {
+            assert!(mask.is_outside(u4(i)), "ALL should have all bits set");
+        }
+    }
+}

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -5,6 +5,7 @@
 pub(crate) mod tests;
 
 pub(crate) mod changes;
+mod childmask;
 mod merge;
 /// Parallel merkle
 pub mod parallel;
@@ -21,7 +22,7 @@ use firewood_storage::{
     BranchNode, Child, Children, FileIoError, HashType, HashableShunt, HashedNodeReader,
     ImmutableProposal, IntoHashType, LeafNode, MaybePersistedNode, Mutable, MutableKind,
     NibblesIterator, Node, NodeStore, Parentable, Path, PathBuf, PathComponent, Propose,
-    ReadableStorage, SharedNode, TrieHash, TrieReader, ValueDigest,
+    ReadableStorage, SharedNode, TrieHash, TrieReader, U4, ValueDigest,
 };
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
@@ -36,10 +37,7 @@ pub type Key = Box<[u8]>;
 /// Values are boxed u8 slices
 pub type Value = Box<[u8]>;
 
-/// Bitmask indicating which of a branch node's 16 children are "outside" the
-/// proven range and should use the proof's original hashes instead of being
-/// recomputed from the proving trie.
-type ChildMask = [bool; 16];
+use childmask::ChildMask;
 
 macro_rules! write_attributes {
     ($writer:ident, $node:expr, $value:expr) => {
@@ -191,7 +189,6 @@ fn verify_edge<H: ProofCollection + ?Sized>(
 /// The `boundary_key` (in bytes, not nibbles) is used to determine the on-path
 /// nibble at the terminal proof node, since there is no subsequent proof node
 /// to derive it from.
-#[expect(clippy::indexing_slicing)]
 fn compute_outside_children(
     proof_nodes: &[ProofNode],
     boundary_key: Option<&[u8]>,
@@ -200,18 +197,17 @@ fn compute_outside_children(
     let mut result: HashMap<PathBuf, ChildMask> = HashMap::new();
 
     // Non-terminal nodes: derive the on-path nibble from the next proof node
-    for window in proof_nodes.windows(2) {
-        let (parent, child) = (&window[0], &window[1]);
+    for (parent, child) in proof_nodes.iter().zip(proof_nodes.iter().skip(1)) {
         let on_path_nibble = child
             .key
             .get(parent.key.len())
             .ok_or(ProofError::ShouldBePrefixOfNextKey)?;
-        mark_outside(
-            &mut result,
-            parent.key.clone(),
-            on_path_nibble.as_u8(),
-            is_left_edge,
-        );
+        let entry = result.entry(parent.key.clone()).or_default();
+        *entry = if is_left_edge {
+            entry.mark_left_outside(on_path_nibble.0)
+        } else {
+            entry.mark_right_outside(on_path_nibble.0)
+        };
     }
 
     // Terminal node: derive the on-path nibble from the boundary key.
@@ -220,80 +216,47 @@ fn compute_outside_children(
     if let (Some(terminal), Some(boundary)) = (proof_nodes.last(), boundary_key) {
         let boundary_nibbles: Vec<u8> = NibblesIterator::new(boundary).collect();
 
-        // Check if boundary nibbles match the terminal's key up to terminal.key.len().
-        // Find the first position where they diverge.
+        // Find the first position where boundary and terminal key diverge,
+        // capturing the diverging values to avoid re-indexing.
         let divergence = terminal
             .key
             .iter()
             .zip(boundary_nibbles.iter())
-            .position(|(tk, &bn)| tk.as_u8() != bn);
+            .find(|(tk, bn)| tk.as_u8() != **bn);
 
-        match divergence {
-            None if boundary_nibbles.len() > terminal.key.len() => {
-                // No divergence found and the boundary key is longer than the
-                // terminal's key, so the terminal node is an ancestor of the
-                // boundary key in the trie. The next nibble of the boundary
-                // tells us which child branch leads toward the boundary.
-                let on_path_nibble = boundary_nibbles[terminal.key.len()];
-                mark_outside(
-                    &mut result,
-                    terminal.key.clone(),
-                    on_path_nibble,
-                    is_left_edge,
-                );
-                // The on-path child also needs the proof hash. In the full
-                // trie we're verifying against, this child's subtree may
-                // contain keys outside the proven range. Our proving trie
-                // lacks those keys, so its locally-computed hash would be
-                // wrong — we must use the proof's hash instead.
-                result
-                    .get_mut(&terminal.key)
-                    .expect("just inserted by mark_outside")[on_path_nibble as usize] = true;
+        if let Some((tk, bn)) = divergence {
+            // Boundary diverges within the terminal's key at this position.
+            // If boundary is "past" the terminal (left edge: B > terminal,
+            // right edge: B < terminal), all children are outside.
+            let all_outside = if is_left_edge {
+                *bn > tk.as_u8()
+            } else {
+                *bn < tk.as_u8()
+            };
+            if all_outside {
+                result.insert(terminal.key.clone(), ChildMask::ALL);
             }
-            Some(d) => {
-                // Boundary diverges within the terminal's key at position d.
-                // If boundary is "past" the terminal (left edge: B > terminal,
-                // right edge: B < terminal), all children are outside.
-                let all_outside = if is_left_edge {
-                    boundary_nibbles[d] > terminal.key[d].as_u8()
-                } else {
-                    boundary_nibbles[d] < terminal.key[d].as_u8()
-                };
-                if all_outside {
-                    result.insert(terminal.key.clone(), [true; 16]);
-                }
-                // Otherwise (boundary is "before" terminal), no children are outside.
+            // Otherwise (boundary is "before" terminal), no children are outside.
+        } else if let Some(on_path_byte) = boundary_nibbles.get(terminal.key.len()) {
+            // Terminal is an ancestor of the boundary key. The next
+            // nibble tells us which child leads toward the boundary.
+            // Mark children on the far side of that nibble as outside,
+            // and also mark the on-path child itself: its subtree may
+            // contain keys beyond the proven range, so we must use the
+            // proof's hash rather than recomputing it.
+            let on_path_nibble = U4::new_masked(*on_path_byte);
+            let entry = result.entry(terminal.key.clone()).or_default();
+            *entry = if is_left_edge {
+                entry.mark_left_outside(on_path_nibble)
+            } else {
+                entry.mark_right_outside(on_path_nibble)
             }
-            _ => {
-                // Boundary is same length as or shorter than terminal key and
-                // matches fully — terminal is the boundary node itself. No
-                // children need marking.
-            }
+            .set_outside(on_path_nibble);
         }
+        // Otherwise boundary matches terminal exactly — no children need marking.
     }
 
     Ok(result)
-}
-
-/// Marks children at the given node as "outside" the proven range.
-#[expect(clippy::indexing_slicing)]
-fn mark_outside(
-    map: &mut HashMap<PathBuf, ChildMask>,
-    key: PathBuf,
-    on_path_nibble: u8,
-    is_left_edge: bool,
-) {
-    let entry = map.entry(key).or_default();
-    if is_left_edge {
-        for nibble in 0..on_path_nibble {
-            entry[nibble as usize] = true;
-        }
-    } else {
-        #[expect(clippy::arithmetic_side_effects)]
-        for nibble in (on_path_nibble + 1)..16 {
-            entry[nibble as usize] = true;
-        }
-    }
 }
 
 /// Recursively computes the hash of a node in the proving trie, merging
@@ -304,7 +267,6 @@ fn mark_outside(
 /// proven range (as indicated by `outside_children`) get their hash from the
 /// corresponding proof node. Children not in the trie that are **inside** the
 /// range are left as `None`, causing a hash mismatch if they should exist.
-#[expect(clippy::indexing_slicing)]
 fn compute_root_hash_with_proofs(
     node: &Node,
     path_prefix: &[PathComponent],
@@ -330,7 +292,7 @@ fn compute_root_hash_with_proofs(
         (proof_nodes.get(&full_key), outside_children.get(&full_key))
     {
         for (nibble, hash) in proof_node.child_hashes.iter_present() {
-            if outside[nibble.as_u8() as usize] {
+            if outside.is_outside(nibble.0) {
                 child_hashes[nibble] = Some(hash.clone());
             }
         }
@@ -474,11 +436,34 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
         .chain(proof.end_proof().as_ref())
         .collect();
 
-    // Verify that proof nodes with values within the range are included in key_values.
-    // Without this check, an attacker could hide key-value pairs that exist on an edge
-    // proof path by omitting them from key_values while reconciliation silently inserts
-    // them, making the root hash correct.
-    for proof_node in &all_proof_nodes {
+    verify_proof_node_values(
+        &all_proof_nodes,
+        first_key_bytes,
+        last_key_bytes,
+        key_values,
+    )?;
+
+    verify_root_hash(
+        &all_proof_nodes,
+        key_values,
+        proof,
+        first_key_bytes,
+        last_key_bytes,
+        root_hash,
+    )
+}
+
+/// Verifies that proof nodes with values within the range are included in `key_values`.
+/// Without this check, an attacker could hide key-value pairs that exist on an edge
+/// proof path by omitting them from `key_values` while reconciliation silently inserts
+/// them, making the root hash correct.
+fn verify_proof_node_values(
+    proof_nodes: &[&ProofNode],
+    first_key_bytes: Option<&[u8]>,
+    last_key_bytes: Option<&[u8]>,
+    key_values: &[(impl KeyType, impl ValueType)],
+) -> Result<(), api::Error> {
+    for proof_node in proof_nodes {
         // Only even-nibble-length keys correspond to byte keys with values
         if !proof_node.key.len().is_multiple_of(2) {
             continue;
@@ -505,7 +490,19 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
             ));
         }
     }
+    Ok(())
+}
 
+/// Reconstructs the trie from key-value pairs and proof nodes, then verifies
+/// that the computed root hash matches the expected one.
+fn verify_root_hash<H: ProofCollection<Node = ProofNode>>(
+    all_proof_nodes: &[&ProofNode],
+    key_values: &[(impl KeyType, impl ValueType)],
+    proof: &RangeProof<impl KeyType, impl ValueType, H>,
+    first_key_bytes: Option<&[u8]>,
+    last_key_bytes: Option<&[u8]>,
+    root_hash: &TrieHash,
+) -> Result<(), api::Error> {
     // Build in-memory merkle from key-value pairs
     let memstore = MemStore::default();
     let nodestore = NodeStore::new_empty_proposal(memstore.into());
@@ -520,15 +517,8 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     // (partial paths and child layout) to match the proof, so that hash
     // computation produces the same trie shape as the original.
     // Conflicting proof nodes (same key, different data) are rejected.
-    let all_proof_nodes: Vec<&ProofNode> = proof
-        .start_proof()
-        .as_ref()
-        .iter()
-        .chain(proof.end_proof().as_ref())
-        .collect();
-
     let mut proof_node_map: HashMap<PathBuf, &ProofNode> = HashMap::new();
-    for proof_node in &all_proof_nodes {
+    for proof_node in all_proof_nodes {
         proving_merkle.reconcile_branch_proof_node(proof_node)?;
         match proof_node_map.entry(proof_node.key.clone()) {
             std::collections::hash_map::Entry::Occupied(existing) => {
@@ -548,9 +538,7 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     for (key, flags) in compute_outside_children(proof.end_proof().as_ref(), last_key_bytes, false)?
     {
         let entry = outside_children.entry(key).or_default();
-        for (e, flag) in entry.iter_mut().zip(flags.iter()) {
-            *e |= flag;
-        }
+        *entry = entry.merge(flags);
     }
 
     // Compute root hash of the proving trie with proof sibling hashes

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -3,8 +3,155 @@
 
 use super::*;
 use crate::RangeProof;
+use firewood_storage::U4;
 
 type KeyValuePairs = Vec<(Box<[u8]>, Box<[u8]>)>;
+
+/// Helper to build a `PathBuf` from a slice of nibble values.
+fn nibble_path(nibbles: &[u8]) -> PathBuf {
+    nibbles
+        .iter()
+        .map(|&n| PathComponent(U4::new_masked(n)))
+        .collect()
+}
+
+/// Helper to build a minimal `ProofNode` with the given nibble key.
+fn proof_node(nibbles: &[u8]) -> ProofNode {
+    ProofNode {
+        key: nibble_path(nibbles),
+        partial_len: 0,
+        value_digest: None,
+        child_hashes: Children::new(),
+    }
+}
+
+#[test]
+fn outside_children_empty_proof() {
+    let result = compute_outside_children(&[], None, true).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn outside_children_single_node_no_boundary() {
+    let nodes = [proof_node(&[1, 2])];
+    let result = compute_outside_children(&nodes, None, true).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn outside_children_single_node_exact_match() {
+    // Boundary matches terminal exactly — no children marked.
+    let nodes = [proof_node(&[1, 2])];
+    // boundary key 0x12 expands to nibbles [1, 2]
+    let result = compute_outside_children(&nodes, Some(&[0x12]), true).unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn outside_children_ancestor_left_edge() {
+    // Terminal key [1], boundary key 0x15 → nibbles [1, 5].
+    // Terminal is ancestor of boundary. On-path nibble = 5.
+    // Left edge: children < 5 are outside, plus child 5 itself.
+    let nodes = [proof_node(&[1])];
+    let result = compute_outside_children(&nodes, Some(&[0x15]), true).unwrap();
+    let mask = result[&nibble_path(&[1])];
+    // Children 0..=5 should be outside (left of 5, plus 5 itself)
+    for i in 0..16u8 {
+        assert_eq!(
+            mask.is_outside(U4::new_masked(i)),
+            i <= 5,
+            "left edge ancestor: child {i}"
+        );
+    }
+}
+
+#[test]
+fn outside_children_ancestor_right_edge() {
+    // Terminal key [1], boundary key 0x15 → nibbles [1, 5].
+    // Right edge: children > 5 are outside, plus child 5 itself.
+    let nodes = [proof_node(&[1])];
+    let result = compute_outside_children(&nodes, Some(&[0x15]), false).unwrap();
+    let mask = result[&nibble_path(&[1])];
+    for i in 0..16u8 {
+        assert_eq!(
+            mask.is_outside(U4::new_masked(i)),
+            i >= 5,
+            "right edge ancestor: child {i}"
+        );
+    }
+}
+
+#[test]
+fn outside_children_diverges_past_terminal_left() {
+    // Terminal key [1, 3], boundary nibbles [1, 5] (diverge at pos 1: 5 > 3).
+    // Left edge + boundary past terminal → all children outside.
+    let nodes = [proof_node(&[1, 3])];
+    let result = compute_outside_children(&nodes, Some(&[0x15]), true).unwrap();
+    let mask = result[&nibble_path(&[1, 3])];
+    for i in 0..16u8 {
+        assert!(
+            mask.is_outside(U4::new_masked(i)),
+            "all outside when boundary past terminal (left): child {i}"
+        );
+    }
+}
+
+#[test]
+fn outside_children_diverges_before_terminal_left() {
+    // Terminal key [1, 7], boundary nibbles [1, 5] (diverge at pos 1: 5 < 7).
+    // Left edge + boundary before terminal → no children outside.
+    let nodes = [proof_node(&[1, 7])];
+    let result = compute_outside_children(&nodes, Some(&[0x15]), true).unwrap();
+    assert!(
+        !result.contains_key(&nibble_path(&[1, 7])),
+        "no mask when boundary before terminal"
+    );
+}
+
+#[test]
+fn outside_children_two_nodes_left_edge() {
+    // Parent [1], child [1, 5]. On-path nibble = 5.
+    // Left edge: children < 5 on parent are outside.
+    let nodes = [proof_node(&[1]), proof_node(&[1, 5])];
+    let result = compute_outside_children(&nodes, None, true).unwrap();
+    let mask = result[&nibble_path(&[1])];
+    for i in 0..16u8 {
+        assert_eq!(
+            mask.is_outside(U4::new_masked(i)),
+            i < 5,
+            "two nodes left: child {i}"
+        );
+    }
+}
+
+#[test]
+fn outside_children_two_nodes_right_edge() {
+    // Parent [1], child [1, 5]. On-path nibble = 5.
+    // Right edge: children > 5 on parent are outside.
+    let nodes = [proof_node(&[1]), proof_node(&[1, 5])];
+    let result = compute_outside_children(&nodes, None, false).unwrap();
+    let mask = result[&nibble_path(&[1])];
+    for i in 0..16u8 {
+        assert_eq!(
+            mask.is_outside(U4::new_masked(i)),
+            i > 5,
+            "two nodes right: child {i}"
+        );
+    }
+}
+
+#[test]
+fn outside_children_child_not_prefixed_by_parent() {
+    // Child key [2, 5] is not prefixed by parent key [1].
+    // child.key.get(parent.key.len()) = [2,5].get(1) = Some(5), so no error;
+    // but child key [1] with parent [1, 2] means child.key.get(2) = None → error.
+    let nodes = [proof_node(&[1, 2]), proof_node(&[1])];
+    let result = compute_outside_children(&nodes, None, true);
+    assert!(
+        matches!(result, Err(ProofError::ShouldBePrefixOfNextKey)),
+        "expected ShouldBePrefixOfNextKey, got {result:?}"
+    );
+}
 
 #[test]
 // Tests that missing keys can also be proven. The test explicitly uses a single


### PR DESCRIPTION
## Why this should be merged

A ChildMask is much cleaner as a newtype and using bit manipulations. Compiler explorer shows that most of this reduces to a few bit operations.

Also verify_range_proof became enormous, so it was split up in this diff as well. Just created verify_proof_node_values and verify_root_hash as helpers.

Also, added some unit tests for outside_children. This allowed for some refactoring and testing at a higher level to detect problems a bit earlier.

## How this was tested

CI

## Breaking Changes

None