### PR TITLE
fix(clippy): disallow panicking slice methods via clippy lint

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -12,6 +12,30 @@ doc-valid-idents = [
 disallowed-methods = [
   { path = "rand::rng", replacement = "firewood_storage::SeededRng::from_env_or_random", reason = "use a prng with a user-defined seed instead", allow-invalid = true },
   { path = "std::os::unix::fs::FileExt::write_at", replacement = "write_all_at", reason = "use write_all_at instead of write_at to handle short writes ensuring the entire buffer is written", allow-invalid = true },
+  # Out-of-bounds index panics
+  { path = "slice::split_at", reason = "split_at panics on out-of-bounds index; verify the index is in bounds and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::split_at_mut", reason = "split_at_mut panics on out-of-bounds index; verify the index is in bounds and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::swap", reason = "swap panics on out-of-bounds index; verify both indices are in bounds and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::copy_within", reason = "copy_within panics if src or dest is out of bounds; verify the ranges are in bounds and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::rotate_left", reason = "rotate_left panics if mid > len; verify mid is in bounds and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::rotate_right", reason = "rotate_right panics if k > len; verify k is in bounds and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::select_nth_unstable", reason = "select_nth_unstable panics if index >= len; verify the index is in bounds and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::select_nth_unstable_by", reason = "select_nth_unstable_by panics if index >= len; verify the index is in bounds and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::select_nth_unstable_by_key", reason = "select_nth_unstable_by_key panics if index >= len; verify the index is in bounds and add #[allow] with a safety comment", allow-invalid = true },
+  # Length mismatch panics
+  { path = "slice::clone_from_slice", reason = "clone_from_slice panics if source and destination lengths differ; verify lengths match and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::copy_from_slice", reason = "copy_from_slice panics if source and destination lengths differ; verify lengths match and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::swap_with_slice", reason = "swap_with_slice panics if source and destination lengths differ; verify lengths match and add #[allow] with a safety comment", allow-invalid = true },
+  # Zero-size argument panics
+  { path = "slice::windows", reason = "windows panics if size is 0; verify size is non-zero and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::chunks", reason = "chunks panics if chunk_size is 0; verify chunk_size is non-zero and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::chunks_mut", reason = "chunks_mut panics if chunk_size is 0; verify chunk_size is non-zero and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::chunks_exact", reason = "chunks_exact panics if chunk_size is 0; verify chunk_size is non-zero and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::chunks_exact_mut", reason = "chunks_exact_mut panics if chunk_size is 0; verify chunk_size is non-zero and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::rchunks", reason = "rchunks panics if chunk_size is 0; verify chunk_size is non-zero and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::rchunks_mut", reason = "rchunks_mut panics if chunk_size is 0; verify chunk_size is non-zero and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::rchunks_exact", reason = "rchunks_exact panics if chunk_size is 0; verify chunk_size is non-zero and add #[allow] with a safety comment", allow-invalid = true },
+  { path = "slice::rchunks_exact_mut", reason = "rchunks_exact_mut panics if chunk_size is 0; verify chunk_size is non-zero and add #[allow] with a safety comment", allow-invalid = true },
 ]
 
 disallowed-types = [

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -28,7 +28,15 @@ fn child_in_range(
     // the same-length prefix of acc_prefix; the right half's first element
     // (if any) is compared against child_nib to break ties.
     let split = depth.min(start_nib.len());
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "split is min(depth, len), always in bounds"
+    )]
     let (start_pre, start_rest) = start_nib.split_at(split);
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "split is min(depth, len), always in bounds"
+    )]
     let (acc_start, _) = acc_prefix.split_at(split);
     let above_start = match acc_start.cmp(start_pre) {
         Ordering::Greater => true,
@@ -40,7 +48,15 @@ fn child_in_range(
     };
 
     let split = depth.min(end_nib.len());
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "split is min(depth, len), always in bounds"
+    )]
     let (end_pre, end_rest) = end_nib.split_at(split);
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "split is min(depth, len), always in bounds"
+    )]
     let (acc_end, _) = acc_prefix.split_at(split);
     let below_end = match acc_end.cmp(end_pre) {
         Ordering::Less => true,
@@ -205,6 +221,10 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             return Err(api::Error::ProofError(ProofError::ProofNodeUnreachable));
         }
 
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "diverge == pp.len() <= key.len() by the check above"
+        )]
         let (_, key_rest) = key.split_at(diverge);
 
         let Some((&child_component, deeper)) = key_rest.split_first() else {

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -1683,6 +1683,10 @@ impl<'a, T: PartialEq> PrefixOverlap<'a, T> {
             .position(|(a, b)| *a != *b)
             .unwrap_or_else(|| std::cmp::min(a.len(), b.len()));
 
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "split_index is min(a.len(), b.len()) or earlier, always <= a.len()"
+        )]
         let (shared, unique_a) = a.split_at(split_index);
         let unique_b = b.get(split_index..).expect("");
 

