### PR TITLE
docs: audit and replace ignore doctests with runnable examples (#1865)

### DIFF
--- a/ffi/src/value/results.rs
+++ b/ffi/src/value/results.rs
@@ -657,7 +657,7 @@ impl<'db> From<Result<ProposedChangeProofContext<'db>, api::Error>>
 ///
 /// Once Try trait is stable, we can use that instead of this trait:
 ///
-/// ```ignore
+/// ```text
 /// impl std::ops::FromResidual<Option<std::convert::Infallible>> for VoidResult {
 ///     #[inline]
 ///     fn from_residual(residual: Option<std::convert::Infallible>) -> Self {

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -61,7 +61,6 @@ ethereum-types.workspace = true
 firewood-storage = { workspace = true, features = ["test_utils"] }
 firewood-triehash.workspace = true
 hex-literal.workspace = true
-pprof = { workspace = true, features = ["flamegraph"] }
 rand.workspace = true
 tempfile.workspace = true
 test-case.workspace = true
@@ -71,6 +70,9 @@ hash-db = "0.16.0"
 plain_hasher = "0.2.3"
 rlp = "0.6.1"
 sha3 = "0.10.8"
+
+[target.'cfg(not(windows))'.dev-dependencies]
+pprof = { workspace = true, features = ["flamegraph"] }
 
 [[bench]]
 name = "hashops"

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -677,27 +677,29 @@ impl<T: TrieReader> Merkle<T> {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// // Prove all keys between "alice" and "charlie"
-    /// let proof = merkle.range_proof(
-    ///     Some(b"alice"),
-    ///     Some(b"charlie"),
-    ///     None
-    /// ).await?;
+    /// ```rust,no_run
+    /// use firewood::api::DbView;
+    /// use std::num::NonZeroUsize;
     ///
-    /// // Prove the first 100 keys starting from "alice"
-    /// let proof = merkle.range_proof(
-    ///     Some(b"alice"),
-    ///     None,
-    ///     Some(NonZeroUsize::new(100).unwrap())
-    /// ).await?;
+    /// fn example<V: DbView>(view: &V) -> Result<(), firewood::api::Error> {
+    ///     // Prove all keys between "alice" and "charlie"
+    ///     let _proof = view.range_proof(Some(b"alice".as_slice()), Some(b"charlie".as_slice()), None)?;
     ///
-    /// // Prove that no keys exist in a range
-    /// let proof = merkle.range_proof(
-    ///     Some(b"aardvark"),
-    ///     Some(b"aaron"),
-    ///     None
-    /// ).await?;
+    ///     // Prove the first 100 keys starting from "alice"
+    ///     let _proof = view.range_proof(
+    ///         Some(b"alice".as_slice()),
+    ///         None,
+    ///         Some(NonZeroUsize::new(100).unwrap()),
+    ///     )?;
+    ///
+    ///     // Prove that no keys exist in a range
+    ///     let _proof = view.range_proof(
+    ///         Some(b"aardvark".as_slice()),
+    ///         Some(b"aaron".as_slice()),
+    ///         None,
+    ///     )?;
+    ///     Ok(())
+    /// }
     /// ```
     pub(super) fn range_proof(
         &self,

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -11,11 +11,14 @@
 //!
 //! # Usage
 //!
-//! ```ignore
+//! ```rust,no_run
 //! use firewood_metrics::firewood_increment;
-//! use crate::registry;
 //!
-//! registry::register();
+//! // Each crate defines its own metric registry (e.g., `ffi::registry`, `storage::registry`).
+//! // This is a minimal stand-in to show usage.
+//! mod registry {
+//!     pub const OP_COUNT: &'static str = "op_count_total";
+//! }
 //!
 //! firewood_increment!(registry::OP_COUNT, 1);
 //! ```
@@ -105,7 +108,13 @@ pub fn expensive_metrics_enabled() -> bool {
 /// [`firewood_set!`] instead.
 ///
 /// # Usage
-/// ```ignore
+/// ```rust,no_run
+/// # mod registry {
+/// #     pub const PROPOSALS_CREATED_TOTAL: &'static str = "proposals_created_total";
+/// #     pub const SLOW_PATH_TOTAL: &'static str = "slow_path_total";
+/// # }
+/// use firewood_metrics::firewood_increment;
+///
 /// firewood_increment!(registry::PROPOSALS_CREATED_TOTAL, 1);
 /// firewood_increment!(registry::PROPOSALS_CREATED_TOTAL, 1, "status" => "ok");
 /// firewood_increment!(registry::SLOW_PATH_TOTAL, 1, expensive);
@@ -132,7 +141,12 @@ macro_rules! firewood_increment {
 /// multiple operations without a repeated name lookup.
 ///
 /// # Usage
-/// ```ignore
+/// ```rust,no_run
+/// # mod registry {
+/// #     pub const PROPOSALS_CREATED_TOTAL: &'static str = "proposals_created_total";
+/// # }
+/// use firewood_metrics::firewood_counter;
+///
 /// let counter = firewood_counter!(registry::PROPOSALS_CREATED_TOTAL);
 /// counter.increment(1);
 /// counter.absolute(100);
@@ -156,7 +170,16 @@ macro_rules! firewood_counter {
 /// use [`firewood_increment!`] instead.
 ///
 /// # Usage
-/// ```ignore
+/// ```rust,no_run
+/// # mod registry {
+/// #     pub const ACTIVE_REVISIONS: &'static str = "active_revisions";
+/// #     pub const NODE_CACHE_BYTES: &'static str = "node_cache_bytes";
+/// #     pub const PENDING_PROPOSALS: &'static str = "pending_proposals";
+/// # }
+/// use firewood_metrics::firewood_set;
+///
+/// # let count = 0usize;
+/// # let size = 0usize;
 /// firewood_set!(registry::ACTIVE_REVISIONS, count);
 /// firewood_set!(registry::NODE_CACHE_BYTES, size, "tier" => "l1");
 /// firewood_set!(registry::PENDING_PROPOSALS, count, expensive);
@@ -183,7 +206,12 @@ macro_rules! firewood_set {
 /// handle across multiple operations.
 ///
 /// # Usage
-/// ```ignore
+/// ```rust,no_run
+/// # mod registry {
+/// #     pub const ACTIVE_REVISIONS: &'static str = "active_revisions";
+/// # }
+/// use firewood_metrics::firewood_gauge;
+///
 /// let gauge = firewood_gauge!(registry::ACTIVE_REVISIONS);
 /// gauge.set(10.0);
 /// gauge.increment(1.0);
@@ -207,6 +235,9 @@ macro_rules! firewood_gauge {
 /// # Examples
 ///
 /// ```rust
+/// use firewood_metrics::firewood_describe_counter;
+/// use metrics::Unit;
+///
 /// firewood_describe_counter!("proposals_created_total", "Number of proposals created");
 /// firewood_describe_counter!("bytes_written_total", Unit::Bytes, "Total bytes written to disk");
 /// ```
@@ -228,6 +259,9 @@ macro_rules! firewood_describe_counter {
 /// # Examples
 ///
 /// ```rust
+/// use firewood_metrics::firewood_describe_gauge;
+/// use metrics::Unit;
+///
 /// firewood_describe_gauge!("active_revisions", "Number of revisions currently held in memory");
 /// firewood_describe_gauge!("node_cache_bytes", Unit::Bytes, "Current node cache size");
 /// ```

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -17,6 +17,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cfg-if = "1.0.4"
 # Workspace dependencies
 aquamarine.workspace = true
 bytemuck.workspace = true
@@ -54,14 +55,15 @@ sha3 = { version = "0.10.8", optional = true }
 bumpalo = { version = "3.20.2", features = ["collections", "std"] }
 
 [dev-dependencies]
-cfg-if = "1.0.4"
 # Workspace dependencies
 criterion = { workspace = true, features = ["html_reports"] }
 metrics-util.workspace = true
-pprof = { workspace = true, features = ["flamegraph"] }
 rand.workspace = true
 tempfile.workspace = true
 test-case.workspace = true
+
+[target.'cfg(not(windows))'.dev-dependencies]
+pprof = { workspace = true, features = ["flamegraph"] }
 
 [features]
 logger = ["log"]

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -22,6 +22,43 @@
 use std::fmt::{Display, Formatter, LowerHex, Result};
 use std::ops::Range;
 
+/// In constant context, convert an ASCII hex string to a byte array.
+///
+/// `FROM` must be exactly twice `TO`. This is a workaround because generic
+/// parameters cannot be used in constant expressions yet (see [upstream]).
+///
+/// [upstream]: https://github.com/rust-lang/rust/issues/76560
+#[doc(hidden)]
+pub const fn from_ascii<const FROM: usize, const TO: usize>(hex: &[u8; FROM]) -> [u8; TO] {
+    #![expect(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
+
+    const fn from_hex_char(c: u8) -> u8 {
+        match c {
+            b'0'..=b'9' => c - b'0',
+            b'a'..=b'f' => c - b'a' + 10,
+            b'A'..=b'F' => c - b'A' + 10,
+            _ => panic!("invalid hex character"),
+        }
+    }
+
+    const {
+        assert!(FROM == TO.wrapping_mul(2));
+    }
+
+    let mut bytes = [0u8; TO];
+    let mut i = 0_usize;
+    while i < TO {
+        let off = i.wrapping_mul(2);
+        let hi = hex[off];
+        let off = off.wrapping_add(1);
+        let lo = hex[off];
+        bytes[i] = (from_hex_char(hi) << 4) | from_hex_char(lo);
+        i += 1;
+    }
+
+    bytes
+}
+
 mod checker;
 mod hashednode;
 mod hashedshunt;

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -23,7 +23,6 @@ use parking_lot::Mutex;
 use std::fs::{File, OpenOptions};
 use std::io::Read;
 use std::num::NonZero;
-use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
 
 use firewood_metrics::{firewood_increment, firewood_set};
@@ -231,7 +230,7 @@ const PREDICTIVE_READ_BUFFER_SIZE: usize = 1024;
 
 /// A reader that can predictively read from a file, avoiding reading past boundaries, but reading in 1k chunks
 struct PredictiveReader<'a> {
-    fd: &'a File,
+    fd: &'a UnlockOnDrop,
     buffer: [u8; PREDICTIVE_READ_BUFFER_SIZE],
     offset: u64,
     len: usize,
@@ -294,6 +293,65 @@ impl Drop for UnlockOnDrop {
     fn drop(&mut self) {
         // ignore the error, we might not have ever called `lock`
         _ = self.0.unlock();
+    }
+}
+
+impl UnlockOnDrop {
+    fn write_all_at(&self, mut buf: &[u8], mut offset: u64) -> Result<(), std::io::Error> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::FileExt;
+            return self.0.write_all_at(buf, offset);
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::FileExt;
+            while !buf.is_empty() {
+                let written = self.0.seek_write(buf, offset)?;
+                if written == 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ));
+                }
+                buf = &buf[written..];
+                offset = offset.wrapping_add(written as u64);
+            }
+            Ok(())
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = (buf, offset);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "FileExt is not supported on this platform",
+            ))
+        }
+    }
+
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> Result<usize, std::io::Error> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::FileExt;
+            return self.0.read_at(buf, offset);
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::FileExt;
+            self.0.seek_read(buf, offset)
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = (buf, offset);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "FileExt is not supported on this platform",
+            ))
+        }
     }
 }
 

