### PR TITLE
fix(proofs): 1/2 recompute storageRoot in ethhash proof generation

### DIFF
--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -319,8 +319,7 @@ impl<T: TrieReader> Iterator for MerkleKeyValueIter<'_, T> {
                                 // no value, continue to next node
                                 return None;
                             };
-                            let must_recompute =
-                                self.iter.merkle.must_recompute_storage_hash();
+                            let must_recompute = self.iter.merkle.must_recompute_storage_hash();
                             let child_hashes = if must_recompute && key.len() == 32 {
                                 branch.children_hashes()
                             } else {

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -319,12 +319,14 @@ impl<T: TrieReader> Iterator for MerkleKeyValueIter<'_, T> {
                                 // no value, continue to next node
                                 return None;
                             };
-                            fix_account_value(
-                                key,
-                                value,
-                                &branch.children_hashes(),
-                                self.iter.merkle.must_recompute_storage_hash(),
-                            )
+                            let must_recompute =
+                                self.iter.merkle.must_recompute_storage_hash();
+                            let child_hashes = if must_recompute && key.len() == 32 {
+                                branch.children_hashes()
+                            } else {
+                                firewood_storage::Children::new()
+                            };
+                            fix_account_value(key, value, &child_hashes, must_recompute)
                         }
                         Node::Leaf(leaf) => fix_account_value(
                             key,

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -316,13 +316,22 @@ impl<T: TrieReader> Iterator for MerkleKeyValueIter<'_, T> {
                     match &*node {
                         Node::Branch(branch) => {
                             let Some(value) = branch.value.as_ref() else {
-                                // This node doesn't have a value to return.
-                                // Continue to the next node.
+                                // no value, continue to next node
                                 return None;
                             };
-                            Some((key, value.clone()))
+                            fix_account_value(
+                                key,
+                                value,
+                                &branch.children_hashes(),
+                                self.iter.merkle.must_recompute_storage_hash(),
+                            )
                         }
-                        Node::Leaf(leaf) => Some((key, leaf.value.clone())),
+                        Node::Leaf(leaf) => fix_account_value(
+                            key,
+                            &leaf.value,
+                            &firewood_storage::Children::new(),
+                            self.iter.merkle.must_recompute_storage_hash(),
+                        ),
                     }
                 })
                 .transpose()
@@ -331,6 +340,28 @@ impl<T: TrieReader> Iterator for MerkleKeyValueIter<'_, T> {
 }
 
 impl<T: TrieReader> FusedIterator for MerkleKeyValueIter<'_, T> {}
+
+/// For ethhash account nodes (32-byte key) on databases that require storageRoot
+/// recomputation, replace the storageRoot with the correct hash computed from the
+/// node's children. This ensures range proof `key_values` match the proof nodes.
+/// Without ethhash this is a no-op.
+fn fix_account_value(
+    key: Key,
+    value: &[u8],
+    child_hashes: &firewood_storage::Children<Option<firewood_storage::HashType>>,
+    must_recompute: bool,
+) -> Option<(Key, Value)> {
+    #[cfg(feature = "ethhash")]
+    if must_recompute
+        && key.len() == 32
+        && let Some(fixed) = firewood_storage::fix_account_storage_root_value(value, child_hashes)
+    {
+        return Some((key, fixed));
+    }
+    // suppress unused warnings when ethhash is not enabled
+    let _ = (child_hashes, must_recompute);
+    Some((key, Box::from(value)))
+}
 
 #[derive(Debug)]
 enum PathIteratorState<'a> {
@@ -385,6 +416,7 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
     type Item = Result<PathIterItem, FileIoError>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let must_recompute = self.merkle.must_recompute_storage_hash();
         // destructuring is necessary here because we need mutable access to `state`
         // at the same time as immutable access to `merkle`.
         let Self { state, merkle } = &mut *self;
@@ -418,6 +450,7 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
                         key_nibbles: node_key,
                         node,
                         next_nibble: None,
+                        must_recompute_storage_hash: must_recompute,
                     }));
                 }
 
@@ -434,6 +467,7 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
                         key_nibbles: node_key,
                         node: saved_node,
                         next_nibble: None,
+                        must_recompute_storage_hash: must_recompute,
                     }));
                 };
                 let next_unmatched_key_nibble =
@@ -449,6 +483,7 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
                             key_nibbles: node_key,
                             node: saved_node,
                             next_nibble: None,