--- a/firewood/src/merkle/tests/proof.rs
+++ b/firewood/src/merkle/tests/proof.rs
@@ -250,6 +250,7 @@ fn proof_path_construction_and_corruption() {
 
     // Positive: check path monotonicity (each node key is a prefix of the next)
     let nodes = proof.as_ref();
+    #[expect(clippy::disallowed_methods, reason = "window size is the literal 2")]
     for w in nodes.windows(2) {
         let cur = w[0].key.as_ref();
         let nxt = w[1].key.as_ref();

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -248,7 +248,15 @@ fn test_bad_range_proof_out_of_order() {
         if index_1 == index_2 {
             continue;
         }
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "index_1 and index_2 are in 0..end-start, which is the vec length"
+        )]
         keys.swap(index_1, index_2);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "index_1 and index_2 are in 0..end-start, which is the vec length"
+        )]
         vals.swap(index_1, index_2);
 
         let key_values: KeyValuePairs = keys
@@ -1544,7 +1552,15 @@ fn test_bad_range_proof_truncated_non_existent_edge() {
         .map(|i| {
             let mut key = [0u8; 32];
             let mut value = [0u8; 32];
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "to_be_bytes() returns [u8; 4], matching [..4]"
+            )]
             key[..4].copy_from_slice(&i.to_be_bytes());
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "to_be_bytes() returns [u8; 4], matching [..4]"
+            )]
             value[..4].copy_from_slice(&(i + 100).to_be_bytes());
             (key, value)
         })
@@ -1623,7 +1639,15 @@ fn test_range_proof_with_limit() {
         .map(|i| {
             let mut key = [0u8; 32];
             let mut value = [0u8; 20];
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "to_be_bytes() returns [u8; 4], matching [..4]"
+            )]
             key[..4].copy_from_slice(&i.to_be_bytes());
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "to_be_bytes() returns [u8; 4], matching [..4]"
+            )]
             value[..4].copy_from_slice(&(i + 100).to_be_bytes());
             (key, value)
         })