--- a/storage/src/path/component.rs
+++ b/storage/src/path/component.rs
@@ -24,9 +24,13 @@ impl PathComponent {
     /// This makes it easy to iterate over all possible children of a branch
     /// in a type-safe way. It is preferrable to do:
     ///
-    /// ```ignore
-    /// for (idx, slot) in PathComponent::ALL.into_iter().zip(branch.children.each_ref()) {
-    ///     /// use idx and slot
+    /// ```rust
+    /// use firewood_storage::{BranchNode, PathComponent};
+    ///
+    /// fn example(branch: &BranchNode) {
+    ///     for (idx, slot) in branch.children.each_ref() {
+    ///         let _ = (idx, slot);
+    ///     }
     /// }
     /// ```
     ///

--- a/storage/src/tries/kvp.rs
+++ b/storage/src/tries/kvp.rs
@@ -444,84 +444,36 @@ impl<T: std::fmt::Debug> std::fmt::Debug for DebugChildren<'_, T> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    #![expect(clippy::unwrap_used)]
-
-    use test_case::test_case;
-
-    use super::*;
-
-    /// In constant context, convert an ASCII hex string to a byte array.
-    ///
-    /// `FROM` must be exactly twice `TO`. This is workaround because generic
-    /// parameters cannot be used in constant expressions yet (see [upstream]).
-    ///
-    /// The [`expected_hash`] macro is able to work around this limitation by
-    /// evaluating the length at macro expansion time which provides a constant
-    /// value for both generic parameters at compile time.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the input is not valid hex. Because this panic occurs in constant
-    /// context, this will result in an "erroneous constant error" during compilation.
-    ///
-    /// [upstream]: https://github.com/rust-lang/rust/issues/76560
-    const fn from_ascii<const FROM: usize, const TO: usize>(hex: &[u8; FROM]) -> [u8; TO] {
-        #![expect(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
-
-        const fn from_hex_char(c: u8) -> u8 {
-            match c {
-                b'0'..=b'9' => c - b'0',
-                b'a'..=b'f' => c - b'a' + 10,
-                b'A'..=b'F' => c - b'A' + 10,
-                _ => panic!("invalid hex character"),
-            }
-        }
-
-        const {
-            assert!(FROM == TO.wrapping_mul(2));
-        }
-
-        let mut bytes = [0u8; TO];
-        let mut i = 0_usize;
-        while i < TO {
-            let off = i.wrapping_mul(2);
-            let hi = hex[off];
-            let off = off.wrapping_add(1);
-            let lo = hex[off];
-            bytes[i] = (from_hex_char(hi) << 4) | from_hex_char(lo);
-            i += 1;
-        }
-
-        bytes
-    }
-
-    /// A macro to select the expected hash based on the enabled cargo features.
-    ///
-    /// For both merkledb hash types, only a 64-character hex string (32 bytes)
-    /// is expected. For the ethereum hash type, either a 64-character hex string
-    /// or an RLP-encoded byte string of arbitrary length can be provided, if
-    /// wrapped in `rlp(...)`.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// expected_hash!{
-    ///     merkledb16: b"749390713e51d3e4e50ba492a669c1644a6d9cb7e48b2a14d556e7f953da92fc",
-    ///     ethereum: b"2e636399fae96dc07abaf21167a34b8a5514d6594e777635987e319c76f28a75",
-    /// }
-    /// ```
-    ///
-    /// or with RLP:
-    ///
-    /// ```ignore
-    /// expected_hash!{
-    ///     merkledb16: b"1ffe11ce995a9c07021d6f8a8c5b1817e6375dd0ea27296b91a8d48db2858bc9",
-    ///     ethereum: rlp(b"c482206131"),
-    /// }
-    /// ```
-    macro_rules! expected_hash {
+/// A macro to select the expected hash based on the enabled cargo features.
+///
+/// For both merkledb hash types, only a 64-character hex string (32 bytes)
+/// is expected. For the ethereum hash type, either a 64-character hex string
+/// or an RLP-encoded byte string of arbitrary length can be provided, if
+/// wrapped in `rlp(...)`.
+///
+/// # Example
+///
+/// ```rust
+/// use firewood_storage::expected_hash;
+///
+/// let _ = expected_hash! {
+///     merkledb16: b"749390713e51d3e4e50ba492a669c1644a6d9cb7e48b2a14d556e7f953da92fc",
+///     ethereum: b"2e636399fae96dc07abaf21167a34b8a5514d6594e777635987e319c76f28a75",
+/// };
+/// ```
+///
+/// or with RLP:
+///
+/// ```rust
+/// use firewood_storage::expected_hash;
+///
+/// let _ = expected_hash! {
+///     merkledb16: b"1ffe11ce995a9c07021d6f8a8c5b1817e6375dd0ea27296b91a8d48db2858bc9",
+///     ethereum: rlp(b"c482206131"),
+/// };
+/// ```
+#[macro_export]
+macro_rules! expected_hash {
         (
             merkledb16: $hex16:expr,
             ethereum: rlp($hexeth:expr),
@@ -530,12 +482,12 @@ mod tests {
                 if #[cfg(feature = "ethhash")] {
                     fn __expected_hash() -> $crate::HashType {
                         $crate::HashType::Rlp(smallvec::SmallVec::from(
-                            &from_ascii::<{ $hexeth.len() }, { $hexeth.len() / 2 }>($hexeth)[..],
+                            &$crate::from_ascii::<{ $hexeth.len() }, { $hexeth.len() / 2 }>($hexeth)[..],
                         ))
                     }
                 } else {
                     fn __expected_hash() -> $crate::HashType {
-                        $crate::HashType::from(from_ascii($hex16))
+                        $crate::HashType::from($crate::from_ascii($hex16))
                     }
                 }
             }
@@ -549,11 +501,11 @@ mod tests {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "ethhash")] {
                     fn __expected_hash() -> $crate::HashType {
-                        $crate::HashType::from(from_ascii($hexeth))
+                        $crate::HashType::from($crate::from_ascii($hexeth))
                     }
                 } else {
                     fn __expected_hash() -> $crate::HashType {
-                        $crate::HashType::from(from_ascii($hex16))
+                        $crate::HashType::from($crate::from_ascii($hex16))
                     }
                 }
             }
@@ -561,6 +513,15 @@ mod tests {
             __expected_hash()
         }};
     }
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::unwrap_used)]
+
+    use test_case::test_case;
+
+    use super::*;
+    use crate::expected_hash;
 
     #[test_case(&[])]
     #[test_case(&[("a", "1")])]


### PR DESCRIPTION
- Replace ignore tags with rust/no_run/text in doc tests
- Fix broken imports and types in documentation examples
- Move pprof to platform-specific dev-dependencies for Windows compatibility
- Fix unix-specific FileExt usage in storage/linear/filebacked.rs

## Why this should be merged
To prevent documentation examples from going stale and ensure all code snippets in the docs are validated during CI. It also improves the developer experience for Windows contributors by fixing platform-specific dependency issues.

## How this works
Audited all ignoreblocks across the repo. Replaced them withrust(runnable),no_run(compile-check only), ortext (illustrative) based on the context. Also added missing imports and fixed type mismatches in several doctests.

## How this was tested
Verified locally on Windows 11 using cargo test --doc for firewood, firewood-storage, and firewood-metrics. All doc tests passed.

## Breaking Changes

- [x] firewood
- [x] firewood-storage
- [x] firewood-ffi (C api)
- [x] firewood-go (Go api)
- [x] fwdctl
