### PR TITLE
docs: document empty-value semantics for batch operations

### DIFF
--- a/ffi/batch_op.go
+++ b/ffi/batch_op.go
@@ -8,6 +8,11 @@ import "C"
 
 // BatchOp represents a single batch operation to be applied to the database.
 // Create BatchOp values using the [Put], [Delete], and [PrefixDelete] functions.
+//
+// BatchOp uses an explicit tagged representation so that the intent of each
+// operation is unambiguous. In particular, a [Put] with an empty (zero-length)
+// value stores an empty value — it does NOT delete the key. Use [Delete] or
+// [PrefixDelete] to remove keys.
 type BatchOp struct {
 	tag   C.BatchOp_Tag
 	key   []byte // key for Put/Delete, prefix for DeleteRange

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -302,7 +302,9 @@ func New(dbDir string, nodeHashAlgorithm NodeHashAlgorithm, opts ...Option) (*Da
 // root node after the batch is applied. This is equivalent to creating a proposal
 // with [Database.Propose], then committing it with [Proposal.Commit].
 //
-// Use [Put], [Delete], and [PrefixDelete] to create batch operations.
+// Use [Put], [Delete], and [PrefixDelete] to create batch operations. A [Put]
+// with an empty value stores an empty value; use [Delete] or [PrefixDelete] to
+// remove keys.
 //
 // This function conflicts with all other calls that access the latest state of the database,
 // and will lock for the duration of this function.
@@ -328,7 +330,9 @@ func (db *Database) Update(batch []BatchOp) (Hash, error) {
 // is not committed until [Proposal.Commit] is called. See [Database.Close] regarding
 // freeing proposals. All proposals should be freed before closing the database.
 //
-// Use [Put], [Delete], and [PrefixDelete] to create batch operations.
+// Use [Put], [Delete], and [PrefixDelete] to create batch operations. A [Put]
+// with an empty value stores an empty value; use [Delete] or [PrefixDelete] to
+// remove keys.
 //
 // This function conflicts with all other calls that access the latest state of the database,
 // and will lock for the duration of this function.

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -204,6 +204,12 @@ typedef struct BorrowedSlice_u8 BorrowedBytes;
  *
  * This is a tagged union that explicitly distinguishes between different
  * operation types instead of relying on nil vs empty pointer semantics.
+ *
+ * Unlike the `TryIntoBatch` impl for tuples in the core library (which treats
+ * an empty value as a prefix deletion), this type preserves the operation as
+ * given: a `Put` with an empty value remains a `Put` with an empty value.
+ * Callers should use the appropriate variant (`Put`, `Delete`, `DeleteRange`)
+ * to express their intent.
  */
 enum BatchOp_Tag {
   /**

--- a/ffi/proposal.go
+++ b/ffi/proposal.go
@@ -109,7 +109,9 @@ func (p *Proposal) Iter(key []byte) (*Iterator, error) {
 // The returned proposal cannot be committed until the parent proposal `p` has been
 // committed. Additionally, it must be committed or released before the [Database] is closed.
 //
-// Use [Put], [Delete], and [PrefixDelete] to create batch operations.
+// Use [Put], [Delete], and [PrefixDelete] to create batch operations. A [Put]
+// with an empty value stores an empty value; use [Delete] or [PrefixDelete] to
+// remove keys.
 func (p *Proposal) Propose(batch []BatchOp) (*Proposal, error) {
 	p.keepAliveHandle.mu.RLock()
 	defer p.keepAliveHandle.mu.RUnlock()

--- a/ffi/src/value/kvp.rs
+++ b/ffi/src/value/kvp.rs
@@ -14,6 +14,12 @@ pub type OwnedKeyValueBatch = OwnedSlice<OwnedKeyValuePair>;
 ///
 /// This is a tagged union that explicitly distinguishes between different
 /// operation types instead of relying on nil vs empty pointer semantics.
+///
+/// Unlike the `TryIntoBatch` impl for tuples in the core library (which treats
+/// an empty value as a prefix deletion), this type preserves the operation as
+/// given: a `Put` with an empty value remains a `Put` with an empty value.
+/// Callers should use the appropriate variant (`Put`, `Delete`, `DeleteRange`)
+/// to express their intent.
 #[derive(Debug, Clone, Copy)]
 #[repr(C, usize)]
 pub enum BatchOp<'a> {

--- a/firewood/src/batch_op.rs
+++ b/firewood/src/batch_op.rs
@@ -159,6 +159,17 @@ impl<T: KeyValuePair<Error = std::convert::Infallible>, E: Into<FileIoError>> Ke
 }
 
 /// A key/value pair that can be used in a batch.
+///
+/// # Empty values and tuple conversions
+///
+/// When converting from a `(key, value)` tuple, an empty value is treated as a
+/// [`BatchOp::DeleteRange`] on the key rather than a [`BatchOp::Put`] with an
+/// empty value. This is because a bare tuple has no way to distinguish between
+/// "put an empty value" and "delete by prefix".
+///
+/// To store an empty value or to express deletions explicitly, use [`BatchOp`]
+/// directly instead of a tuple. The FFI layer uses an explicit tagged enum for
+/// this reason — see the FFI `BatchOp` type for details.
 pub trait TryIntoBatch {
     /// The key type
     type Key: KeyType;
@@ -205,6 +216,9 @@ impl<K: KeyType, V: ValueType> TryIntoBatch for (K, V) {
     #[inline]
     fn try_into_batch(self) -> Result<BatchOp<Self::Key, Self::Value>, Self::Error> {
         let (key, value) = self;
+        // A tuple cannot distinguish "put empty value" from "delete by prefix",
+        // so empty values are interpreted as prefix deletions. Use `BatchOp`
+        // directly when you need to store an empty value.
         if value.as_ref().is_empty() {
             Ok(BatchOp::DeleteRange { prefix: key })
         } else {


### PR DESCRIPTION
## Why this should be merged

Clarify that TryIntoBatch for tuples treats empty values as DeleteRange operations, while the FFI BatchOp tagged enum preserves Put with empty values as-is. Add documentation to the Rust trait, FFI BatchOp, and Go BatchOp type, Update, Propose, and Proposal.Propose methods.

## How this works

Just docs

## How this was tested

CI

## Breaking Changes

None