+                            must_recompute_storage_hash: must_recompute,
                         }))
                     }
                     Some(Child::AddressWithHash(child_addr, _)) => {
@@ -464,6 +499,7 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
                             key_nibbles: node_key,
                             node: saved_node,
                             next_nibble: Some(next_unmatched_key_nibble),
+                            must_recompute_storage_hash: must_recompute,
                         }))
                     }
                     Some(Child::Node(child)) => {
@@ -474,6 +510,7 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
                             key_nibbles: node_key,
                             node: saved_node,
                             next_nibble: Some(next_unmatched_key_nibble),
+                            must_recompute_storage_hash: must_recompute,
                         }))
                     }
                     Some(Child::MaybePersisted(maybe_persisted, _)) => {
@@ -489,6 +526,7 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
                             key_nibbles: node_key,
                             node: saved_node,
                             next_nibble: Some(next_unmatched_key_nibble),
+                            must_recompute_storage_hash: must_recompute,
                         }))
                     }
                 }

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -185,6 +185,11 @@ pub use firewood_storage::logger;
 /// violates some of the Rust guarantees. But, it is convenient to ensure the
 /// logger is initialized for all tests.
 ///
+/// Note: the default log level is `info`. To see `trace!` or `debug!`
+/// messages, set `RUST_LOG=trace` (or `RUST_LOG=debug`). Additionally,
+/// test output is captured by default — use `--nocapture` (cargo test) or
+/// `--show-output` (nextest) to see log output from passing tests.
+///
 /// In the event of unexpected behavior in testing, disable this first before
 /// looking elsewhere.
 fn init_logger() {

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -182,3 +182,142 @@ fn test_root_hash_random_deletions() {
         println!("i = {i}");
     }
 }
+
+/// Keccak256 of empty bytes — the codeHash for accounts with no contract code.
+fn empty_code_hash() -> [u8; 32] {
+    Keccak256::digest([]).into()
+}
+
+/// Keccak256 of RLP-encoded empty string (0x80) — the hash of an empty storage trie.
+fn empty_trie_root() -> [u8; 32] {
+    Keccak256::digest(rlp::NULL_RLP).into()
+}
+
+/// RLP-encode an Ethereum account value: [nonce, balance, storageRoot, codeHash].
+fn rlp_encode_account(
+    nonce: u64,
+    balance: u64,
+    storage_root: &[u8; 32],
+    code_hash: &[u8; 32],
+) -> Box<[u8]> {
+    use rlp::RlpStream;
+
+    let mut rlp = RlpStream::new_list(4);
+    rlp.append(&nonce);
+    rlp.append(&balance);
+    rlp.append(&storage_root.as_slice());
+    rlp.append(&code_hash.as_slice());
+    rlp.out().to_vec().into_boxed_slice()
+}
+
+/// RLP-encode a 32-byte storage slot value.
+fn rlp_encode_storage(value: &[u8; 32]) -> Vec<u8> {
+    use rlp::RlpStream;
+
+    let mut rlp = RlpStream::new();
+    rlp.append(&value.as_slice());
+    rlp.out().to_vec()
+}
+
+/// Verify that a range proof bounded to account keys contains the corrected
+/// storageRoot fields. The left account has no storage children so its
+/// storageRoot must be keccak256(0x80) (empty trie root). The right account
+/// has one storage child so its storageRoot must be the computed hash of that
+/// storage sub-trie — neither the dummy zeros nor the empty trie root.
+///
+/// The range proof spans exactly the two account keys and excludes the
+/// storage entry that lives under the right account.
+#[test]
+fn test_range_proof_accounts_have_computed_storage_root() {
+    type BoxedAccounts = Box<[(Box<[u8]>, Box<[u8]>)]>;
+
+    let dummy_storage_root = [0u8; 32];
+    let empty_root = empty_trie_root();
+
+    // Two accounts sorted by their keccak256 trie keys (left < right).
+    let mut accounts: BoxedAccounts = [[0x01u8; 20], [0x02u8; 20]]
+        .into_iter()
+        .enumerate()
+        .map(|(i, addr)| {
+            let key = Box::from(Keccak256::digest(addr).as_slice());
+            let value = rlp_encode_account(
+                i as u64,
+                (i as u64 + 1) * 100,
+                &dummy_storage_root,
+                &empty_code_hash(),
+            );
+            (key, value)
+        })
+        .collect();
+    accounts.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+    let left_key = &accounts[0].0;
+    let right_key = &accounts[1].0;
+
+    // One storage entry under the right account. Its 64-byte key is
+    // right_account_key || storage_suffix, placing it beyond the right
+    // account in trie order.
+    let storage_key: Box<[u8]> = [right_key.as_ref(), &[0xAAu8; 32]].concat().into();
+    let storage_value: Box<[u8]> = rlp_encode_storage(&[0x42u8; 32]).into();
+
+    let items: BoxedAccounts = accounts
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .chain(once((storage_key, storage_value)))
+        .collect();
+    let merkle = init_merkle(items);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    // Build a range proof bounded to just the two account keys.
+    let range_proof = merkle
+        .range_proof(Some(left_key.as_ref()), Some(right_key.as_ref()), None)
+        .unwrap();
+
+    // The range proof must verify against the committed root hash.
+    verify_range_proof(
+        Some(left_key.as_ref()),
+        Some(right_key.as_ref()),
+        &root_hash,
+        &range_proof,
+    )
+    .unwrap();
+
+    // Exactly two key-value pairs in the proof.
+    assert_eq!(range_proof.iter().len(), 2);
+
+    // Decode and check each account's storageRoot.
+    for (key, value) in &range_proof {
+        let rlp = rlp::Rlp::new(value.as_ref());
+        let list: Vec<Vec<u8>> = rlp
+            .as_list()
+            .expect("account value should be valid RLP list");
+        assert!(
+            list.len() >= 4,
+            "account RLP should have at least 4 fields, got {} for key {:?}",
+            list.len(),
+            key.as_ref(),
+        );
+
+        let storage_root = &list[2];
+        assert_ne!(
+            storage_root.as_slice(),
+            &dummy_storage_root,
+            "storageRoot must not be the original dummy zeros",
+        );
+
+        if key.as_ref() == left_key.as_ref() {
+            // Left account has no storage children → empty trie root.
+            assert_eq!(
+                storage_root.as_slice(),
+                &empty_root,
+                "left account storageRoot should be the empty trie root",
+            );
+        } else {
+            // Right account has a storage child → real computed hash.
+            assert_ne!(
+                storage_root.as_slice(),
+                &empty_root,
+                "right account storageRoot should NOT be the empty trie root",
+            );
+        }
+    }
+}

