### PR TITLE
chore(ci): pin rust-overlay in flake

### DIFF
--- a/ffi/flake.lock
+++ b/ffi/flake.lock
@@ -123,6 +123,7 @@
       },
       "original": {
         "owner": "oxalica",
+        "ref": "d8b1b209203665924c81eabf750492530754f27e",
         "repo": "rust-overlay",
         "type": "github"
       }

--- a/ffi/flake.nix
+++ b/ffi/flake.nix
@@ -9,7 +9,7 @@
 
   inputs = {
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2505.*.tar.gz";
-    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.url = "github:oxalica/rust-overlay?ref=d8b1b209203665924c81eabf750492530754f27e";
     crane.url = "github:ipetkov/crane";
     flake-utils.url = "github:numtide/flake-utils";
     golang.url = "github:ava-labs/avalanchego?dir=nix/go&ref=50585cbbdfe1af02a2c11bdc9fa77fca26e6b838";


### PR DESCRIPTION
## Why this should be merged

The `rust-overlay` repo is updated nearly every day which causes the CI action that verifies if the lock file is up-to-date to begin to fail nearly every day. https://github.com/oxalica/rust-overlay/commits/master/

## How this works

This pins `rust-overlay` to the hash we're currently using.

## How this was tested

CI

## Breaking Changes

n/a