### PR TITLE
docs(proofs): add range and change proof verification algorithm documentation

### DIFF
--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -138,19 +138,8 @@ pub mod registry;
 
 /// Cryptographic proof system for Merkle tries.
 ///
-/// This module provides types and functionality for creating and verifying proofs
-/// of key-value pairs in Firewood's Merkle trie. For convenience, the most commonly
-/// used types are re-exported at the crate root level.
-///
-/// # Recommended Usage
-///
-/// Import proof types directly from the crate root rather than through this module:
-///
-/// ```rust,ignore
-/// use firewood::{Proof, ProofNode, RangeProof};  // Recommended
-/// // instead of
-/// use firewood::proofs::{Proof, ProofNode, RangeProof};  // Also works
-/// ```
+/// Provides types and verification for single-key, range, and change proofs.
+/// Commonly used types are re-exported at the crate root.
 pub mod proofs;
 
 // Re-export commonly used proof types at the crate root for ergonomic access

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -1,6 +1,30 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+//! Trie diff generation for change proofs.
+//!
+//! Computes the minimal set of [`BatchOp`]s (puts and deletes) that transform
+//! one trie revision into another. This is the *generation* side of change
+//! proofs — see [`crate::proofs`] for the verification side.
+//!
+//! # Algorithm
+//!
+//! [`DiffMerkleNodeStream`] performs a lock-step pre-order traversal of two
+//! tries (left = old revision, right = new revision). At each step it compares
+//! the current nodes' full paths:
+//!
+//! - **Left < Right** — the left node's key was deleted; advance left.
+//! - **Left > Right** — the right node's key was inserted; advance right.
+//! - **Equal paths, equal hashes** — subtrees are identical; skip children
+//!   of both.
+//! - **Equal paths, different hashes** — descend into both to find the
+//!   divergent keys.
+//! - **Equal paths, different values** — emit a put or delete for the key.
+//!
+//! The hash comparison lets the iterator skip entire subtrees that haven't
+//! changed, making the diff proportional to the number of changed keys rather
+//! than the trie size.
+
 use std::fmt::Debug;
 use std::{cmp::Ordering, iter::once};
 

--- a/firewood/src/proofs/mod.rs
+++ b/firewood/src/proofs/mod.rs
@@ -33,24 +33,6 @@
 //! - `childmask` (in `merkle`): Compact bitmap for tracking present children.
 //! - `magic`: Magic constants for proof format identification (internal).
 //!
-//! # Usage
-//!
-//! For most use cases, import proof types directly from the top level of the crate:
-//!
-//! ```rust,ignore
-//! use firewood::{Proof, ProofNode, RangeProof};
-//!
-//! // Verify a single key
-//! let proof: Proof<Vec<ProofNode>> = /* ... */;
-//! proof.verify(b"key", Some(b"value"), &root_hash)?;
-//!
-//! // Verify a key range
-//! let range_proof: RangeProof<Vec<u8>, Vec<u8>, Vec<ProofNode>> = /* ... */;
-//! for (key, value) in &range_proof {
-//!     // Process key-value pairs
-//! }
-//! ```
-//!
 //! # Proof Format
 //!
 //! Proofs are serialized in a compact binary format that includes:
@@ -64,6 +46,33 @@
 //!
 //! The serialization format is versioned to allow for future evolution while maintaining
 //! backward compatibility with proof verification.
+//!
+//! # Range Proof Verification Algorithm
+//!
+//! Range proof verification confirms that a contiguous set of key-value pairs
+//! exists within a specific key range of a trie with a given root hash.
+//!
+//! [`verify_range_proof`] proceeds in two phases:
+//!
+//! ## Phase 1 — Structural and boundary validation
+//!
+//! Validates that key-value pairs are strictly ascending and within the
+//! requested `[first_key, last_key]` range. Proof nodes carrying in-range
+//! values must appear in the key-value list (prevents an attacker from
+//! hiding keys that sit on a proof path). Start and end boundary proofs
+//! are verified against `root_hash` via hash chain checks.
+//!
+//! ## Phase 2 — Root hash verification
+//!
+//! A fresh in-memory **proving trie** is built from the key-value pairs.
+//! Boundary proof nodes are reconciled into it via
+//! `reconcile_branch_proof_node`, which inserts branch structure matching
+//! the original trie's layout. Value mismatches between the proof and the
+//! **proving trie** cause early rejection.
+//! `compute_root_hash_with_proofs` then computes a **hybrid root hash**:
+//! in-range children are hashed from the **proving trie**, while
+//! out-of-range children (identified by `compute_outside_children`) use
+//! hashes from the proof nodes. The result must match `root_hash`.
 
 pub(super) mod de;
 pub(crate) mod header;

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -333,7 +333,13 @@ impl From<PathIterItem> for ProofNode {
     }
 }
 
-/// A proof that a given key-value pair either exists or does not exist in a trie.
+/// A Merkle proof that a given key-value pair either exists (inclusion) or does
+/// not exist (exclusion) in a trie.
+///
+/// `T` is a [`ProofCollection`] — an ordered sequence of [`ProofNode`]s forming
+/// the path from the trie root to the proven key. Common concrete types are
+/// `Vec<ProofNode>` and `Box<[ProofNode]>`; use [`EmptyProofCollection`] for a
+/// zero-node proof (e.g., when a boundary proof is absent).
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct Proof<T: ?Sized>(T);
 


### PR DESCRIPTION
## Why this should be merged

The proof system is complex and the existing documentation didn't explain the verification algorithms. This makes it harder for contributors to understand and review proof-related changes.

## How this works

- Adds a Range Proof Verification Algorithm section to the `proofs` module docs, covering both phases (structural validation and root hash verification).
- Adds a module-level doc block to `merkle/changes.rs` explaining the `DiffMerkleNodeStream` trie diff algorithm.
- Expands the `Proof` type doc in `proofs/types.rs` with inclusion/exclusion semantics and the `T` parameter.
- Condenses the `proofs` module doc in `lib.rs`.

## How this was tested

`cargo doc --no-deps` builds cleanly with no warnings.

## Breaking Changes

None.