### PR TITLE
feat: add pathdb config + 33m block option

### DIFF
--- a/fwdctl/src/launch/mod.rs
+++ b/fwdctl/src/launch/mod.rs
@@ -135,6 +135,8 @@ pub enum NBlocks {
     TenK = 10_000,
     #[value(name = "1m")]
     OneM = 1_000_000,
+    #[value(name = "33m")]
+    ThirtyThreeM = 33_000_000,
     #[value(name = "50m")]
     FiftyM = 50_000_000,
     #[value(name = "77m")]
@@ -145,6 +147,8 @@ pub enum NBlocks {
 pub enum Config {
     Firewood,
     FirewoodArchive,
+    #[value(name = "pathdb")]
+    PathDB,
     Archive,
     Default,
 }
@@ -160,6 +164,7 @@ impl NBlocks {
         match self {
             Self::TenK => "10k",
             Self::OneM => "1m",
+            Self::ThirtyThreeM => "33m",
             Self::FiftyM => "50m",
             Self::SeventySevenM => "77m",
         }
@@ -172,6 +177,7 @@ impl Config {
         match self {
             Self::Firewood => "firewood",
             Self::FirewoodArchive => "firewood-archive",
+            Self::PathDB => "pathdb",
             Self::Archive => "archive",
             Self::Default => "default",
         }


### PR DESCRIPTION
## Why this should be merged

Adds support for using PathDB in the reexecution tests. Also allows users to execute the first 33m blocks.

## How this works

- Adds `pathdb` VM config as specified here: https://github.com/ava-labs/avalanchego/blob/c8a1e07301774ef416d1ecccc8daa5fc64d6d79a/tests/reexecute/c/vm_reexecute.go#L69-L72
- Adds `33m` option for the `--num-blocks` option.

## How this was tested

Ran reexecution test.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