--- a/firewood/src/proofs/de.rs
+++ b/firewood/src/proofs/de.rs
@@ -168,8 +168,15 @@ impl Version0 for BatchOp<Key, Value> {
 
 impl Version0 for ProofNode {
     fn read_v0_item(reader: &mut V0Reader<'_>) -> Result<Self, ReadError> {
-        let key = reader.read_v0_item()?;
+        let key = reader.read_v0_item::<PathBuf>()?;
         let partial_len = reader.read_item()?;
+        if partial_len > key.len() {
+            return Err(reader.invalid_item(
+                "partial key length",
+                "value less than or equal to the key length",
+                partial_len,
+            ));
+        }
         let value_digest = reader.read_item()?;
 
         let children_map = reader.read_item::<ChildMask>()?;

--- a/firewood/src/proofs/reader.rs
+++ b/firewood/src/proofs/reader.rs
@@ -43,6 +43,10 @@ impl<'a> ProofReader<'a> {
 
     pub fn read_slice(&mut self, n: usize) -> Result<&'a [u8], ReadError> {
         if self.remainder().len() >= n {
+            #[expect(
+                clippy::disallowed_methods,
+                reason = "n is checked against remainder().len() on the line above"
+            )]
             let (slice, _) = self.remainder().split_at(n);
             #[expect(clippy::arithmetic_side_effects)]
             {

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -20,7 +20,7 @@ fn create_valid_range_proof() -> (FrozenRangeProof, Vec<u8>) {
 }
 
 #[test_case(
-    |data| data[0..8].copy_from_slice(b"badmagic"),
+    |data| *<&mut [u8; 8]>::try_from(&mut data[0..8]).unwrap() = *b"badmagic",
     |err| matches!(err, InvalidHeader::InvalidMagic { found } if found == b"badmagic");
     "invalid magic"
 )]
@@ -151,7 +151,7 @@ fn test_incomplete_item(
     "invalid option discriminant"
 )]
 #[test_case(
-    |_, data| data[32..42].copy_from_slice(&[0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89]),
+    |_, data| *<&mut [u8; 10]>::try_from(&mut data[32..42]).unwrap() = [0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89],
     "array length",
     "byte with no MSB within 9 bytes",
     "[128, 129, 130, 131, 132, 133, 134, 135, 136, 137]";

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -199,6 +199,38 @@ fn test_invalid_item(
 }
 
 #[test]
+fn test_partial_key_len_exceeds_key_len() {
+    let (proof, mut data) = create_valid_range_proof();
+
+    let node = &proof.start_proof()[0];
+    let key_len = node.key.len();
+    let original_partial_len_size = node.partial_len.required_space();
+    let invalid_partial_len: usize = key_len + 1;
+
+    let offset =
+        32 + proof.start_proof().len().required_space() + key_len.required_space() + key_len;
+
+    data.splice(
+        offset..offset + original_partial_len_size,
+        invalid_partial_len.encode_var_vec(),
+    );
+
+    match FrozenRangeProof::from_slice(&data) {
+        Err(ReadError::InvalidItem {
+            item,
+            expected,
+            found,
+            ..
+        }) => {
+            assert_eq!(item, "partial key length");
+            assert_eq!(expected, "value less than or equal to the key length");
+            assert_eq!(found, invalid_partial_len.to_string());
+        }
+        other => panic!("Expected ReadError::InvalidItem, got: {other:?}"),
+    }
+}
+
+#[test]
 fn test_empty_proof() {
     #[rustfmt::skip]
     let bytes = [

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -290,11 +290,19 @@ impl Hashable for ProofNode {
         Self: 'a;
 
     fn parent_prefix_path(&self) -> Self::LeadingPath<'_> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "partial_len is validated <= key.len() during deserialization"
+        )]
         let (prefix, _) = self.key.split_at(self.partial_len);
         prefix
     }
 
     fn partial_path(&self) -> Self::PartialPath<'_> {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "partial_len is validated <= key.len() during deserialization"
+        )]
         let (_, suffix) = self.key.split_at(self.partial_len);
         suffix
     }

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -304,6 +304,10 @@ impl Read for PredictiveReader<'_> {
             self.pos = 0;
         }
         let max_to_return = std::cmp::min(buf.len(), self.len - self.pos);
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "both slices are exactly max_to_return long"
+        )]
         buf[..max_to_return].copy_from_slice(&self.buffer[self.pos..self.pos + max_to_return]);
         self.pos += max_to_return;
         self.bytes_read += max_to_return as u64;

--- a/storage/src/linear/memory.rs
+++ b/storage/src/linear/memory.rs
@@ -50,6 +50,10 @@ impl WritableStorage for MemStore {
         if offset + object.len() > guard.len() {
             guard.resize(offset + object.len(), 0);
         }
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "destination slice is exactly object.len() wide"
+        )]
         guard[offset..offset + object.len()].copy_from_slice(object);
         Ok(object.len())
     }

