### PR TITLE
perf(storage): use binary search in AreaIndex::from_size

### DIFF
--- a/storage/src/nodestore/primitives.rs
+++ b/storage/src/nodestore/primitives.rs
@@ -89,15 +89,8 @@ impl AreaIndex {
             return Err(Error::new(ErrorKind::OutOfMemory, AreaSizeError(n)));
         }
 
-        if n <= Self::MIN_AREA_SIZE {
-            return Ok(AreaIndex(0));
-        }
-
-        AREA_SIZES
-            .iter()
-            .position(|&size| size >= n)
-            .map(|index| AreaIndex(index as u8))
-            .ok_or_else(|| Error::new(ErrorKind::OutOfMemory, AreaSizeError(n)))
+        let index = AREA_SIZES.partition_point(|&size| size < n);
+        Ok(AreaIndex(index as u8))
     }
 
     /// Get the underlying index as u8.


### PR DESCRIPTION
## Why this should be merged

Replace the linear .position() scan with .partition_point() over the ascending AREA_SIZES array. The compiler unrolls the binary search into a fixed log2(n)+2 comparisons for the 23-element table, improving cache and branch-predictor behavior.

The n <= MIN_AREA_SIZE short-circuit is now redundant: partition_point returns 0 for any n at or below the first element.

## How this works

Closes #1704

## How this was tested

CI covers this code fairly well.

## Breaking Changes

None
