### PR TITLE
chore: remove unused mutable iter_present from Children

### DIFF
--- a/storage/src/node/children.rs
+++ b/storage/src/node/children.rs
@@ -18,12 +18,6 @@ pub type IterPresentRef<'a, T> = std::iter::FilterMap<
     fn((PathComponent, &'a Option<T>)) -> Option<(PathComponent, &'a T)>,
 >;
 
-/// The type of iterator returned by [`Children::iter_present`].
-pub type IterPresentMut<'a, T> = std::iter::FilterMap<
-    ChildrenSlots<&'a mut Option<T>>,
-    fn((PathComponent, &'a mut Option<T>)) -> Option<(PathComponent, &'a mut T)>,
->;
-
 /// Type alias for a collection of children in a branch node.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Children<T>([T; MAX_CHILDREN]);
@@ -179,18 +173,11 @@ impl<'a, T> Children<&'a Option<T>> {
     }
 }
 
-impl<'a, T> Children<&'a mut Option<T>> {
+impl<T> Children<&mut Option<T>> {
     /// Returns the number of [`Some`] elements in this collection.
     #[must_use]
     pub fn count(&self) -> usize {
         self.0.iter().filter(|c| c.is_some()).count()
-    }
-
-    /// Returns an iterator over each [`Some`] element with its corresponding
-    /// [`PathComponent`].
-    pub fn iter_present(self) -> IterPresentMut<'a, T> {
-        self.into_iter()
-            .filter_map(|(pc, opt)| opt.as_mut().map(|v| (pc, v)))
     }
 }
 


### PR DESCRIPTION
## Why this should be merged                                                                                                                                                                                                                         
                  
IterPresentMut and the mutable iter_present method on Children<&mut Option<T>> are dead code. Removing them simplifies the Children API. The lifetime on the remaining impl block is also simplified since the explicit 'a is no longer needed.

take_only_child will be added in https://github.com/ava-labs/firewood/pull/1904/
                                                                                                                                                                                                                                                    
## How this works                                                                                                                                                                                                                                    
   
  - Remove IterPresentMut type alias                                                                                                                                                                                                                
  - Remove iter_present method from impl Children<&'a mut Option<T>>
  - Simplify impl<'a, T> Children<&'a mut Option<T>> to impl<T> Children<&mut Option<T>>
                                                                                                                                                                                                                                                    
## How this was tested                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                    
  CI                                                                                                                                                  
                  
## Breaking Changes                                                                                                                                                                                                                                  
                  
  - None.