### PR TITLE
perf(storage): reuse persist scratch storage across commits

### DIFF
--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -49,7 +49,7 @@ use firewood_metrics::{
 };
 use firewood_storage::{
     Committed, FileBacked, FileIoError, HashedNodeReader, LinearAddress, NodeStore,
-    NodeStoreHeader, TrieHash,
+    NodeStoreHeader, PersistScratch, TrieHash,
 };
 use parking_lot::{Condvar, Mutex, MutexGuard};
 
@@ -147,7 +147,11 @@ impl PersistWorker {
         let metrics_context = current_metrics_context();
         let handle = thread::spawn(move || {
             let _guard = set_metrics_context(metrics_context);
-            PersistLoop { shared: bg_shared }.run()
+            PersistLoop {
+                shared: bg_shared,
+                scratch: PersistScratch::new(),
+            }
+            .run()
         });
 
         Self {
@@ -512,6 +516,8 @@ struct SharedState {
 struct PersistLoop {
     /// Shared state for coordination with `PersistWorker`.
     shared: Arc<SharedState>,
+    /// Scratch state reused across persists.
+    scratch: PersistScratch,
 }
 
 impl Drop for PersistLoop {
@@ -527,7 +533,7 @@ impl PersistLoop {
     ///
     /// If the event loop exits with an error, it is stored in shared state
     /// so the main thread can observe it without joining.
-    fn run(self) -> Result<(), PersistError> {
+    fn run(mut self) -> Result<(), PersistError> {
         let result = self.event_loop();
         if let Err(ref err) = result {
             self.shared.error.set(err.clone()).expect("should be empty");
@@ -536,17 +542,17 @@ impl PersistLoop {
     }
 
     /// Processes pending work until shutdown or an error occurs.
-    fn event_loop(&self) -> Result<(), PersistError> {
+    fn event_loop(&mut self) -> Result<(), PersistError> {
         while let Ok(mut persist_data) = self.shared.channel.pop() {
             let cycle_start = std::time::Instant::now();
 
             for nodestore in std::mem::take(&mut persist_data.pending_reaps) {
-                self.reap(nodestore)?;
+                Self::reap(&self.shared, nodestore)?;
             }
 
             if let Some(revision) = persist_data.latest_committed.take() {
-                self.persist_to_disk(&revision)
-                    .and_then(|()| self.maybe_save_to_root_store(&revision))?;
+                Self::persist_to_disk(&self.shared, &mut self.scratch, &revision)
+                    .and_then(|()| Self::maybe_save_to_root_store(&self.shared, &revision))?;
                 firewood_counter!(COMMITS_TOTAL).increment(1);
             }
 
@@ -558,34 +564,43 @@ impl PersistLoop {
         if let Some(revision) = self.shared.persist_on_shutdown.get().cloned()
             && !self.shared.channel.empty()
         {
-            self.persist_to_disk(&revision)
-                .and_then(|()| self.maybe_save_to_root_store(&revision))?;
+            Self::persist_to_disk(&self.shared, &mut self.scratch, &revision)
+                .and_then(|()| Self::maybe_save_to_root_store(&self.shared, &revision))?;
         }
 
         Ok(())
     }
 
     /// Persists the revision to disk.
-    fn persist_to_disk(&self, revision: &CommittedRevision) -> Result<(), PersistError> {
+    fn persist_to_disk(
+        shared: &SharedState,
+        scratch: &mut PersistScratch,
+        revision: &CommittedRevision,
+    ) -> Result<(), PersistError> {
         // BLOCKING: mutex lock on the shared `NodeStoreHeader`. Held for the entire duration of
         // the disk flush (serializes all node writes + header write). Any concurrent caller of
         // `RevisionManager::locked_header()` (e.g. `Db::check`) will stall until this returns.
         // Under heavy I/O this can take tens to hundreds of milliseconds.
-        let mut header = self.shared.header.lock();
-        revision.persist(&mut header).map_err(|e| {
-            error!("Failed to persist revision: {e}");
-            PersistError::FileIo(Arc::new(e))
-        })
+        let mut header = shared.header.lock();
+        revision
+            .persist_with_scratch(&mut header, scratch)
+            .map_err(|e| {
+                error!("Failed to persist revision: {e}");
+                PersistError::FileIo(Arc::new(e))
+            })
     }
 
     /// Adds the nodes of this revision to the free lists.
-    fn reap(&self, nodestore: NodeStore<Committed, FileBacked>) -> Result<(), PersistError> {
+    fn reap(
+        shared: &SharedState,
+        nodestore: NodeStore<Committed, FileBacked>,
+    ) -> Result<(), PersistError> {
         // BLOCKING: same header mutex as `persist_to_disk`. Held while writing all freed-node
         // metadata back to the free-list in storage. Contends with any `persist_to_disk` that
         // might be running concurrently (they cannot — both run in the single background thread —
         // but the lock also blocks external `locked_header()` callers).
         nodestore
-            .reap_deleted(&mut self.shared.header.lock())
+            .reap_deleted(&mut shared.header.lock())
             .map_err(|e| {
                 error!("Failed to reap deleted nodes: {e}");
                 PersistError::FileIo(Arc::new(e))
@@ -593,8 +608,11 @@ impl PersistLoop {
     }
 
     /// Saves the revision's root address to `RootStore` if configured.
-    fn maybe_save_to_root_store(&self, revision: &CommittedRevision) -> Result<(), PersistError> {
-        if let Some(ref store) = self.shared.root_store
+    fn maybe_save_to_root_store(
+        shared: &SharedState,
+        revision: &CommittedRevision,
+    ) -> Result<(), PersistError> {
+        if let Some(ref store) = shared.root_store
             && let (Some(hash), Some(addr)) = (revision.root_hash(), revision.root_address())
         {
             save_to_root_store(store, &hash, &addr)?;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -60,7 +60,8 @@ pub use nodestore::fix_account_storage_root_value;
 pub use nodestore::{
     AreaIndex, Committed, HashedNodeReader, ImmutableProposal, LinearAddress, Mutable, MutableKind,
     NodeHashAlgorithm, NodeHashAlgorithmTryFromIntError, NodeReader, NodeStore, NodeStoreHeader,
-    Parentable, Propose, Recon, Reconstructed, ReconstructionSource, RootReader, TrieReader,
+    Parentable, PersistScratch, Propose, Recon, Reconstructed, ReconstructionSource, RootReader,
+    TrieReader,
 };
 pub use path::{
     ComponentIter, IntoSplitPath, JoinedPath, PackedBytes, PackedPathComponents, PackedPathRef,

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -62,6 +62,7 @@ use std::time::Instant;
 // Re-export types from alloc module
 pub use alloc::NodeAllocator;
 pub use hash_algo::{NodeHashAlgorithm, NodeHashAlgorithmTryFromIntError};
+pub use persist::PersistScratch;
 pub use primitives::{AreaIndex, LinearAddress};
 // Re-export types from header module
 #[cfg(feature = "ethhash")]

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -46,6 +46,40 @@ use super::{Committed, NodeStore};
 #[cfg(not(test))]
 use super::RootReader;
 
+/// Reusable scratch state for node persistence.
+///
+/// The background persist worker can hold on to this across commits so `bumpalo`
+/// keeps its chunks instead of deallocating and reallocating them on every
+/// persist.
+#[derive(Debug)]
+pub struct PersistScratch {
+    bump: Bump,
+}
+
+impl PersistScratch {
+    /// Create scratch storage sized for the common node serialization batch.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            bump: Bump::with_capacity(super::INITIAL_BUMP_SIZE),
+        }
+    }
+
+    const fn bump_mut(&mut self) -> &mut Bump {
+        &mut self.bump
+    }
+
+    fn reset(&mut self) {
+        self.bump.reset();
+    }
+}
+
+impl Default for PersistScratch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NodeStoreHeader {
     /// Persist this header to storage.
     ///
@@ -177,19 +211,25 @@ fn serialize_node_to_bump<'a>(
 }
 
 impl<S: WritableStorage> NodeStore<Committed, S> {
-    /// Persist all the nodes of a proposal to storage, updating the header with new allocations.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`FileIoError`] if any node cannot be written to storage.
+    /// Persist all nodes using caller-provided scratch storage that can be
+    /// reused across commits.
     #[fastrace::trace(short_name = true)]
-    fn flush_nodes(&self, header: &mut NodeStoreHeader) -> Result<(), FileIoError> {
+    fn flush_nodes_with_scratch(
+        &self,
+        header: &mut NodeStoreHeader,
+        scratch: &mut PersistScratch,
+    ) -> Result<(), FileIoError> {
         let flush_start = Instant::now();
 
         let mut node_allocator = NodeAllocator::new(self.storage.as_ref(), header);
-        let mut bump = Bump::with_capacity(super::INITIAL_BUMP_SIZE);
-
-        self.process_unpersisted_nodes(&mut bump, &mut node_allocator, super::INITIAL_BUMP_SIZE)?;
+        scratch.reset();
+        let result = self.process_unpersisted_nodes(
+            scratch.bump_mut(),
+            &mut node_allocator,
+            super::INITIAL_BUMP_SIZE,
+        );
+        scratch.reset();
+        result?;
 
         firewood_histogram!(cheap: FLUSH_DURATION_SECONDS)
             .record(flush_start.elapsed().as_secs_f64());
@@ -285,8 +325,23 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
     /// Returns a [`FileIoError`] if any of the persistence operations fail.
     #[fastrace::trace(short_name = true)]
     pub fn persist(&self, header: &mut NodeStoreHeader) -> Result<(), FileIoError> {
+        let mut scratch = PersistScratch::new();
+        self.persist_with_scratch(header, &mut scratch)
+    }
+
+    /// Persist the entire nodestore using caller-provided scratch storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`FileIoError`] if any of the persistence operations fail.
+    #[fastrace::trace(short_name = true)]
+    pub fn persist_with_scratch(
+        &self,
+        header: &mut NodeStoreHeader,
+        scratch: &mut PersistScratch,
+    ) -> Result<(), FileIoError> {
         // First persist all the nodes
-        self.flush_nodes(header)?;
+        self.flush_nodes_with_scratch(header, scratch)?;
 
         // Set the root address in the header based on the persisted root
         let root_location = self.kind.root.as_ref().and_then(|child| {
@@ -307,8 +362,8 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
 mod tests {
     use super::*;
     use crate::{
-        Child, Children, HashType, ImmutableProposal, LinearAddress, NodeHashAlgorithm, NodeStore,
-        NodeStoreHeader, Path, PathComponent, SharedNode,
+        Child, Children, HashType, HashedNodeReader, ImmutableProposal, LinearAddress,
+        NodeHashAlgorithm, NodeStore, NodeStoreHeader, Path, PathComponent, SharedNode,
         linear::memory::MemStore,
         node::{BranchNode, LeafNode, Node},
         nodestore::{Mutable, Propose},
@@ -586,5 +641,52 @@ mod tests {
             .unwrap();
         assert_eq!(*child2_node.partial_path(), Path::from(&[4, 5, 6]));
         assert_eq!(child2_node.value(), Some(&b"value2"[..]));
+    }
+
+    #[test]
+    fn test_persist_with_reused_scratch() {
+        let mem_store = MemStore::default();
+        let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
+        let base_committed = NodeStore::new_empty_committed(mem_store.into());
+        let mut scratch = PersistScratch::new();
+
+        let mut first_proposal = NodeStore::new(&base_committed).unwrap();
+        first_proposal
+            .root_mut()
+            .replace(create_leaf(&[1, 2, 3], b"value1"));
+        let first_immutable: NodeStore<Arc<ImmutableProposal>, _> =
+            first_proposal.try_into().unwrap();
+        let first_committed = first_immutable.as_committed();
+        first_committed
+            .persist_with_scratch(&mut header, &mut scratch)
+            .unwrap();
+
+        let mut second_proposal = NodeStore::new(&first_committed).unwrap();
+        second_proposal
+            .root_mut()
+            .replace(create_leaf(&[4, 5, 6], b"value2"));
+        let second_immutable: NodeStore<Arc<ImmutableProposal>, _> =
+            second_proposal.try_into().unwrap();
+        let second_committed = second_immutable.as_committed();
+        second_committed
+            .persist_with_scratch(&mut header, &mut scratch)
+            .unwrap();
+
+        let first_root = first_committed.kind.root.as_ref().unwrap();
+        let first_root_node = first_root
+            .as_maybe_persisted_node()
+            .as_shared_node(&first_committed)
+            .unwrap();
+        assert_eq!(*first_root_node.partial_path(), Path::from(&[1, 2, 3]));
+        assert_eq!(first_root_node.value(), Some(&b"value1"[..]));
+
+        let second_root = second_committed.kind.root.as_ref().unwrap();
+        let second_root_node = second_root
+            .as_maybe_persisted_node()
+            .as_shared_node(&second_committed)
+            .unwrap();
+        assert_eq!(*second_root_node.partial_path(), Path::from(&[4, 5, 6]));
+        assert_eq!(second_root_node.value(), Some(&b"value2"[..]));
+        assert_eq!(header.root_address(), second_committed.root_address());
     }
 }


### PR DESCRIPTION
## Why this should be merged

The background persist worker currently allocates fresh bump storage for each persist cycle. Repeated allocation churn is avoidable because the worker is long-lived and serializes persists on a single thread.

## How this works

- Adds `PersistScratch`, a reusable wrapper around the persistence bump allocator.
- Adds `NodeStore::persist_with_scratch` so callers can reuse scratch storage across commits.
- Updates the deferred persist worker to keep one `PersistScratch` for the lifetime of the background loop.
- Keeps the existing `persist` API unchanged by having it allocate temporary scratch internally.
- Adds a regression test covering reuse of the same scratch value across multiple persists.

## How this was tested

UT.

## Performance Evaluation and Numbers

TBD.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
