### PR TITLE
fix(proofs): proofs of nodes that contain storage accounts are unverifiable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ metrics-util = "0.20.1"
 metrics-exporter-prometheus = { version = "0.18.1", default-features = false }
 nonzero_ext = "0.3.0"
 parking_lot = "0.12.5"
+rlp = "0.6.1"
 rand_distr = "0.6.0"
 sha2 = "0.10.9"
 smallvec = { version = "1.15.1", features = ["write", "union", "const_new"] }

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -35,6 +35,7 @@ hex.workspace = true
 integer-encoding.workspace = true
 thiserror.workspace = true
 # Regular dependencies
+rlp = { workspace = true, optional = true }
 typed-builder = "0.23.2"
 rayon = "1.11.0"
 parking_lot.workspace = true
@@ -46,7 +47,7 @@ default = []
 nightly = []
 io-uring = ["firewood-storage/io-uring"]
 logger = ["firewood-storage/logger"]
-ethhash = ["firewood-storage/ethhash"]
+ethhash = ["firewood-storage/ethhash", "dep:rlp"]
 # Exposes internal types (e.g. `Merkle`) for use by benchmarks, integration
 # tests, and the FFI. Not part of the public API; do not use in production code.
 test_utils = ["firewood-storage/test_utils"]

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -1587,7 +1587,7 @@ mod test {
 
         let mut version = [0_u8; 16];
         file.read_exact_at(&mut version, 0).unwrap();
-        assert_eq!(&version, b"firewood-v1\0\0\0\0\0");
+        assert_eq!(&version, b"firewood-v1-hfix");
 
         // overwrite the magic string to simulate an older version
         file.write_all_at(b"firewood 0.0.18\0", 0).unwrap();

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -316,13 +316,14 @@ impl<T: TrieReader> Iterator for MerkleKeyValueIter<'_, T> {
                     match &*node {
                         Node::Branch(branch) => {
                             let Some(value) = branch.value.as_ref() else {
-                                // This node doesn't have a value to return.
-                                // Continue to the next node.
+                                // no value, continue to next node
                                 return None;
                             };
-                            Some((key, value.clone()))
+                            fix_account_value(key, value, &branch.children_hashes())
                         }
-                        Node::Leaf(leaf) => Some((key, leaf.value.clone())),
+                        Node::Leaf(leaf) => {
+                            fix_account_value(key, &leaf.value, &firewood_storage::Children::new())
+                        }
                     }
                 })
                 .transpose()
@@ -331,6 +332,42 @@ impl<T: TrieReader> Iterator for MerkleKeyValueIter<'_, T> {
 }
 
 impl<T: TrieReader> FusedIterator for MerkleKeyValueIter<'_, T> {}
+
+/// For ethhash account nodes (32-byte key), replace a stale or zeroed
+/// storageRoot with the correct hash computed from the node's children.
+/// This ensures range proof `key_values` match the proof nodes, which apply
+/// the same fix via `ProofNode::from()`. Without ethhash this is a no-op.
+///
+/// In debug builds, the hash is always recomputed and compared against the
+/// stored value to catch inconsistencies early. In release builds, we only
+/// recompute when the stored storageRoot is all zeros (the legacy sentinel).
+fn fix_account_value(
+    key: Key,
+    value: &[u8],
+    child_hashes: &firewood_storage::Children<Option<firewood_storage::HashType>>,
+) -> Option<(Key, Value)> {
+    #[cfg(feature = "ethhash")]
+    if key.len() == 32 {
+        let has_zeroed_storage_root = rlp::Rlp::new(value)
+            .as_list::<Vec<u8>>()
+            .ok()
+            .and_then(|list| list.get(2).cloned())
+            .is_some_and(|root| root.iter().all(|&b| b == 0));
+
+        if (has_zeroed_storage_root || cfg!(debug_assertions))
+            && let Some(fixed) =
+                firewood_storage::fix_account_storage_root_value(value, child_hashes)
+        {
+            if has_zeroed_storage_root {
+                return Some((key, fixed));
+            }
+            debug_assert_eq!(&*fixed, value, "hash mismatch on non-sentinel storageRoot");
+        }
+    }
+    // suppress unused warning when ethhash is not enabled
+    let _ = child_hashes;
+    Some((key, value.to_vec().into_boxed_slice()))
+}
 
 #[derive(Debug)]
 enum PathIteratorState<'a> {

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -48,27 +48,8 @@ macro_rules! write_attributes {
                 .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
         }
         if !$value.is_empty() {
-            match std::str::from_utf8($value) {
-                Ok(string) if string.chars().all(char::is_alphanumeric) => {
-                    write!($writer, " val={:.6}", string)
-                        .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
-                    if string.len() > 6 {
-                        $writer.write_all(b"...").map_err(|e| {
-                            FileIoError::from_generic_no_file(e, "write attributes")
-                        })?;
-                    }
-                }
-                _ => {
-                    let hex = hex::encode($value);
-                    write!($writer, " val={:.6}", hex)
-                        .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
-                    if hex.len() > 6 {
-                        $writer.write_all(b"...").map_err(|e| {
-                            FileIoError::from_generic_no_file(e, "write attributes")
-                        })?;
-                    }
-                }
-            }
+            firewood_storage::format_node_value($value, $writer)
+                .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
         }
     };
 }

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -118,6 +118,168 @@ fn make_key(hex_str: &str) -> Key {
     hex::decode(hex_str).unwrap().into_boxed_slice()
 }
 
