### PR TITLE
storage: fix 'occured' -> 'occurred' in io_uring.rs doc comment

### DIFF
--- a/storage/src/linear/io_uring.rs
+++ b/storage/src/linear/io_uring.rs
@@ -694,7 +694,7 @@ mod errors {
 
     /// A collection of errors encountered during an io-uring write batch.
     ///
-    /// A least one error occured for this to be returned. Incurable errors can be
+    /// A least one error occurred for this to be returned. Incurable errors can be
     /// observed via [`BatchErrors::incurable_error`].
     #[must_use]
     pub struct BatchErrors {


### PR DESCRIPTION
Doc comment in `storage/src/linear/io_uring.rs` line 697 reads `error occured for this`. Fixed to `occurred`. Comment-only change.