### PR TITLE
fix: resolve false rejection at straddling nibbles in collapse_strip

### DIFF
--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -9,13 +9,15 @@ use firewood_storage::{
 
 use crate::{ProofError, api, merkle::Merkle};
 
-/// Returns `true` when a child at nibble `child_nib` under the accumulated
-/// prefix `acc_prefix` falls within `[start_nib, end_nib]` (inclusive).
+/// Returns `true` when a nibble at position `child_nib` under the accumulated
+/// prefix `acc_prefix` could contain keys within `[start_nib, end_nib]`.
 ///
-/// Used by [`Merkle::collapse_strip`] to distinguish in-range children
-/// (which indicate tampered `batch_ops`) from out-of-range children (which
-/// are stripped normally).
-fn child_in_range(
+/// This is a fast, nibble-level check used by [`Merkle::child_in_range`] as
+/// a first pass. It may return `true` for straddling nibbles — positions
+/// where the boundary passes through the subtree — even if no actual keys
+/// in the subtree are in range. `child_in_range` recurses into the subtree
+/// to resolve those cases.
+fn nibble_in_range(
     acc_prefix: &[u8],
     nibble: PathComponent,
     start_nib: &[u8],
@@ -287,15 +289,61 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
         Ok(node)
     }
 
+    /// Returns `true` when the subtree rooted at `child` contains any key
+    /// within `[start_nib, end_nib]`.
+    ///
+    /// Reads the child node, computes its full nibble prefix, and checks
+    /// whether the key is in range. For leaves this is a direct comparison.
+    /// For branches, recurses into children whose nibble passes
+    /// [`nibble_in_range`] to resolve straddling positions.
+    ///
+    /// The caller is responsible for checking [`nibble_in_range`] and taking
+    /// the child from its slot before calling this method. The child is
+    /// consumed regardless of the result.
+    fn child_in_range(
+        &mut self,
+        child: Child,
+        acc_prefix: &[u8],
+        nibble: PathComponent,
+        start_nib: &[u8],
+        end_nib: &[u8],
+    ) -> Result<bool, api::Error> {
+        if !nibble_in_range(acc_prefix, nibble, start_nib, end_nib) {
+            return Ok(false);
+        }
+
+        let mut child_node = self.read_for_update(child)?;
+        let pfx = build_child_prefix(acc_prefix, nibble.0.as_u8(), &child_node);
+        let key_in_range = pfx.as_ref() >= start_nib && pfx.as_ref() <= end_nib;
+
+        let Some(branch) = child_node.as_branch_mut() else {
+            return Ok(key_in_range);
+        };
+
+        if key_in_range && branch.value.is_some() {
+            return Ok(true);
+        }
+
+        for (child_nibble, child_slot) in &mut branch.children {
+            let Some(inner_child) = child_slot.take() else {
+                continue;
+            };
+            if self.child_in_range(inner_child, &pfx, child_nibble, start_nib, end_nib)? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     /// Strip non-on-path children from an intermediate branch and recurse.
     /// Flattens single-child branches to match `end_root`'s path-compressed
     /// structure.
     ///
-    /// Children that are both in-range AND proposal-local (created by this
-    /// proposal's `batch_ops`) trigger `EndRootMismatch` — they indicate
-    /// tampered operations since `end_root` has no branch at this position.
-    /// In-range children inherited from the parent are legitimate unchanged
-    /// keys and are stripped normally (handled by proof hashes).
+    /// Non-on-path children containing in-range keys trigger
+    /// `EndRootMismatch` — they indicate tampered `batch_ops` since
+    /// `end_root` has no branch at this position. Non-on-path children
+    /// containing only out-of-range keys are stripped normally (accounted
+    /// for by proof hashes).
     fn collapse_strip(
         &mut self,
         mut node: Node,
@@ -313,17 +361,19 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
         };
 
         for (nibble, slot) in &mut branch.children {
-            if nibble == on_path || slot.is_none() {
+            if nibble == on_path {
                 continue;
             }
 
+            let Some(child) = slot.take() else {
+                continue;
+            };
+
             if let Some((start_nib, end_nib)) = range
-                && child_in_range(acc_prefix, nibble, start_nib, end_nib)
+                && self.child_in_range(child, acc_prefix, nibble, start_nib, end_nib)?
             {
                 return Err(api::Error::ProofError(ProofError::EndRootMismatch));
             }
-
-            *slot = None;
         }
         branch.value = None;
 
@@ -374,35 +424,35 @@ mod tests {
     }
 
     #[test]
-    fn test_child_in_range() {
+    fn test_nibble_in_range() {
         let pc = |n| PathComponent::try_new(n).unwrap();
 
         // inside range
-        assert!(child_in_range(&[0xa], pc(0x5), &[0xa, 0x0], &[0xa, 0xf]));
+        assert!(nibble_in_range(&[0xa], pc(0x5), &[0xa, 0x0], &[0xa, 0xf]));
         // before start
-        assert!(!child_in_range(&[0xa], pc(0x2), &[0xa, 0x5], &[0xa, 0xf]));
+        assert!(!nibble_in_range(&[0xa], pc(0x2), &[0xa, 0x5], &[0xa, 0xf]));
         // after end
-        assert!(!child_in_range(&[0xa], pc(0xf), &[0xa, 0x0], &[0xa, 0x5]));
+        assert!(!nibble_in_range(&[0xa], pc(0xf), &[0xa, 0x0], &[0xa, 0x5]));
         // at start boundary
-        assert!(child_in_range(&[0xa], pc(0x5), &[0xa, 0x5], &[0xa, 0xf]));
+        assert!(nibble_in_range(&[0xa], pc(0x5), &[0xa, 0x5], &[0xa, 0xf]));
         // at end boundary
-        assert!(child_in_range(&[0xa], pc(0x5), &[0xa, 0x0], &[0xa, 0x5]));
+        assert!(nibble_in_range(&[0xa], pc(0x5), &[0xa, 0x0], &[0xa, 0x5]));
         // acc_prefix past start — in range regardless of nibble
-        assert!(child_in_range(&[0xb], pc(0x0), &[0xa, 0x5], &[0xf, 0x0]));
+        assert!(nibble_in_range(&[0xb], pc(0x0), &[0xa, 0x5], &[0xf, 0x0]));
         // acc_prefix before end — in range regardless of nibble
-        assert!(child_in_range(&[0xa], pc(0xf), &[0x0, 0x0], &[0xb, 0x0]));
+        assert!(nibble_in_range(&[0xa], pc(0xf), &[0x0, 0x0], &[0xb, 0x0]));
         // empty prefix
-        assert!(child_in_range(&[], pc(0x5), &[0x0], &[0xf]));
-        assert!(!child_in_range(&[], pc(0x5), &[0x6], &[0xf]));
+        assert!(nibble_in_range(&[], pc(0x5), &[0x0], &[0xf]));
+        assert!(!nibble_in_range(&[], pc(0x5), &[0x6], &[0xf]));
         // start shorter than depth — child is past start
-        assert!(child_in_range(
+        assert!(nibble_in_range(
             &[0xa, 0xb],
             pc(0x0),
             &[0xa],
             &[0xa, 0xb, 0xf]
         ));
         // end shorter than depth — child is past end
-        assert!(!child_in_range(
+        assert!(!nibble_in_range(
             &[0xa, 0xb],
             pc(0x0),
             &[0xa, 0xb, 0x0],

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -296,13 +296,9 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
     /// whether the key is in range. For leaves this is a direct comparison.
     /// For branches, recurses into children whose nibble passes
     /// [`nibble_in_range`] to resolve straddling positions.
-    ///
-    /// The caller is responsible for checking [`nibble_in_range`] and taking
-    /// the child from its slot before calling this method. The child is
-    /// consumed regardless of the result.
     fn child_in_range(
-        &mut self,
-        child: Child,
+        &self,
+        child: &Child,
         acc_prefix: &[u8],
         nibble: PathComponent,
         start_nib: &[u8],
@@ -312,11 +308,11 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             return Ok(false);
         }
 
-        let mut child_node = self.read_for_update(child)?;
+        let child_node = child.as_shared_node(&self.nodestore)?;
         let pfx = build_child_prefix(acc_prefix, nibble.0.as_u8(), &child_node);
         let key_in_range = pfx.as_ref() >= start_nib && pfx.as_ref() <= end_nib;
 
-        let Some(branch) = child_node.as_branch_mut() else {
+        let Some(branch) = child_node.as_branch() else {
             return Ok(key_in_range);
         };
 
@@ -324,8 +320,8 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             return Ok(true);
         }
 
-        for (child_nibble, child_slot) in &mut branch.children {
-            let Some(inner_child) = child_slot.take() else {
+        for (child_nibble, child_slot) in &branch.children {
+            let Some(inner_child) = child_slot else {
                 continue;
             };
             if self.child_in_range(inner_child, &pfx, child_nibble, start_nib, end_nib)? {
@@ -365,15 +361,14 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
                 continue;
             }
 
-            let Some(child) = slot.take() else {
-                continue;
-            };
-
             if let Some((start_nib, end_nib)) = range
+                && let Some(child) = slot.as_ref()
                 && self.child_in_range(child, acc_prefix, nibble, start_nib, end_nib)?
             {
                 return Err(api::Error::ProofError(ProofError::EndRootMismatch));
             }
+
+            *slot = None;
         }
         branch.value = None;
 
@@ -449,7 +444,7 @@ mod tests {
         let child = setup(&mut merkle);
         let pc = PathComponent::try_new(nibble).unwrap();
         let result = merkle
-            .child_in_range(child, acc_prefix, pc, start_nib, end_nib)
+            .child_in_range(&child, acc_prefix, pc, start_nib, end_nib)
             .unwrap();
         assert_eq!(
             result, expected,

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -423,6 +423,113 @@ mod tests {
         Merkle { nodestore }
     }
 
+    type TestMerkle = Merkle<NodeStore<Mutable<Propose>, MemStore>>;
+
+    fn branch_child(m: &mut TestMerkle, keys: &[&[u8]], nibble: u8) -> Child {
+        for key in keys {
+            m.insert(key, Box::from(b"v".as_slice())).unwrap();
+        }
+        let mut root = m.nodestore.root_mut().take().unwrap();
+        root.as_branch_mut()
+            .unwrap()
+            .children
+            .take(PathComponent::try_new(nibble).unwrap())
+            .unwrap()
+    }
+
+    fn check_child_in_range(
+        setup: impl FnOnce(&mut TestMerkle) -> Child,
+        acc_prefix: &[u8],
+        nibble: u8,
+        start_nib: &[u8],
+        end_nib: &[u8],
+        expected: bool,
+    ) {
+        let mut merkle = create_test_merkle();
+        let child = setup(&mut merkle);
+        let pc = PathComponent::try_new(nibble).unwrap();
+        let result = merkle
+            .child_in_range(child, acc_prefix, pc, start_nib, end_nib)
+            .unwrap();
+        assert_eq!(
+            result, expected,
+            "acc_prefix={acc_prefix:x?} nibble={nibble:#x} range=[{start_nib:x?}, {end_nib:x?}]"
+        );
+    }
+
+    #[test]
+    fn test_child_in_range() {
+        // nibble clearly out of range — returns false without reading
+        check_child_in_range(
+            |m| branch_child(m, &[b"\x50", b"\x60"], 0x5),
+            &[],
+            0x5,
+            &[0x8],
+            &[0xf],
+            false,
+        );
+
+        // leaf: nibble straddles start, full key [0,0] < start [0,1]
+        check_child_in_range(
+            |m| branch_child(m, &[b"\x00", b"\x10"], 0x0),
+            &[],
+            0x0,
+            &[0x0, 0x1],
+            &[0x1, 0x0],
+            false,
+        );
+
+        // leaf: nibble straddles start, full key [0,5] >= start [0,1]
+        check_child_in_range(
+            |m| branch_child(m, &[b"\x05", b"\x10"], 0x0),
+            &[],
+            0x0,
+            &[0x0, 0x1],
+            &[0x1, 0x0],
+            true,
+        );
+
+        // leaf: nibble straddles end, full key [3,f] > end [3,0]
+        check_child_in_range(
+            |m| branch_child(m, &[b"\x3f", b"\x10"], 0x3),
+            &[],
+            0x3,
+            &[0x1, 0x0],
+            &[0x3, 0x0],
+            false,
+        );
+
+        // branch: all children out of range ([0,0,0,0] and [0,0,5,0] both < [0,1])
+        check_child_in_range(
+            |m| branch_child(m, &[b"\x00\x00", b"\x00\x50", b"\x10"], 0x0),
+            &[],
+            0x0,
+            &[0x0, 0x1],
+            &[0x0, 0xf],
+            false,
+        );
+
+        // branch: one child in range ([0,1,0,0] >= [0,1])
+        check_child_in_range(
+            |m| branch_child(m, &[b"\x00\x00", b"\x01\x00", b"\x10"], 0x0),
+            &[],
+            0x0,
+            &[0x0, 0x1],
+            &[0x0, 0xf],
+            true,
+        );
+
+        // branch with value: key [0,0] in range [0,0]..[0,f], has value
+        check_child_in_range(
+            |m| branch_child(m, &[b"\x00", b"\x00\x50", b"\x10"], 0x0),
+            &[],
+            0x0,
+            &[0x0, 0x0],
+            &[0x0, 0xf],
+            true,
+        );
+    }
+
     #[test]
     fn test_nibble_in_range() {
         let pc = |n| PathComponent::try_new(n).unwrap();

--- a/firewood/src/merkle/tests/change/attack.rs
+++ b/firewood/src/merkle/tests/change/attack.rs
@@ -1,0 +1,77 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+//! Attack detection: forged, omitted, or spurious batch ops.
+
+use super::*;
+
+/// Helper: returns true if the (possibly corrupted) proof is rejected by
+/// either the structural check or the root hash check.
+fn is_rejected(
+    db: &Db,
+    proof: &FrozenChangeProof,
+    end_root: api::HashKey,
+    start_key: Option<&[u8]>,
+    end_key: Option<&[u8]>,
+    start_root: api::HashKey,
+) -> bool {
+    match verify_change_proof_structure(proof, end_root, start_key, end_key, None) {
+        Err(_) => true,
+        Ok(ctx) => verify_and_check(db, proof, &ctx, start_root).is_err(),
+    }
+}
+
+/// Security test: an attacker removes `Delete(\x05)` from `batch_ops`.
+///
+/// `\x05` is in-range (>= `start_key` `\x01`) and shares nibble 0 with the
+/// out-of-range `\x00`. If the collapse step unconditionally strips all
+/// non-on-path children (without checking for in-range keys), the proving
+/// trie is flattened to match `end_root` and the tampered proof is accepted.
+///
+/// The verifier would then commit the incomplete `batch_ops`, leaving `\x05`
+/// in their state when `end_root` says it shouldn't exist.
+#[test]
+fn test_crafted_omitted_delete_at_straddling_nibble() {
+    // start_root: \x00, \x05, \x10
+    let (db, _dir) = setup_db![(b"\x00", b"a"), (b"\x05", b"e"), (b"\x10", b"b")];
+    let root1 = db.root_hash().unwrap();
+
+    // end_root: only \x10 (both \x00 and \x05 deleted)
+    db.propose(vec![
+        BatchOp::Delete {
+            key: b"\x00" as &[u8],
+        },
+        BatchOp::Delete { key: b"\x05" },
+        BatchOp::Put {
+            key: b"\x10",
+            value: b"changed",
+        },
+    ])
+    .unwrap()
+    .commit()
+    .unwrap();
+    let root2 = db.root_hash().unwrap();
+
+    // Generate the honest proof (start_key=\x01: \x00 delete is out of range)
+    let honest = db
+        .change_proof(root1.clone(), root2.clone(), Some(b"\x01"), None, None)
+        .unwrap();
+
+    // The honest proof should have Delete(\x05) and Put(\x10, "changed")
+    assert_eq!(honest.batch_ops().len(), 2);
+
+    // Craft a tampered proof: remove Delete(\x05), keep only Put(\x10)
+    let tampered = FrozenChangeProof::new(
+        crate::Proof::new(honest.start_proof().as_ref().into()),
+        crate::Proof::new(honest.end_proof().as_ref().into()),
+        Box::new([BatchOp::Put {
+            key: b"\x10".to_vec().into(),
+            value: b"changed".to_vec().into(),
+        }]),
+    );
+
+    assert!(
+        is_rejected(&db, &tampered, root2, Some(b"\x01"), None, root1),
+        "tampered proof with omitted Delete at straddling nibble should be rejected"
+    );
+}

--- a/firewood/src/merkle/tests/change/bounds.rs
+++ b/firewood/src/merkle/tests/change/bounds.rs
@@ -41,6 +41,42 @@ fn test_verify(start_key: Option<&[u8]>, end_key: Option<&[u8]>, change_key: &[u
     assert_eq!(target.root_hash().unwrap(), root2);
 }
 
+/// Delete a key outside the requested range while changing one inside it.
+/// The start boundary (`b"\x01"`) falls between the deleted key (`b"\x00"`)
+/// and the changed key (`b"\x10"`), so the delete is out-of-range and the
+/// proof must still verify.
+#[test]
+fn test_inherited_key_at_start_boundary_accepted() {
+    let (db, _dir) = setup_db![(b"\x00", b"a"), (b"\x10", b"b")];
+    let root1 = db.root_hash().unwrap();
+    db.propose(vec![
+        BatchOp::Delete {
+            key: b"\x00" as &[u8],
+        },
+        BatchOp::Put {
+            key: b"\x10",
+            value: b"changed",
+        },
+    ])
+    .unwrap()
+    .commit()
+    .unwrap();
+    let root2 = db.root_hash().unwrap();
+
+    let proof = db
+        .change_proof(
+            root1.clone(),
+            root2.clone(),
+            Some(b"\x01".as_ref()),
+            None,
+            None,
+        )
+        .unwrap();
+
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x01"), None, None).unwrap();
+    verify_and_check(&db, &proof, &ctx, root1).unwrap();
+}
+
 /// When `requested_end_key` is set and the proof is complete (not truncated),
 /// the right edge proof anchors at `requested_end_key`, not the last batch key.
 #[test]

--- a/firewood/src/merkle/tests/change/mod.rs
+++ b/firewood/src/merkle/tests/change/mod.rs
@@ -75,6 +75,7 @@ pub(super) fn verify_and_check(
 
 // ── Test modules ──────────────────────────────────────────────────────────
 
+mod attack;
 mod bounds;
 // Empty start trie tests require ethhash: without it, the empty trie has no
 // root hash, so change proofs from an empty database can't be generated.


### PR DESCRIPTION
## Why this should be merged                                                                                                                                                                                                                         
                  
collapse_strip incorrectly rejects valid change proofs when an inherited out-of-range key sits at a nibble position that straddles the proof's boundary range. The nibble-level range check (child_in_range) cannot distinguish inherited         
out-of-range keys from in-range keys that indicate tampered batch_ops, causing legitimate proofs to fail with EndRootMismatch.
                                                                                                                                                                                                                                                      
## How this works                                                                                                                                                                                                                                    
                  
Renames the existing nibble-level check to nibble_in_range and introduces a new child_in_range method that recurses into the subtree when the nibble-level check is ambiguous (straddling). For leaves, the full key is compared directly against the range. For branches, children are pruned with nibble_in_range and checked recursively. The recursion terminates quickly because path compression keeps subtrees between proof nodes shallow.

child_in_range is read-only — it borrows the child via as_shared_node and inspects the subtree without mutating the nodestore. The caller in collapse_strip strips the child afterward.
                                                                                                                                                                                                                                                    
  - Out-of-range subtrees: stripped                                                                                                                                                                                             
  - In-range keys found: rejected with EndRootMismatch
                                                                                                                                                                                                                                                    
## How this was tested
                                                                                                                                                                                                                                                    
  - test_inherited_key_at_start_boundary_accepted — legitimate proof with only out-of-range keys under a straddling nibble (previously failed, now passes)                                                                                          
  - test_crafted_omitted_delete_at_straddling_nibble — tampered proof with in-range key hidden under the same straddling nibble (security test, passes)
  - New test_child_in_range unit test. Old one renamed test_nibble_in_range.
  -  CI 
                                                                                                                                                                                                                                                    
## Breaking Changes                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                    
  - None