+/// Keccak256 of empty bytes — the codeHash for accounts with no contract code.
+fn empty_code_hash() -> [u8; 32] {
+    Keccak256::digest([]).into()
+}
+
+/// Keccak256 of RLP-encoded empty string (0x80) — the hash of an empty storage trie.
+fn empty_trie_root() -> [u8; 32] {
+    Keccak256::digest(rlp::NULL_RLP).into()
+}
+
+/// RLP-encode an Ethereum account value: [nonce, balance, storageRoot, codeHash].
+fn rlp_encode_account(
+    nonce: u64,
+    balance: u64,
+    storage_root: &[u8; 32],
+    code_hash: &[u8; 32],
+) -> Box<[u8]> {
+    use rlp::RlpStream;
+
+    let mut rlp = RlpStream::new_list(4);
+    rlp.append(&nonce);
+    rlp.append(&balance);
+    rlp.append(&storage_root.as_slice());
+    rlp.append(&code_hash.as_slice());
+    rlp.out().to_vec().into_boxed_slice()
+}
+
+/// Insert an account (and optional storage entries) into a trie, commit it,
+/// then read back the account value and verify the storageRoot field was
+/// updated from the original `input_storage_root`.
+fn commit_and_read_storage_root(
+    account_key: &[u8],
+    account_value: &[u8],
+    input_storage_root: &[u8; 32],
+    storage_entries: &[(&[u8], &[u8])],
+) -> Vec<u8> {
+    use rlp::Rlp;
+
+    let account_key_hash = Keccak256::digest(account_key);
+
+    let mut items = vec![(
+        Box::from(account_key_hash.as_slice()),
+        Box::from(account_value),
+    )];
+    for (suffix, value) in storage_entries {
+        let key: Box<[u8]> = [account_key_hash.as_slice(), *suffix].concat().into();
+        items.push((key, Box::from(*value)));
+    }
+
+    let merkle = init_merkle(items);
+
+    let stored = merkle
+        .get_value(account_key_hash.as_slice())
+        .unwrap()
+        .expect("account should exist");
+
+    let rlp = Rlp::new(&stored);
+    let list: Vec<Vec<u8>> = rlp.as_list().unwrap();
+    assert!(
+        list.len() >= 3,
+        "account value should have at least 3 RLP items"
+    );
+
+    let persisted_storage_root = list.into_iter().nth(2).unwrap();
+    assert_ne!(
+        persisted_storage_root.as_slice(),
+        input_storage_root.as_slice(),
+        "storageRoot should have been updated from its original value"
+    );
+    persisted_storage_root
+}
+
+/// Verify that storageRoot is autocomputed during hashing for both
+/// 4-item (standard) and 5-item (coreth with trailing empty byte) account RLP.
+#[test_case(&[1u64, 0, 0, 0]; "4 item")]
+#[test_case(&[1u64, 0, 0, 0, 0]; "5 item")]
+fn test_autocompute_hash(fields: &[u64]) {
+    use rlp::RlpStream;
+
+    let account_addr = [0u8; 20];
+    let dummy_storage_root = [0u8; 32];
+
+    let mut rlp = RlpStream::new_list(fields.len());
+    for field in fields {
+        rlp.append(field);
+    }
+    let account_value: Box<[u8]> = rlp.out().to_vec().into();
+
+    let storage_root =
+        commit_and_read_storage_root(&account_addr, &account_value, &dummy_storage_root, &[]);
+
+    assert_eq!(
+        storage_root,
+        empty_trie_root(),
+        "storageRoot should be autocomputed as empty trie root"
+    );
+}
+
+/// RLP-encode a 32-byte storage slot value.
+fn rlp_encode_storage(value: &[u8; 32]) -> Vec<u8> {
+    use rlp::RlpStream;
+
+    let mut rlp = RlpStream::new();
+    rlp.append(&value.as_slice());
+    rlp.out().to_vec()
+}
+
+/// A branch account (one storage entry) should have its storageRoot set to
+/// the hash of the single-node storage sub-trie.
+#[test]
+fn test_persisted_storage_root_one_storage_entry() {
+    let account_addr = [0u8; 20];
+    let dummy_storage_root = [0u8; 32];
+    let account_value = rlp_encode_account(0, 44, &dummy_storage_root, &empty_code_hash());
+
+    let storage_key = [1u8; 32];
+    let storage_value = rlp_encode_storage(&[2u8; 32]);
+
+    let storage_root = commit_and_read_storage_root(
+        &account_addr,
+        &account_value,
+        &dummy_storage_root,
+        &[(&storage_key, &storage_value)],
+    );
+
+    assert_ne!(
+        storage_root,
+        empty_trie_root().to_vec(),
+        "should not be empty trie root"
+    );
+}
+
+/// A branch account (two storage entries) should have its storageRoot set to
+/// the hash of the two-node storage sub-trie.
+#[test]
+fn test_persisted_storage_root_two_storage_entries() {
+    let account_addr = [0u8; 20];
+    let dummy_storage_root = [0u8; 32];
+    let account_value = rlp_encode_account(0, 44, &dummy_storage_root, &empty_code_hash());
+
+    let storage_key_a = [1u8; 32];
+    let storage_key_b = [2u8; 32];
+    let storage_value_a = rlp_encode_storage(&[0xAAu8; 32]);
+    let storage_value_b = rlp_encode_storage(&[0xBBu8; 32]);
+
+    let storage_root = commit_and_read_storage_root(
+        &account_addr,
+        &account_value,
+        &dummy_storage_root,
+        &[
+            (&storage_key_a, &storage_value_a),
+            (&storage_key_b, &storage_value_b),
+        ],
+    );
+
+    assert_ne!(
+        storage_root,
+        empty_trie_root().to_vec(),
+        "should not be empty trie root"
+    );
+}
+
 #[test]
 fn test_root_hash_random_deletions() {
     use rand::seq::SliceRandom;

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -344,3 +344,293 @@ fn test_root_hash_random_deletions() {
         println!("i = {i}");
     }
 }