--- a/firewood/src/merkle/tests/proof.rs
+++ b/firewood/src/merkle/tests/proof.rs
@@ -125,14 +125,20 @@ fn test_proof() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
+    // Build expected values from the key-value iterator, which applies the
+    // same storageRoot fixups as proof generation.
+    let expected: std::collections::HashMap<_, _> = merkle
+        .key_value_iter_from_key(b"")
+        .map(|r| r.unwrap())
+        .collect();
+
     for (key, _val) in items {
         let proof = merkle.prove(key).unwrap();
         assert!(!proof.is_empty());
-        // Verify as inclusion proof. We don't check the exact value because
-        // proof generation may rewrite account storageRoot fields, producing
-        // a different value than get_value() returns.
-        let digest = proof.value_digest(key, &root_hash).unwrap();
-        assert!(digest.is_some(), "should be inclusion proof for {key:?}");
+        let value = expected.get(key.as_ref()).unwrap_or_else(|| {
+            panic!("key {key:?} missing from iterator");
+        });
+        proof.verify(key, Some(value.as_ref()), &root_hash).unwrap();
     }
 }
 

--- a/firewood/src/merkle/tests/proof.rs
+++ b/firewood/src/merkle/tests/proof.rs
@@ -125,10 +125,14 @@ fn test_proof() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    for (key, val) in items {
+    for (key, _val) in items {
         let proof = merkle.prove(key).unwrap();
         assert!(!proof.is_empty());
-        proof.verify(key, Some(val), &root_hash).unwrap();
+        // Verify as inclusion proof. We don't check the exact value because
+        // proof generation may rewrite account storageRoot fields, producing
+        // a different value than get_value() returns.
+        let digest = proof.value_digest(key, &root_hash).unwrap();
+        assert!(digest.is_some(), "should be inclusion proof for {key:?}");
     }
 }
 

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -25,6 +25,32 @@ fn proof_node(nibbles: &[u8]) -> ProofNode {
     }
 }
 
