### PR TITLE
perf(metrics): cache metric handles after recorder install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,6 +1773,7 @@ dependencies = [
  "fastrace",
  "fastrace-opentelemetry",
  "firewood",
+ "firewood-metrics",
  "firewood-storage",
  "hex",
  "log",

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -26,6 +26,7 @@ clap = { workspace = true, features = ['string'] }
 env_logger.workspace = true
 fastrace = { workspace = true, features = ["enable"] }
 firewood.workspace = true
+firewood-metrics.workspace = true
 firewood-storage = { workspace = true, features = ["test_utils"] }
 hex.workspace = true
 log.workspace = true

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -306,6 +306,7 @@ fn spawn_prometheus_listener(
 
     // Register the Prometheus recorder directly; prefixing is handled by Grafana/Prometheus relabeling.
     metrics::set_global_recorder(recorder)?;
+    firewood_metrics::mark_global_recorder_installed();
 
     Ok(handle)
 }

--- a/ffi/src/metrics.rs
+++ b/ffi/src/metrics.rs
@@ -61,6 +61,7 @@ pub fn setup_metrics() -> Result<(), Box<dyn Error>> {
     RECORDER
         .set(handle)
         .map_err(|_| "recorder already initialized")?;
+    firewood_metrics::mark_global_recorder_installed();
 
     Ok(())
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -38,6 +38,7 @@
 //! For registration, use the [`define_metrics!`] macro in your crate's registry module.
 
 use std::cell::Cell;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Sealed helper for [`GaugeExt`]: integer types that can be stored in a gauge as `f64`.
 ///
@@ -179,6 +180,8 @@ thread_local! {
     static METRICS_CONTEXT: Cell<Option<MetricsContext>> = const { Cell::new(None) };
 }
 
+static GLOBAL_RECORDER_INSTALLED: AtomicBool = AtomicBool::new(false);
+
 /// A guard that restores the previous thread-local [`MetricsContext`].
 #[derive(Debug)]
 pub struct MetricsContextGuard {
@@ -210,6 +213,20 @@ pub fn current_metrics_context() -> Option<MetricsContext> {
 #[must_use]
 pub fn expensive_metrics_enabled() -> bool {
     current_metrics_context().is_some_and(MetricsContext::expensive_metrics_enabled)
+}
+
+/// Marks the process-global metrics recorder as installed.
+///
+/// Call this immediately after successfully installing the recorder. Once set,
+/// the flag remains enabled for the rest of the process lifetime.
+pub fn mark_global_recorder_installed() {
+    GLOBAL_RECORDER_INSTALLED.store(true, Ordering::Release);
+}
+
+/// Returns whether the process-global metrics recorder has been installed.
+#[must_use]
+pub fn global_recorder_installed() -> bool {
+    GLOBAL_RECORDER_INSTALLED.load(Ordering::Acquire)
 }
 
 /// Defines metric name constants and a `register()` function from a single schema.
@@ -529,6 +546,11 @@ macro_rules! define_metrics {
 /// firewood_counter!(PROPOSALS_CREATED_TOTAL, "status" => "ok").increment(1);
 /// firewood_counter!(expensive: SLOW_PATH_TOTAL).increment(1);
 /// ```
+///
+/// Once the process-global recorder is installed, no-label callsites and callsites
+/// whose labels are all literals cache the returned handle in a per-callsite
+/// `OnceLock`. Callsites with runtime-valued labels take the uncached path because
+/// the metric identity can vary per invocation.
 // `crate` in the expansion refers to the invocation crate, not `firewood_metrics` — see
 // the `firewood_histogram!` doc for the full explanation of why this is intentional.
 #[expect(
@@ -538,23 +560,47 @@ macro_rules! define_metrics {
 )]
 #[macro_export]
 macro_rules! firewood_counter {
-    (expensive: $name:ident) => {
+    (expensive: $name:ident) => {{
         if $crate::expensive_metrics_enabled() {
+            $crate::firewood_counter!($name)
+        } else {
+            $crate::__private::metrics::Counter::noop()
+        }
+    }};
+    (expensive: $name:ident, $($labels:tt)+) => {{
+        if $crate::expensive_metrics_enabled() {
+            $crate::firewood_counter!($name, $($labels)+)
+        } else {
+            $crate::__private::metrics::Counter::noop()
+        }
+    }};
+    ($name:ident) => {{
+        static __FW_CACHED: ::std::sync::OnceLock<$crate::__private::metrics::Counter> =
+            ::std::sync::OnceLock::new();
+        if $crate::global_recorder_installed() {
+            __FW_CACHED
+                .get_or_init(|| $crate::__private::metrics::counter!(crate::registry::$name))
+                .clone()
+        } else {
             $crate::__private::metrics::counter!(crate::registry::$name)
-        } else {
-            $crate::__private::metrics::Counter::noop()
         }
-    };
-    (expensive: $name:ident, $($labels:tt)+) => {
-        if $crate::expensive_metrics_enabled() {
-            $crate::__private::metrics::counter!(crate::registry::$name, $($labels)+)
+    }};
+    ($name:ident, $($key:literal => $val:literal),+ $(,)?) => {{
+        static __FW_CACHED: ::std::sync::OnceLock<$crate::__private::metrics::Counter> =
+            ::std::sync::OnceLock::new();
+        if $crate::global_recorder_installed() {
+            __FW_CACHED
+                .get_or_init(|| {
+                    $crate::__private::metrics::counter!(
+                        crate::registry::$name,
+                        $($key => $val),+
+                    )
+                })
+                .clone()
         } else {
-            $crate::__private::metrics::Counter::noop()
+            $crate::__private::metrics::counter!(crate::registry::$name, $($key => $val),+)
         }
-    };
-    ($name:ident) => {
-        $crate::__private::metrics::counter!(crate::registry::$name)
-    };
+    }};
     ($name:ident, $($labels:tt)+) => {
         $crate::__private::metrics::counter!(crate::registry::$name, $($labels)+)
     };
@@ -591,6 +637,10 @@ macro_rules! firewood_counter {
 /// firewood_gauge!(ACTIVE_REVISIONS).increment(1.0);
 /// firewood_gauge!(ACTIVE_REVISIONS).decrement(1.0);
 /// ```
+///
+/// Once the process-global recorder is installed, no-label callsites and callsites
+/// whose labels are all literals cache the returned handle in a per-callsite
+/// `OnceLock`. See [`firewood_counter!`] for the runtime-label behavior.
 // `crate` in the expansion refers to the invocation crate — intentional; see `firewood_histogram!`.
 #[expect(
     clippy::crate_in_macro_def,
@@ -599,23 +649,47 @@ macro_rules! firewood_counter {
 )]
 #[macro_export]
 macro_rules! firewood_gauge {
-    (expensive: $name:ident) => {
+    (expensive: $name:ident) => {{
         if $crate::expensive_metrics_enabled() {
+            $crate::firewood_gauge!($name)
+        } else {
+            $crate::__private::metrics::Gauge::noop()
+        }
+    }};
+    (expensive: $name:ident, $($labels:tt)+) => {{
+        if $crate::expensive_metrics_enabled() {
+            $crate::firewood_gauge!($name, $($labels)+)
+        } else {
+            $crate::__private::metrics::Gauge::noop()
+        }
+    }};
+    ($name:ident) => {{
+        static __FW_CACHED: ::std::sync::OnceLock<$crate::__private::metrics::Gauge> =
+            ::std::sync::OnceLock::new();
+        if $crate::global_recorder_installed() {
+            __FW_CACHED
+                .get_or_init(|| $crate::__private::metrics::gauge!(crate::registry::$name))
+                .clone()
+        } else {
             $crate::__private::metrics::gauge!(crate::registry::$name)
-        } else {
-            $crate::__private::metrics::Gauge::noop()
         }
-    };
-    (expensive: $name:ident, $($labels:tt)+) => {
-        if $crate::expensive_metrics_enabled() {
-            $crate::__private::metrics::gauge!(crate::registry::$name, $($labels)+)
+    }};
+    ($name:ident, $($key:literal => $val:literal),+ $(,)?) => {{
+        static __FW_CACHED: ::std::sync::OnceLock<$crate::__private::metrics::Gauge> =
+            ::std::sync::OnceLock::new();
+        if $crate::global_recorder_installed() {
+            __FW_CACHED
+                .get_or_init(|| {
+                    $crate::__private::metrics::gauge!(
+                        crate::registry::$name,
+                        $($key => $val),+
+                    )
+                })
+                .clone()
         } else {
-            $crate::__private::metrics::Gauge::noop()
+            $crate::__private::metrics::gauge!(crate::registry::$name, $($key => $val),+)
         }
-    };
-    ($name:ident) => {
-        $crate::__private::metrics::gauge!(crate::registry::$name)
-    };
+    }};
     ($name:ident, $($labels:tt)+) => {
         $crate::__private::metrics::gauge!(crate::registry::$name, $($labels)+)
     };
@@ -655,6 +729,10 @@ macro_rules! firewood_gauge {
 /// // Always records (e.g. for low-overhead infrastructure metrics):
 /// firewood_histogram!(cheap: GATHER_DURATION_SECONDS).record(0.01);
 /// ```
+///
+/// Once the process-global recorder is installed, no-label callsites and callsites
+/// whose labels are all literals cache the returned handle in a per-callsite
+/// `OnceLock`. See [`firewood_counter!`] for the runtime-label behavior.
 // `crate` in the expansion refers to the invocation crate — intentional; see the doc above.
 #[expect(
     clippy::crate_in_macro_def,
@@ -664,23 +742,47 @@ macro_rules! firewood_gauge {
 )]
 #[macro_export]
 macro_rules! firewood_histogram {
-    ($name:ident) => {
+    ($name:ident) => {{
         if $crate::expensive_metrics_enabled() {
+            $crate::firewood_histogram!(cheap: $name)
+        } else {
+            $crate::__private::metrics::Histogram::noop()
+        }
+    }};
+    ($name:ident, $($labels:tt)+) => {{
+        if $crate::expensive_metrics_enabled() {
+            $crate::firewood_histogram!(cheap: $name, $($labels)+)
+        } else {
+            $crate::__private::metrics::Histogram::noop()
+        }
+    }};
+    (cheap: $name:ident) => {{
+        static __FW_CACHED: ::std::sync::OnceLock<$crate::__private::metrics::Histogram> =
+            ::std::sync::OnceLock::new();
+        if $crate::global_recorder_installed() {
+            __FW_CACHED
+                .get_or_init(|| $crate::__private::metrics::histogram!(crate::registry::$name))
+                .clone()
+        } else {
             $crate::__private::metrics::histogram!(crate::registry::$name)
-        } else {
-            $crate::__private::metrics::Histogram::noop()
         }
-    };
-    ($name:ident, $($labels:tt)+) => {
-        if $crate::expensive_metrics_enabled() {
-            $crate::__private::metrics::histogram!(crate::registry::$name, $($labels)+)
+    }};
+    (cheap: $name:ident, $($key:literal => $val:literal),+ $(,)?) => {{
+        static __FW_CACHED: ::std::sync::OnceLock<$crate::__private::metrics::Histogram> =
+            ::std::sync::OnceLock::new();
+        if $crate::global_recorder_installed() {
+            __FW_CACHED
+                .get_or_init(|| {
+                    $crate::__private::metrics::histogram!(
+                        crate::registry::$name,
+                        $($key => $val),+
+                    )
+                })
+                .clone()
         } else {
-            $crate::__private::metrics::Histogram::noop()
+            $crate::__private::metrics::histogram!(crate::registry::$name, $($key => $val),+)
         }
-    };
-    (cheap: $name:ident) => {
-        $crate::__private::metrics::histogram!(crate::registry::$name)
-    };
+    }};
     (cheap: $name:ident, $($labels:tt)+) => {
         $crate::__private::metrics::histogram!(crate::registry::$name, $($labels)+)
     };
@@ -777,5 +879,10 @@ mod tests {
             // Parent context is unaffected.
             assert_eq!(current_metrics_context(), Some(ctx));
         });
+    }
+
+    #[test]
+    fn global_recorder_flag_defaults_to_false() {
+        assert!(!global_recorder_installed());
     }
 }

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -25,15 +25,59 @@ use std::io::Read;
 use std::num::NonZero;
 use std::os::unix::fs::FileExt;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use firewood_metrics::{GaugeExt, firewood_counter, firewood_gauge, firewood_histogram};
 use lru::LruCache as EntryLruCache;
 use lru_mem::LruCache as MemLruCache;
+use metrics::Counter;
 
 use crate::linear::ReadableNodeMode;
 use crate::{CacheReadStrategy, CachedNode, LinearAddress, MaybePersistedNode, SharedNode};
 
 use super::{FileIoError, OffsetReader, ReadableStorage, WritableStorage};
+
+const CACHE_NODE_MODES: [&str; 4] = ["open", "read", "recon-read", "write"];
+const CACHE_RESULT_TYPES: [&str; 2] = ["miss", "hit"];
+
+type CacheNodeCounters = [[Counter; CACHE_RESULT_TYPES.len()]; CACHE_NODE_MODES.len()];
+
+const fn cache_node_mode_index(mode: &ReadableNodeMode) -> usize {
+    match mode {
+        ReadableNodeMode::Open => 0,
+        ReadableNodeMode::Read => 1,
+        ReadableNodeMode::ReconRead => 2,
+        ReadableNodeMode::Write => 3,
+    }
+}
+
+fn cache_node_counter(mode: &ReadableNodeMode, hit: bool) -> Option<&'static Counter> {
+    static COUNTERS: OnceLock<CacheNodeCounters> = OnceLock::new();
+    firewood_metrics::global_recorder_installed().then(|| {
+        &COUNTERS.get_or_init(|| {
+            std::array::from_fn(|mode_index| {
+                std::array::from_fn(|result_index| {
+                    firewood_counter!(
+                        CACHE_NODE,
+                        "mode" => CACHE_NODE_MODES[mode_index],
+                        "type" => CACHE_RESULT_TYPES[result_index]
+                    )
+                })
+            })
+        })[cache_node_mode_index(mode)][usize::from(hit)]
+    })
+}
+
+fn free_list_cache_counter(hit: bool) -> Option<&'static Counter> {
+    static COUNTERS: OnceLock<[Counter; CACHE_RESULT_TYPES.len()]> = OnceLock::new();
+    firewood_metrics::global_recorder_installed().then(|| {
+        &COUNTERS.get_or_init(|| {
+            std::array::from_fn(|result_index| {
+                firewood_counter!(CACHE_FREELIST, "type" => CACHE_RESULT_TYPES[result_index])
+            })
+        })[usize::from(hit)]
+    })
+}
 
 /// A [`ReadableStorage`] and [`WritableStorage`] backed by a file
 #[derive(Debug)]
@@ -139,7 +183,11 @@ impl ReadableStorage for FileBacked {
         // point — all trie traversals contend here. Impact scales with reader concurrency.
         let mut guard = self.cache.lock();
         let cached = guard.get(&addr).map(|cached_node| cached_node.0.clone());
-        firewood_counter!(CACHE_NODE, "mode" => mode.as_str(), "type" => if cached.is_some() { "hit" } else { "miss" }).increment(1);
+        if let Some(counter) = cache_node_counter(&mode, cached.is_some()) {
+            counter.increment(1);
+        } else {
+            firewood_counter!(CACHE_NODE, "mode" => mode.as_str(), "type" => if cached.is_some() { "hit" } else { "miss" }).increment(1);
+        }
         cached
     }
 
@@ -148,8 +196,12 @@ impl ReadableStorage for FileBacked {
         // every proposal/commit. Contends with writes that also update the free-list cache.
         let mut guard = self.free_list_cache.lock();
         let cached = guard.pop(&addr);
-        firewood_counter!(CACHE_FREELIST, "type" => if cached.is_some() { "hit" } else { "miss" })
-            .increment(1);
+        if let Some(counter) = free_list_cache_counter(cached.is_some()) {
+            counter.increment(1);
+        } else {
+            firewood_counter!(CACHE_FREELIST, "type" => if cached.is_some() { "hit" } else { "miss" })
+                .increment(1);
+        }
         firewood_gauge!(FREELIST_CACHE_SIZE).set_integer(guard.len());
         cached
     }

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -28,10 +28,12 @@ use crate::node::branch::{ReadSerializable, Serializable};
 use crate::nodestore::NodeStoreHeader;
 use firewood_metrics::{firewood_counter, firewood_gauge};
 use integer_encoding::VarIntReader;
+use metrics::Counter;
 
 use std::io::{Error, ErrorKind, Read};
 use std::iter::FusedIterator;
 use std::mem::size_of;
+use std::sync::OnceLock;
 
 use crate::{FreeListParent, MaybePersistedNode, ReadableStorage, WritableStorage};
 
@@ -42,6 +44,35 @@ const fn var_int_max_size<VI>() -> usize {
 
 /// `FreeLists` is an array of `Option<LinearAddress>` for each area size.
 pub type FreeLists = [Option<LinearAddress>; AreaIndex::NUM_AREA_SIZES];
+
+type AreaMetricCounters = [Counter; AreaIndex::NUM_AREA_SIZES];
+
+fn init_area_metric_counters(metric: &'static str) -> AreaMetricCounters {
+    std::array::from_fn(|index| {
+        let index = AreaIndex::new(index as u8).expect("area metric index within range");
+        metrics::counter!(metric, "index" => index_name(index))
+    })
+}
+
+/// Increment an area-indexed counter by `value`, caching the per-index `Counter`
+/// handles once the global recorder is installed. The runtime `"index"` label
+/// cannot use the literal-label cache path in `firewood_counter!`, so this keeps
+/// a per-metric array at the callsite.
+macro_rules! increment_area_counter {
+    ($metric:ident, $index:expr, $value:expr) => {{
+        static COUNTERS: OnceLock<AreaMetricCounters> = OnceLock::new();
+        let index: AreaIndex = $index;
+        if firewood_metrics::global_recorder_installed() {
+            COUNTERS
+                .get_or_init(|| init_area_metric_counters(crate::registry::$metric))
+                .get(index.as_usize())
+                .expect("area index within bounds")
+                .increment($value);
+        } else {
+            firewood_counter!($metric, "index" => index_name(index)).increment($value);
+        }
+    }};
+}
 
 /// A [`FreeArea`] is stored at the start of the area that contained a node that
 /// has been freed.
@@ -253,7 +284,7 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
                 *free_stored_area_addr = free_head.next_free_block;
             }
 
-            firewood_counter!(SPACE_REUSED, "index" => index_name(index)).increment(index.size());
+            increment_area_counter!(SPACE_REUSED, index, index.size());
             firewood_gauge!(FREE_LIST_ENTRIES, "index" => index_name(index)).decrement(1.0);
 
             // Return the address of the newly allocated block.
@@ -262,7 +293,7 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
         }
 
         trace!("No free blocks of sufficient size {index} found");
-        firewood_counter!(SPACE_FROM_END, "index" => index_name(index)).increment(index.size());
+        increment_area_counter!(SPACE_FROM_END, index, index.size());
         Ok(None)
     }
 
@@ -325,9 +356,8 @@ impl<S: WritableStorage> NodeAllocator<'_, S> {
 
         let (area_size_index, _) = self.area_index_and_size(addr)?;
         trace!("Deleting node at {addr:?} of size {area_size_index}");
-        firewood_counter!(DELETE_NODE, "index" => index_name(area_size_index)).increment(1);
-        firewood_counter!(SPACE_FREED, "index" => index_name(area_size_index))
-            .increment(area_size_index.size());
+        increment_area_counter!(DELETE_NODE, area_size_index, 1);
+        increment_area_counter!(SPACE_FREED, area_size_index, area_size_index.size());
         firewood_gauge!(FREE_LIST_ENTRIES, "index" => index_name(area_size_index)).increment(1.0);
 
         // The area that contained the node is now free.


### PR DESCRIPTION
## Why this should be merged

Metric recording is on hot storage paths, and repeated recorder lookups add avoidable overhead once the global metrics recorder is installed.

## How this works

- Tracks when the process-global metrics recorder has been installed.
- Caches counter/gauge/histogram handles in per-callsite `OnceLock`s for no-label and literal-label metric callsites.
- Adds explicit cached counter arrays for storage cache and area-indexed metrics where labels are runtime-derived but bounded.
- Marks the recorder as installed from both FFI metrics setup and benchmark Prometheus setup.
- Allows Go metrics tests to skip cleanly in EPERM-restricted environments.

## How this was tested

UT.

## Performance Evaluation and Numbers

TBD.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
