### PR TITLE
fix(proofs): reject truncated exclusion proofs with reachable children

### DIFF
--- a/firewood/src/merkle/tests/proof.rs
+++ b/firewood/src/merkle/tests/proof.rs
@@ -308,3 +308,41 @@ fn roundtrip_range_proof(proof: &FrozenRangeProof) -> FrozenRangeProof {
     assert_eq!(proof, &deserialized);
     deserialized
 }
+
+/// Truncated exclusion proof must be rejected. If the terminal proof node
+/// is an ancestor of the proven key and has a child at the next nibble,
+/// the proof is incomplete — it must include that child to demonstrate
+/// the key's absence.
+#[test]
+fn truncated_exclusion_proof_rejected() {
+    // \x10 and \x20 exist. \x15 does not.
+    let merkle = init_merkle([(b"\x10" as &[u8], b"a"), (b"\x20", b"b")]);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    // Full exclusion proof for \x15 — proves it doesn't exist.
+    let full_proof = merkle.prove(b"\x15").unwrap();
+    assert!(
+        full_proof
+            .value_digest(b"\x15", &root_hash)
+            .unwrap()
+            .is_none(),
+        "full proof should be a valid exclusion proof"
+    );
+
+    // Truncate: remove the terminal node.
+    let mut nodes: Vec<crate::ProofNode> = full_proof.as_ref().to_vec();
+    assert!(
+        nodes.len() >= 2,
+        "proof must have at least 2 nodes to truncate"
+    );
+    nodes.pop();
+    let truncated = crate::Proof::new(nodes.into_boxed_slice());
+
+    // The truncated proof must be rejected — the remaining terminal node
+    // has a child toward \x15 but the proof doesn't include it.
+    let result = truncated.value_digest(b"\x15", &root_hash);
+    assert!(
+        matches!(result, Err(crate::ProofError::ExclusionProofMissingChild)),
+        "truncated exclusion proof should be rejected with ExclusionProofMissingChild, got {result:?}"
+    );
+}

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -487,9 +487,6 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
         // extends past or diverges from the key), this is the valid
         // "divergent child" case — the node occupies the position where
         // the key would be, proving it cannot exist.
-        //
-        // This matches AvalancheGo's verifyProofPath behavior which
-        // returns ErrExclusionProofMissingEndNodes in the ancestor case.
         if let Some(next_idx) = next_nibble(last_node.full_path(), key.as_components())
             && last_node.children()[next_idx].is_some()
         {

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -239,6 +239,11 @@ pub enum ProofError {
     /// Proof node is unreachable in the proving trie during collapse                                                 
     #[error("proof node unreachable in proving trie")]
     ProofNodeUnreachable,
+
+    /// Exclusion proof is incomplete — the terminal node has a child at the
+    /// boundary index, so the proof must include that child.
+    #[error("exclusion proof missing child at boundary index")]
+    ExclusionProofMissingChild,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -466,7 +471,31 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
             return Ok(last_node.value_digest());
         }
 
-        // This is an exclusion proof.
+        // Exclusion proof validation.
+        //
+        // If the last node is an ancestor of the key (its key is a strict
+        // prefix of the proven key), check whether a child exists at the
+        // next nibble. If a child exists there, the proof is incomplete —
+        // it must include that child to demonstrate the key's absence.
+        // Without the child, the verifier cannot tell whether the key
+        // exists deeper in the trie.
+        //
+        // When no child exists at the next nibble, the ancestor alone is
+        // sufficient: the absence of a child proves the key cannot exist.
+        //
+        // When the last node's key is NOT an ancestor of the key (it
+        // extends past or diverges from the key), this is the valid
+        // "divergent child" case — the node occupies the position where
+        // the key would be, proving it cannot exist.
+        //
+        // This matches AvalancheGo's verifyProofPath behavior which
+        // returns ErrExclusionProofMissingEndNodes in the ancestor case.
+        if let Some(next_idx) = next_nibble(last_node.full_path(), key.as_components())
+            && last_node.children()[next_idx].is_some()
+        {
+            return Err(ProofError::ExclusionProofMissingChild);
+        }
+
         Ok(None)
     }
 


### PR DESCRIPTION
## Why this should be merged

This is porting a fix from the rkuris/restructure-squashed branch that was accidentally omitted in the previous PRs. Interestingly, none of our unit/integration tests caught this missing fix. It was only discovered as I was porting over the fuzz tests. I've added a new regression test specifically for this case.

This PR fixes the following: An exclusion proof can be truncated by removing the terminal node. If the remaining terminal node is an ancestor of the proven key and has a child at the next nibble toward that key, the truncated proof is incomplete. The verifier cannot determine whether the key exists deeper in the trie. Without the check added in this PR, a truncated exclusion proof can pass both structural validation and root hash verification, allowing an attacker to mask tampered batch_ops in change proofs.

This check matches AvalancheGo's verifyProofPath behavior which returns ErrExclusionProofMissingEndNodes in the ancestor case.

## How this works

  - Add ExclusionProofMissingChild variant to ProofError
  - In Proof::value_digest(), before returning Ok(None) for exclusion proofs, check if the terminal node has a child at the next nibble toward the key. If it does, the proof is incomplete — return Err(ExclusionProofMissingChild)
  - Add regression test truncated_exclusion_proof_rejected that creates an exclusion proof, truncates the terminal node, and verifies rejection

## How this was tested

  - truncated_exclusion_proof_rejected — fails without fix (returns Ok(None)), passes with fix
  - CI

## Breaking Changes

  - None