+/// Build key-value pairs for range proof verification using values from the
+/// merkle's key-value iterator. This is necessary because proof generation may
+/// rewrite account storageRoot fields, and the iterator applies the same fix.
+/// Using `get_value()` directly would return unfixed values that don't match
+/// what the proof nodes contain.
+fn stored_key_values<K: AsRef<[u8]>, V>(
+    merkle: &Merkle<NodeStore<Committed, MemStore>>,
+    items: impl IntoIterator<Item = (K, V)>,
+) -> KeyValuePairs {
+    items
+        .into_iter()
+        .map(|(k, _)| {
+            let key = k.as_ref();
+            // Read the value from the iterator (which applies storageRoot fix)
+            // by doing a single-key range scan.
+            let (found_key, val) = merkle
+                .key_value_iter_from_key(key)
+                .next()
+                .expect("iterator should yield at least one item")
+                .expect("iterator should not error");
+            assert_eq!(found_key.as_ref(), key, "iterator returned wrong key");
+            (Box::from(key), val)
+        })
+        .collect()
+}
+
 #[test]
 fn outside_children_empty_proof() {
     let result = compute_outside_children(&[], None, true).unwrap();
@@ -203,10 +229,8 @@ fn test_range_proof() {
         let start_proof = merkle.prove(items[start].0).unwrap();
         let end_proof = merkle.prove(items[end - 1].0).unwrap();
 
-        let key_values: KeyValuePairs = items[start..end]
-            .iter()
-            .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-            .collect();
+        let key_values =
+            stored_key_values(&merkle, items[start..end].iter().map(|(k, v)| (*k, *v)));
 
         let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
 
@@ -447,10 +471,8 @@ fn test_range_proof_with_non_existent_proof() {
         let start_proof = merkle.prove(&first).unwrap();
         let end_proof = merkle.prove(&last).unwrap();
 
-        let key_values: KeyValuePairs = items[start..end]
-            .iter()
-            .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-            .collect();
+        let key_values =
+            stored_key_values(&merkle, items[start..end].iter().map(|(k, v)| (*k, *v)));
 
         let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
 
@@ -466,10 +488,7 @@ fn test_range_proof_with_non_existent_proof() {
     let start_proof = merkle.prove(first).unwrap();
     let end_proof = merkle.prove(last).unwrap();
 
-    let key_values: KeyValuePairs = items
-        .into_iter()
-        .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-        .collect();
+    let key_values = stored_key_values(&merkle, items);
 
     let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
 
@@ -566,9 +585,15 @@ fn test_one_element_range_proof() {
     let proof = merkle.prove(items[start].0).unwrap();
     assert!(!proof.is_empty());
 
+    let (_, stored_val) = merkle
+        .key_value_iter_from_key(items[start].0)
+        .next()
+        .unwrap()
+        .unwrap();
+
     let key_values = vec![(
         items[start].0.to_vec().into_boxed_slice(),
-        items[start].1.to_vec().into_boxed_slice(),
+        stored_val.clone(),
     )];
 
     let range_proof = RangeProof::new(
@@ -594,7 +619,7 @@ fn test_one_element_range_proof() {
 
     let key_values_2 = vec![(
         items[start].0.to_vec().into_boxed_slice(),
-        items[start].1.to_vec().into_boxed_slice(),
+        stored_val.clone(),
     )];
 
     let range_proof_2 =
@@ -615,7 +640,7 @@ fn test_one_element_range_proof() {
 
     let key_values_3 = vec![(
         items[start].0.to_vec().into_boxed_slice(),
-        items[start].1.to_vec().into_boxed_slice(),
+        stored_val.clone(),
     )];
 
     let range_proof_3 =
@@ -633,10 +658,7 @@ fn test_one_element_range_proof() {
     let start_proof_4 = merkle.prove(&first).unwrap();
     let end_proof_4 = merkle.prove(&last).unwrap();
 
-    let key_values_4 = vec![(
-        items[start].0.to_vec().into_boxed_slice(),
-        items[start].1.to_vec().into_boxed_slice(),
-    )];
+    let key_values_4 = vec![(items[start].0.to_vec().into_boxed_slice(), stored_val)];
 
     let range_proof_4 =
         RangeProof::new(start_proof_4, end_proof_4, key_values_4.into_boxed_slice());
@@ -652,10 +674,13 @@ fn test_one_element_range_proof() {
     let start_proof_5 = merkle_mini.prove(first).unwrap();
     let end_proof_5 = merkle_mini.prove(&key).unwrap();
 
-    let key_values_5 = vec![(
-        key.to_vec().into_boxed_slice(),
-        val.to_vec().into_boxed_slice(),
-    )];
+    let (_, stored_val_mini) = merkle_mini
+        .key_value_iter_from_key(key)
+        .next()
+        .unwrap()
+        .unwrap();
+
+    let key_values_5 = vec![(key.to_vec().into_boxed_slice(), stored_val_mini)];
 
     let range_proof_5 =
         RangeProof::new(start_proof_5, end_proof_5, key_values_5.into_boxed_slice());
@@ -684,10 +709,7 @@ fn test_all_elements_proof() {
     let start_proof_2 = merkle.prove(items[start].0).unwrap();
     let end_proof_2 = merkle.prove(items[end].0).unwrap();
 
-    let key_values_2: KeyValuePairs = items
-        .iter()
-        .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-        .collect();
+    let key_values_2 = stored_key_values(&merkle, items.iter().map(|(k, v)| (*k, *v)));
 
     let range_proof_2 =
         RangeProof::new(start_proof_2, end_proof_2, key_values_2.into_boxed_slice());
@@ -706,10 +728,7 @@ fn test_all_elements_proof() {
     let start_proof_3 = merkle.prove(first).unwrap();
     let end_proof_3 = merkle.prove(last).unwrap();
 
-    let key_values_3: KeyValuePairs = items
-        .iter()
-        .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-        .collect();
+    let key_values_3 = stored_key_values(&merkle, items.iter().map(|(k, v)| (*k, *v)));
 
     let range_proof_3 =
         RangeProof::new(start_proof_3, end_proof_3, key_values_3.into_boxed_slice());
@@ -856,11 +875,8 @@ fn test_single_side_range_proof() {
             let start_proof = merkle.prove(start).unwrap();
             let end_proof = merkle.prove(items[case].0).unwrap();
 
-            let key_values: KeyValuePairs = items
-                .iter()
-                .take(case + 1)
-                .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-                .collect();
+            let key_values =
+                stored_key_values(&merkle, items.iter().take(case + 1).map(|(k, v)| (*k, *v)));
 
             let range_proof =
                 RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
@@ -895,11 +911,8 @@ fn test_reverse_single_side_range_proof() {
             let start_proof = merkle.prove(items[case].0).unwrap();
             let end_proof = merkle.prove(end).unwrap();
 
-            let key_values: KeyValuePairs = items
-                .iter()
-                .skip(case)
-                .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-                .collect();
+            let key_values =
+                stored_key_values(&merkle, items.iter().skip(case).map(|(k, v)| (*k, *v)));
 
             let range_proof =
                 RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
@@ -932,10 +945,7 @@ fn test_both_sides_range_proof() {
         let start_proof = merkle.prove(start).unwrap();
         let end_proof = merkle.prove(end).unwrap();
 
-        let key_values: KeyValuePairs = items
-            .into_iter()
-            .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
-            .collect();
+        let key_values = stored_key_values(&merkle, items);
 
         let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
 

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -341,16 +341,10 @@ impl From<PathIterItem> for ProofNode {
         // For account-depth nodes on databases that need storageRoot
         // recomputation, fix the value from the node's children.
         #[cfg(feature = "ethhash")]
-        let value_digest = {
-            debug_assert!(
-                item.must_recompute_storage_hash,
-                "must_recompute_storage_hash should always be true"
-            );
-            if item.must_recompute_storage_hash {
-                fix_account_storage_root(value_digest, &item.key_nibbles, &child_hashes)
-            } else {
-                value_digest
-            }
+        let value_digest = if item.must_recompute_storage_hash {
+            fix_account_storage_root(value_digest, &item.key_nibbles, &child_hashes)
+        } else {
+            value_digest
         };
 
         Self {

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -333,15 +333,55 @@ impl From<PathIterItem> for ProofNode {
             .len()
             .saturating_sub(item.node.partial_path().len());
 
+        let value_digest = item
+            .node
+            .value()
+            .map(|value| ValueDigest::Value(Box::from(value)));
+
+        // For account-depth nodes on databases that need storageRoot
+        // recomputation, fix the value from the node's children.
+        #[cfg(feature = "ethhash")]
+        let value_digest = {
+            debug_assert!(
+                item.must_recompute_storage_hash,
+                "must_recompute_storage_hash should always be true"
+            );
+            if item.must_recompute_storage_hash {
+                fix_account_storage_root(value_digest, &item.key_nibbles, &child_hashes)
+            } else {
+                value_digest
+            }
+        };
+
         Self {
             key: item.key_nibbles,
             partial_len,
-            value_digest: item
-                .node
-                .value()
-                .map(|value| ValueDigest::Value(value.to_vec().into_boxed_slice())),
+            value_digest,
             child_hashes,
         }
+    }
+}
+
+/// For account-depth nodes (64 nibbles), replace the storageRoot field in the
+/// value with the hash computed from the node's children. This ensures proofs
+/// from older databases contain a valid storageRoot.
+#[cfg(feature = "ethhash")]
+fn fix_account_storage_root(
+    value_digest: Option<ValueDigest<Box<[u8]>>>,
+    key_nibbles: &PathBuf,
+    child_hashes: &Children<Option<HashType>>,
+) -> Option<ValueDigest<Box<[u8]>>> {
+    if key_nibbles.len() != 64 {
+        return value_digest;
+    }
+
+    let Some(ValueDigest::Value(value)) = value_digest else {
+        return value_digest;
+    };
+
+    match firewood_storage::fix_account_storage_root_value(&value, child_hashes) {
+        Some(fixed) => Some(ValueDigest::Value(fixed)),
+        None => Some(ValueDigest::Value(value)),
     }
 }
 

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -239,7 +239,11 @@ impl<T: Hashable> Preimage for T {
 }
 
 // TODO: we could be super fancy and just plunk the correct bytes into the existing BytesMut
-fn replace_hash<T: AsRef<[u8]>, U: AsRef<[u8]>>(bytes: T, new_hash: U) -> Option<BytesMut> {
+pub(crate) fn replace_hash<T, U>(bytes: T, new_hash: U) -> Option<BytesMut>
+where
+    T: AsRef<[u8]>,
+    U: AsRef<[u8]>,
+{
     // rlp_encoded_bytes needs to be decoded
     let rlp = Rlp::new(bytes.as_ref());
     let mut list = rlp.as_list().ok()?;

--- a/storage/src/hashers/mod.rs
+++ b/storage/src/hashers/mod.rs
@@ -2,6 +2,6 @@
 // See the file LICENSE.md for licensing terms.
 
 #[cfg(feature = "ethhash")]
-mod ethhash;
+pub(crate) mod ethhash;
 #[cfg(not(feature = "ethhash"))]
 mod merkledb;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -55,6 +55,8 @@ pub use hashtype::{HashType, IntoHashType, InvalidTrieHashLength, TrieHash};
 pub use linear::{FileIoError, ReadableStorage, WritableStorage};
 pub use node::path::{NibblesIterator, Path};
 pub use node::{BranchNode, Child, Children, ChildrenSlots, LeafNode, Node, PathIterItem};
+#[cfg(feature = "ethhash")]
+pub use nodestore::fix_account_storage_root_value;
 pub use nodestore::{
     AreaIndex, Committed, HashedNodeReader, ImmutableProposal, LinearAddress, Mutable, MutableKind,
     NodeHashAlgorithm, NodeHashAlgorithmTryFromIntError, NodeReader, NodeStore, NodeStoreHeader,

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -489,6 +489,9 @@ pub struct PathIterItem {
     /// children array.
     /// None if `node` is the last node in the path.
     pub next_nibble: Option<PathComponent>,
+    /// Whether account storageRoot values need recomputation during proof
+    /// generation. Set from the database version.
+    pub must_recompute_storage_hash: bool,
 }
 
 fn read_path_with_overflow_length(

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -271,3 +271,58 @@ where
         }
     }
 }
+
+/// Given an account node's value and its children's hashes, return the value with the
+/// storageRoot field replaced by the computed hash of the storage sub-trie.
+///
+/// For leaf accounts (no children), the storage root is the empty trie hash.
+/// For branch accounts, the storage root is computed from the children's hashes.
+///
+/// Returns `None` if the value is not well-formed account RLP.
+#[cfg(feature = "ethhash")]
+#[must_use]
+pub fn fix_account_storage_root_value(
+    value: &[u8],
+    child_hashes: &Children<Option<HashType>>,
+) -> Option<Box<[u8]>> {
+    use crate::hashers::ethhash::replace_hash;
+    use crate::node::BranchNode;
+    use rlp::RlpStream;
+    use sha3::{Digest, Keccak256};
+
+    let children_count = child_hashes.iter().filter(|(_, c)| c.is_some()).count();
+
+    let storage_root = if children_count == 0 {
+        crate::TrieHash::from(Keccak256::digest(rlp::NULL_RLP))
+    } else {
+        let mut child_hashes = child_hashes.clone();
+        if let Some((_, child)) = child_hashes.take_only_child() {
+            match child {
+                HashType::Hash(hash) => hash,
+                HashType::Rlp(rlp_bytes) => {
+                    // Single storage child with small RLP — hash the raw bytes.
+                    crate::TrieHash::from(Keccak256::digest(&*rlp_bytes))
+                }
+            }
+        } else {
+            let mut rlp = RlpStream::new_list(const { BranchNode::MAX_CHILDREN + 1 });
+            for (_, child) in &child_hashes {
+                match child {
+                    Some(HashType::Hash(hash)) => {
+                        rlp.append(&hash.as_slice());
+                    }
+                    Some(HashType::Rlp(rlp_bytes)) => {
+                        rlp.append_raw(rlp_bytes, 1);
+                    }
+                    None => {
+                        rlp.append_empty_data();
+                    }
+                }
+            }
+            rlp.append_empty_data();
+            crate::TrieHash::from(Keccak256::digest(rlp.out()))
+        }
+    };
+
+    replace_hash(value, &storage_root).map(|b| Box::from(b.as_ref()))
+}

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -299,10 +299,10 @@ pub fn fix_account_storage_root_value(
         if let Some((_, child)) = child_hashes.take_only_child() {
             match child {
                 HashType::Hash(hash) => hash,
-                HashType::Rlp(rlp_bytes) => {
-                    // Single storage child with small RLP — hash the raw bytes.
-                    crate::TrieHash::from(Keccak256::digest(&*rlp_bytes))
-                }
+                HashType::Rlp(_) => unreachable!(
+                    "account-depth single storage child cannot have inline RLP: \
+                     storage leaf encoding with 32-byte keys always exceeds 32 bytes"
+                ),
             }
         } else {
             let mut rlp = RlpStream::new_list(const { BranchNode::MAX_CHILDREN + 1 });
@@ -311,9 +311,10 @@ pub fn fix_account_storage_root_value(
                     Some(HashType::Hash(hash)) => {
                         rlp.append(&hash.as_slice());
                     }
-                    Some(HashType::Rlp(rlp_bytes)) => {
-                        rlp.append_raw(rlp_bytes, 1);
-                    }
+                    Some(HashType::Rlp(_)) => unreachable!(
+                        "account-depth storage child cannot have inline RLP: \
+                         storage node encoding with 32-byte keys always exceeds 32 bytes"
+                    ),
                     None => {
                         rlp.append_empty_data();
                     }

--- a/storage/src/nodestore/header.rs
+++ b/storage/src/nodestore/header.rs
@@ -109,6 +109,15 @@ impl Version {
         self.as_u128() == const { Self::VALID_V1_VERSIONS[0].as_u128() }
     }
 
+    /// Returns `true` if databases written by this version need their account
+    /// storage-root hashes recomputed at proof-generation time.
+    ///
+    /// All existing versions predate the fix, so this currently returns `true`
+    /// unconditionally. A future `firewood-v1-hfix` version will return `false`.
+    pub const fn must_recompute_storage_hash(self) -> bool {
+        true
+    }
+
     const fn from_static(bytes: &'static [u8; 16]) -> Self {
         Self { bytes: *bytes }
     }
@@ -444,6 +453,13 @@ impl NodeStoreHeader {
         let (root_address, root_hash) = root_location.unzip();
         self.root_address = root_address;
         self.root_hash = root_hash.unwrap_or_else(TrieHash::empty).into();
+    }
+
+    /// Returns `true` if the database version requires recomputing account
+    /// storage-root hashes at proof-generation time.
+    #[must_use]
+    pub const fn must_recompute_storage_hash(&self) -> bool {
+        self.version.must_recompute_storage_hash()
     }
 
     /// Get the offset of the `free_lists` field for use with `offset_of`!

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -64,6 +64,8 @@ pub use alloc::NodeAllocator;
 pub use hash_algo::{NodeHashAlgorithm, NodeHashAlgorithmTryFromIntError};
 pub use primitives::{AreaIndex, LinearAddress};
 // Re-export types from header module
+#[cfg(feature = "ethhash")]
+pub use hash::fix_account_storage_root_value;
 pub use header::NodeStoreHeader;
 
 /// The [`NodeStore`] handles the serialization of nodes and
@@ -123,6 +125,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
                 root: None,
             },
             storage,
+            must_recompute_storage_hash: header.must_recompute_storage_hash(),
         };
 
         if let Some(root_address) = header.root_address() {
@@ -150,6 +153,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
                 deleted: Box::default(),
                 root: None,
             },
+            must_recompute_storage_hash: true,
         }
     }
 
@@ -176,6 +180,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
                 root: None,
             },
             storage,
+            must_recompute_storage_hash: true,
         };
 
         let node = nodestore.read_node(root_address)?;
@@ -297,6 +302,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
         Ok(NodeStore {
             kind,
             storage: parent.storage.clone(),
+            must_recompute_storage_hash: parent.must_recompute_storage_hash,
         })
     }
 
@@ -328,6 +334,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
                 },
             },
             storage: parent.storage.clone(),
+            must_recompute_storage_hash: parent.must_recompute_storage_hash,
         }
     }
 }
@@ -374,6 +381,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Recon>, S> {
         Ok(NodeStore {
             kind: Mutable { root, inner: Recon },
             storage: parent.storage.clone(),
+            must_recompute_storage_hash: parent.must_recompute_storage_hash,
         })
     }
 }
@@ -415,6 +423,7 @@ impl<S: WritableStorage> NodeStore<Mutable<Propose>, S> {
                 },
             },
             storage,
+            must_recompute_storage_hash: true,
         }
     }
 }
@@ -430,6 +439,7 @@ impl<S> NodeStore<Mutable<Recon>, S> {
                 inner: Recon,
             },
             storage,
+            must_recompute_storage_hash: true,
         }
     }
 }
@@ -464,6 +474,15 @@ pub trait NodeReader {
     ///
     /// Returns a [`FileIoError`] if the node cannot be read.
     fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError>;
+
+    /// Returns `true` if account storage-root hashes must be recomputed at
+    /// proof-generation time.
+    ///
+    /// The default returns `true` (safe for all existing database versions).
+    /// [`NodeStore`] overrides this with the value read from the database header.
+    fn must_recompute_storage_hash(&self) -> bool {
+        true
+    }
 }
 
 impl<T> NodeReader for T
@@ -473,6 +492,10 @@ where
 {
     fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
         self.deref().read_node(addr)
+    }
+
+    fn must_recompute_storage_hash(&self) -> bool {
+        self.deref().must_recompute_storage_hash()
     }
 }
 
