### PR TITLE
fix(proofs, de): verify partial len is within bounds

### DIFF
--- a/firewood/src/proofs/de.rs
+++ b/firewood/src/proofs/de.rs
@@ -168,8 +168,15 @@ impl Version0 for BatchOp<Key, Value> {
 
 impl Version0 for ProofNode {
     fn read_v0_item(reader: &mut V0Reader<'_>) -> Result<Self, ReadError> {
-        let key = reader.read_v0_item()?;
+        let key = reader.read_v0_item::<PathBuf>()?;
         let partial_len = reader.read_item()?;
+        if partial_len > key.len() {
+            return Err(reader.invalid_item(
+                "partial key length",
+                "value less than or equal to the key length",
+                partial_len,
+            ));
+        }
         let value_digest = reader.read_item()?;
 
         let children_map = reader.read_item::<ChildMask>()?;

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -199,6 +199,38 @@ fn test_invalid_item(
 }
 
 #[test]
+fn test_partial_key_len_exceeds_key_len() {
+    let (proof, mut data) = create_valid_range_proof();
+
+    let node = &proof.start_proof()[0];
+    let key_len = node.key.len();
+    let original_partial_len_size = node.partial_len.required_space();
+    let invalid_partial_len: usize = key_len + 1;
+
+    let offset =
+        32 + proof.start_proof().len().required_space() + key_len.required_space() + key_len;
+
+    data.splice(
+        offset..offset + original_partial_len_size,
+        invalid_partial_len.encode_var_vec(),
+    );
+
+    match FrozenRangeProof::from_slice(&data) {
+        Err(ReadError::InvalidItem {
+            item,
+            expected,
+            found,
+            ..
+        }) => {
+            assert_eq!(item, "partial key length");
+            assert_eq!(expected, "value less than or equal to the key length");
+            assert_eq!(found, invalid_partial_len.to_string());
+        }
+        other => panic!("Expected ReadError::InvalidItem, got: {other:?}"),
+    }
+}
+
+#[test]
 fn test_empty_proof() {
     #[rustfmt::skip]
     let bytes = [


### PR DESCRIPTION
## Why this should be merged

A deserialized `ProofNode` carries both a `key` (the full nibble path to the node) and a
`partial_len` (how many leading nibbles of that path belong to the parent, i.e. the shared
prefix length). Semantically, `partial_len` must never exceed `key.len()` — if it did, the
node's own partial path would be negative-length, which is nonsensical.

Previously this invariant was not checked during deserialization, so a malformed proof could
produce a `ProofNode` with `partial_len > key.len()`, silently corrupting any downstream
logic that depends on `key[partial_len..]` being a valid slice.

## How this works

In `ProofNode::read_v0_item` (`firewood/src/proofs/de.rs`), after reading `partial_len`,
we now immediately check:

```rust
if partial_len > key.len() {
    return Err(reader.invalid_item(
        "partial key length",
        "value less than or equal to the key length",
        partial_len,
    ));
}
```

The turbofish `reader.read_v0_item::<PathBuf>()` was also added to the key read to make
the type explicit and satisfy the compiler with the new borrow of `key.len()` on the
following line.

## How this was tested

Added `test_partial_key_len_exceeds_key_len` to `firewood/src/proofs/tests.rs`. The test:

1. Serializes a valid range proof.
2. Locates the `partial_len` varint for the first proof node.
3. Splices in `key_len + 1` (the smallest out-of-bounds value) using the same varint
   encoding the deserializer expects.
4. Asserts that `FrozenRangeProof::from_slice` returns `ReadError::InvalidItem` with the
   correct `item`, `expected`, and `found` fields.

## Breaking Changes

n/a