### PR TITLE
chore: update go linter rules

### DIFF
--- a/.github/.golangci.yaml.patch
+++ b/.github/.golangci.yaml.patch
@@ -1,5 +1,5 @@
---- .github/.golangci.yaml	2026-03-19 15:26:49
-+++ ffi/.golangci.yaml	2026-03-19 15:18:18
+--- .github/.golangci.yaml	2026-04-13 13:37:17
++++ ffi/.golangci.yaml	2026-04-13 13:37:17
 @@ -40,7 +40,7 @@
          - standard
          - default
@@ -9,14 +9,14 @@
          - alias
          - dot
        custom-order: true
-@@ -56,26 +56,26 @@
+@@ -56,25 +56,26 @@
      - copyloopvar
      - depguard
      - durationcheck
 -    # - embeddedstructfieldcheck
 +    - embeddedstructfieldcheck
      - errcheck
-     - errorlint
++    - errorlint
      - forbidigo
      - goconst
      - gocheckcompilerdirectives
@@ -41,7 +41,7 @@
      - nolintlint
      - perfsprint
      - prealloc
-@@ -93,12 +93,12 @@
+@@ -92,59 +93,35 @@
      - usestdlibvars
      - whitespace
    settings:
@@ -56,7 +56,14 @@
              - pkg: github.com/golang/mock/gomock
                desc: go.uber.org/mock/gomock should be used instead.
              # Note: testify/assert is checked separately by test_warn_testify_assert
-@@ -113,33 +113,10 @@
+             # in lint.sh to produce warnings instead of errors.
+             - pkg: io/ioutil
+               desc: io/ioutil is deprecated. Use package io or os instead.
++    errorlint:
++      # Check for plain type assertions and type switches.
++      asserts: false
++      # Check for plain error comparisons.
++      comparison: false
      forbidigo:
        # Forbid the following identifiers (list of regexp).
        forbid:
@@ -68,7 +75,9 @@
 -        - pattern: require\.ErrorContains$(# ErrorIs should be used instead)?
 -        - pattern: require\.EqualValues$(# Equal should be used instead)?
 -        - pattern: require\.NotEqualValues$(# NotEqual should be used instead)?
-         - pattern: ^(t|b|tb|f)\.(Fatal|Fatalf|Error|Errorf)$(# the assert and require libraries should be used instead)?
+-        - pattern: require\.Fail$(# t.Fatal should be used instead)?
+-        - pattern: require\.FailNow$(# t.Fatal should be used instead)?
++        - pattern: ^(t|b|tb|f)\.(Fatal|Fatalf|Error|Errorf)$(# the assert and require libraries should be used instead)?
          - pattern: ^sort\.(Slice|Strings)$(# the slices package should be used instead)?
        # Exclude godoc examples from forbidigo checks.
        exclude-godoc-examples: false
@@ -90,7 +99,25 @@
      revive:
        rules:
          # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#bool-literal-in-expr
-@@ -203,17 +180,6 @@
+         - name: bool-literal-in-expr
+           disabled: false
+-        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#context-as-argument
+-        - name: context-as-argument
+-          disabled: false
+-          arguments:
+-            - allowTypesBefore: "*testing.T,*testing.B,*testing.F,testing.TB"
+         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#early-return
+         - name: early-return
+           disabled: false
+@@ -197,25 +174,12 @@
+         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+         - name: unused-parameter
+           disabled: false
+-          arguments:
+-            - allowRegex: "^ctx$"
+         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
+         - name: unused-receiver
+           disabled: false
          # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#useless-break
          - name: useless-break
            disabled: false
@@ -108,3 +135,23 @@
      tagalign:
        align: true
        sort: true
+@@ -234,13 +198,13 @@
+         - go-require
+         - float-compare
+     usetesting:
+-      os-create-temp: true # Disallow `os.CreateTemp("", ...)`
+-      os-mkdir-temp: true # Disallow `os.MkdirTemp()`
+-      os-setenv: true # Disallow `os.Setenv()`
+-      os-temp-dir: true # Disallow `os.TempDir()`
+-      os-chdir: true # Disallow `os.Chdir()`
++      os-create-temp:     true # Disallow `os.CreateTemp("", ...)`
++      os-mkdir-temp:      true # Disallow `os.MkdirTemp()`
++      os-setenv:          true # Disallow `os.Setenv()`
++      os-temp-dir:        true # Disallow `os.TempDir()`
++      os-chdir:           true # Disallow `os.Chdir()`
+       context-background: true # Disallow `context.Background()`
+-      context-todo: true # Disallow `context.TODO()`
++      context-todo:       true # Disallow `context.TODO()`
+     unused:
+       # Mark all struct fields that have been written to as used.
+       # Default: true


### PR DESCRIPTION
## Why this should be merged
Build on main is failing due to the following avalanchego PRs:

```text
style: ban require.Fail/require.FailNow, demote t.Fatal to warning (#5225)
style: add yamllinter (#5219)
style: enforce context-as-argument ordering, remove errorlint, un-interface coreth client (#5224)
```

our linter rules are out of date

## How this works

Just ran `.github/scripts/verify_golangci_yaml_changes.sh update`

## How this was tested

CI

## Breaking Changes

None