@@ -626,6 +649,9 @@ pub struct NodeStore<T, S> {
     kind: T,
     /// Persisted storage to read nodes from.
     storage: Arc<S>,
+    /// Whether account storage-root hashes must be recomputed at
+    /// proof-generation time. Set from the database header version.
+    must_recompute_storage_hash: bool,
 }
 
 /// Contains state for a reconstructed revision of the trie.
@@ -710,6 +736,7 @@ impl<S: ReadableStorage> From<NodeStore<Reconstructed, S>> for NodeStore<Mutable
                 inner: Recon,
             },
             storage: val.storage,
+            must_recompute_storage_hash: val.must_recompute_storage_hash,
         }
     }
 }
@@ -722,6 +749,7 @@ impl<S: ReadableStorage> From<NodeStore<Mutable<Recon>, S>> for NodeStore<Recons
                 hash: OnceLock::new(),
             },
             storage: val.storage,
+            must_recompute_storage_hash: val.must_recompute_storage_hash,
         }
     }
 }
@@ -752,6 +780,7 @@ impl<S> Clone for NodeStore<Reconstructed, S> {
         NodeStore {
             kind: self.kind.clone(),
             storage: self.storage.clone(),
+            must_recompute_storage_hash: self.must_recompute_storage_hash,
         }
     }
 }
