### PR TITLE
chore: export errRevisionNotFound

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -376,7 +376,7 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 	val, err := getValueFromValueResult(C.fwd_get_latest(db.handle, newBorrowedBytes(key, &pinner)))
 	// The revision won't be found if the database is empty.
 	// This is valid, but should be treated as a non-existent key
-	if errors.Is(err, errRevisionNotFound) {
+	if errors.Is(err, ErrRevisionNotFound) {
 		return nil, nil
 	}
 
@@ -425,7 +425,7 @@ func (db *Database) LatestRevision() (*Revision, error) {
 	defer db.commitLock.Unlock()
 	root := db.root()
 	if root == EmptyRoot {
-		return nil, errRevisionNotFound
+		return nil, ErrRevisionNotFound
 	}
 	return db.Revision(root)
 }

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -1119,7 +1119,7 @@ func TestInvalidRevision(t *testing.T) {
 	// Create a fake revision with an valid root.
 	validRoot := Hash([]byte("counting 32 bytes to make a hash"))
 	_, err := db.Revision(validRoot)
-	r.ErrorIs(err, errRevisionNotFound, "Revision(valid root)")
+	r.ErrorIs(err, ErrRevisionNotFound, "Revision(valid root)")
 }
 
 // Tests that edge case `Get` calls are handled correctly.

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -300,7 +300,7 @@ func getValueFromValueResult(result C.ValueResult) ([]byte, error) {
 	case C.ValueResult_RevisionNotFound:
 		// NOTE: the result value contains the provided root hash, we could use
 		// it in the error message if needed.
-		return nil, errRevisionNotFound
+		return nil, ErrRevisionNotFound
 	case C.ValueResult_None:
 		return nil, nil
 	case C.ValueResult_Some:

--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -698,7 +698,7 @@ func getRangeProofFromRangeProofResult(result C.RangeProofResult) (*RangeProof, 
 	case C.RangeProofResult_RevisionNotFound:
 		// NOTE: the result value contains the provided root hash, we could use
 		// it in the error message if needed.
-		return nil, errRevisionNotFound
+		return nil, ErrRevisionNotFound
 	case C.RangeProofResult_EmptyTrie:
 		return nil, errEmptyTrie
 	case C.RangeProofResult_Ok:

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -151,7 +151,7 @@ func TestRangeProofEmptyDB(t *testing.T) {
 	db := newTestDatabase(t)
 
 	proof, err := db.RangeProof(EmptyRoot, nothing(), nothing(), rangeProofLenUnbounded)
-	r.ErrorIs(err, errRevisionNotFound)
+	r.ErrorIs(err, ErrRevisionNotFound)
 	r.Nil(proof)
 }
 
@@ -168,7 +168,7 @@ func TestRangeProofNonExistentRoot(t *testing.T) {
 	root[0] ^= 0xFF
 
 	proof, err := db.RangeProof(root, nothing(), nothing(), rangeProofLenUnbounded)
-	r.ErrorIs(err, errRevisionNotFound)
+	r.ErrorIs(err, ErrRevisionNotFound)
 	r.Nil(proof)
 }
 

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	ErrDroppedRevision       = errors.New("revision already dropped")
-	errRevisionNotFound      = errors.New("revision not found")
+	ErrRevisionNotFound      = errors.New("revision not found")
 	ErrEndRevisionNotFound   = errors.New("end revision not found")
 	ErrStartRevisionNotFound = errors.New("start revision not found")
 )
@@ -156,7 +156,7 @@ func getRevisionFromResult(result C.RevisionResult, wg *sync.WaitGroup) (*Revisi
 	case C.RevisionResult_NullHandlePointer:
 		return nil, errDBClosed
 	case C.RevisionResult_RevisionNotFound:
-		return nil, errRevisionNotFound
+		return nil, ErrRevisionNotFound
 	case C.RevisionResult_Ok:
 		body := (*C.RevisionResult_Ok_Body)(unsafe.Pointer(&result.anon0))
 		hashKey := *(*Hash)(unsafe.Pointer(&body.root_hash._0))


### PR DESCRIPTION
## Why this should be merged

In https://github.com/ava-labs/avalanchego/pull/5318, the block reexecution tests for using Firewood in archival mode check that the revision doesn't exist to verify that we're reexecuting blocks. We've had to define a new error `ErrNoRevisionFound` in Coreth for usage with `require.ErrorIs(...)` but Firewood already defines its own error for this: `errRevisionNotFound` - being able to use this error would be cleaner.

## How this works

Exports `errRevisionNotFound`

## How this was tested

CI

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
