### PR TITLE
fix(range-proof): use last_kv_key as right-edge anchor for inclusion-style end_proofs

### DIFF
--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -417,6 +417,38 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     let left_edge = left_edge_key.map(|(k, v)| (k.as_ref(), v.as_ref()));
     let right_edge = right_edge_key.map(|(k, v)| (k.as_ref(), v.as_ref()));
 
+    // Determine the right-edge anchor key.
+    //
+    // The end_proof is one of two shapes:
+    //
+    //   * Inclusion proof of `last_kv_key`. This happens both when the proof
+    //     is truncated (a `max_length` was hit before reaching `bound`) and
+    //     when `bound` itself exists in the trie (so `bound == last_kv_key`).
+    //     In both cases the proof anchors at `last_kv_key` and must be
+    //     verified against it; using `bound` would walk a different path.
+    //
+    //   * Exclusion proof of some key past `last_kv_key` — produced for a
+    //     complete proof of `[start, bound]` when `bound` is not in the trie.
+    //     The proof anchors at `bound` (the requested upper boundary).
+    //
+    // We detect inclusion-of-last-kv by examining the terminal node: if it has
+    // a value digest and its full nibble path equals `last_kv_key`'s nibbles,
+    // it is the inclusion case and the anchor must be `last_kv_key`.
+    let right_edge_anchor: Option<&[u8]> = if let (Some(_bound), Some((last_kv_k, _))) =
+        (last_key_bytes, key_values.last())
+        && let Some(terminal) = proof.end_proof().as_ref().last()
+        && terminal.value_digest.is_some()
+        && terminal
+            .key
+            .iter()
+            .map(|c| c.as_u8())
+            .eq(NibblesIterator::new(last_kv_k.as_ref()))
+    {
+        Some(last_kv_k.as_ref())
+    } else {
+        last_key_bytes
+    };
+
     if !proof.start_proof().is_empty() {
         verify_edge(
             first_key_bytes,
@@ -428,7 +460,7 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     }
     if !proof.end_proof().is_empty() {
         verify_edge(
-            last_key_bytes,
+            right_edge_anchor,
             right_edge,
             proof.end_proof(),
             root_hash,
@@ -455,7 +487,7 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
         key_values,
         proof,
         first_key_bytes,
-        last_key_bytes,
+        right_edge_anchor,
         root_hash,
     )
 }

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -496,10 +496,11 @@ pub(crate) fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Resu
 ///   `Inclusive(Some(last_kv))`. The end-proof anchors directly at
 ///   `last_kv`. Covered by
 ///   `test_dropped_trailing_key_accepted_as_partial_coverage`.
-/// * **Everything else** — terminal is a strict prefix of `last_kv` with
-///   an on-path child set, terminal has no value digest, `end_proof`
-///   empty, or `key_values` empty — → `Inclusive(fallback_last)`,
-///   anchored at the caller's requested bound. Covered by
+/// * **Everything else** — terminal value-node with `K < last_kv` (whether
+///   `K` is a strict prefix of `last_kv` or a divergent lex-less node),
+///   terminal has no value digest, `end_proof` empty, or `key_values`
+///   empty — → `Inclusive(fallback_last)`, anchored at the caller's
+///   requested bound. Covered by
 ///   `test_terminal_strict_prefix_of_last_kv_verifies` and
 ///   `test_tampered_in_range_value_rejected`.
 ///
@@ -551,8 +552,8 @@ pub(crate) fn right_edge<'a>(
     };
 
     // Terminal anchors at a real byte key only when it carries a value
