### PR TITLE
chore: minor clippy fixes for 1.95

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -1256,7 +1256,7 @@ mod test {
         let committed = db.root_hash().unwrap();
         let revision = db.revision(committed).unwrap();
 
-        for (k, v) in keys.into_iter().zip(vals.into_iter()) {
+        for (k, v) in keys.into_iter().zip(vals) {
             assert_eq!(revision.val(k).unwrap().unwrap(), v);
         }
     }

--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -418,7 +418,7 @@ impl PersistChannel {
         use firewood_storage::logger::warn;
         use std::time::Duration;
 
-        const WARN_INTERVAL: Duration = Duration::from_secs(60);
+        const WARN_INTERVAL: Duration = Duration::from_mins(1);
 
         let mut state = self.state.lock();
         let mut elapsed_secs = 0;

--- a/fwdctl/src/launch/ec2_util.rs
+++ b/fwdctl/src/launch/ec2_util.rs
@@ -17,7 +17,7 @@ use tokio::time::{sleep, timeout};
 use super::{DeployOptions, LaunchError};
 
 /// Time to wait after launch for the instance to transition to `running`.
-const WAIT_RUNNING_TIMEOUT: Duration = Duration::from_secs(300);
+const WAIT_RUNNING_TIMEOUT: Duration = Duration::from_mins(5);
 /// Poll interval while waiting for the instance state to change.
 const POLL_INTERVAL_RUNNING: Duration = Duration::from_secs(3);
 /// Canonical's AWS account ID for official Ubuntu AMIs.

--- a/fwdctl/src/launch/ssm_monitor.rs
+++ b/fwdctl/src/launch/ssm_monitor.rs
@@ -21,7 +21,7 @@ const SSM_RETRY_DELAY: Duration = Duration::from_secs(5);
 /// Poll interval while waiting for an SSM command invocation status update.
 const SSM_COMMAND_POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// Timeout for a single SSM command invocation.
-const SSM_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
+const SSM_COMMAND_TIMEOUT: Duration = Duration::from_mins(2);
 /// Poll interval for cloud-init state and bootstrap log streaming loops.
 const LOG_POLL_INTERVAL: Duration = Duration::from_secs(3);
 /// Number of log lines fetched per SSM read when tailing bootstrap output.
@@ -29,7 +29,7 @@ const LOG_CHUNK_SIZE: u64 = 500;
 /// Log file containing benchmark re-execution output on the remote host.
 const BOOTSTRAP_LOG: &str = "/var/log/bootstrap.log";
 /// Maximum time to wait for cloud-init to publish its JSON state file.
-const STATE_FILE_TIMEOUT: Duration = Duration::from_secs(600);
+const STATE_FILE_TIMEOUT: Duration = Duration::from_mins(10);
 
 pub async fn ssm_client(region: &str) -> SsmClient {
     SsmClient::new(&aws_config(Some(region)).await)


### PR DESCRIPTION
## Why this should be merged

Rust 1.95 was released today and introduced new lints.

## How this works

This resolves those new lints.

## How this was tested

CI

## Breaking Changes

none