+
+/// Verify that a range proof bounded to account keys contains the corrected
+/// storageRoot fields. The left account has no storage children so its
+/// storageRoot must be keccak256(0x80) (empty trie root). The right account
+/// has one storage child so its storageRoot must be the computed hash of that
+/// storage sub-trie — neither the dummy zeros nor the empty trie root.
+///
+/// The range proof spans exactly the two account keys and excludes the
+/// storage entry that lives under the right account.
+#[test]
+fn test_range_proof_accounts_have_computed_storage_root() {
+    use crate::RangeProof;
+    type BoxedAccounts = Box<[(Box<[u8]>, Box<[u8]>)]>;
+
+    let dummy_storage_root = [0u8; 32];
+    let empty_root = empty_trie_root();
+
+    // Two accounts sorted by their keccak256 trie keys (left < right).
+    let mut accounts: BoxedAccounts = [[0x01u8; 20], [0x02u8; 20]]
+        .into_iter()
+        .enumerate()
+        .map(|(i, addr)| {
+            let key = Box::from(Keccak256::digest(addr).as_slice());
+            let value = rlp_encode_account(
+                i as u64,
+                (i as u64 + 1) * 100,
+                &dummy_storage_root,
+                &empty_code_hash(),
+            );
+            (key, value)
+        })
+        .collect();
+    accounts.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+    let left_key = &accounts[0].0;
+    let right_key = &accounts[1].0;
+
+    // One storage entry under the right account. Its 64-byte key is
+    // right_account_key || storage_suffix, placing it beyond the right
+    // account in trie order.
+    let storage_key: Box<[u8]> = [right_key.as_ref(), &[0xAAu8; 32]].concat().into();
+    let storage_value: Box<[u8]> = rlp_encode_storage(&[0x42u8; 32]).into();
+
+    let items: BoxedAccounts = accounts
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .chain(once((storage_key, storage_value)))
+        .collect();
+    let merkle = init_merkle(items);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    // Build a range proof bounded to just the two account keys.
+    let start_proof = merkle.prove(left_key.as_ref()).unwrap();
+    let end_proof = merkle.prove(right_key.as_ref()).unwrap();
+
+    // Read committed values for the two account keys only (not the storage entry).
+    let key_values: BoxedAccounts = accounts
+        .iter()
+        .map(|(k, _)| {
+            let val = merkle
+                .get_value(k.as_ref())
+                .unwrap()
+                .expect("account key should exist");
+            (k.to_vec().into_boxed_slice(), val)
+        })
+        .collect();
+
+    let range_proof = RangeProof::new(start_proof, end_proof, key_values);
+
+    // The range proof must verify against the committed root hash.
+    verify_range_proof(
+        Some(left_key.as_ref()),
+        Some(right_key.as_ref()),
+        &root_hash,
+        &range_proof,
+    )
+    .unwrap();
+
+    // Exactly two key-value pairs in the proof.
+    assert_eq!(range_proof.iter().len(), 2);
+
+    // Decode and check each account's storageRoot.
+    for (key, value) in &range_proof {
+        let rlp = rlp::Rlp::new(value.as_ref());
+        let list: Vec<Vec<u8>> = rlp
+            .as_list()
+            .expect("account value should be valid RLP list");
+        assert!(
+            list.len() >= 4,
+            "account RLP should have at least 4 fields, got {} for key {:?}",
+            list.len(),
+            key.as_ref(),
+        );
+
+        let storage_root = &list[2];
+        assert_ne!(
+            storage_root.as_slice(),
+            &dummy_storage_root,
+            "storageRoot must not be the original dummy zeros",
+        );
+
+        if key.as_ref() == left_key.as_ref() {
+            // Left account has no storage children → empty trie root.
+            assert_eq!(
+                storage_root.as_slice(),
+                &empty_root,
+                "left account storageRoot should be the empty trie root",
+            );
+        } else {
+            // Right account has a storage child → real computed hash.
+            assert_ne!(
+                storage_root.as_slice(),
+                &empty_root,
+                "right account storageRoot should NOT be the empty trie root",
+            );
+        }
+    }
+}
+
+/// Find `value_bytes` in the raw [`MemStore`] and overwrite it with `replacement`.
+/// The two slices must be the same length. Returns the number of occurrences
+/// replaced.
+///
+/// This is used to simulate legacy databases that stored zeroed hashes inside
+/// the RLP-encoded account values. We search for the full serialized value
+/// (not just the 32-byte hash) so we won't accidentally corrupt unrelated
+/// node hashes or structural data in the [`MemStore`].
+#[expect(clippy::arithmetic_side_effects)]
+fn clobber_value_in_memstore(
+    storage: &firewood_storage::MemStore,
+    value_bytes: &[u8],
+    replacement: &[u8],
+) -> usize {
+    use firewood_storage::{ReadableStorage, WritableStorage};
+    use std::io::Read;
+    assert_eq!(value_bytes.len(), replacement.len());
+
+    let mut buf = Vec::new();
+    storage
+        .stream_from(0)
+        .unwrap()
+        .read_to_end(&mut buf)
+        .unwrap();
+
+    let len = value_bytes.len();
+    let mut count = 0;
+    for offset in 0..buf.len().saturating_sub(len.saturating_sub(1)) {
+        if buf.get(offset..offset + len) == Some(value_bytes) {
+            storage.write(offset as u64, replacement).unwrap();
+            count += 1;
+        }
+    }
+    count
+}
+
+/// Given an RLP-encoded account value, return a copy with field 2 (storageRoot)
+/// replaced by the given 32-byte value.
+fn zero_storage_root_in_rlp(value: &[u8], replacement: &[u8; 32]) -> Vec<u8> {
+    let list: Vec<Vec<u8>> = rlp::Rlp::new(value).as_list().unwrap();
+    assert!(list.len() >= 3);
+
+    let mut rlp = rlp::RlpStream::new_list(list.len());
+    for (i, item) in list.iter().enumerate() {
+        if i == 2 {
+            rlp.append(&replacement.as_slice());
+        } else {
+            rlp.append(item);
+        }
+    }
+    rlp.out().to_vec()
+}
+
+/// Simulate a pre-fix database: after committing normally (which computes the
+/// correct storageRoot), clobber the persisted storageRoot bytes back to zeros
+/// in the raw [`MemStore`]. This replicates what old databases look like — correct
+/// root hash, but stale zeros in the stored account values.
+///
+/// Then generate a range proof and verify it still passes. The proof-time fix
+/// in `ProofNode::from()` should detect the zeros and recompute the correct
+/// storageRoot from the node's children.
+#[test]
+fn test_range_proof_fixes_legacy_zeroed_storage_root() {
+    use crate::RangeProof;
+    type BoxedAccounts = Box<[(Box<[u8]>, Box<[u8]>)]>;
+
+    let dummy_storage_root = [0u8; 32];
+
+    // Two accounts sorted by their keccak256 trie keys (left < right).
+    let mut accounts: BoxedAccounts = [[0x01u8; 20], [0x02u8; 20]]
+        .into_iter()
+        .enumerate()
+        .map(|(i, addr)| {
+            let key = Box::from(Keccak256::digest(addr).as_slice());
+            let value = rlp_encode_account(
+                i as u64,
+                (i as u64 + 1) * 100,
+                &dummy_storage_root,
+                &empty_code_hash(),
+            );
+            (key, value)
+        })
+        .collect();
+    accounts.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+    let left_key = &accounts[0].0;
+    let right_key = &accounts[1].0;
+
+    // One storage entry under the right account.
+    let storage_key: Box<[u8]> = [right_key.as_ref(), &[0xAAu8; 32]].concat().into();
+    let storage_value: Box<[u8]> = rlp_encode_storage(&[0x42u8; 32]).into();
+
+    let items: BoxedAccounts = accounts
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .chain(once((storage_key, storage_value)))
+        .collect();
+    let (merkle, header) = init_merkle_with_header(items);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    // ── Phase 1: generate a correct range proof to learn the real storageRoot values ──
+    let start_proof = merkle.prove(left_key.as_ref()).unwrap();
+    let end_proof = merkle.prove(right_key.as_ref()).unwrap();
+    let key_values: BoxedAccounts = accounts
+        .iter()
+        .map(|(k, _)| {
+            let val = merkle
+                .get_value(k.as_ref())
+                .unwrap()
+                .expect("account key should exist");
+            (k.to_vec().into_boxed_slice(), val)
+        })
+        .collect();
+
+    let range_proof = RangeProof::new(start_proof, end_proof, key_values);
+    verify_range_proof(
+        Some(left_key.as_ref()),
+        Some(right_key.as_ref()),
+        &root_hash,
+        &range_proof,
+    )
+    .unwrap();
+
+    // ── Phase 2: clobber account values in the MemStore ──
+    //
+    // For each account, find its full RLP-encoded value in the raw storage
+    // and replace it with a copy where the storageRoot field is zeroed.
+    // This surgically targets only the value bytes, avoiding collateral
+    // damage to node hashes. Then re-open so all reads come from disk.
+    let storage = merkle.nodestore().get_storage();
+    for (k, _) in &*accounts {
+        let stored = merkle.get_value(k.as_ref()).unwrap().unwrap();
+        let zeroed = zero_storage_root_in_rlp(&stored, &dummy_storage_root);
+        let replaced = clobber_value_in_memstore(&storage, &stored, &zeroed);
+        assert_eq!(
+            replaced,
+            1,
+            "expected exactly one occurrence of account value in MemStore for key {:02x?}",
+            k.as_ref(),
+        );
+    }
+
+    // Re-open from the clobbered MemStore so all reads come from disk.
+    let merkle = Merkle::from(NodeStore::open(&header, storage).unwrap());
+
+    // Sanity check: the stored values now contain dummy zeros.
+    for (k, _) in &*accounts {
+        let stored = merkle.get_value(k.as_ref()).unwrap().unwrap();
+        let list: Vec<Vec<u8>> = rlp::Rlp::new(&stored).as_list().unwrap();
+        assert_eq!(
+            list[2].as_slice(),
+            &dummy_storage_root,
+            "stored value should now have zeroed storageRoot",
+        );
+    }
+
+    // ── Phase 3: generate a range proof from the legacy-style database ──
+    // Use the real range_proof() API which collects key_values via the
+    // iterator — that's where the fix applies. The proof should verify
+    // against the original root hash because both ProofNode construction
+    // and the iterator now recompute the correct storageRoot.
+    let range_proof = merkle
+        .range_proof(Some(left_key.as_ref()), Some(right_key.as_ref()), None)
+        .unwrap();
+
+    verify_range_proof(
+        Some(left_key.as_ref()),
+        Some(right_key.as_ref()),
+        &root_hash,
+        &range_proof,
+    )
+    .unwrap();
+}

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -88,8 +88,19 @@ where
         let key = k.as_ref();
         let value = v.as_ref();
 
