### PR TITLE
fix: remove duplicate children loop in compute_root_hash_with_proofs

### DIFF
--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -315,26 +315,6 @@ fn compute_root_hash_with_proofs(
         }
     }
 
-    // For children in the in-memory trie, compute hashes recursively.
-    // These children were inserted from the proven key-value pairs, so they
-    // are *inside* the proven range. A nibble cannot be both inside (present
-    // in the trie) and outside (marked in outside_children) at the same time,
-    // so this does not conflict with the proof hashes set above.
-    let mut child_prefix: PathBuf = full_key.iter().copied().collect();
-    for (nibble, child_opt) in &branch.children {
-        if let Some(Child::Node(child_node)) = child_opt {
-            child_prefix.push(nibble);
-            let child_hash = compute_root_hash_with_proofs(
-                child_node,
-                &child_prefix,
-                proof_nodes,
-                outside_children,
-            );
-            child_hashes[nibble] = Some(child_hash);
-            child_prefix.pop();
-        }
-    }
-
     // Use the branch's value if it exists. Otherwise, fall back to the
     // proof node's value digest (which may be a Hash for out-of-range
     // nodes where no key-value pair was inserted). The proof node's


### PR DESCRIPTION
## Why this should be merged                                                                                                                                                                                                                         
                  
compute_root_hash_with_proofs has two loops iterating over branch.children. The first loop (added in #1930) correctly skips outside children and handles persisted children. The second loop (the original range proof implementation) re-hashes  
all Child::Node entries without checking the outside mask. The second loop should have been removed when the first was added. It was accidentally kept during the merge.
                                                                                                                                                                                                                                                    
For range proofs, the second loop is redundant. The proving trie is built from scratch with only in-range keys, so all Child::Node entries are in-range. Both loops produce the same result.                                                     
   
For change proofs, the second loop is incorrect. The proving trie is forked from the proposal which contains all keys. If reconciliation or collapse converts an outside child from persisted to Child::Node, the second loop would re-hash it,  
overwriting the correct proof hash set between the two loops. With that said, creating a test case that triggers this is challenging.
                                                                                                                                                                                                                                                    
Note that the rkuris/cp-restructure-squashed branch (https://github.com/ava-labs/firewood/blob/rkuris/cp-restructure-squashed/firewood/src/merkle/mod.rs#L282) has only the first loop. The second was intentionally not included when the function was rewritten for change proof support.
                                                                                                                                                                                                                                                    
## How this works  

Remove the second children loop from compute_root_hash_with_proofs. The first loop already handles all cases: outside children (skipped), persisted children (hash reused), and in-range Child::Node (recursed).                                                                                                                                                                                                                                                                
                  
## How this was tested

  - CI                                                                                                                                                     
   
## Breaking Changes                                                                                                                                                                                                                                  
                  
  - None   