--- a/storage/src/path/packed.rs
+++ b/storage/src/path/packed.rs
@@ -85,6 +85,10 @@ impl SplitPath for PackedPathRef<'_> {
             // the mid consumed the prefix, if it existed
             if mid.is_multiple_of(2) {
                 // middle is split cleanly
+                #[expect(
+                    clippy::disallowed_methods,
+                    reason = "mid is bounded by the assert at function entry"
+                )]
                 let (a_middle, b_middle) = self.middle.split_at(mid / 2);
                 let prefix = Self {
                     prefix: self.prefix,
@@ -100,6 +104,10 @@ impl SplitPath for PackedPathRef<'_> {
             } else {
                 // mid splits a middle component into the suffix of `prefix` and the
                 // prefix of `suffix`
+                #[expect(
+                    clippy::disallowed_methods,
+                    reason = "mid is bounded by the assert at function entry"
+                )]
                 let (a_middle, b_middle) = self.middle.split_at(mid / 2);
                 let Some((&middle_byte, b_middle)) = b_middle.split_first() else {
                     // `mid` is oob of `b_middle`, which happens if self.suffix is Some,

--- a/storage/src/path/split.rs
+++ b/storage/src/path/split.rs
@@ -100,6 +100,10 @@ impl<A: SplitPath, B: SplitPath, C> PathCommonPrefix<A, B, C> {
 
 impl SplitPath for &[PathComponent] {
     fn split_at(self, mid: usize) -> (Self, Self) {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "panics are the documented SplitPath::split_at contract"
+        )]
         self.split_at(mid)
     }
 

--- a/storage/src/tries/kvp.rs
+++ b/storage/src/tries/kvp.rs
@@ -104,6 +104,10 @@ impl<'a, T: AsRef<[u8]> + ?Sized> KeyValueTrieRoot<'a, T> {
             [(k, v)] => Ok(Some(Self::new_leaf(k.as_ref(), v.as_ref()))),
             _ => {
                 let mid = slice.len() / 2;
+                #[expect(
+                    clippy::disallowed_methods,
+                    reason = "mid is slice.len() / 2, always in bounds"
+                )]
                 let (lhs, rhs) = slice.split_at(mid);
                 let lhs = Self::from_slice(lhs)?;
                 let rhs = Self::from_slice(rhs)?;

--- a/triehash/src/lib.rs
+++ b/triehash/src/lib.rs
@@ -105,9 +105,11 @@ where
     }
 
     // then move them to a vector
+    #[expect(clippy::disallowed_methods, reason = "window size is the literal 2")]
+    let windows = lens.windows(2);
     let input = input
         .into_iter()
-        .zip(lens.windows(2))
+        .zip(windows)
         .map(|((_, v), w)| (&nibbles[w[0]..w[1]], v))
         .collect::<Vec<_>>();
 
@@ -174,11 +176,9 @@ fn hex_prefix_encode(nibbles: &[u8], leaf: bool) -> impl Iterator<Item = u8> + '
         }
         bits
     };
-    once(first_byte).chain(
-        nibbles[oddness_factor..]
-            .chunks(2)
-            .map(|ch| (ch[0] << 4) | ch[1]),
-    )
+    #[expect(clippy::disallowed_methods, reason = "chunk size is the literal 2")]
+    let chunks = nibbles[oddness_factor..].chunks(2);
+    once(first_byte).chain(chunks.map(|ch| (ch[0] << 4) | ch[1]))
 }
 
 fn hash256rlp<H, A, B>(input: &[(A, B)], pre_len: usize, stream: &mut RlpStream)


### PR DESCRIPTION
## Why this should be merged

Add all stable panicking slice methods to `disallowed-methods` in clippy.toml so that every call site must carry an `#[expect]` with a safety comment explaining why the precondition is met.

Ideally all of these should be rewritten so the preconditions are not required to be checked and we use _checked variants of these methods when possible.

Disallowed methods by category:
- Out-of-bounds index: split_at, split_at_mut, swap, copy_within, rotate_left, rotate_right, select_nth_unstable{,_by,_by_key}
- Length mismatch: clone_from_slice, copy_from_slice, swap_with_slice
- Zero-size argument: windows, chunks, chunks_mut, chunks_exact, chunks_exact_mut, rchunks, rchunks_mut, rchunks_exact, rchunks_exact_mut

## How this works

Annotated all existing call sites with per-site `#[expect]` and safety comments.

## How this was tested

ci

## Breaking Changes

none