+        let stored = merkle.get_value(key).unwrap();
+        // In ethhash mode, account keys (32 bytes) have their storageRoot field
+        // updated during hashing, so the stored value will differ from the original.
+        #[cfg(feature = "ethhash")]
+        if key.len() == 32 {
+            assert!(
+                stored.is_some(),
+                "Failed to get account key after committing: {key:?}"
+            );
+            continue;
+        }
         assert_eq!(
-            merkle.get_value(key).unwrap().as_deref(),
+            stored.as_deref(),
             Some(value),
             "Failed to get key after committing: {key:?}"
         );

--- a/firewood/src/merkle/tests/proof.rs
+++ b/firewood/src/merkle/tests/proof.rs
@@ -125,10 +125,15 @@ fn test_proof() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    for (key, val) in items {
+    for (key, _val) in items {
         let proof = merkle.prove(key).unwrap();
         assert!(!proof.is_empty());
-        proof.verify(key, Some(val), &root_hash).unwrap();
+        // Read the stored value rather than using the original input because
+        // ethhash mode rewrites the storageRoot field in account-depth values
+        // during hashing. The proof must be verified against what was actually
+        // committed, not what was originally inserted.
+        let stored_val = merkle.get_value(key).unwrap().expect("key should exist");
+        proof.verify(key, Some(&stored_val), &root_hash).unwrap();
     }
 }
 

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -911,11 +911,8 @@ fn test_reverse_single_side_range_proof() {
             let start_proof = merkle.prove(items[case].0).unwrap();
             let end_proof = merkle.prove(end).unwrap();
 
-            let key_values: KeyValuePairs = items
-                .iter()
-                .skip(case)
-                .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-                .collect();
+            let key_values =
+                stored_key_values(&merkle, items.iter().skip(case).map(|(k, v)| (*k, *v)));
 
             let range_proof =
                 RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
@@ -948,10 +945,7 @@ fn test_both_sides_range_proof() {
         let start_proof = merkle.prove(start).unwrap();
         let end_proof = merkle.prove(end).unwrap();
 
-        let key_values: KeyValuePairs = items
-            .into_iter()
-            .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-            .collect();
+        let key_values = stored_key_values(&merkle, items.into_iter().map(|(k, v)| (*k, *v)));
 
         let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
 

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -7,6 +7,27 @@ use firewood_storage::U4;
 
 type KeyValuePairs = Vec<(Box<[u8]>, Box<[u8]>)>;
 
+/// Build key-value pairs for range proof verification using the values actually
+/// stored in the merkle trie. In ethhash mode, account-depth values may have
+/// their storageRoot rewritten during hashing, so we must use the committed
+/// values rather than the original inputs.
+fn stored_key_values<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+    merkle: &Merkle<NodeStore<Committed, MemStore>>,
+    items: impl IntoIterator<Item = (K, V)>,
+) -> KeyValuePairs {
+    items
+        .into_iter()
+        .map(|(k, v)| {
+            let key = k.as_ref();
+            let val = merkle
+                .get_value(key)
+                .unwrap()
+                .unwrap_or_else(|| v.as_ref().to_vec().into_boxed_slice());
+            (key.to_vec().into_boxed_slice(), val)
+        })
+        .collect()
+}
+
 /// Helper to build a `PathBuf` from a slice of nibble values.
 fn nibble_path(nibbles: &[u8]) -> PathBuf {
     nibbles
@@ -203,10 +224,8 @@ fn test_range_proof() {
         let start_proof = merkle.prove(items[start].0).unwrap();
         let end_proof = merkle.prove(items[end - 1].0).unwrap();
 
-        let key_values: KeyValuePairs = items[start..end]
-            .iter()
-            .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-            .collect();
+        let key_values =
+            stored_key_values(&merkle, items[start..end].iter().map(|(k, v)| (*k, *v)));
 
         let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
 
@@ -856,11 +875,8 @@ fn test_single_side_range_proof() {
             let start_proof = merkle.prove(start).unwrap();
             let end_proof = merkle.prove(items[case].0).unwrap();
 
-            let key_values: KeyValuePairs = items
-                .iter()
-                .take(case + 1)
-                .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-                .collect();
+            let key_values =
+                stored_key_values(&merkle, items.iter().take(case + 1).map(|(k, v)| (*k, *v)));
 
             let range_proof =
                 RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -333,15 +333,46 @@ impl From<PathIterItem> for ProofNode {
             .len()
             .saturating_sub(item.node.partial_path().len());
 
+        let value_digest = item
+            .node
+            .value()
+            .map(|value| ValueDigest::Value(value.to_vec().into_boxed_slice()));
+
+        // For account-depth nodes, ensure the storageRoot in the value reflects the
+        // actual storage sub-trie. Older databases may have a stale or zeroed
+        // storageRoot that was only replaced ephemerally during hashing.
+        #[cfg(feature = "ethhash")]
+        let value_digest = fix_account_storage_root(value_digest, &item.key_nibbles, &child_hashes);
+
         Self {
             key: item.key_nibbles,
             partial_len,
-            value_digest: item
-                .node
-                .value()
-                .map(|value| ValueDigest::Value(value.to_vec().into_boxed_slice())),
+            value_digest,
             child_hashes,
         }
+    }
+}
+
+/// For account-depth nodes (64 nibbles), replace the storageRoot field in the
+/// value with the hash computed from the node's children. This ensures proofs
+/// from older databases (before firewood-v1-hfix) contain a valid storageRoot.
+#[cfg(feature = "ethhash")]
+fn fix_account_storage_root(
+    value_digest: Option<ValueDigest<Box<[u8]>>>,
+    key_nibbles: &PathBuf,
+    child_hashes: &Children<Option<HashType>>,
+) -> Option<ValueDigest<Box<[u8]>>> {
+    if key_nibbles.len() != 64 {
+        return value_digest;
+    }
+
+    let Some(ValueDigest::Value(value)) = value_digest else {
+        return value_digest;
+    };
+
+    match firewood_storage::fix_account_storage_root_value(&value, child_hashes) {
+        Some(fixed) => Some(ValueDigest::Value(fixed)),
+        None => Some(ValueDigest::Value(value)),
     }
 }
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -49,7 +49,7 @@ weak-table = "0.3.2"
 bytes = { version = "1.11.1", optional = true }
 io-uring = { version = "0.7.11", optional = true }
 log = { version = "0.4.29", optional = true }
-rlp = { version = "0.6.1", optional = true }
+rlp = { workspace = true, optional = true }
 sha3 = { version = "0.10.8", optional = true }
 bumpalo = { version = "3.20.2", features = ["collections", "std"] }
 

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -40,7 +40,7 @@ impl HasUpdate for Keccak256 {
 // B is 1 if the input had an odd number of nibbles
 // CCCC is the first nibble if B is 1, otherwise it is all 0s
 
-fn nibbles_to_eth_compact<T: TriePath>(nibbles: T, is_leaf: bool) -> SmallVec<[u8; 32]> {
+pub(crate) fn nibbles_to_eth_compact<T: TriePath>(nibbles: T, is_leaf: bool) -> SmallVec<[u8; 32]> {
     // This is a bitfield that represents the first byte of the output, documented above
     bitfield! {
         struct CompactFirstByte(u8);
@@ -117,7 +117,7 @@ impl<T: Hashable> Preimage for T {
                     Some(ValueDigest::Value(bytes)) => {
                         let new_hash = Keccak256::digest(rlp::NULL_RLP).as_slice().to_vec();
                         let bytes_mut = BytesMut::from(bytes);
-                        if let Some(result) = replace_hash(bytes_mut, new_hash) {
+                        if let Some(result) = replace_hash(bytes_mut, &new_hash) {
                             rlp.append(&&*result);
                         } else {
                             rlp.append(&bytes);
@@ -199,7 +199,7 @@ impl<T: Hashable> Preimage for T {
                     };
                     trace!("replacement hash {:?}", hex::encode(&replacement_hash));
 
-                    let bytes = replace_hash(rlp_encoded_bytes, replacement_hash)
+                    let bytes = replace_hash(rlp_encoded_bytes, &replacement_hash)
                         .unwrap_or_else(|| BytesMut::from(rlp_encoded_bytes));
                     trace!("updated encoded value {:02X?}", hex::encode(&bytes));
                     bytes
@@ -238,13 +238,18 @@ impl<T: Hashable> Preimage for T {
     }
 }
 
-// TODO: we could be super fancy and just plunk the correct bytes into the existing BytesMut
-fn replace_hash<T: AsRef<[u8]>, U: AsRef<[u8]>>(bytes: T, new_hash: U) -> Option<BytesMut> {
-    // rlp_encoded_bytes needs to be decoded
+pub(crate) fn replace_hash<T: AsRef<[u8]>, U: AsRef<[u8]>>(
+    bytes: T,
+    new_hash: U,
+) -> Option<BytesMut> {
+    // Decode RLP as [nonce, balance, storageRoot, ...].
+    // Coreth may append extra trailing fields beyond the standard 4.
     let rlp = Rlp::new(bytes.as_ref());
-    let mut list = rlp.as_list().ok()?;
-    let replace = list.get_mut(2)?;
-    *replace = Vec::from(new_hash.as_ref());
+    let mut list: Vec<Vec<u8>> = rlp.as_list().ok()?;
+    let [_, _, storage_root, ..] = list.as_mut_slice() else {
+        return None;
+    };
+    *storage_root = Vec::from(new_hash.as_ref());
 
     trace!("inbound bytes: {}", hex::encode(bytes.as_ref()));
     trace!("list length was {}", list.len());

--- a/storage/src/hashers/mod.rs
+++ b/storage/src/hashers/mod.rs
@@ -2,6 +2,6 @@
 // See the file LICENSE.md for licensing terms.
 
 #[cfg(feature = "ethhash")]
-mod ethhash;
+pub(crate) mod ethhash;
 #[cfg(not(feature = "ethhash"))]
 mod merkledb;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -407,3 +407,122 @@ impl From<CheckerError> for Vec<CheckerError> {
         vec![error]
     }
 }
+
+/// Write a human-readable representation of a node value to `writer`.
+///
+/// The caller should not pass an empty `value` — this function assumes at
+/// least one byte is present and will produce a spurious ` val=` prefix
+/// for empty input.
+///
+/// With ethhash enabled, values that look like non-empty RLP lists (first
+/// byte >= 0xc0) are decoded and displayed as ` rlp=[field0,field1,...]`
+/// with hex-encoded fields truncated to 12 characters. If the value cannot
+/// be decoded as an RLP list, the raw bytes are dumped instead. Other values
+/// are displayed as plaintext (` val=...`) if they are alphanumeric UTF-8,
+/// or as truncated hex otherwise.
+///
+/// # Errors
+///
+/// Returns an error if writing to `writer` fails.
+pub fn format_node_value<W: std::io::Write + ?Sized>(
+    value: &[u8],
+    writer: &mut W,
+) -> std::io::Result<()> {
+    #[cfg(feature = "ethhash")]
+    if value.first().is_some_and(|&b| b >= 0xc0)
+        && let Ok(rlp_list) = rlp::Rlp::new(value).as_list::<Vec<u8>>()
+        && !rlp_list.is_empty()
+    {
+        write!(writer, " rlp=[")?;
+        for (i, item) in rlp_list.iter().enumerate() {
+            if i > 0 {
+                write!(writer, ",")?;
+            }
+            let hex = hex::encode(item);
+            write!(writer, "{hex:.12}")?;
+            if hex.len() > 12 {
+                writer.write_all(b"..")?;
+            }
+        }
+        write!(writer, "]")?;
+        return Ok(());
+    }
+    match std::str::from_utf8(value) {
+        Ok(string) if string.chars().all(char::is_alphanumeric) => {
+            write!(writer, " val={string:.6}")?;
+            if string.len() > 6 {
+                writer.write_all(b"...")?;
+            }
+        }
+        _ => {
+            let hex = hex::encode(value);
+            write!(writer, " val={hex:.6}")?;
+            if hex.len() > 6 {
+                writer.write_all(b"...")?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod format_node_value_tests {
+    use super::*;
+
+    fn fmt(value: &[u8]) -> String {
+        let mut buf = Vec::new();
+        format_node_value(value, &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn alphanumeric_plaintext() {
+        assert_eq!(fmt(b"hello"), " val=hello");
+        assert_eq!(fmt(b"value1"), " val=value1");
+    }
+
+    #[test]
+    fn long_alphanumeric_truncated() {
+        assert_eq!(fmt(b"longvalue"), " val=longva...");
+    }
+
+    #[test]
+    fn non_utf8_as_hex() {
+        assert_eq!(fmt(&[0xff, 0xfe]), " val=fffe");
+    }
+
+    #[test]
+    fn long_hex_truncated() {
+        assert_eq!(fmt(&[0xde, 0xad, 0xbe, 0xef]), " val=deadbe...");
+    }
+
+    #[test]
+    fn non_alphanumeric_utf8_as_hex() {
+        // Space is not alphanumeric, so falls through to hex.
+        assert_eq!(fmt(b"hi there"), " val=686920...");
+    }
+
+    #[cfg(feature = "ethhash")]
+    #[test]
+    fn rlp_list_decoded() {
+        // RLP encode [0x01, 0x02] as a 2-item list.
+        let mut rlp = rlp::RlpStream::new_list(2);
+        rlp.append(&vec![0x01u8]);
+        rlp.append(&vec![0x02u8]);
+        let encoded = rlp.out();
+        assert_eq!(fmt(&encoded), " rlp=[01,02]");
+    }
+
+    #[cfg(feature = "ethhash")]
+    #[test]
+    fn empty_rlp_list_falls_through() {
+        // 0xc0 is an empty RLP list — as_list returns Ok([]) which we
+        // treat as non-RLP since there are no fields to display.
+        let result = fmt(&[0xc0]);
+        assert!(
+            result.starts_with(" val="),
+            "expected hex fallback, got: {result}"
+        );
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -55,6 +55,8 @@ pub use hashtype::{HashType, IntoHashType, InvalidTrieHashLength, TrieHash};
 pub use linear::{FileIoError, ReadableStorage, WritableStorage};
 pub use node::path::{NibblesIterator, Path};
 pub use node::{BranchNode, Child, Children, ChildrenSlots, LeafNode, Node, PathIterItem};
+#[cfg(feature = "ethhash")]
+pub use nodestore::fix_account_storage_root_value;
 pub use nodestore::{
     AreaIndex, Committed, HashedNodeReader, ImmutableProposal, LinearAddress, Mutable, MutableKind,
     NodeHashAlgorithm, NodeHashAlgorithmTryFromIntError, NodeReader, NodeStore, NodeStoreHeader,

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -222,8 +222,15 @@ where
                 *child = Some(Child::MaybePersisted(child_node, child_hash));
                 trace!("child now {child:?}");
             }
+
+            #[cfg(feature = "ethhash")]
+            update_account_storage_root(&mut node, &path_prefix);
         }
-        // At this point, we either have a leaf or a branch with all children hashed.
+
+        // Handle leaf account nodes (no children, at account depth).
+        #[cfg(feature = "ethhash")]
+        update_account_storage_root(&mut node, &path_prefix);
+
         // if the encoded child hash <32 bytes then we use that RLP
 
         #[cfg(feature = "ethhash")]
@@ -268,6 +275,138 @@ where
             hash_node(&fake_root, path_prefix)
         } else {
             hash_node(node, path_prefix)
+        }
+    }
+}
+
+/// Given an account node's value and its children's hashes, return the value with the
+/// storageRoot field replaced by the computed hash of the storage sub-trie.
+///
+/// For leaf accounts (no children), the storage root is the empty trie hash.
+/// For branch accounts, the storage root is computed from the children's hashes.
+///
+/// Returns `None` if the value is not well-formed account RLP.
+#[cfg(feature = "ethhash")]
+#[must_use]
+pub fn fix_account_storage_root_value(
+    value: &[u8],
+    child_hashes: &Children<Option<HashType>>,
+) -> Option<Box<[u8]>> {
+    use crate::hashers::ethhash::replace_hash;
+    use crate::node::BranchNode;
+    use rlp::RlpStream;
+    use sha3::{Digest, Keccak256};
+
+    let children_count = child_hashes.iter().filter(|(_, c)| c.is_some()).count();
+
+    let storage_root = if children_count == 0 {
+        crate::TrieHash::from(Keccak256::digest(rlp::NULL_RLP))
+    } else {
+        let mut child_hashes = child_hashes.clone();
+        if let Some((_, child)) = child_hashes.take_only_child() {
+            match child {
+                HashType::Hash(hash) => hash,
+                HashType::Rlp(rlp_bytes) => {
+                    // Single storage child with small RLP — hash the raw bytes.
+                    crate::TrieHash::from(Keccak256::digest(&*rlp_bytes))
+                }
+            }
+        } else {
+            let mut rlp = RlpStream::new_list(const { BranchNode::MAX_CHILDREN + 1 });
+            for (_, child) in &child_hashes {
+                match child {
+                    Some(HashType::Hash(hash)) => {
+                        rlp.append(&hash.as_slice());
+                    }
+                    Some(HashType::Rlp(rlp_bytes)) => {
+                        rlp.append_raw(rlp_bytes, 1);
+                    }
+                    None => {
+                        rlp.append_empty_data();
+                    }
+                }
+            }
+            rlp.append_empty_data();
+            crate::TrieHash::from(Keccak256::digest(rlp.out()))
+        }
+    };
+
+    replace_hash(value, &storage_root).map(|b| b.to_vec().into_boxed_slice())
+}
+
+/// Updates the storageRoot field in an account node's RLP-encoded value to match
+/// the actual hash of its storage sub-trie. Only acts on nodes at account depth
+/// (64 nibbles) whose values are well-formed Ethereum account RLP.
+///
+/// For branch nodes, the storage root is computed from the children's hashes.
+/// For leaf nodes (no storage sub-trie), the storage root is the empty trie hash.
+#[cfg(feature = "ethhash")]
+fn update_account_storage_root(node: &mut Node, path_prefix: &Path) {
+    use crate::hashers::ethhash::{nibbles_to_eth_compact, replace_hash};
+    use crate::node::BranchNode;
+    use rlp::RlpStream;
+    use sha3::{Digest, Keccak256};
+
+    // Both lengths are usize counts of nibbles in a trie path, so their
+    // sum cannot overflow on any platform firewood targets.
+    let total_depth = path_prefix
+        .0
+        .len()
+        .wrapping_add(node.partial_path().0.len());
+    if total_depth != 64 {
+        return;
+    }
+
+    match node {
+        Node::Branch(b) => {
+            let Some(ref old_value) = b.value else {
+                return;
+            };
+
+            let mut child_hashes = b.children_hashes();
+
+            let storage_root = if let Some((_, child)) = child_hashes.take_only_child() {
+                match child {
+                    HashType::Hash(hash) => hash,
+                    HashType::Rlp(rlp_bytes) => {
+                        let mut rlp = RlpStream::new_list(2);
+                        rlp.append(&&*nibbles_to_eth_compact(
+                            b.partial_path.as_components(),
+                            true,
+                        ));
+                        rlp.append_raw(&rlp_bytes, 1);
+                        crate::TrieHash::from(Keccak256::digest(rlp.out()))
+                    }
+                }
+            } else {
+                // Multiple children: construct branch RLP and hash it
+                let mut rlp = RlpStream::new_list(const { BranchNode::MAX_CHILDREN + 1 });
+                for (_, child) in &child_hashes {
+                    match child {
+                        Some(HashType::Hash(hash)) => {
+                            rlp.append(&hash.as_slice());
+                        }
+                        Some(HashType::Rlp(rlp_bytes)) => {
+                            rlp.append_raw(rlp_bytes, 1);
+                        }
+                        None => {
+                            rlp.append_empty_data();
+                        }
+                    }
+                }
+                rlp.append_empty_data();
+                crate::TrieHash::from(Keccak256::digest(rlp.out()))
+            };
+
+            if let Some(new_value) = replace_hash(old_value.as_ref(), &storage_root) {
+                b.value = Some(new_value.to_vec().into_boxed_slice());
+            }
+        }
+        Node::Leaf(l) => {
+            let empty_root = Keccak256::digest(rlp::NULL_RLP);
+            if let Some(new_value) = replace_hash(&l.value, empty_root) {
+                l.value = new_value.to_vec().into_boxed_slice();
+            }
         }
     }
 }

--- a/storage/src/nodestore/header.rs
+++ b/storage/src/nodestore/header.rs
@@ -106,7 +106,9 @@ impl Version {
     }
 
     const fn is_firewood_v1(self) -> bool {
+        // Check against both the current and previous version strings
         self.as_u128() == const { Self::VALID_V1_VERSIONS[0].as_u128() }
+            || self.as_u128() == const { Self::VALID_V1_VERSIONS[1].as_u128() }
     }
 
     const fn from_static(bytes: &'static [u8; 16]) -> Self {
@@ -116,7 +118,8 @@ impl Version {
     /// After making the version a static string, there is no need to use semver
     /// to parse the valid version strings since there are a finite set of valid
     /// strings.
-    const VALID_V1_VERSIONS: [Version; 16] = [
+    const VALID_V1_VERSIONS: [Version; 17] = [
+        Version::from_static(b"firewood-v1-hfix"),
         Version::from_static(b"firewood-v1\0\0\0\0\0"),
         Version::from_static(b"firewood 0.0.18\0"),
         Version::from_static(b"firewood 0.0.17\0"),

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -43,6 +43,8 @@
 
 pub(crate) mod alloc;
 pub(crate) mod hash;
+#[cfg(feature = "ethhash")]
+pub use hash::fix_account_storage_root_value;
 pub(crate) mod hash_algo;
 pub(crate) mod header;
 pub(crate) mod persist;


### PR DESCRIPTION
## Why this should be merged

Because we didn't actually store the value being hashed in the node,
when nodes are generated for proofs they contain sentinel values for
the account storageRoot. That means proofs generated that contain
accounts are unusable.

This relies on the fact that coreth always inserts zeroes as the hash
value for the storage root and expects firewood to calculate the hash
as necessary.

## How this works

This fix addresses the bug in a few ways. First, if a database is
created from scratch, it will calculate and store the roots along with
the node. This means that everything "just works", including even
re-hashing.

For existing databases, the problem is a bit more complicated. If a
node is found while traversing a proof, we check to see if there is a
sentinel value of all zeroes, and if so, we recompute the hash at
proof generation time. This applies both to ProofNode construction
(proofs/types.rs) and to range proof key_values emitted by the
key-value iterator (iter.rs).

The database version was updated so we can get a little more aggressive
about not checking or recalculating the hash for older databases later.

Also fixed: the merkle dump display for non-RLP values with ethhash
enabled. The write_attributes! macro called rlp::as_list() on non-list
values, which silently returns Ok(vec![]) due to an rlp crate quirk,
producing "rlp=[]" for plain values. Now checks the first byte before
attempting RLP list decode.

## How this was tested

- New test: `test_range_proof_accounts_have_computed_storage_root` verifies
  range proofs contain correct storageRoot for leaf and branch account nodes.
- New test: `test_range_proof_fixes_legacy_zeroed_storage_root` surgically
  clobbers a MemStore to simulate a pre-fix database, then verifies
  range_proof() still produces a valid proof.
- Fixed existing range proof tests (`test_reverse_single_side_range_proof`,
  `test_both_sides_range_proof`) to use committed values via `stored_key_values()`
  instead of raw input values, since ethhash hashing may rewrite account values.
- Full test suite: 559 passed, 0 failed.

## Breaking Changes

None