-    // digest. (Callers reject end_proof terminals whose nibble path is
-    // odd-length but carry a value before reaching here — see
+    // digest. (Callers reject *any* end_proof node whose nibble path is
+    // odd-length but carries a value before reaching here — see
     // [`reject_odd_nibble_value_digests`] — so we don't re-check parity.)
     if terminal.value_digest.is_some() {
         let nibs: Vec<u8> = terminal.key.iter().map(|c| c.as_u8()).collect();
@@ -583,10 +584,11 @@ pub(crate) fn right_edge<'a>(
 ///    `last_key`; partial coverage is a valid outcome, not an error.
 /// 3. **Boundary proof verification**: Cryptographically verify the start
 ///    proof against `first_key`. The right edge is verified against the
-///    *proof-derived* anchor — which may be `last_kv` or the caller's
-///    `last_key`, depending on whether the right boundary is inclusive
-///    or exclusive. For the exclusive case only, the cryptographic check
-///    is folded into the hash reconstruction below instead.
+///    *proof-derived* right boundary — for the inclusive case via
+///    `verify_edge` against either `last_kv` or the caller's `last_key`
+///    (whichever the proof anchors at), and for the exclusive case via
+///    the hash reconstruction below, where the anchor is the end-proof
+///    terminal's full key.
 /// 4. **Trie reconstruction**: Build an in-memory Merkle trie from the key-value pairs
 ///    and reconcile it with proof nodes
 /// 5. **Root hash comparison**: Verify the reconstructed trie's root hash matches the

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -187,27 +187,32 @@ pub(crate) enum EdgeBoundary<'a> {
 
 /// The right edge of a range proof.
 ///
-/// `Exclusive` holds a `Cow` because the only path that produces it —
+/// `OutOfRange` holds a `Cow` because the only path that produces it —
 /// `right_edge` for a terminal value-node whose full key exceeds
 /// `last_kv` — derives the boundary by reconstructing the terminal's
-/// full byte key from its nibble path, which is owned. `Inclusive`
+/// full byte key from its nibble path, which is owned. `InRange`
 /// always borrows from caller-supplied slices.
+///
+/// Note: "in-range" / "out-of-range" describes whether the boundary
+/// key itself belongs to the proven range. This is independent from
+/// the inclusion-proof vs. exclusion-proof distinction at the proof
+/// layer (which is about whether a key exists in the trie).
 #[derive(Debug)]
 pub(crate) enum RightBoundary<'a> {
-    /// Inclusive at `end_key` (or no upper bound if `None`). `end_key`
-    /// itself is part of the proven range.
-    Inclusive(Option<&'a [u8]>),
-    /// Exclusive at `end_key`. `end_key` always exists for this variant
-    /// — it sits at the end-proof's terminal node — and is *not* part
-    /// of the proven range.
-    Exclusive(Cow<'a, [u8]>),
+    /// The boundary key (or no upper bound if `None`) is part of the
+    /// proven range — the right end is "closed" at `end_key`.
+    InRange(Option<&'a [u8]>),
+    /// The boundary key is *not* part of the proven range — the right
+    /// end is "open" at `end_key`. `end_key` always exists for this
+    /// variant; it sits at the end-proof's terminal node.
+    OutOfRange(Cow<'a, [u8]>),
 }
 
 impl RightBoundary<'_> {
     fn boundary_key(&self) -> Option<&[u8]> {
         match self {
-            RightBoundary::Inclusive(k) => *k,
-            RightBoundary::Exclusive(k) => Some(k.as_ref()),
+            RightBoundary::InRange(k) => *k,
+            RightBoundary::OutOfRange(k) => Some(k.as_ref()),
         }
     }
 }
@@ -225,7 +230,7 @@ impl EdgeBoundary<'_> {
     }
 
     const fn is_right_exclusive(&self) -> bool {
-        matches!(self, EdgeBoundary::Right(RightBoundary::Exclusive(_)))
+        matches!(self, EdgeBoundary::Right(RightBoundary::OutOfRange(_)))
     }
 }
 
@@ -239,7 +244,7 @@ impl EdgeBoundary<'_> {
 /// on-path nibble at the terminal proof node, since there is no subsequent
 /// proof node to derive it from.
 ///
-/// For [`RightBoundary::Exclusive`], the boundary itself sits at the
+/// For [`RightBoundary::OutOfRange`], the boundary itself sits at the
 /// proof's terminal node and is *not* part of the proven range. The on-path
 /// child at the terminal's parent leads only to that terminal, so we mark
 /// it outside in addition to the usual "children with index > the on-path
@@ -250,11 +255,11 @@ fn compute_outside_children(
     proof_nodes: &[ProofNode],
     boundary: EdgeBoundary<'_>,
 ) -> Result<HashMap<PathBuf, ChildMask>, ProofError> {
-    // Invariant from `right_edge`: `RightBoundary::Exclusive(K)` is only
+    // Invariant from `right_edge`: `RightBoundary::OutOfRange(K)` is only
     // constructed when `K` is the end-proof's terminal full key (and
     // `K > last_kv`). Pin that here so a future change to `right_edge`
     // that breaks it surfaces immediately in tests.
-    if let EdgeBoundary::Right(RightBoundary::Exclusive(boundary_key)) = &boundary {
+    if let EdgeBoundary::Right(RightBoundary::OutOfRange(boundary_key)) = &boundary {
         debug_assert!(
             proof_nodes.last().is_some_and(|terminal| {
                 terminal
@@ -263,7 +268,7 @@ fn compute_outside_children(
                     .map(|c| c.as_u8())
                     .eq(NibblesIterator::new(boundary_key.as_ref()))
             }),
-            "RightBoundary::Exclusive must match the end-proof terminal's full nibble path",
+            "RightBoundary::OutOfRange must match the end-proof terminal's full nibble path",
         );
     }
 
@@ -442,7 +447,7 @@ fn compute_root_hash_with_proofs(
 /// a proof. This is a cheap structural sanity check that callers run on
 /// a proof's nodes before any anchoring decision is made — see e.g. the
 /// call before [`right_edge`] in `verify_range_proof`.
-pub(crate) fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Result<(), ProofError> {
+fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Result<(), ProofError> {
     for node in proof_nodes {
         if !node.key.len().is_multiple_of(2) && node.value_digest.is_some() {
             return Err(ProofError::ValueAtOddNibbleLength);
@@ -453,7 +458,7 @@ pub(crate) fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Resu
 
 /// Compute the right edge of the proven range — the boundary key the
 /// end-proof actually anchors at, and whether that boundary is inclusive
-/// (in-range) or exclusive (out-of-range).
+/// in-range or out-of-range relative to the proven range.
 ///
 /// A previous heuristic on this code path was: "if the end-proof terminal
 /// has a value digest AND its nibble path equals `nibbles(last_kv)`, anchor
@@ -480,26 +485,26 @@ pub(crate) fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Resu
 /// [`RightBoundary`] whose variant encodes inclusivity. The caller treats
 /// each variant as follows:
 ///
-/// * [`RightBoundary::Inclusive`] — runs the full `verify_edge` against
+/// * [`RightBoundary::InRange`] — runs the full `verify_edge` against
 ///   the boundary to cryptographically anchor the proof.
-/// * [`RightBoundary::Exclusive`] — skips `verify_edge`; the anchor check
-///   is folded into the hash reconstruction via the exclusive-boundary
+/// * [`RightBoundary::OutOfRange`] — skips `verify_edge`; the anchor check
+///   is folded into the hash reconstruction via the out-of-range-boundary
 ///   path in [`compute_outside_children`].
 ///
 /// The classification:
 ///
 /// * **Terminal value-node, full key `K > last_kv`** →
-///   `Exclusive(Cow::Owned(K))`. The proof structurally proves
+///   `OutOfRange(Cow::Owned(K))`. The proof structurally proves
 ///   `[first, K)`; `last_kv` is in that range, `K` is not. Covered by
 ///   `test_divergent_terminal_past_last_kv`.
 /// * **Terminal value-node, full key `K == last_kv`** →
-///   `Inclusive(Some(last_kv))`. The end-proof anchors directly at
+///   `InRange(Some(last_kv))`. The end-proof anchors directly at
 ///   `last_kv`. Covered by
 ///   `test_dropped_trailing_key_accepted_as_partial_coverage`.
 /// * **Everything else** — terminal value-node with `K < last_kv` (whether
 ///   `K` is a strict prefix of `last_kv` or a divergent lex-less node),
 ///   terminal has no value digest, `end_proof` empty, or `key_values`
-///   empty — → `Inclusive(fallback_last)`, anchored at the caller's
+///   empty — → `InRange(fallback_last)`, anchored at the caller's
 ///   requested bound. Covered by
 ///   `test_terminal_strict_prefix_of_last_kv_verifies` and
 ///   `test_tampered_in_range_value_rejected`.
@@ -534,7 +539,7 @@ pub(crate) fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Resu
 ///
 /// # Asymmetry with the left edge
 ///
-/// There is no `LeftExclusive` counterpart to `RightBoundary::Exclusive`.
+/// There is no `LeftOutOfRange` counterpart to `RightBoundary::OutOfRange`.
 /// The mirror construction (`terminal_full_key < first_kv` via a divergent
 /// leaf in `prove(first_key)`) is empirically handled by the existing
 /// [`EdgeBoundary::Left`] path; see `test_divergent_terminal_before_first_kv`.
@@ -542,13 +547,13 @@ pub(crate) fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Resu
 /// construction, present in `key_values`, so there is no off-path single-node
 /// subtree past `first_kv` that could synthesize incorrectly during hash
 /// reconstruction.
-pub(crate) fn right_edge<'a>(
+fn right_edge<'a>(
     end_proof: &[ProofNode],
     last_kv: Option<&'a [u8]>,
     fallback_last: Option<&'a [u8]>,
 ) -> RightBoundary<'a> {
     let (Some(terminal), Some(last_kv_k)) = (end_proof.last(), last_kv) else {
-        return RightBoundary::Inclusive(fallback_last);
+        return RightBoundary::InRange(fallback_last);
     };
 
     // Terminal anchors at a real byte key only when it carries a value
@@ -560,14 +565,14 @@ pub(crate) fn right_edge<'a>(
         let terminal_full_key: Vec<u8> = Path::from(nibs.as_slice()).bytes_iter().collect();
         match terminal_full_key.as_slice().cmp(last_kv_k) {
             std::cmp::Ordering::Greater => {
-                return RightBoundary::Exclusive(Cow::Owned(terminal_full_key));
+                return RightBoundary::OutOfRange(Cow::Owned(terminal_full_key));
             }
-            std::cmp::Ordering::Equal => return RightBoundary::Inclusive(Some(last_kv_k)),
+            std::cmp::Ordering::Equal => return RightBoundary::InRange(Some(last_kv_k)),
             std::cmp::Ordering::Less => { /* fall through to fallback */ }
         }
     }
 
-    RightBoundary::Inclusive(fallback_last)
+    RightBoundary::InRange(fallback_last)
 }
 
 /// Verify that a range proof is valid for the specified key range and root hash.
@@ -584,15 +589,31 @@ pub(crate) fn right_edge<'a>(
 ///    `last_key`; partial coverage is a valid outcome, not an error.
 /// 3. **Boundary proof verification**: Cryptographically verify the start
 ///    proof against `first_key`. The right edge is verified against the
-///    *proof-derived* right boundary — for the inclusive case via
+///    *proof-derived* right boundary — when the boundary is in-range, via
 ///    `verify_edge` against either `last_kv` or the caller's `last_key`
-///    (whichever the proof anchors at), and for the exclusive case via
-///    the hash reconstruction below, where the anchor is the end-proof
+///    (whichever the proof anchors at); when the boundary is out-of-range,
+///    via the hash reconstruction below, where the anchor is the end-proof
 ///    terminal's full key.
 /// 4. **Trie reconstruction**: Build an in-memory Merkle trie from the key-value pairs
 ///    and reconcile it with proof nodes
 /// 5. **Root hash comparison**: Verify the reconstructed trie's root hash matches the
 ///    expected hash
+///
+/// # Partial coverage
+///
+/// A successful return does **not** guarantee that the proof covered the
+/// caller's full requested range `[first_key, last_key]`. The proof
+/// generator may have truncated the response (e.g. hit a max-length limit),
+/// in which case the proven range is `[first_key, key_values.last()]` with
+/// `key_values.last() < last_key`. This is a valid outcome of verification,
+/// not an error.
+///
+/// Callers who need the full requested range must compare
+/// `proof.key_values().last()` against their requested `last_key` after a
+/// successful verification. If the proven right edge is short, re-request
+/// `(key_values.last(), last_key]` and verify that next slice. Iterating
+/// this loop is the canonical way to assemble full-range coverage from
+/// truncated proofs.
 ///
 /// # Errors
 ///
@@ -673,33 +694,33 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     }
 
     // Right edge:
-    //   * Inclusive (terminal == last_kv, or fallback to the caller's
+    //   * InRange (terminal == last_kv, or fallback to the caller's
     //     requested bound): run full `verify_edge`. This is what
     //     cryptographically anchors the proof at `last_kv`'s value when
     //     the proof's terminal sits at or above `last_kv`, since the
     //     hash-reconstruction path treats `last_kv`'s on-path child as
     //     outside-the-range and would otherwise miss a tampered `last_kv`
     //     value.
-    //   * Exclusive (terminal_full_key > last_kv): skip
+    //   * OutOfRange (terminal_full_key > last_kv): skip
     //     `proof.verify(...)` — the proof was structurally generated for
     //     a deeper bound, and the cryptographic check is folded into the
-    //     hash reconstruction via the exclusive-boundary path in
+    //     hash reconstruction via the out-of-range-boundary path in
     //     `compute_outside_children`. We still keep the ordering sanity
     //     check.
     let last_kv_bytes = key_values.last().map(|(k, _)| k.as_ref());
     let right_boundary = right_edge(proof.end_proof().as_ref(), last_kv_bytes, last_key_bytes);
     match &right_boundary {
-        RightBoundary::Inclusive(bound) => {
+        RightBoundary::InRange(bound) => {
             verify_edge(*bound, right_edge_kv, proof.end_proof(), root_hash, false)?;
         }
-        RightBoundary::Exclusive(bound) => {
-            // `right_edge` only returns `Exclusive(K)` when `K > last_kv`
+        RightBoundary::OutOfRange(bound) => {
+            // `right_edge` only returns `OutOfRange(K)` when `K > last_kv`
             // strictly (terminal value-node past last_kv). The runtime
             // check below catches a broken contract; the debug_assert pins
             // the intended invariant.
             debug_assert!(
                 right_edge_kv.is_none_or(|(edge_key, _)| bound.as_ref() > edge_key),
-                "RightBoundary::Exclusive must be strictly greater than last_kv",
+                "RightBoundary::OutOfRange must be strictly greater than last_kv",
             );
             if let Some((edge_key, _)) = right_edge_kv
                 && bound.as_ref() < edge_key
@@ -741,8 +762,8 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
 /// them, making the root hash correct.
 ///
 /// The right edge of the in-range comparison comes from `right_boundary`:
-/// `Inclusive(b)` includes `b`, `Exclusive(b)` excludes it,
-/// `Inclusive(None)` has no upper bound.
+/// `InRange(b)` includes `b`, `OutOfRange(b)` excludes it,
+/// `InRange(None)` has no upper bound.
 fn verify_proof_node_values(
     proof_nodes: &[&ProofNode],
     first_key_bytes: Option<&[u8]>,
@@ -766,9 +787,9 @@ fn verify_proof_node_values(
             .collect();
         let node_key_bytes: Vec<u8> = Path::from(key_nibbles.as_slice()).bytes_iter().collect();
         let within_right = match right_boundary {
-            RightBoundary::Inclusive(None) => true,
-            RightBoundary::Inclusive(Some(end)) => node_key_bytes.as_slice() <= *end,
-            RightBoundary::Exclusive(end) => node_key_bytes.as_slice() < end.as_ref(),
+            RightBoundary::InRange(None) => true,
+            RightBoundary::InRange(Some(end)) => node_key_bytes.as_slice() <= *end,
+            RightBoundary::OutOfRange(end) => node_key_bytes.as_slice() < end.as_ref(),
         };
         let in_range =
             within_right && first_key_bytes.is_none_or(|start| node_key_bytes.as_slice() >= start);
@@ -797,7 +818,7 @@ fn verify_proof_node_values(
 /// that the computed root hash matches the expected one.
 ///
 /// `right_boundary` describes the right edge of the proven range. When the
-/// variant is [`RightBoundary::Exclusive`], the boundary key sits at the
+/// variant is [`RightBoundary::OutOfRange`], the boundary key sits at the
 /// end-proof's terminal node and is treated as outside the proven range.
 fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
     all_proof_nodes: &[&ProofNode],
@@ -1040,7 +1061,7 @@ pub fn verify_change_proof_root_hash(
     )?;
     for (key, flags) in compute_outside_children(
         end_nodes,
-        EdgeBoundary::Right(RightBoundary::Inclusive(
+        EdgeBoundary::Right(RightBoundary::InRange(
             verification.right_edge_key.as_deref(),
         )),
     )? {

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -434,12 +434,14 @@ fn compute_root_hash_with_proofs(
     .to_hash()
 }
 
-/// Reject any proof node that carries a `Value` digest at an odd-length
+/// Reject any proof node that carries a value digest (either
+/// [`ValueDigest::Value`] or [`ValueDigest::Hash`]) at an odd-length
 /// nibble path. Byte keys are always even-nibble, so a value at an
-/// odd-length path can't correspond to any real key in the trie. This is
-/// a cheap structural sanity check that callers run on a proof's nodes
-/// before any anchoring decision is made — see e.g. the call before
-/// [`right_edge`] in `verify_range_proof`.
+/// odd-length path can't correspond to any real key in the trie — this
+/// is the same invariant [`Proof::value_digest`] enforces while walking
+/// a proof. This is a cheap structural sanity check that callers run on
+/// a proof's nodes before any anchoring decision is made — see e.g. the
+/// call before [`right_edge`] in `verify_range_proof`.
 pub(crate) fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Result<(), ProofError> {
     for node in proof_nodes {
         if !node.key.len().is_multiple_of(2) && node.value_digest.is_some() {
@@ -580,9 +582,11 @@ pub(crate) fn right_edge<'a>(
 ///    the actual bound the end-proof anchors at. This may be smaller than
 ///    `last_key`; partial coverage is a valid outcome, not an error.
 /// 3. **Boundary proof verification**: Cryptographically verify the start
-///    proof against `first_key`. The right edge is *not* re-verified against
-///    the caller's `last_key`; its cryptographic check is folded into the
-///    hash reconstruction below via the proof-derived anchor.
+///    proof against `first_key`. The right edge is verified against the
+///    *proof-derived* anchor — which may be `last_kv` or the caller's
+///    `last_key`, depending on whether the right boundary is inclusive
+///    or exclusive. For the exclusive case only, the cryptographic check
+///    is folded into the hash reconstruction below instead.
 /// 4. **Trie reconstruction**: Build an in-memory Merkle trie from the key-value pairs
 ///    and reconcile it with proof nodes
 /// 5. **Root hash comparison**: Verify the reconstructed trie's root hash matches the

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -30,6 +30,7 @@ use firewood_storage::{
     NibblesIterator, Node, NodeStore, Path, PathBuf, PathComponent, Propose, ReadableStorage,
     SharedNode, TrieHash, TrieReader, U4, ValueDigest,
 };
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::io::Error;
@@ -167,41 +168,139 @@ fn verify_edge<H: ProofCollection + ?Sized>(
     Ok(())
 }
 
+/// Describes the boundary of one edge of a range proof.
+///
+/// The variants encode "which edge"; the right edge's inclusivity lives
+/// inside [`RightBoundary`]. Splitting these two concerns lets sites that
+/// only operate on the right edge (e.g. `verify_proof_node_values`) take
+/// `RightBoundary` directly without an `unreachable!()` arm for `Left`,
+/// while keeping a single unified type for the one place that genuinely
+/// dispatches on left-vs-right at runtime: `compute_outside_children`.
+#[derive(Debug)]
+pub(crate) enum EdgeBoundary<'a> {
+    /// Left edge, inclusive at `start_key`. `None` proves from the very
+    /// beginning of the trie.
+    Left(Option<&'a [u8]>),
+    /// Right edge, with inclusivity carried by the inner variant.
+    Right(RightBoundary<'a>),
+}
+
+/// The right edge of a range proof.
+///
+/// `Exclusive` holds a `Cow` because the only path that produces it —
+/// `right_edge` for a terminal value-node whose full key exceeds
+/// `last_kv` — derives the boundary by reconstructing the terminal's
+/// full byte key from its nibble path, which is owned. `Inclusive`
+/// always borrows from caller-supplied slices.
+#[derive(Debug)]
+pub(crate) enum RightBoundary<'a> {
+    /// Inclusive at `end_key` (or no upper bound if `None`). `end_key`
+    /// itself is part of the proven range.
+    Inclusive(Option<&'a [u8]>),
+    /// Exclusive at `end_key`. `end_key` always exists for this variant
+    /// — it sits at the end-proof's terminal node — and is *not* part
+    /// of the proven range.
+    Exclusive(Cow<'a, [u8]>),
+}
+
+impl RightBoundary<'_> {
+    fn boundary_key(&self) -> Option<&[u8]> {
+        match self {
+            RightBoundary::Inclusive(k) => *k,
+            RightBoundary::Exclusive(k) => Some(k.as_ref()),
+        }
+    }
+}
+
+impl EdgeBoundary<'_> {
+    fn boundary_key(&self) -> Option<&[u8]> {
+        match self {
+            EdgeBoundary::Left(k) => *k,
+            EdgeBoundary::Right(r) => r.boundary_key(),
+        }
+    }
+
+    const fn is_left(&self) -> bool {
+        matches!(self, EdgeBoundary::Left(_))
+    }
+
+    const fn is_right_exclusive(&self) -> bool {
+        matches!(self, EdgeBoundary::Right(RightBoundary::Exclusive(_)))
+    }
+}
+
 /// For a proof edge path, computes which child indices at each proof node are
 /// "outside" the proven range and should use the proof's child hashes.
 ///
 /// For the left edge: children with index < the on-path child are outside.
 /// For the right edge: children with index > the on-path child are outside.
 ///
-/// The `boundary_key` (in bytes, not nibbles) is used to determine the on-path
-/// nibble at the terminal proof node, since there is no subsequent proof node
-/// to derive it from.
+/// The boundary key (in bytes, not nibbles) is used to determine the
+/// on-path nibble at the terminal proof node, since there is no subsequent
+/// proof node to derive it from.
+///
+/// For [`RightBoundary::Exclusive`], the boundary itself sits at the
+/// proof's terminal node and is *not* part of the proven range. The on-path
+/// child at the terminal's parent leads only to that terminal, so we mark
+/// it outside in addition to the usual "children with index > the on-path
+/// child" marking — the hash check then substitutes the proof's stored
+/// child hash there instead of recursing into the proving trie's
+/// (irrelevant) subtree.
 fn compute_outside_children(
     proof_nodes: &[ProofNode],
-    boundary_key: Option<&[u8]>,
-    is_left_edge: bool,
+    boundary: EdgeBoundary<'_>,
 ) -> Result<HashMap<PathBuf, ChildMask>, ProofError> {
+    // Invariant from `right_edge`: `RightBoundary::Exclusive(K)` is only
+    // constructed when `K` is the end-proof's terminal full key (and
+    // `K > last_kv`). Pin that here so a future change to `right_edge`
+    // that breaks it surfaces immediately in tests.
+    if let EdgeBoundary::Right(RightBoundary::Exclusive(boundary_key)) = &boundary {
+        debug_assert!(
+            proof_nodes.last().is_some_and(|terminal| {
+                terminal
+                    .key
+                    .iter()
+                    .map(|c| c.as_u8())
+                    .eq(NibblesIterator::new(boundary_key.as_ref()))
+            }),
+            "RightBoundary::Exclusive must match the end-proof terminal's full nibble path",
+        );
+    }
+
     let mut result: HashMap<PathBuf, ChildMask> = HashMap::new();
 
     // Non-terminal nodes: derive the on-path nibble from the next proof node
-    for (parent, child) in proof_nodes.iter().zip(proof_nodes.iter().skip(1)) {
+    let mut pairs = proof_nodes
+        .iter()
+        .zip(proof_nodes.iter().skip(1))
+        .peekable();
+    while let Some((parent, child)) = pairs.next() {
         let on_path_nibble = child
             .key
             .get(parent.key.len())
             .ok_or(ProofError::ShouldBePrefixOfNextKey)?;
         let entry = result.entry(parent.key.clone()).or_default();
-        *entry = if is_left_edge {
+        *entry = if boundary.is_left() {
             entry.set_below(on_path_nibble.0)
         } else {
             entry.set_above(on_path_nibble.0)
         };
+
+        // Right-edge exclusive: at the terminal's parent (i.e., the last
+        // non-terminal pair), the on-path child's whole subtree is just
+        // the terminal, which is itself outside the proven range. Mark it
+        // outside so the hash check uses the proof's stored child hash
+        // here instead of recursing into the proving trie.
+        if boundary.is_right_exclusive() && pairs.peek().is_none() {
+            *entry = entry.set(on_path_nibble.0);
+        }
     }
 
     // Terminal node: derive the on-path nibble from the boundary key.
     // If the boundary key diverges within the terminal node's partial path,
     // either all or none of the children are outside the range.
-    if let (Some(terminal), Some(boundary)) = (proof_nodes.last(), boundary_key) {
-        let boundary_nibbles: Vec<u8> = NibblesIterator::new(boundary).collect();
+    if let (Some(terminal), Some(boundary_key)) = (proof_nodes.last(), boundary.boundary_key()) {
+        let boundary_nibbles: Vec<u8> = NibblesIterator::new(boundary_key).collect();
 
         // Find the first position where boundary and terminal key diverge,
         // capturing the diverging values to avoid re-indexing.
@@ -215,7 +314,7 @@ fn compute_outside_children(
             // Boundary diverges within the terminal's key at this position.
             // If boundary is "past" the terminal (left edge: B > terminal,
             // right edge: B < terminal), all children are outside.
-            let all_outside = if is_left_edge {
+            let all_outside = if boundary.is_left() {
                 *bn > tk.as_u8()
             } else {
                 *bn < tk.as_u8()
@@ -233,13 +332,13 @@ fn compute_outside_children(
             // proof's hash rather than recomputing it.
             let on_path_nibble = U4::new_masked(*on_path_byte);
             let entry = result.entry(terminal.key.clone()).or_default();
-            *entry = if is_left_edge {
+            *entry = if boundary.is_left() {
                 entry.set_below(on_path_nibble)
             } else {
                 entry.set_above(on_path_nibble)
             }
             .set(on_path_nibble);
-        } else if !is_left_edge {
+        } else if !boundary.is_left() {
             // Boundary is a prefix of or exactly matches the terminal key.
             // For the right edge, all children extend beyond end_key (they
             // represent keys longer than end_key sharing its prefix), so
@@ -335,22 +434,158 @@ fn compute_root_hash_with_proofs(
     .to_hash()
 }
 
+/// Reject any proof node that carries a `Value` digest at an odd-length
+/// nibble path. Byte keys are always even-nibble, so a value at an
+/// odd-length path can't correspond to any real key in the trie. This is
+/// a cheap structural sanity check that callers run on a proof's nodes
+/// before any anchoring decision is made — see e.g. the call before
+/// [`right_edge`] in `verify_range_proof`.
+pub(crate) fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Result<(), ProofError> {
+    for node in proof_nodes {
+        if !node.key.len().is_multiple_of(2) && node.value_digest.is_some() {
+            return Err(ProofError::ValueAtOddNibbleLength);
+        }
+    }
+    Ok(())
+}
+
+/// Compute the right edge of the proven range — the boundary key the
+/// end-proof actually anchors at, and whether that boundary is inclusive
+/// (in-range) or exclusive (out-of-range).
+///
+/// A previous heuristic on this code path was: "if the end-proof terminal
+/// has a value digest AND its nibble path equals `nibbles(last_kv)`, anchor
+/// at `last_kv`; otherwise anchor at the caller's `last_key` bound."
+/// Suppose we have two structurally different proof shapes that produce
+/// identical end-proofs:
+///
+/// 1. A complete *exclusion proof* of `last_key` whose path happens to
+///    terminate at the node where `last_kv` lives (i.e., the terminal is the
+///    real value node for `last_kv`, even though the caller asked about a
+///    different — absent — `last_key`).
+/// 2. An *inclusion proof of `last_kv`* (which arises when the response is
+///    truncated, or whenever `last_kv == last_key`).
+///
+/// The old heuristic conflated the two. An attacker could drop trailing
+/// entries from `key_values` so the new `last_kv` happened to coincide with
+/// the proof's terminal; the dropped keys were then absorbed silently into
+/// "outside the proven range" via the proof's stored child hashes, and the
+/// tampered range still verified against the honest root.
+///
+/// # What this function does — the three legal shapes
+///
+/// Classifies the end-proof terminal against `last_kv` and returns a
+/// [`RightBoundary`] whose variant encodes inclusivity. The caller treats
+/// each variant as follows:
+///
+/// * [`RightBoundary::Inclusive`] — runs the full `verify_edge` against
+///   the boundary to cryptographically anchor the proof.
+/// * [`RightBoundary::Exclusive`] — skips `verify_edge`; the anchor check
+///   is folded into the hash reconstruction via the exclusive-boundary
+///   path in [`compute_outside_children`].
+///
+/// The classification:
+///
+/// * **Terminal value-node, full key `K > last_kv`** →
+///   `Exclusive(Cow::Owned(K))`. The proof structurally proves
+///   `[first, K)`; `last_kv` is in that range, `K` is not. Covered by
+///   `test_divergent_terminal_past_last_kv`.
+/// * **Terminal value-node, full key `K == last_kv`** →
+///   `Inclusive(Some(last_kv))`. The end-proof anchors directly at
+///   `last_kv`. Covered by
+///   `test_dropped_trailing_key_accepted_as_partial_coverage`.
+/// * **Everything else** — terminal is a strict prefix of `last_kv` with
+///   an on-path child set, terminal has no value digest, `end_proof`
+///   empty, or `key_values` empty — → `Inclusive(fallback_last)`,
+///   anchored at the caller's requested bound. Covered by
+///   `test_terminal_strict_prefix_of_last_kv_verifies` and
+///   `test_tampered_in_range_value_rejected`.
+///
+/// # Why partial coverage is OK
+///
+/// In the inclusive-at-`last_kv` shape (case 2), the proven range may be
+/// strictly narrower than what the caller requested — the dropped-trailing-
+/// key scenario (`test_dropped_trailing_key_accepted_as_partial_coverage`)
+/// is the canonical case, since the attacker shrunk it on purpose. This is
+/// a *valid* outcome, not a verification error. The caller is expected to
+/// compare `key_values.last()` against their requested `last_key`; if the
+/// proven range is narrower, they re-request `(last_kv, last_key]`. No data
+/// is hidden — at most one extra round trip is induced, and the attacker
+/// gains nothing.
+///
+/// # Why we still take `fallback_last`
+///
+/// Aspirationally we would like the hash reconstruction to depend *only* on
+/// the proof and `key_values`, with `first_key` / `last_key` used solely for
+/// structural range checks on the caller-provided bounds. We are not there
+/// yet on the right edge: when the end-proof's terminal is a strict prefix
+/// of `last_kv` with the on-path child set, [`compute_outside_children`]
+/// marks `last_kv`'s on-path child as outside, so the hash reconstruction
+/// substitutes the proof's stored child hash and would *not* notice a
+/// tampered `last_kv` value. The cryptographic `verify_edge` call against
+/// the caller's `last_key` is what catches that case
+/// (`test_tampered_in_range_value_rejected`). We have no known attack
+/// against the current design; the dependency on the caller's bound is
+/// documented here so a future refactor can audit and remove it
+/// deliberately if a fully self-contained verifier is wanted.
+///
+/// # Asymmetry with the left edge
+///
+/// There is no `LeftExclusive` counterpart to `RightBoundary::Exclusive`.
+/// The mirror construction (`terminal_full_key < first_kv` via a divergent
+/// leaf in `prove(first_key)`) is empirically handled by the existing
+/// [`EdgeBoundary::Left`] path; see `test_divergent_terminal_before_first_kv`.
+/// The asymmetry holds because the in-range data on the left side is, by
+/// construction, present in `key_values`, so there is no off-path single-node
+/// subtree past `first_kv` that could synthesize incorrectly during hash
+/// reconstruction.
+pub(crate) fn right_edge<'a>(
+    end_proof: &[ProofNode],
+    last_kv: Option<&'a [u8]>,
+    fallback_last: Option<&'a [u8]>,
+) -> RightBoundary<'a> {
+    let (Some(terminal), Some(last_kv_k)) = (end_proof.last(), last_kv) else {
+        return RightBoundary::Inclusive(fallback_last);
+    };
+
+    // Terminal anchors at a real byte key only when it carries a value
+    // digest. (Callers reject end_proof terminals whose nibble path is
+    // odd-length but carry a value before reaching here — see
+    // [`reject_odd_nibble_value_digests`] — so we don't re-check parity.)
+    if terminal.value_digest.is_some() {
+        let nibs: Vec<u8> = terminal.key.iter().map(|c| c.as_u8()).collect();
+        let terminal_full_key: Vec<u8> = Path::from(nibs.as_slice()).bytes_iter().collect();
+        match terminal_full_key.as_slice().cmp(last_kv_k) {
+            std::cmp::Ordering::Greater => {
+                return RightBoundary::Exclusive(Cow::Owned(terminal_full_key));
+            }
+            std::cmp::Ordering::Equal => return RightBoundary::Inclusive(Some(last_kv_k)),
+            std::cmp::Ordering::Less => { /* fall through to fallback */ }
+        }
+    }
+
+    RightBoundary::Inclusive(fallback_last)
+}
+
 /// Verify that a range proof is valid for the specified key range and root hash.
 ///
 /// This function validates a range proof by constructing a partial trie from the
-/// proof data and verifying that it produces the expected root hash. The proof may
-/// contain fewer key-value pairs than requested if the peer chose to limit the
-/// response size.
+/// proof data and verifying that it produces the expected root hash.
 ///
 /// # Verification Process
 ///
 /// 1. **Structural validation**: Ensure key-value pairs are in strictly ascending order,
 ///    within the requested `[first_key, last_key]` range, and reject unexpected proofs
-/// 2. **Boundary proof verification**: Cryptographically verify start/end proofs against
-///    the provided root hash
-/// 3. **Trie reconstruction**: Build an in-memory Merkle trie from the key-value pairs
+/// 2. **Right-edge anchor derivation**: Determine, from the proof's structure,
+///    the actual bound the end-proof anchors at. This may be smaller than
+///    `last_key`; partial coverage is a valid outcome, not an error.
+/// 3. **Boundary proof verification**: Cryptographically verify the start
+///    proof against `first_key`. The right edge is *not* re-verified against
+///    the caller's `last_key`; its cryptographic check is folded into the
+///    hash reconstruction below via the proof-derived anchor.
+/// 4. **Trie reconstruction**: Build an in-memory Merkle trie from the key-value pairs
 ///    and reconcile it with proof nodes
-/// 4. **Root hash comparison**: Verify the reconstructed trie's root hash matches the
+/// 5. **Root hash comparison**: Verify the reconstructed trie's root hash matches the
 ///    expected hash
 ///
 /// # Errors
@@ -358,7 +593,6 @@ fn compute_root_hash_with_proofs(
 /// Returns [`api::Error::ProofError`] if the proof is structurally invalid,
 /// keys are outside the requested range, boundary proofs fail verification,
 /// or the reconstructed root hash doesn't match.
-#[allow(clippy::too_many_lines)]
 pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     first_key: Option<impl KeyType>,
     last_key: Option<impl KeyType>,
@@ -411,61 +645,64 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
         return Err(api::Error::ProofError(ProofError::NoEndProof));
     }
 
-    let left_edge_key = key_values.first();
-    let right_edge_key = key_values.last();
+    // Sanity-check end_proof's structural invariants before any anchoring
+    // decision is made. The right-edge `verify_edge` call below is conditional
+    // (skipped when the boundary is exclusive), so without this scan the
+    // end_proof would be unvalidated when `right_edge` reads its terminal
+    // and could feed `right_edge` an odd-nibble value-node.
+    reject_odd_nibble_value_digests(proof.end_proof().as_ref())?;
 
-    let left_edge = left_edge_key.map(|(k, v)| (k.as_ref(), v.as_ref()));
-    let right_edge = right_edge_key.map(|(k, v)| (k.as_ref(), v.as_ref()));
+    let left_edge_kv = key_values.first().map(|(k, v)| (k.as_ref(), v.as_ref()));
+    let right_edge_kv = key_values.last().map(|(k, v)| (k.as_ref(), v.as_ref()));
 
-    // Determine the right-edge anchor key.
-    //
-    // The end_proof is one of two shapes:
-    //
-    //   * Inclusion proof of `last_kv_key`. This happens both when the proof
-    //     is truncated (a `max_length` was hit before reaching `bound`) and
-    //     when `bound` itself exists in the trie (so `bound == last_kv_key`).
-    //     In both cases the proof anchors at `last_kv_key` and must be
-    //     verified against it; using `bound` would walk a different path.
-    //
-    //   * Exclusion proof of some key past `last_kv_key` — produced for a
-    //     complete proof of `[start, bound]` when `bound` is not in the trie.
-    //     The proof anchors at `bound` (the requested upper boundary).
-    //
-    // We detect inclusion-of-last-kv by examining the terminal node: if it has
-    // a value digest and its full nibble path equals `last_kv_key`'s nibbles,
-    // it is the inclusion case and the anchor must be `last_kv_key`.
-    let right_edge_anchor: Option<&[u8]> = if let (Some(_bound), Some((last_kv_k, _))) =
-        (last_key_bytes, key_values.last())
-        && let Some(terminal) = proof.end_proof().as_ref().last()
-        && terminal.value_digest.is_some()
-        && terminal
-            .key
-            .iter()
-            .map(|c| c.as_u8())
-            .eq(NibblesIterator::new(last_kv_k.as_ref()))
-    {
-        Some(last_kv_k.as_ref())
-    } else {
-        last_key_bytes
-    };
-
+    // Left edge: full verification — the proof must anchor at `first_key`.
     if !proof.start_proof().is_empty() {
         verify_edge(
             first_key_bytes,
-            left_edge,
+            left_edge_kv,
             proof.start_proof(),
             root_hash,
             true,
         )?;
     }
-    if !proof.end_proof().is_empty() {
-        verify_edge(
-            right_edge_anchor,
-            right_edge,
-            proof.end_proof(),
-            root_hash,
-            false,
-        )?;
+
+    // Right edge:
+    //   * Inclusive (terminal == last_kv, or fallback to the caller's
+    //     requested bound): run full `verify_edge`. This is what
+    //     cryptographically anchors the proof at `last_kv`'s value when
+    //     the proof's terminal sits at or above `last_kv`, since the
+    //     hash-reconstruction path treats `last_kv`'s on-path child as
+    //     outside-the-range and would otherwise miss a tampered `last_kv`
+    //     value.
+    //   * Exclusive (terminal_full_key > last_kv): skip
+    //     `proof.verify(...)` — the proof was structurally generated for
+    //     a deeper bound, and the cryptographic check is folded into the
+    //     hash reconstruction via the exclusive-boundary path in
+    //     `compute_outside_children`. We still keep the ordering sanity
+    //     check.
+    let last_kv_bytes = key_values.last().map(|(k, _)| k.as_ref());
+    let right_boundary = right_edge(proof.end_proof().as_ref(), last_kv_bytes, last_key_bytes);
+    match &right_boundary {
+        RightBoundary::Inclusive(bound) => {
+            verify_edge(*bound, right_edge_kv, proof.end_proof(), root_hash, false)?;
+        }
+        RightBoundary::Exclusive(bound) => {
+            // `right_edge` only returns `Exclusive(K)` when `K > last_kv`
+            // strictly (terminal value-node past last_kv). The runtime
+            // check below catches a broken contract; the debug_assert pins
+            // the intended invariant.
+            debug_assert!(
+                right_edge_kv.is_none_or(|(edge_key, _)| bound.as_ref() > edge_key),
+                "RightBoundary::Exclusive must be strictly greater than last_kv",
+            );
+            if let Some((edge_key, _)) = right_edge_kv
+                && bound.as_ref() < edge_key
+            {
+                return Err(api::Error::ProofError(
+                    ProofError::RangeProofEndBeforeLastKey,
+                ));
+            }
+        }
     }
 
     let all_proof_nodes: Box<[&ProofNode]> = proof
@@ -478,7 +715,7 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     verify_proof_node_values(
         &all_proof_nodes,
         first_key_bytes,
-        last_key_bytes,
+        &right_boundary,
         key_values,
     )?;
 
@@ -487,7 +724,7 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
         key_values,
         proof,
         first_key_bytes,
-        right_edge_anchor,
+        right_boundary,
         root_hash,
     )
 }
@@ -496,10 +733,14 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
 /// Without this check, an attacker could hide key-value pairs that exist on an edge
 /// proof path by omitting them from `key_values` while reconciliation silently inserts
 /// them, making the root hash correct.
+///
+/// The right edge of the in-range comparison comes from `right_boundary`:
+/// `Inclusive(b)` includes `b`, `Exclusive(b)` excludes it,
+/// `Inclusive(None)` has no upper bound.
 fn verify_proof_node_values(
     proof_nodes: &[&ProofNode],
     first_key_bytes: Option<&[u8]>,
-    last_key_bytes: Option<&[u8]>,
+    right_boundary: &RightBoundary<'_>,
     key_values: &[(impl KeyType, impl ValueType)],
 ) -> Result<(), api::Error> {
     for proof_node in proof_nodes {
@@ -507,18 +748,24 @@ fn verify_proof_node_values(
         if !proof_node.key.len().is_multiple_of(2) {
             continue;
         }
-        // Only check nodes that have values
-        if !matches!(proof_node.value_digest, Some(ValueDigest::Value(_))) {
+        // Only check nodes whose value digest is the actual value (not a Hash)
+        let Some(ValueDigest::Value(proof_value_bytes)) = &proof_node.value_digest else {
             continue;
-        }
+        };
+        let proof_value = proof_value_bytes.as_ref();
         let key_nibbles: Vec<u8> = proof_node
             .key
             .iter()
             .map(|component| component.as_u8())
             .collect();
         let node_key_bytes: Vec<u8> = Path::from(key_nibbles.as_slice()).bytes_iter().collect();
-        let in_range = first_key_bytes.is_none_or(|start| node_key_bytes.as_slice() >= start)
-            && last_key_bytes.is_none_or(|end| node_key_bytes.as_slice() <= end);
+        let within_right = match right_boundary {
+            RightBoundary::Inclusive(None) => true,
+            RightBoundary::Inclusive(Some(end)) => node_key_bytes.as_slice() <= *end,
+            RightBoundary::Exclusive(end) => node_key_bytes.as_slice() < end.as_ref(),
+        };
+        let in_range =
+            within_right && first_key_bytes.is_none_or(|start| node_key_bytes.as_slice() >= start);
         if in_range {
             match key_values.binary_search_by(|(k, _)| k.as_ref().cmp(node_key_bytes.as_slice())) {
                 Err(_) => {
@@ -527,10 +774,6 @@ fn verify_proof_node_values(
                     ));
                 }
                 Ok(idx) => {
-                    let proof_value = match &proof_node.value_digest {
-                        Some(ValueDigest::Value(v)) => v.as_ref(),
-                        _ => unreachable!("guarded by matches! check above"),
-                    };
                     let Some((_, kv_value)) = key_values.get(idx) else {
                         unreachable!("binary_search returned valid index");
                     };
@@ -546,12 +789,16 @@ fn verify_proof_node_values(
 
 /// Reconstructs the trie from key-value pairs and proof nodes, then verifies
 /// that the computed root hash matches the expected one.
+///
+/// `right_boundary` describes the right edge of the proven range. When the
+/// variant is [`RightBoundary::Exclusive`], the boundary key sits at the
+/// end-proof's terminal node and is treated as outside the proven range.
 fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
     all_proof_nodes: &[&ProofNode],
     key_values: &[(impl KeyType, impl ValueType)],
     proof: &RangeProof<impl KeyType, impl ValueType, H>,
     first_key_bytes: Option<&[u8]>,
-    last_key_bytes: Option<&[u8]>,
+    right_boundary: RightBoundary<'_>,
     root_hash: &TrieHash,
 ) -> Result<(), api::Error> {
     // Build in-memory merkle from key-value pairs
@@ -596,10 +843,14 @@ fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
     }
 
     // Compute which children at each edge node are outside the proven range
-    let mut outside_children =
-        compute_outside_children(proof.start_proof().as_ref(), first_key_bytes, true)?;
-    for (key, flags) in compute_outside_children(proof.end_proof().as_ref(), last_key_bytes, false)?
-    {
+    let mut outside_children = compute_outside_children(
+        proof.start_proof().as_ref(),
+        EdgeBoundary::Left(first_key_bytes),
+    )?;
+    for (key, flags) in compute_outside_children(
+        proof.end_proof().as_ref(),
+        EdgeBoundary::Right(right_boundary),
+    )? {
         let entry = outside_children.entry(key).or_default();
         *entry |= flags;
     }
@@ -777,11 +1028,16 @@ pub fn verify_change_proof_root_hash(
 
     // Compute which children at each boundary node are outside the proven
     // range via `compute_outside_children`.
-    let mut outside_children =
-        compute_outside_children(start_nodes, verification.start_key.as_deref(), true)?;
-    for (key, flags) in
-        compute_outside_children(end_nodes, verification.right_edge_key.as_deref(), false)?
-    {
+    let mut outside_children = compute_outside_children(
+        start_nodes,
+        EdgeBoundary::Left(verification.start_key.as_deref()),
+    )?;
+    for (key, flags) in compute_outside_children(
+        end_nodes,
+        EdgeBoundary::Right(RightBoundary::Inclusive(
+            verification.right_edge_key.as_deref(),
+        )),
+    )? {
         let entry = outside_children.entry(key).or_default();
         *entry |= flags;
     }

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -214,6 +214,35 @@ fn test_missing_key_proof() {
 }
 
 #[test]
+// A truncated bounded range proof: caller asks for [start, end] with a limit
+// that is hit, so the generator anchors `end_proof` at the last returned key
+// rather than at `end`. The verifier must accept the proof when called with
+// the originally requested `(start, end)` — those are the only bounds the
+// caller has; it cannot predict the post-truncation anchor.
+fn test_truncated_bounded_range_proof_round_trip() {
+    let items: Vec<([u8; 4], [u8; 4])> = (0u32..1000)
+        .map(|i| (i.to_be_bytes(), i.to_be_bytes()))
+        .collect();
+    let merkle = init_merkle(items.iter().map(|(k, v)| (k.as_slice(), v.as_slice())));
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    // Bound covers many keys; limit forces truncation.
+    let start = items[10].0;
+    let end = items[900].0;
+    let limit = NonZeroUsize::new(8).unwrap();
+
+    let range_proof = merkle
+        .range_proof(Some(&start), Some(&end), Some(limit))
+        .unwrap();
+
+    assert_eq!(range_proof.key_values().len(), limit.get());
+
+    // Verify with the *original* requested bounds — the only ones the caller
+    // can provide. End_proof anchors at the last returned key, not `end`.
+    verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
+}
+
+#[test]
 // Tests normal range proof with both edge proofs as the existent proof.
 // The test cases are generated randomly.
 fn test_range_proof() {

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -55,14 +55,14 @@ fn stored_key_values<K: AsRef<[u8]>>(
 
 #[test]
 fn outside_children_empty_proof() {
-    let result = compute_outside_children(&[], None, true).unwrap();
+    let result = compute_outside_children(&[], EdgeBoundary::Left(None)).unwrap();
     assert!(result.is_empty());
 }
 
 #[test]
 fn outside_children_single_node_no_boundary() {
     let nodes = [proof_node(&[1, 2])];
-    let result = compute_outside_children(&nodes, None, true).unwrap();
+    let result = compute_outside_children(&nodes, EdgeBoundary::Left(None)).unwrap();
     assert!(result.is_empty());
 }
 
@@ -71,7 +71,7 @@ fn outside_children_single_node_exact_match() {
     // Boundary matches terminal exactly — no children marked.
     let nodes = [proof_node(&[1, 2])];
     // boundary key 0x12 expands to nibbles [1, 2]
-    let result = compute_outside_children(&nodes, Some(&[0x12]), true).unwrap();
+    let result = compute_outside_children(&nodes, EdgeBoundary::Left(Some(&[0x12]))).unwrap();
     assert!(result.is_empty());
 }
 
@@ -79,7 +79,11 @@ fn outside_children_single_node_exact_match() {
 fn outside_children_single_node_exact_match_right_edge() {
     // Boundary matches terminal exactly on right edge — all children marked outside.
     let nodes = [proof_node(&[1, 2])];
-    let result = compute_outside_children(&nodes, Some(&[0x12]), false).unwrap();
+    let result = compute_outside_children(
+        &nodes,
+        EdgeBoundary::Right(RightBoundary::Inclusive(Some(&[0x12]))),
+    )
+    .unwrap();
     // Look up the mask for the terminal node at [1, 2].
     let mask = result[&nibble_path(&[1, 2])];
     for i in 0..16u8 {
@@ -96,7 +100,7 @@ fn outside_children_ancestor_left_edge() {
     // Terminal is ancestor of boundary. On-path nibble = 5.
     // Left edge: children < 5 are outside, plus child 5 itself.
     let nodes = [proof_node(&[1])];
-    let result = compute_outside_children(&nodes, Some(&[0x15]), true).unwrap();
+    let result = compute_outside_children(&nodes, EdgeBoundary::Left(Some(&[0x15]))).unwrap();
     let mask = result[&nibble_path(&[1])];
     // Children 0..=5 should be outside (left of 5, plus 5 itself)
     for i in 0..16u8 {
@@ -113,7 +117,11 @@ fn outside_children_ancestor_right_edge() {
     // Terminal key [1], boundary key 0x15 → nibbles [1, 5].
     // Right edge: children > 5 are outside, plus child 5 itself.
     let nodes = [proof_node(&[1])];
-    let result = compute_outside_children(&nodes, Some(&[0x15]), false).unwrap();
+    let result = compute_outside_children(
+        &nodes,
+        EdgeBoundary::Right(RightBoundary::Inclusive(Some(&[0x15]))),
+    )
+    .unwrap();
     let mask = result[&nibble_path(&[1])];
     for i in 0..16u8 {
         assert_eq!(
@@ -129,7 +137,7 @@ fn outside_children_diverges_past_terminal_left() {
     // Terminal key [1, 3], boundary nibbles [1, 5] (diverge at pos 1: 5 > 3).
     // Left edge + boundary past terminal → all children outside.
     let nodes = [proof_node(&[1, 3])];
-    let result = compute_outside_children(&nodes, Some(&[0x15]), true).unwrap();
+    let result = compute_outside_children(&nodes, EdgeBoundary::Left(Some(&[0x15]))).unwrap();
     let mask = result[&nibble_path(&[1, 3])];
     for i in 0..16u8 {
         assert!(
@@ -144,7 +152,7 @@ fn outside_children_diverges_before_terminal_left() {
     // Terminal key [1, 7], boundary nibbles [1, 5] (diverge at pos 1: 5 < 7).
     // Left edge + boundary before terminal → no children outside.
     let nodes = [proof_node(&[1, 7])];
-    let result = compute_outside_children(&nodes, Some(&[0x15]), true).unwrap();
+    let result = compute_outside_children(&nodes, EdgeBoundary::Left(Some(&[0x15]))).unwrap();
     assert!(
         !result.contains_key(&nibble_path(&[1, 7])),
         "no mask when boundary before terminal"
@@ -156,7 +164,7 @@ fn outside_children_two_nodes_left_edge() {
     // Parent [1], child [1, 5]. On-path nibble = 5.
     // Left edge: children < 5 on parent are outside.
     let nodes = [proof_node(&[1]), proof_node(&[1, 5])];
-    let result = compute_outside_children(&nodes, None, true).unwrap();
+    let result = compute_outside_children(&nodes, EdgeBoundary::Left(None)).unwrap();
     let mask = result[&nibble_path(&[1])];
     for i in 0..16u8 {
         assert_eq!(
@@ -172,7 +180,9 @@ fn outside_children_two_nodes_right_edge() {
     // Parent [1], child [1, 5]. On-path nibble = 5.
     // Right edge: children > 5 on parent are outside.
     let nodes = [proof_node(&[1]), proof_node(&[1, 5])];
-    let result = compute_outside_children(&nodes, None, false).unwrap();
+    let result =
+        compute_outside_children(&nodes, EdgeBoundary::Right(RightBoundary::Inclusive(None)))
+            .unwrap();
     let mask = result[&nibble_path(&[1])];
     for i in 0..16u8 {
         assert_eq!(
@@ -189,7 +199,7 @@ fn outside_children_child_not_prefixed_by_parent() {
     // child.key.get(parent.key.len()) = [2,5].get(1) = Some(5), so no error;
     // but child key [1] with parent [1, 2] means child.key.get(2) = None → error.
     let nodes = [proof_node(&[1, 2]), proof_node(&[1])];
-    let result = compute_outside_children(&nodes, None, true);
+    let result = compute_outside_children(&nodes, EdgeBoundary::Left(None));
     assert!(
         matches!(result, Err(ProofError::ShouldBePrefixOfNextKey)),
         "expected ShouldBePrefixOfNextKey, got {result:?}"
@@ -240,6 +250,215 @@ fn test_truncated_bounded_range_proof_round_trip() {
     // Verify with the *original* requested bounds — the only ones the caller
     // can provide. End_proof anchors at the last returned key, not `end`.
     verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
+}
+
+#[test]
+// End-proof terminal is a value-node strict prefix of last_kv: trie
+// {0x05, 0x10, 0x10\x10, 0x10\x50}, range [0x05, 0x10\x30]. The end_proof
+// terminates at the branch node `0x10` (which has value "parent" and
+// children at nibbles 1 and 5). The terminal's full key 0x10 is *less
+// than* last_kv 0x10\x10, so the right-edge anchor is the caller's
+// requested bound `0x10\x30` (inclusive); verify_edge then anchors the
+// proof against `0x10\x30` and the hash check correctly catches any
+// tampering of `0x10\x10`'s value.
+fn test_terminal_strict_prefix_of_last_kv_verifies() {
+    let items: &[(&[u8], &[u8])] = &[
+        (b"\x05", b"before"),
+        (b"\x10", b"parent"),
+        (b"\x10\x10", b"in_range"),
+        (b"\x10\x50", b"after"),
+    ];
+    let merkle = init_merkle(items.iter().copied());
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let range_proof = merkle
+        .range_proof(Some(b"\x05".as_slice()), Some(b"\x10\x30".as_slice()), None)
+        .unwrap();
+
+    // Honest proof contains the three in-range keys.
+    assert_eq!(range_proof.key_values().len(), 3);
+
+    verify_range_proof(
+        Some(b"\x05".as_slice()),
+        Some(b"\x10\x30".as_slice()),
+        &root_hash,
+        &range_proof,
+    )
+    .unwrap();
+}
+
+#[test]
+// Dropped trailing key collapses to a smaller proven range: same trie as
+// `test_terminal_strict_prefix_of_last_kv_verifies`, but an attacker
+// omits `0x10\x10` from key_values. The end_proof's terminal is the
+// branch `0x10` — terminal_full_key now equals the (tampered) last_kv
+// 0x10, so the right-edge anchor is **inclusive at last_kv = 0x10**.
+// Under that anchor the proof verifies (it is structurally a valid proof
+// of [0x05, 0x10]). The verifier reports success; the *caller* observes
+// that `last_kv < the requested bound` and re-requests `(0x10, 0x10\x30]`
+// — that follow-up query is what surfaces the omitted `0x10\x10`. No
+// information is hidden.
+fn test_dropped_trailing_key_accepted_as_partial_coverage() {
+    let items: &[(&[u8], &[u8])] = &[
+        (b"\x05", b"before"),
+        (b"\x10", b"parent"),
+        (b"\x10\x10", b"in_range"),
+        (b"\x10\x50", b"after"),
+    ];
+    let merkle = init_merkle(items.iter().copied());
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let honest = merkle
+        .range_proof(Some(b"\x05".as_slice()), Some(b"\x10\x30".as_slice()), None)
+        .unwrap();
+
+    // Drop `0x10\x10` from key_values, keeping the original end_proof.
+    let tampered_kvs: KeyValuePairs = honest
+        .key_values()
+        .iter()
+        .filter(|(k, _)| k.as_ref() != b"\x10\x10")
+        .map(|(k, v)| (k.as_ref().into(), v.as_ref().into()))
+        .collect();
+    assert_eq!(tampered_kvs.len(), 2);
+    assert_eq!(tampered_kvs.last().unwrap().0.as_ref(), b"\x10");
+
+    let tampered = RangeProof::new(
+        crate::Proof::<Box<[ProofNode]>>::new(honest.start_proof().as_ref().into()),
+        crate::Proof::<Box<[ProofNode]>>::new(honest.end_proof().as_ref().into()),
+        tampered_kvs.into_boxed_slice(),
+    );
+
+    // The verifier accepts: the proof is internally consistent and proves
+    // `[0x05, 0x10]`. It is *not* the verifier's job to enforce that the
+    // proven range matches the requested range — partial coverage is a
+    // valid outcome the caller is responsible for handling.
+    verify_range_proof(
+        Some(b"\x05".as_slice()),
+        Some(b"\x10\x30".as_slice()),
+        &root_hash,
+        &tampered,
+    )
+    .unwrap();
+
+    // The caller's `last_kv < requested_last` check is what flags partial
+    // coverage and should drive a follow-up request.
+    assert!(tampered.key_values().last().unwrap().0.as_ref() < b"\x10\x30".as_slice());
+}
+
+#[test]
+// Tampering the *value* of an in-range key must be rejected. Same trie
+// and request as `test_terminal_strict_prefix_of_last_kv_verifies`, but
+// the value of `0x10\x10` is altered in key_values. With anchor =
+// requested bound `0x10\x30` (inclusive, fallback path),
+// `compute_outside_children` keeps `0x10`'s child 1 in-range, so the
+// hash check recurses into the proving trie's tampered `0x10\x10` leaf
+// and the root hash mismatches.
+fn test_tampered_in_range_value_rejected() {
+    let items: &[(&[u8], &[u8])] = &[
+        (b"\x05", b"before"),
+        (b"\x10", b"parent"),
+        (b"\x10\x10", b"in_range"),
+        (b"\x10\x50", b"after"),
+    ];
+    let merkle = init_merkle(items.iter().copied());
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let honest = merkle
+        .range_proof(Some(b"\x05".as_slice()), Some(b"\x10\x30".as_slice()), None)
+        .unwrap();
+
+    let mut tampered_kvs: KeyValuePairs = honest
+        .key_values()
+        .iter()
+        .map(|(k, v)| (k.as_ref().into(), v.as_ref().into()))
+        .collect();
+    // Tamper the value of `0x10\x10`.
+    for (k, v) in &mut tampered_kvs {
+        if k.as_ref() == b"\x10\x10" {
+            *v = b"WRONG".to_vec().into_boxed_slice();
+        }
+    }
+
+    let tampered = RangeProof::new(
+        crate::Proof::<Box<[ProofNode]>>::new(honest.start_proof().as_ref().into()),
+        crate::Proof::<Box<[ProofNode]>>::new(honest.end_proof().as_ref().into()),
+        tampered_kvs.into_boxed_slice(),
+    );
+
+    let result = verify_range_proof(
+        Some(b"\x05".as_slice()),
+        Some(b"\x10\x30".as_slice()),
+        &root_hash,
+        &tampered,
+    );
+    assert!(
+        result.is_err(),
+        "tampered \\x10\\x10 value should be rejected, got: {result:?}"
+    );
+}
+
+#[test]
+// Divergent terminal past last_kv: trie {0x05, 0x10\x50}, range
+// [0x05, 0x10\x30]. The end_proof of `0x10\x30` walks root → leaf
+// `0x10\x50` (the leaf's path diverges from `0x10\x30` at the `5` vs `3`
+// nibble). terminal.value_digest is set, terminal_full_key = 0x10\x50 >
+// last_kv 0x05 → right-edge anchor is **exclusive at 0x10\x50**. The
+// proof structurally proves `[0x05, 0x10\x50)`, which covers the
+// requested `[0x05, 0x10\x30]`.
+fn test_divergent_terminal_past_last_kv() {
+    let items: &[(&[u8], &[u8])] = &[(b"\x05", b"a"), (b"\x10\x50", b"z")];
+    let merkle = init_merkle(items.iter().copied());
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let range_proof = merkle
+        .range_proof(Some(b"\x05".as_slice()), Some(b"\x10\x30".as_slice()), None)
+        .unwrap();
+
+    // Only `0x05` is in [0x05, 0x10\x30]; `0x10\x50` is past the bound.
+    assert_eq!(range_proof.key_values().len(), 1);
+    assert_eq!(range_proof.key_values()[0].0.as_ref(), b"\x05");
+
+    verify_range_proof(
+        Some(b"\x05".as_slice()),
+        Some(b"\x10\x30".as_slice()),
+        &root_hash,
+        &range_proof,
+    )
+    .unwrap();
+}
+
+#[test]
+// Symmetric mirror of `test_divergent_terminal_past_last_kv` on the left
+// edge: trie {0x05, 0x10}, range [0x07, 0x10]. `start_key = 0x07` doesn't
+// exist; `prove(0x07)` walks root → leaf 0x05 (divergent), so the
+// start_proof's terminal is a value-node at full key 0x05, which is
+// *less than* `first_kv = 0x10`. This is the structural mirror of the
+// right-edge "exclusive at terminal" case — the terminal's full key is
+// outside the proven range, on the wrong side of the left boundary.
+//
+// The current code uses `EdgeBoundary::Left(start_key)` (always inclusive
+// on the left edge); if the existing logic implicitly handles this case
+// correctly, this test passes. If it doesn't, we'd need a `LeftExclusive`
+// variant for symmetry.
+fn test_divergent_terminal_before_first_kv() {
+    let items: &[(&[u8], &[u8])] = &[(b"\x05", b"a"), (b"\x10", b"b")];
+    let merkle = init_merkle(items.iter().copied());
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let range_proof = merkle
+        .range_proof(Some(b"\x07".as_slice()), Some(b"\x10".as_slice()), None)
+        .unwrap();
+
+    assert_eq!(range_proof.key_values().len(), 1);
+    assert_eq!(range_proof.key_values()[0].0.as_ref(), b"\x10");
+
+    verify_range_proof(
+        Some(b"\x07".as_slice()),
+        Some(b"\x10".as_slice()),
+        &root_hash,
+        &range_proof,
+    )
+    .unwrap();
 }
 
 #[test]

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -81,7 +81,7 @@ fn outside_children_single_node_exact_match_right_edge() {
     let nodes = [proof_node(&[1, 2])];
     let result = compute_outside_children(
         &nodes,
-        EdgeBoundary::Right(RightBoundary::Inclusive(Some(&[0x12]))),
+        EdgeBoundary::Right(RightBoundary::InRange(Some(&[0x12]))),
     )
     .unwrap();
     // Look up the mask for the terminal node at [1, 2].
@@ -119,7 +119,7 @@ fn outside_children_ancestor_right_edge() {
     let nodes = [proof_node(&[1])];
     let result = compute_outside_children(
         &nodes,
-        EdgeBoundary::Right(RightBoundary::Inclusive(Some(&[0x15]))),
+        EdgeBoundary::Right(RightBoundary::InRange(Some(&[0x15]))),
     )
     .unwrap();
     let mask = result[&nibble_path(&[1])];
@@ -181,7 +181,7 @@ fn outside_children_two_nodes_right_edge() {
     // Right edge: children > 5 on parent are outside.
     let nodes = [proof_node(&[1]), proof_node(&[1, 5])];
     let result =
-        compute_outside_children(&nodes, EdgeBoundary::Right(RightBoundary::Inclusive(None)))
+        compute_outside_children(&nodes, EdgeBoundary::Right(RightBoundary::InRange(None)))
             .unwrap();
     let mask = result[&nibble_path(&[1])];
     for i in 0..16u8 {
@@ -438,7 +438,7 @@ fn test_divergent_terminal_past_last_kv() {
 //
 // The current code uses `EdgeBoundary::Left(start_key)` (always inclusive
 // on the left edge); if the existing logic implicitly handles this case
-// correctly, this test passes. If it doesn't, we'd need a `LeftExclusive`
+// correctly, this test passes. If it doesn't, we'd need a `LeftOutOfRange`
 // variant for symmetry.
 fn test_divergent_terminal_before_first_kv() {
     let items: &[(&[u8], &[u8])] = &[(b"\x05", b"a"), (b"\x10", b"b")];

--- a/firewood/src/proofs/change.rs
+++ b/firewood/src/proofs/change.rs
@@ -15,11 +15,26 @@ use crate::{
 /// - A start proof: proves that the smallest key does/doesn't exist
 /// - An end proof: proves the the largest key does/doesn't exist
 /// - The actual `BatchOp`s that specify the difference between the start and end tries.
-#[derive(Debug)]
 pub struct ChangeProof<K: AsRef<[u8]> + Debug, V: AsRef<[u8]> + Debug, H> {
     start_proof: Proof<H>,
     end_proof: Proof<H>,
     batch_ops: Box<[BatchOp<K, V>]>,
+}
+
+impl<K, V, H> std::fmt::Debug for ChangeProof<K, V, H>
+where
+    K: AsRef<[u8]> + Debug,
+    V: AsRef<[u8]> + Debug,
+    H: ProofCollection,
+    H::Node: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChangeProof")
+            .field("start_proof", &self.start_proof)
+            .field("end_proof", &self.end_proof)
+            .field("batch_ops", &self.batch_ops)
+            .finish()
+    }
 }
 
 impl<K, V, H> ChangeProof<K, V, H>

--- a/firewood/src/proofs/change.rs
+++ b/firewood/src/proofs/change.rs
@@ -13,7 +13,7 @@ use crate::{
 /// trie with given start root hash, the resulting trie will have the given end root hash. It
 /// consists of the following:
 /// - A start proof: proves that the smallest key does/doesn't exist
-/// - An end proof: proves the the largest key does/doesn't exist
+/// - An end proof: proves that the largest key does/doesn't exist
 /// - The actual `BatchOp`s that specify the difference between the start and end tries.
 pub struct ChangeProof<K: AsRef<[u8]> + Debug, V: AsRef<[u8]> + Debug, H> {
     start_proof: Proof<H>,

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -76,11 +76,27 @@ use super::types::{Proof, ProofCollection};
 /// - State synchronization between nodes
 /// - Light client verification
 /// - Efficient auditing of specific key ranges
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 pub struct RangeProof<K, V, H> {
     start_proof: Proof<H>,
     end_proof: Proof<H>,
     key_values: Box<[(K, V)]>,
+}
+
+impl<K, V, H> std::fmt::Debug for RangeProof<K, V, H>
+where
+    K: std::fmt::Debug,
+    V: std::fmt::Debug,
+    H: crate::proofs::types::ProofCollection,
+    H::Node: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RangeProof")
+            .field("start_proof", &self.start_proof)
+            .field("end_proof", &self.end_proof)
+            .field("key_values", &self.key_values)
+            .finish()
+    }
 }
 
 impl<K, V, H> RangeProof<K, V, H>

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -87,7 +87,7 @@ impl<K, V, H> std::fmt::Debug for RangeProof<K, V, H>
 where
     K: std::fmt::Debug,
     V: std::fmt::Debug,
-    H: crate::proofs::types::ProofCollection,
+    H: ProofCollection,
     H::Node: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -385,8 +385,28 @@ fn fix_account_storage_root(
 }
 
 /// A proof that a given key-value pair either exists or does not exist in a trie.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct Proof<T: ?Sized>(T);
+
+impl<T> std::fmt::Debug for Proof<T>
+where
+    T: ProofCollection + ?Sized,
+    T::Node: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        struct Indexed<'a, N>(&'a [N]);
+        impl<N: std::fmt::Debug> std::fmt::Debug for Indexed<'_, N> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_map().entries(self.0.iter().enumerate()).finish()
+            }
+        }
+        let nodes = self.0.as_ref();
+        f.debug_struct("Proof")
+            .field("len", &nodes.len())
+            .field("nodes", &Indexed(nodes))
+            .finish()
+    }
+}
 
 impl<T: ProofCollection + ?Sized> Proof<T> {
     /// Verify a proof


### PR DESCRIPTION
## Why this should be merged

Valid truncated range proofs fail verification in many cases.

## How this works

Pass the right-edge anchor key (rather than the caller's requested bound) to verify_edge and verify_range_proof_root_hash when the end_proof is an inclusion proof of the last key-value entry. This covers two cases:

  * Truncated proofs, where a max_length was hit before reaching bound.
  * Complete proofs whose bound exists in the trie (bound == last_kv_key).

In both cases the end_proof's terminal node has a value digest and its full path equals nibbles(last_kv_key); using bound would walk a different descent path and trip ShouldBePrefixOfNextKey from compute_outside_children. The exclusion case (bound not in trie) keeps using bound as the anchor.

## How this was tested

Adds a regression test that constructs a truncated bounded range proof and verifies it against the originally requested (start, end). Also adds a custom Debug impl on Proof that indexes proof nodes, since this was needed to diagnose the bug; ChangeProof and RangeProof get matching manual Debug impls because their derived Debug bound on inner Proof<H> would otherwise be unsatisfiable.

## Breaking Changes

None