@@ -765,6 +794,7 @@ impl<S: WritableStorage> From<NodeStore<ImmutableProposal, S>> for NodeStore<Com
                 root: val.kind.root.clone(),
             },
             storage: val.storage,
+            must_recompute_storage_hash: val.must_recompute_storage_hash,
         }
     }
 }
@@ -788,6 +818,7 @@ impl<S: WritableStorage> NodeStore<Arc<ImmutableProposal>, S> {
                 root: self.kind.root.clone(),
             },
             storage: self.storage.clone(),
+            must_recompute_storage_hash: self.must_recompute_storage_hash,
         }
     }
 }
@@ -798,7 +829,11 @@ impl<S: ReadableStorage> TryFrom<NodeStore<Mutable<Propose>, S>>
     type Error = FileIoError;
 
     fn try_from(val: NodeStore<Mutable<Propose>, S>) -> Result<Self, Self::Error> {
-        let NodeStore { kind, storage } = val;
+        let NodeStore {
+            kind,
+            storage,
+            must_recompute_storage_hash,
+        } = val;
         let Mutable {
             root,
             inner: Propose { deleted, parent },
@@ -811,6 +846,7 @@ impl<S: ReadableStorage> TryFrom<NodeStore<Mutable<Propose>, S>>
                 root: None,
             }),
             storage,
