### PR TITLE
perf(storage): add in-tree `crate::rlp` module + benchmark

### DIFF
--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -60,6 +60,7 @@ criterion = { workspace = true, features = ["html_reports"] }
 metrics-util.workspace = true
 pprof = { workspace = true, features = ["flamegraph"] }
 rand.workspace = true
+rlp = "0.6.1"
 tempfile.workspace = true
 test-case.workspace = true
 
@@ -75,6 +76,10 @@ test_utils = ["dep:metrics-util", "dep:rand"]
 
 [[bench]]
 name = "serializer"
+harness = false
+
+[[bench]]
+name = "rlp"
 harness = false
 
 [lints]

--- a/storage/benches/rlp.rs
+++ b/storage/benches/rlp.rs
@@ -155,7 +155,7 @@ fn bench_decode_field_upstream(c: &mut Criterion) {
         b.iter(|| {
             let bytes = black_box(&value);
             let field = rlp::Rlp::new(bytes).at(3).and_then(|r| r.data()).unwrap();
-            black_box(field.to_vec())
+            black_box(field)
         });
     });
 }

--- a/storage/benches/rlp.rs
+++ b/storage/benches/rlp.rs
@@ -1,0 +1,183 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+//! Benchmarks comparing the in-tree `firewood_storage::rlp` module against
+//! the upstream `rlp = "0.6"` crate on the shapes firewood actually uses.
+//!
+//! Three workloads:
+//!
+//! 1. **`branch_encode`** — encode a 17-element list (the Ethereum MPT
+//!    branch shape: 16 32-byte child hashes + an empty value).
+//! 2. **`leaf_encode`** — encode a 2-element list (compact path + 32-byte
+//!    value), the leaf shape.
+//! 3. **`storage_root_replace`** — the hot account-rewrite path: take a
+//!    pre-encoded `[nonce, balance, storageRoot, codeHash]` list and
+//!    replace the 32-byte `storageRoot` field. This is where the new
+//!    module should win biggest because it skips the upstream crate's
+//!    `Vec<Vec<u8>>` round-trip.
+
+#![expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "benchmarks panic on bad fixtures, that's fine"
+)]
+
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use firewood_storage::rlp as fwd_rlp;
+
+// ---------- fixtures ----------
+
+fn branch_children() -> [[u8; 32]; 16] {
+    let mut out = [[0u8; 32]; 16];
+    for (i, child) in out.iter_mut().enumerate() {
+        child.fill(u8::try_from(i).unwrap_or(0xff));
+    }
+    out
+}
+
+fn account_value() -> Vec<u8> {
+    // [nonce=1, balance=0x1234, storageRoot=0xaa.., codeHash=0xbb..]
+    let nonce: &[u8] = &[0x01];
+    let balance: &[u8] = &[0x12, 0x34];
+    let storage_root = [0xaau8; 32];
+    let code_hash = [0xbbu8; 32];
+
+    let mut s = rlp::RlpStream::new_list(4);
+    s.append(&nonce);
+    s.append(&balance);
+    s.append(&storage_root.as_slice());
+    s.append(&code_hash.as_slice());
+    s.out().to_vec()
+}
+
+// ---------- branch encode ----------
+
+fn bench_branch_encode_upstream(c: &mut Criterion) {
+    let children = branch_children();
+    c.bench_function("branch_encode/upstream", |b| {
+        b.iter(|| {
+            let mut s = rlp::RlpStream::new_list(17);
+            for child in black_box(&children) {
+                s.append(&child.as_slice());
+            }
+            s.append_empty_data();
+            black_box(s.out())
+        });
+    });
+}
+
+fn bench_branch_encode_ours(c: &mut Criterion) {
+    let children = branch_children();
+    c.bench_function("branch_encode/ours", |b| {
+        b.iter(|| {
+            let mut items = [fwd_rlp::RlpItem::Empty; 17];
+            for (slot, child) in items.iter_mut().zip(black_box(&children).iter()) {
+                *slot = fwd_rlp::RlpItem::Bytes(child.as_slice());
+            }
+            black_box(fwd_rlp::encode_list(&items))
+        });
+    });
+}
+
+// ---------- leaf encode ----------
+
+fn bench_leaf_encode_upstream(c: &mut Criterion) {
+    let path: &[u8] = &[0x20, 0x01, 0x02, 0x03, 0x04];
+    let value = [0xccu8; 32];
+    c.bench_function("leaf_encode/upstream", |b| {
+        b.iter(|| {
+            let mut s = rlp::RlpStream::new_list(2);
+            s.append(&black_box(path));
+            s.append(&black_box(value).as_slice());
+            black_box(s.out())
+        });
+    });
+}
+
+fn bench_leaf_encode_ours(c: &mut Criterion) {
+    let path: &[u8] = &[0x20, 0x01, 0x02, 0x03, 0x04];
+    let value = [0xccu8; 32];
+    c.bench_function("leaf_encode/ours", |b| {
+        b.iter(|| {
+            black_box(fwd_rlp::encode_list(&[
+                fwd_rlp::RlpItem::Bytes(black_box(path)),
+                fwd_rlp::RlpItem::Bytes(black_box(value).as_slice()),
+            ]))
+        });
+    });
+}
+
+// ---------- storage root replace ----------
+//
+// This is the firewood-specific hot path: rewrite the storageRoot (field 2)
+// of an account RLP. The upstream version mirrors the current
+// `replace_hash` helper: decode to `Vec<Vec<u8>>`, mutate, re-encode.
+
+fn bench_storage_root_replace_upstream(c: &mut Criterion) {
+    let value = account_value();
+    let new_root = [0xddu8; 32];
+    c.bench_function("storage_root_replace/upstream", |b| {
+        b.iter(|| {
+            let bytes = black_box(&value);
+            let mut list: Vec<Vec<u8>> = rlp::Rlp::new(bytes).as_list().unwrap();
+            list[2] = black_box(new_root).to_vec();
+            let mut s = rlp::RlpStream::new_list(list.len());
+            for item in &list {
+                s.append(item);
+            }
+            black_box(s.out())
+        });
+    });
+}
+
+fn bench_storage_root_replace_ours(c: &mut Criterion) {
+    let value = account_value();
+    let new_root = [0xddu8; 32];
+    c.bench_function("storage_root_replace/ours", |b| {
+        b.iter(|| {
+            black_box(
+                fwd_rlp::replace_list_field(black_box(&value), 2, black_box(&new_root)).unwrap(),
+            )
+        });
+    });
+}
+
+// ---------- decode field 3 (FFI proof code-hash extraction) ----------
+
+fn bench_decode_field_upstream(c: &mut Criterion) {
+    let value = account_value();
+    c.bench_function("decode_field3/upstream", |b| {
+        b.iter(|| {
+            let bytes = black_box(&value);
+            let field = rlp::Rlp::new(bytes).at(3).and_then(|r| r.data()).unwrap();
+            black_box(field.to_vec())
+        });
+    });
+}
+
+fn bench_decode_field_ours(c: &mut Criterion) {
+    let value = account_value();
+    c.bench_function("decode_field3/ours", |b| {
+        b.iter(|| {
+            let bytes = black_box(&value);
+            let list = fwd_rlp::RlpList::parse(bytes).unwrap();
+            let field = list.nth_bytes(3).unwrap();
+            black_box(field)
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_branch_encode_upstream,
+    bench_branch_encode_ours,
+    bench_leaf_encode_upstream,
+    bench_leaf_encode_ours,
+    bench_storage_root_replace_upstream,
+    bench_storage_root_replace_ours,
+    bench_decode_field_upstream,
+    bench_decode_field_ours,
+);
+criterion_main!(benches);

--- a/storage/benches/rlp.rs
+++ b/storage/benches/rlp.rs
@@ -4,7 +4,7 @@
 //! Benchmarks comparing the in-tree `firewood_storage::rlp` module against
 //! the upstream `rlp = "0.6"` crate on the shapes firewood actually uses.
 //!
-//! Three workloads:
+//! Four workloads:
 //!
 //! 1. **`branch_encode`** — encode a 17-element list (the Ethereum MPT
 //!    branch shape: 16 32-byte child hashes + an empty value).
@@ -15,6 +15,9 @@
 //!    replace the 32-byte `storageRoot` field. This is where the new
 //!    module should win biggest because it skips the upstream crate's
 //!    `Vec<Vec<u8>>` round-trip.
+//! 4. **`decode_field3`** — extract field 3 (the code-hash) from a
+//!    pre-encoded account RLP. Mirrors the FFI proof code-hash extractor
+//!    in `ffi/src/proofs/change.rs`.
 
 #![expect(
     clippy::unwrap_used,

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -111,9 +111,9 @@ use crate::{
     BranchNode, HashType, Hashable, Preimage, TrieHash, TriePath, ValueDigest,
     hashednode::HasUpdate, logger::trace,
 };
+use ::rlp::{NULL_RLP, Rlp, RlpStream};
 use bitfield::bitfield;
 use bytes::BytesMut;
-use rlp::{Rlp, RlpStream};
 use sha3::{Digest, Keccak256};
 use smallvec::SmallVec;
 use std::iter::once;
@@ -215,7 +215,7 @@ impl<T: Hashable> Preimage for T {
                 // we are a leaf that is at depth 32
                 match self.value_digest() {
                     Some(ValueDigest::Value(bytes)) => {
-                        let new_hash = Keccak256::digest(rlp::NULL_RLP).as_slice().to_vec();
+                        let new_hash = Keccak256::digest(NULL_RLP).as_slice().to_vec();
                         let bytes_mut = BytesMut::from(bytes);
                         if let Some(result) = replace_hash(bytes_mut, new_hash) {
                             rlp.append(&&*result);

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -41,6 +41,9 @@ mod u4;
 /// Logger module for handling logging functionality
 pub mod logger;
 
+/// Minimal in-tree RLP encoder/decoder used by ethhash and account-value handling.
+pub mod rlp;
+
 #[macro_use]
 /// Macros module for defining macros used in the storage module
 pub mod macros;
@@ -431,8 +434,10 @@ pub fn format_node_value<W: std::io::Write + ?Sized>(
     writer: &mut W,
 ) -> std::io::Result<()> {
     #[cfg(feature = "ethhash")]
+    use ::rlp::Rlp;
+    #[cfg(feature = "ethhash")]
     if value.first().is_some_and(|&b| b >= 0xc0)
-        && let Ok(rlp_list) = rlp::Rlp::new(value).as_list::<Vec<u8>>()
+        && let Ok(rlp_list) = Rlp::new(value).as_list::<Vec<u8>>()
         && !rlp_list.is_empty()
     {
         write!(writer, " rlp=[")?;
@@ -508,8 +513,9 @@ mod format_node_value_tests {
     #[cfg(feature = "ethhash")]
     #[test]
     fn rlp_list_decoded() {
+        use ::rlp::RlpStream;
         // RLP encode [0x01, 0x02] as a 2-item list.
-        let mut rlp = rlp::RlpStream::new_list(2);
+        let mut rlp = RlpStream::new_list(2);
         rlp.append(&vec![0x01u8]);
         rlp.append(&vec![0x02u8]);
         let encoded = rlp.out();

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -287,13 +287,13 @@ pub fn fix_account_storage_root_value(
 ) -> Option<Box<[u8]>> {
     use crate::hashers::ethhash::replace_hash;
     use crate::node::BranchNode;
-    use rlp::RlpStream;
+    use ::rlp::{NULL_RLP, RlpStream};
     use sha3::{Digest, Keccak256};
 
     let children_count = child_hashes.iter().filter(|(_, c)| c.is_some()).count();
 
     let storage_root = if children_count == 0 {
-        crate::TrieHash::from(Keccak256::digest(rlp::NULL_RLP))
+        crate::TrieHash::from(Keccak256::digest(NULL_RLP))
     } else {
         let mut child_hashes = child_hashes.clone();
         if let Some((_, child)) = child_hashes.take_only_child() {

--- a/storage/src/rlp.rs
+++ b/storage/src/rlp.rs
@@ -53,6 +53,7 @@ pub enum RlpItem<'a> {
 
 /// Encode a single byte-string item.
 #[must_use]
+#[inline]
 pub fn encode_bytes(b: &[u8]) -> Box<[u8]> {
     let mut out = Vec::with_capacity(bytes_encoded_len(b));
     write_bytes(&mut out, b);
@@ -61,6 +62,7 @@ pub fn encode_bytes(b: &[u8]) -> Box<[u8]> {
 
 /// Encode a slice of children as one RLP list. Single allocation.
 #[must_use]
+#[inline]
 pub fn encode_list(items: &[RlpItem<'_>]) -> Box<[u8]> {
     let payload_len: usize = items.iter().map(RlpItem::encoded_len).sum();
     // safe: header_len <= 9 and payload_len already fits in memory.
@@ -88,6 +90,7 @@ impl<'a> RlpList<'a> {
     /// Returns [`RlpError::ExpectedList`] if `bytes` encodes a byte string,
     /// [`RlpError::Truncated`] if the input ends mid-item, and
     /// [`RlpError::TrailingBytes`] if extra bytes follow the list.
+    #[inline]
     pub fn parse(bytes: &'a [u8]) -> Result<Self, RlpError> {
         let header = parse_header(bytes)?;
         if header.kind != ItemKind::List {
@@ -112,6 +115,7 @@ impl<'a> RlpList<'a> {
     ///
     /// Returns [`RlpError::ExpectedBytes`] if any child is itself a list,
     /// or any header-decoding error if the payload is malformed.
+    #[inline]
     pub fn fields(&self) -> Result<Vec<&'a [u8]>, RlpError> {
         let mut out = Vec::new();
         let mut rest = self.payload;
@@ -130,6 +134,7 @@ impl<'a> RlpList<'a> {
     /// Returns [`RlpError::IndexOutOfRange`] if the list has fewer than
     /// `i + 1` children, or [`RlpError::ExpectedBytes`] if the target
     /// child is itself a list.
+    #[inline]
     pub fn nth_bytes(&self, i: usize) -> Result<&'a [u8], RlpError> {
         let mut rest = self.payload;
         for _ in 0..i {
@@ -150,6 +155,7 @@ impl<'a> RlpList<'a> {
 /// Read one byte-string child from the start of a non-empty `payload`,
 /// returning the field bytes and the remainder. Errors if the next item is
 /// a list or has a malformed header.
+#[inline]
 fn next_field(payload: &[u8]) -> Result<(&[u8], &[u8]), RlpError> {
     let header = parse_header(payload)?;
     let total = header.total_len()?;
@@ -170,6 +176,7 @@ fn next_field(payload: &[u8]) -> Result<(&[u8], &[u8]), RlpError> {
 ///
 /// Returns an [`RlpError`] if `input` is malformed, is not a list, has fewer
 /// than `field_index + 1` children, or the target child is itself a list.
+#[inline]
 pub fn replace_list_field(
     input: &[u8],
     field_index: usize,
@@ -253,6 +260,7 @@ struct ItemHeader {
 }
 
 impl ItemHeader {
+    #[inline]
     fn total_len(&self) -> Result<usize, RlpError> {
         self.header_len
             .checked_add(self.payload_len)
@@ -261,6 +269,7 @@ impl ItemHeader {
 }
 
 impl RlpItem<'_> {
+    #[inline]
     fn encoded_len(&self) -> usize {
         match self {
             RlpItem::Bytes(b) => bytes_encoded_len(b),
@@ -269,6 +278,7 @@ impl RlpItem<'_> {
         }
     }
 
+    #[inline]
     fn write_into(&self, out: &mut Vec<u8>) {
         match self {
             RlpItem::Bytes(b) => write_bytes(out, b),
@@ -278,6 +288,7 @@ impl RlpItem<'_> {
     }
 }
 
+#[inline]
 fn parse_header(input: &[u8]) -> Result<ItemHeader, RlpError> {
     let &first = input.first().ok_or(RlpError::Truncated)?;
     // All `wrapping_sub`s below are bounded by their match arms.
@@ -312,6 +323,7 @@ fn parse_header(input: &[u8]) -> Result<ItemHeader, RlpError> {
     }
 }
 
+#[inline]
 fn parse_long_header(
     input: &[u8],
     len_of_len: usize,
@@ -336,6 +348,7 @@ fn parse_long_header(
     })
 }
 
+#[inline]
 fn read_be_usize(bytes: &[u8]) -> usize {
     // Caller checks `bytes.len() <= size_of::<usize>()`, so the shift never
     // loses bits.
@@ -344,6 +357,7 @@ fn read_be_usize(bytes: &[u8]) -> usize {
         .fold(0usize, |acc, &b| (acc << 8) | usize::from(b))
 }
 
+#[inline]
 fn write_bytes(out: &mut Vec<u8>, b: &[u8]) {
     if b.len() == 1 && b.first().is_some_and(|&v| v < 0x80) {
         out.extend_from_slice(b);
@@ -353,6 +367,7 @@ fn write_bytes(out: &mut Vec<u8>, b: &[u8]) {
     }
 }
 
+#[inline]
 fn bytes_encoded_len(b: &[u8]) -> usize {
     if b.len() == 1 && b.first().is_some_and(|&v| v < 0x80) {
         1
@@ -362,6 +377,7 @@ fn bytes_encoded_len(b: &[u8]) -> usize {
     }
 }
 
+#[inline]
 const fn header_len(payload_len: usize) -> usize {
     if payload_len < 56 {
         1
@@ -372,6 +388,7 @@ const fn header_len(payload_len: usize) -> usize {
 
 /// Write the RLP header for a payload. `short_base` is `0x80` for byte
 /// strings and `0xc0` for lists; the long-form base is `short_base + 55`.
+#[inline]
 fn write_header(out: &mut Vec<u8>, payload_len: usize, short_base: u8) {
     if payload_len < 56 {
         out.push(short_base.wrapping_add(payload_len as u8));
@@ -388,6 +405,7 @@ fn write_header(out: &mut Vec<u8>, payload_len: usize, short_base: u8) {
     }
 }
 
+#[inline]
 const fn minimal_be_len(n: usize) -> usize {
     if n == 0 {
         0

--- a/storage/src/rlp.rs
+++ b/storage/src/rlp.rs
@@ -1,0 +1,652 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+//! Minimal RLP encoder/decoder tailored to firewood's usage.
+//!
+//! Covers only the shapes firewood needs: encoding flat lists, decoding flat
+//! lists of byte-string children (borrowed, no `Vec<Vec<u8>>`), and splicing
+//! one byte-string field of a list (`replace_list_field`, used for the
+//! account `storageRoot` rewrite). No nested-list decoding, no
+//! `Encodable`/`Decodable` traits, no streaming builder.
+
+use thiserror::Error;
+
+/// RLP encoding of an empty byte string (`0x80`).
+pub const NULL_RLP: &[u8] = &[0x80];
+
+/// Errors produced while decoding RLP.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum RlpError {
+    /// Input ended before the current item finished.
+    #[error("RLP input truncated")]
+    Truncated,
+    /// A length prefix exceeds `usize`.
+    #[error("RLP length prefix overflows")]
+    Overflow,
+    /// Expected a byte-string item, found a list.
+    #[error("expected a byte string, found a list")]
+    ExpectedBytes,
+    /// Expected a list item, found a byte string.
+    #[error("expected a list, found a byte string")]
+    ExpectedList,
+    /// Index past the last element of a list.
+    #[error("RLP index {0} out of range")]
+    IndexOutOfRange(usize),
+    /// Bytes followed the parsed item.
+    #[error("trailing bytes after RLP item")]
+    TrailingBytes,
+    /// Length prefix or single-byte form was not used in its minimal encoding.
+    #[error("non-minimal RLP length encoding")]
+    NonMinimalLength,
+}
+
+/// One child of a list passed to [`encode_list`].
+#[derive(Copy, Clone, Debug)]
+pub enum RlpItem<'a> {
+    /// A byte-string child; the appropriate RLP header is added by the encoder.
+    Bytes(&'a [u8]),
+    /// A pre-encoded RLP item whose bytes are copied verbatim.
+    Raw(&'a [u8]),
+    /// The empty byte-string marker (`0x80`).
+    Empty,
+}
+
+/// Encode a single byte-string item.
+#[must_use]
+pub fn encode_bytes(b: &[u8]) -> Box<[u8]> {
+    let mut out = Vec::with_capacity(bytes_encoded_len(b));
+    write_bytes(&mut out, b);
+    out.into_boxed_slice()
+}
+
+/// Encode a slice of children as one RLP list. Single allocation.
+#[must_use]
+pub fn encode_list(items: &[RlpItem<'_>]) -> Box<[u8]> {
+    let payload_len: usize = items.iter().map(RlpItem::encoded_len).sum();
+    // safe: header_len <= 9 and payload_len already fits in memory.
+    let total = header_len(payload_len).wrapping_add(payload_len);
+    let mut out = Vec::with_capacity(total);
+    write_header(&mut out, payload_len, 0xc0);
+    for item in items {
+        item.write_into(&mut out);
+    }
+    debug_assert_eq!(out.len(), total);
+    out.into_boxed_slice()
+}
+
+/// A parsed RLP list, holding a slice into the caller's buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RlpList<'a> {
+    payload: &'a [u8],
+}
+
+impl<'a> RlpList<'a> {
+    /// Parse `bytes` as a single RLP list item.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RlpError::ExpectedList`] if `bytes` encodes a byte string,
+    /// [`RlpError::Truncated`] if the input ends mid-item, and
+    /// [`RlpError::TrailingBytes`] if extra bytes follow the list.
+    pub fn parse(bytes: &'a [u8]) -> Result<Self, RlpError> {
+        let header = parse_header(bytes)?;
+        if header.kind != ItemKind::List {
+            return Err(RlpError::ExpectedList);
+        }
+        let total = header.total_len()?;
+        if total > bytes.len() {
+            return Err(RlpError::Truncated);
+        }
+        if total < bytes.len() {
+            return Err(RlpError::TrailingBytes);
+        }
+        let payload = bytes
+            .get(header.header_len..total)
+            .ok_or(RlpError::Truncated)?;
+        Ok(Self { payload })
+    }
+
+    /// Collect the list's children into a vector of byte-string slices.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RlpError::ExpectedBytes`] if any child is itself a list,
+    /// or any header-decoding error if the payload is malformed.
+    pub fn fields(&self) -> Result<Vec<&'a [u8]>, RlpError> {
+        let mut out = Vec::new();
+        let mut rest = self.payload;
+        while !rest.is_empty() {
+            let (field, after) = next_field(rest)?;
+            out.push(field);
+            rest = after;
+        }
+        Ok(out)
+    }
+
+    /// Return the `i`-th child as a byte-string slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RlpError::IndexOutOfRange`] if the list has fewer than
+    /// `i + 1` children, or [`RlpError::ExpectedBytes`] if the target
+    /// child is itself a list.
+    pub fn nth_bytes(&self, i: usize) -> Result<&'a [u8], RlpError> {
+        let mut rest = self.payload;
+        for _ in 0..i {
+            if rest.is_empty() {
+                return Err(RlpError::IndexOutOfRange(i));
+            }
+            let (_, after) = next_field(rest)?;
+            rest = after;
+        }
+        if rest.is_empty() {
+            return Err(RlpError::IndexOutOfRange(i));
+        }
+        let (field, _) = next_field(rest)?;
+        Ok(field)
+    }
+}
+
+/// Read one byte-string child from the start of a non-empty `payload`,
+/// returning the field bytes and the remainder. Errors if the next item is
+/// a list or has a malformed header.
+fn next_field(payload: &[u8]) -> Result<(&[u8], &[u8]), RlpError> {
+    let header = parse_header(payload)?;
+    let total = header.total_len()?;
+    let item = payload.get(..total).ok_or(RlpError::Truncated)?;
+    let after = payload.get(total..).unwrap_or(&[]);
+    if header.kind != ItemKind::Bytes {
+        return Err(RlpError::ExpectedBytes);
+    }
+    let field = item.get(header.header_len..).ok_or(RlpError::Truncated)?;
+    Ok((field, after))
+}
+
+/// Return a new RLP list identical to `input` except that the byte-string
+/// at `field_index` is replaced by `replacement`. Equal-length replacement
+/// (the 32-byte hash case) is one allocation plus two `memcpy`s.
+///
+/// # Errors
+///
+/// Returns an [`RlpError`] if `input` is malformed, is not a list, has fewer
+/// than `field_index + 1` children, or the target child is itself a list.
+pub fn replace_list_field(
+    input: &[u8],
+    field_index: usize,
+    replacement: &[u8],
+) -> Result<Box<[u8]>, RlpError> {
+    let outer = parse_header(input)?;
+    if outer.kind != ItemKind::List {
+        return Err(RlpError::ExpectedList);
+    }
+    let total = outer.total_len()?;
+    if total > input.len() {
+        return Err(RlpError::Truncated);
+    }
+    if total < input.len() {
+        return Err(RlpError::TrailingBytes);
+    }
+    let payload = input
+        .get(outer.header_len..total)
+        .ok_or(RlpError::Truncated)?;
+
+    let mut offset = 0usize;
+    let mut idx = 0usize;
+    let (item_start, item_end) = loop {
+        let rest = payload.get(offset..).ok_or(RlpError::Truncated)?;
+        if rest.is_empty() {
+            return Err(RlpError::IndexOutOfRange(field_index));
+        }
+        let item = parse_header(rest)?;
+        let item_total = item.total_len()?;
+        // Reject items whose header advertises more bytes than `rest` actually
+        // contains. Without this, a malicious header could wrap `next` below
+        // and produce silently corrupted output.
+        if item_total > rest.len() {
+            return Err(RlpError::Truncated);
+        }
+        let next = offset.wrapping_add(item_total); // bounded by payload.len()
+        if idx == field_index {
+            if item.kind != ItemKind::Bytes {
+                return Err(RlpError::ExpectedBytes);
+            }
+            break (offset, next);
+        }
+        offset = next;
+        idx = idx.checked_add(1).ok_or(RlpError::Overflow)?;
+    };
+
+    // All wrapping ops below stay non-wrapping by construction:
+    //   item_end > item_start, so the subtract is fine;
+    //   the result is at most payload.len(), so the rest fits in memory.
+    let old_field_encoded_len = item_end.wrapping_sub(item_start);
+    let new_field_encoded_len = bytes_encoded_len(replacement);
+    let new_payload_len = payload
+        .len()
+        .wrapping_sub(old_field_encoded_len)
+        .wrapping_add(new_field_encoded_len);
+    let new_total = header_len(new_payload_len).wrapping_add(new_payload_len);
+    let mut out = Vec::with_capacity(new_total);
+    write_header(&mut out, new_payload_len, 0xc0);
+    let prefix = payload.get(..item_start).ok_or(RlpError::Truncated)?;
+    let suffix = payload.get(item_end..).ok_or(RlpError::Truncated)?;
+    out.extend_from_slice(prefix);
+    write_bytes(&mut out, replacement);
+    out.extend_from_slice(suffix);
+    debug_assert_eq!(out.len(), new_total);
+    Ok(out.into_boxed_slice())
+}
+
+// ---------- internals ----------
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum ItemKind {
+    Bytes,
+    List,
+}
+
+#[derive(Copy, Clone, Debug)]
+struct ItemHeader {
+    kind: ItemKind,
+    header_len: usize,
+    payload_len: usize,
+}
+
+impl ItemHeader {
+    fn total_len(&self) -> Result<usize, RlpError> {
+        self.header_len
+            .checked_add(self.payload_len)
+            .ok_or(RlpError::Overflow)
+    }
+}
+
+impl RlpItem<'_> {
+    fn encoded_len(&self) -> usize {
+        match self {
+            RlpItem::Bytes(b) => bytes_encoded_len(b),
+            RlpItem::Raw(r) => r.len(),
+            RlpItem::Empty => 1,
+        }
+    }
+
+    fn write_into(&self, out: &mut Vec<u8>) {
+        match self {
+            RlpItem::Bytes(b) => write_bytes(out, b),
+            RlpItem::Raw(r) => out.extend_from_slice(r),
+            RlpItem::Empty => out.push(0x80),
+        }
+    }
+}
+
+fn parse_header(input: &[u8]) -> Result<ItemHeader, RlpError> {
+    let &first = input.first().ok_or(RlpError::Truncated)?;
+    // All `wrapping_sub`s below are bounded by their match arms.
+    match first {
+        0x00..=0x7f => Ok(ItemHeader {
+            kind: ItemKind::Bytes,
+            header_len: 0,
+            payload_len: 1,
+        }),
+        0x80..=0xb7 => {
+            let payload_len = first.wrapping_sub(0x80) as usize;
+            // The 0x81 0x?? form must use the single-byte form when ?? < 0x80.
+            if payload_len == 1
+                && let Some(&b) = input.get(1)
+                && b < 0x80
+            {
+                return Err(RlpError::NonMinimalLength);
+            }
+            Ok(ItemHeader {
+                kind: ItemKind::Bytes,
+                header_len: 1,
+                payload_len,
+            })
+        }
+        0xb8..=0xbf => parse_long_header(input, first.wrapping_sub(0xb7) as usize, ItemKind::Bytes),
+        0xc0..=0xf7 => Ok(ItemHeader {
+            kind: ItemKind::List,
+            header_len: 1,
+            payload_len: first.wrapping_sub(0xc0) as usize,
+        }),
+        0xf8..=0xff => parse_long_header(input, first.wrapping_sub(0xf7) as usize, ItemKind::List),
+    }
+}
+
+fn parse_long_header(
+    input: &[u8],
+    len_of_len: usize,
+    kind: ItemKind,
+) -> Result<ItemHeader, RlpError> {
+    if len_of_len > size_of::<usize>() {
+        return Err(RlpError::Overflow);
+    }
+    let header_len = 1usize.wrapping_add(len_of_len); // <= 9
+    let len_bytes = input.get(1..header_len).ok_or(RlpError::Truncated)?;
+    if len_bytes.first().copied() == Some(0) {
+        return Err(RlpError::NonMinimalLength);
+    }
+    let payload_len = read_be_usize(len_bytes);
+    if payload_len < 56 {
+        return Err(RlpError::NonMinimalLength);
+    }
+    Ok(ItemHeader {
+        kind,
+        header_len,
+        payload_len,
+    })
+}
+
+fn read_be_usize(bytes: &[u8]) -> usize {
+    // Caller checks `bytes.len() <= size_of::<usize>()`, so the shift never
+    // loses bits.
+    bytes
+        .iter()
+        .fold(0usize, |acc, &b| (acc << 8) | usize::from(b))
+}
+
+fn write_bytes(out: &mut Vec<u8>, b: &[u8]) {
+    if b.len() == 1 && b.first().is_some_and(|&v| v < 0x80) {
+        out.extend_from_slice(b);
+    } else {
+        write_header(out, b.len(), 0x80);
+        out.extend_from_slice(b);
+    }
+}
+
+fn bytes_encoded_len(b: &[u8]) -> usize {
+    if b.len() == 1 && b.first().is_some_and(|&v| v < 0x80) {
+        1
+    } else {
+        // header_len <= 9 + b.len() (already in memory)
+        header_len(b.len()).wrapping_add(b.len())
+    }
+}
+
+const fn header_len(payload_len: usize) -> usize {
+    if payload_len < 56 {
+        1
+    } else {
+        1usize.wrapping_add(minimal_be_len(payload_len)) // <= 9
+    }
+}
+
+/// Write the RLP header for a payload. `short_base` is `0x80` for byte
+/// strings and `0xc0` for lists; the long-form base is `short_base + 55`.
+fn write_header(out: &mut Vec<u8>, payload_len: usize, short_base: u8) {
+    if payload_len < 56 {
+        out.push(short_base.wrapping_add(payload_len as u8));
+    } else {
+        let bytes = payload_len.to_be_bytes();
+        let start = bytes.len().wrapping_sub(minimal_be_len(payload_len));
+        let len_bytes = bytes.get(start..).unwrap_or(&[]);
+        out.push(
+            short_base
+                .wrapping_add(55)
+                .wrapping_add(len_bytes.len() as u8),
+        );
+        out.extend_from_slice(len_bytes);
+    }
+}
+
+const fn minimal_be_len(n: usize) -> usize {
+    if n == 0 {
+        0
+    } else {
+        // n != 0, so leading_zeros < usize::BITS.
+        let nonzero_bits = usize::BITS.wrapping_sub(n.leading_zeros()) as usize;
+        nonzero_bits.div_ceil(8)
+    }
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "tests use unwrap and direct indexing to keep assertions readable"
+)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    // ---------- single-item byte-string encoding ----------
+
+    #[test]
+    fn encode_empty_string() {
+        assert_eq!(&*encode_bytes(&[]), NULL_RLP);
+    }
+
+    #[test]
+    fn encode_single_byte_below_0x80() {
+        // single bytes < 0x80 encode as themselves
+        for b in 0u8..0x80 {
+            assert_eq!(&*encode_bytes(&[b]), &[b]);
+        }
+    }
+
+    #[test]
+    fn encode_single_byte_at_or_above_0x80() {
+        // single bytes >= 0x80 use the length-prefixed form
+        for b in 0x80u8..=0xff {
+            assert_eq!(&*encode_bytes(&[b]), &[0x81, b]);
+        }
+    }
+
+    /// Verify byte-string header shapes: short form (`< 56`) and long form.
+    #[test_case(55, &[0x80 + 55] ; "max short form")]
+    #[test_case(56, &[0xb8, 56] ; "min long form, 1-byte length")]
+    #[test_case(255, &[0xb8, 255] ; "max 1-byte length")]
+    #[test_case(256, &[0xb9, 0x01, 0x00] ; "min 2-byte length")]
+    #[test_case(65536, &[0xba, 0x01, 0x00, 0x00] ; "min 3-byte length")]
+    fn encode_byte_string_header_shapes(len: usize, expected_header: &[u8]) {
+        let payload = vec![0xaa; len];
+        let encoded = encode_bytes(&payload);
+        assert_eq!(&encoded[..expected_header.len()], expected_header);
+        assert_eq!(&encoded[expected_header.len()..], payload.as_slice());
+    }
+
+    // ---------- list encoding ----------
+
+    #[test]
+    fn encode_empty_list() {
+        let out = encode_list(&[]);
+        assert_eq!(&*out, &[0xc0]);
+    }
+
+    #[test]
+    fn encode_short_list_with_bytes_and_empty() {
+        // 2-element list: ["dog", ""]
+        let out = encode_list(&[RlpItem::Bytes(b"dog"), RlpItem::Empty]);
+        // payload = 0x83 d o g 0x80 = 5 bytes; header = 0xc0 + 5 = 0xc5
+        assert_eq!(&*out, &[0xc5, 0x83, b'd', b'o', b'g', 0x80]);
+    }
+
+    #[test]
+    fn encode_long_list() {
+        // Pick children to push payload past 55 bytes.
+        let one = vec![0u8; 30];
+        let two = vec![1u8; 30];
+        let out = encode_list(&[RlpItem::Bytes(&one), RlpItem::Bytes(&two)]);
+        // each child: 1 byte header (0x80 + 30) + 30 bytes = 31 bytes
+        // total payload = 62; header = 0xf8 0x3e
+        assert_eq!(&out[..2], &[0xf8, 62]);
+        assert_eq!(out.len(), 64);
+    }
+
+    #[test]
+    fn encode_list_with_raw_item() {
+        // Raw children are copied verbatim without an additional header.
+        let raw = encode_bytes(b"cat");
+        let out = encode_list(&[RlpItem::Raw(&raw), RlpItem::Bytes(b"dog")]);
+        let expected = encode_list(&[RlpItem::Bytes(b"cat"), RlpItem::Bytes(b"dog")]);
+        assert_eq!(out, expected);
+    }
+
+    // ---------- decoding ----------
+
+    #[test]
+    fn parse_empty_list() {
+        let list = RlpList::parse(&[0xc0]).unwrap();
+        assert!(list.fields().unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_list_round_trip() {
+        let bytes = encode_list(&[RlpItem::Bytes(b"foo"), RlpItem::Bytes(b"bar")]);
+        let list = RlpList::parse(&bytes).unwrap();
+        assert_eq!(list.fields().unwrap(), vec![&b"foo"[..], &b"bar"[..]]);
+    }
+
+    #[test]
+    fn parse_nth_bytes() {
+        let bytes = encode_list(&[
+            RlpItem::Bytes(b"a"),
+            RlpItem::Bytes(b"bb"),
+            RlpItem::Bytes(b"ccc"),
+            RlpItem::Bytes(b"dddd"),
+        ]);
+        let list = RlpList::parse(&bytes).unwrap();
+        assert_eq!(list.nth_bytes(0).unwrap(), b"a");
+        assert_eq!(list.nth_bytes(3).unwrap(), b"dddd");
+        assert_eq!(list.nth_bytes(4), Err(RlpError::IndexOutOfRange(4)));
+    }
+
+    #[test]
+    fn parse_long_string_in_list() {
+        // 100-byte string forces long-form bytes header
+        let big = vec![0xab; 100];
+        let bytes = encode_list(&[RlpItem::Bytes(&big), RlpItem::Bytes(b"end")]);
+        let list = RlpList::parse(&bytes).unwrap();
+        let items = list.fields().unwrap();
+        assert_eq!(items, vec![big.as_slice(), b"end"]);
+    }
+
+    #[test_case(&[0x80], RlpError::ExpectedList ; "byte-string header")]
+    #[test_case(&[0x42], RlpError::ExpectedList ; "single-byte item")]
+    #[test_case(&[0xc0, 0x42], RlpError::TrailingBytes ; "extra byte after empty list")]
+    #[test_case(&[], RlpError::Truncated ; "no input")]
+    #[test_case(&[0xf8], RlpError::Truncated ; "long-list header without length byte")]
+    #[test_case(&[0xc5, 0x83, b'd'], RlpError::Truncated ; "list payload shorter than claimed")]
+    fn parse_rejects_bad_input(input: &[u8], expected: RlpError) {
+        assert_eq!(RlpList::parse(input), Err(expected));
+    }
+
+    #[test]
+    fn fields_rejects_nested_list() {
+        // List containing a list: 0xc1 0xc0 = list of length 1 containing empty list
+        let list = RlpList::parse(&[0xc1, 0xc0]).unwrap();
+        assert_eq!(list.fields(), Err(RlpError::ExpectedBytes));
+    }
+
+    /// Each input wraps an inner byte-string item that violates a minimal-
+    /// length rule. `fields()` should surface the inner item's error.
+    #[test_case(&[0xc2, 0x81, 0x42] ; "0x81 b where b < 0x80 should be the bare byte")]
+    #[test_case(&{
+        let mut b = vec![0xf8, 57, 0xb8, 0x37];
+        b.extend(std::iter::repeat_n(0u8, 55));
+        b
+    } ; "long-form length 55 fits in short form")]
+    #[test_case(&{
+        let mut b = vec![0xf9, 0x01, 0x02, 0xb9, 0x00, 0xff];
+        b.extend(std::iter::repeat_n(0u8, 0xff));
+        b
+    } ; "long-form length with leading zero")]
+    fn parse_rejects_non_minimal_length(buf: &[u8]) {
+        let list = RlpList::parse(buf).unwrap();
+        assert_eq!(list.fields(), Err(RlpError::NonMinimalLength));
+    }
+
+    // ---------- replace_list_field ----------
+
+    fn account_rlp() -> Vec<u8> {
+        encode_list(&[
+            RlpItem::Bytes(&[0x01]),
+            RlpItem::Bytes(&[0x02]),
+            RlpItem::Bytes(&[0xaa; 32]),
+            RlpItem::Bytes(&[0xbb; 32]),
+        ])
+        .into_vec()
+    }
+
+    /// Replace field 2 of a 4-field account RLP with replacements of
+    /// equal, shorter, and longer length, exercising the three header-
+    /// resize paths.
+    #[test_case(&[0xcc; 32] ; "equal length (32-byte hash)")]
+    #[test_case(&[0x55] ; "shorter")]
+    #[test_case(&[0x42; 100] ; "longer (forces long-form list header)")]
+    fn replace_field_succeeds(replacement: &[u8]) {
+        let original = account_rlp();
+        let updated = replace_list_field(&original, 2, replacement).unwrap();
+        let list = RlpList::parse(&updated).unwrap();
+        let items = list.fields().unwrap();
+        assert_eq!(
+            items,
+            vec![&[0x01][..], &[0x02][..], replacement, &[0xbb; 32][..]]
+        );
+    }
+
+    #[test]
+    fn replace_field_equal_length_preserves_total_length() {
+        let original = account_rlp();
+        let updated = replace_list_field(&original, 2, &[0xcc; 32]).unwrap();
+        assert_eq!(updated.len(), original.len());
+    }
+
+    #[test_case(&account_rlp(), 4, &[0], RlpError::IndexOutOfRange(4) ; "index past end")]
+    #[test_case(&encode_bytes(b"hello"), 0, &[0], RlpError::ExpectedList ; "outer is not a list")]
+    #[test_case(&[0xc1, 0xc0], 0, &[0], RlpError::ExpectedBytes ; "target child is itself a list")]
+    #[test_case(&{
+        // outer claims 9-byte payload (matches); inner header advertises
+        // usize::MAX - 100 bytes that aren't there. Without the bounds
+        // check this would wrap arithmetic and corrupt output silently.
+        let mut b = vec![0xc9, 0xbf];
+        b.extend_from_slice(&(usize::MAX - 100).to_be_bytes());
+        b
+    }, 0, &[0; 32], RlpError::Truncated ; "inner item declares oversized length")]
+    fn replace_field_rejects_bad_input(
+        input: &[u8],
+        index: usize,
+        replacement: &[u8],
+        expected: RlpError,
+    ) {
+        assert_eq!(replace_list_field(input, index, replacement), Err(expected));
+    }
+
+    // ---------- parity with the upstream `rlp` crate ----------
+
+    use ::rlp::RlpStream;
+
+    fn upstream_encode(items: &[&[u8]]) -> Vec<u8> {
+        let mut s = RlpStream::new_list(items.len());
+        for item in items {
+            s.append(&item.to_vec());
+        }
+        s.out().to_vec()
+    }
+
+    /// Encode the same flat byte-string list with both impls and confirm
+    /// the bytes match exactly.
+    #[test_case(&[] ; "empty list")]
+    #[test_case(&[&[][..]] ; "list of one empty string")]
+    #[test_case(&[&[0x42][..]] ; "single low byte child")]
+    #[test_case(&[&[0xff][..]] ; "single high byte child")]
+    #[test_case(&[b"hello", b"world"] ; "two short strings")]
+    #[test_case(&[&[0u8; 100][..], &[1u8; 1][..]] ; "long child + short child")]
+    #[test_case(&[&[0xff; 32][..]; 17] ; "17-element MPT branch shape")]
+    fn parity_encode_matches_upstream(case: &[&[u8]]) {
+        let items: Vec<RlpItem<'_>> = case.iter().map(|b| RlpItem::Bytes(b)).collect();
+        assert_eq!(encode_list(&items).into_vec(), upstream_encode(case));
+    }
+
+    /// Encode with the upstream crate, decode with `RlpList`, expect the
+    /// original byte-string children back.
+    #[test_case(&[] ; "empty list")]
+    #[test_case(&[&[0x42][..]] ; "single-byte child")]
+    #[test_case(&[b"hello", b"world"] ; "two short strings")]
+    #[test_case(&[&[0u8; 100][..], &[1u8; 1][..]] ; "long child + short child")]
+    #[test_case(&[&[0xff; 32][..]; 17] ; "17-element MPT branch shape")]
+    fn parity_decode_matches_upstream(case: &[&[u8]]) {
+        let bytes = upstream_encode(case);
+        let list = RlpList::parse(&bytes).unwrap();
+        assert_eq!(list.fields().unwrap(), case.to_vec());
+    }
+}


### PR DESCRIPTION
First step of #1944. Lands a purpose-built `crate::rlp` module
(`storage/src/rlp.rs`) and a criterion benchmark comparing it against
the upstream `rlp = "0.6"` crate on the shapes firewood actually uses.
No production code paths are migrated yet — the next PR in this stack
swaps every call site over and drops the upstream crate from the
production dependency graph.

## Why this should be merged

The new module is much faster on every shape that hashing and proof
verification touch (criterion, single-thread, M-series Mac):

| Workload                                              | Upstream | In-tree | Speedup |
| ----------------------------------------------------- | -------: | ------: | ------: |
| `branch_encode` (17-element MPT branch)               |  1036 ns |   94 ns |  11.0×  |
| `leaf_encode` (2-element MPT leaf)                    |   115 ns |   28 ns |   4.1×  |
| `storage_root_replace` (4-field account)              |   325 ns |   31 ns |  10.6×  |
| `decode_field3` (FFI account code-hash extract)       |    27 ns | 10.6 ns |   2.5×  |

The biggest wins come from killing the `Vec<Vec<u8>>` round-trip in
the account-rewrite path and from computing the list payload length
up-front so the encoder allocates exactly once.

## How this works

API surface: `NULL_RLP`, `RlpError`, `RlpItem`, `encode_bytes`,
`encode_list`, `RlpList::parse` / `fields` / `nth_bytes`, and
`replace_list_field`. No traits, no streaming builder, no nested-list
decoding — every call site in firewood has a known, flat shape.

Existing storage references to the upstream crate (`rlp::Rlp`,
`rlp::RlpStream`, `rlp::NULL_RLP`) are rewritten to use the absolute
path (`::rlp::...`) so they don't conflict with the new local
`crate::rlp` module.

## How this was tested

- 46 unit tests in `storage::rlp::tests` cover encoding shapes, decode
  failure modes, `replace_list_field` length variants (incl. a
  malicious-input regression for inner-item bounds), and parity
  (round-trip in both directions) against the upstream crate.
- `cargo nextest run --workspace --features ethhash,logger --all-targets --profile ci` — 699/699 passing.
- Reproduce the benchmark with: `cargo bench -p firewood-storage --bench rlp --features ethhash,logger`.

## Breaking changes

None. `rlp` is still in the production dependency graph after this
PR; it gets removed in the follow-up PR in this stack.