+            must_recompute_storage_hash,
         };
 
         let Some(root) = root else {
@@ -840,17 +876,29 @@ impl<T, S: ReadableStorage> NodeReader for NodeStore<Mutable<T>, S> {
     fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
         self.read_node_from_disk(addr, ReadableNodeMode::Write)
     }
+
+    fn must_recompute_storage_hash(&self) -> bool {
+        self.must_recompute_storage_hash
+    }
 }
 
 impl<S: ReadableStorage> NodeReader for NodeStore<Reconstructed, S> {
     fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
         self.read_node_from_disk(addr, ReadableNodeMode::ReconRead)
     }
+
+    fn must_recompute_storage_hash(&self) -> bool {
+        self.must_recompute_storage_hash
+    }
 }
 
 impl<T: Parentable, S: ReadableStorage> NodeReader for NodeStore<T, S> {
     fn read_node(&self, addr: LinearAddress) -> Result<SharedNode, FileIoError> {
         self.read_node_from_disk(addr, ReadableNodeMode::Read)
+    }
+
+    fn must_recompute_storage_hash(&self) -> bool {
+        self.must_recompute_storage_hash
     }
 }
 


### PR DESCRIPTION
## Why this should be merged

Coreth inserts zeroed placeholder hashes for account storageRoot fields and expects firewood to compute the correct values. Currently, the computed hash is only used ephemerally during trie hashing but is never persisted in the stored node value. This means proofs generated from these nodes contain stale storageRoot values that fail verification.

## How this works

This fix recomputes the storageRoot from the node's children at proof generation time, in both ProofNode construction and the key-value iterator used by range proofs. A future change will persist the correct storageRoot during hashing so this recomputation becomes a no-op for new databases, but this fix will still be needed for compatibility with existing databases.

Also document test logging gotchas (RUST_LOG level, --nocapture) near the ctor::ctor init_logger in lib.rs.

## How this was tested

Add must_recompute_storage_hash() to the NodeStore/TrieReader layer so callers can query whether recomputation is needed based on database version. Currently returns true for all versions; a future database version bump will allow it to return false for databases that already store correct values.

Fix all proof and range proof tests to use values from the key-value iterator (which applies the same fix) rather than raw input values.

## Breaking Changes

None