### PR TITLE
fix(manager): resolve empty-trie revision under ethhash without RootStore (TOB-FIREWOOD-7)

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -509,7 +509,7 @@ impl RevisionManager {
 
         // 2. Default empty-trie short-circuit. An empty trie has no on-disk
         //    root node, so `RootStore` can never produce it; synthesize one
-        //    against the file backing carried by any committed revision.
+        //    against the file backing carried by the latest committed revision.
         if HashKey::default_root_hash().as_ref() == Some(&root_hash) {
             let storage = self.current_revision().storage().clone();
             return Ok(Arc::new(NodeStore::new_empty_committed(storage)));

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -124,15 +124,6 @@ pub(crate) struct RevisionManager {
 
     /// Worker responsible for persisting revisions to disk.
     persist_worker: PersistWorker,
-
-    /// File backing shared with all nodestores managed here.
-    ///
-    /// Retained so that `revision()` can synthesize an empty committed
-    /// nodestore when the caller requests the default empty-trie hash but no
-    /// in-memory revision matches. An empty trie has no on-disk root node and
-    /// therefore cannot be indexed in `RootStore`, so the lookup must be
-    /// resolved without consulting `RootStore`.
-    storage: Arc<FileBacked>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -238,7 +229,6 @@ impl RevisionManager {
             threadpool: OnceLock::new(),
             root_store,
             persist_worker,
-            storage,
         };
 
         // On startup, we always write the latest revision to RootStore
@@ -500,11 +490,8 @@ impl RevisionManager {
     /// Retrieve a committed revision by its root hash.
     /// To retrieve a revision involves a few steps:
     /// 1. Check the in-memory revision manager.
-    /// 2. If the caller requested the default empty-trie hash, synthesize an
-    ///    empty committed nodestore. An empty trie has no on-disk root node
-    ///    and therefore no `LinearAddress` to record in `RootStore`, so the
-    ///    persistence layer can never produce this revision and we must not
-    ///    consult `RootStore` for it. (TOB-FIREWOOD-7)
+    /// 2. If the caller requested the default empty-trie hash, return an
+    ///    empty committed nodestore.
     /// 3. Check `RootStore` (if it exists).
     pub fn revision(&self, root_hash: HashKey) -> Result<CommittedRevision, RevisionManagerError> {
         // 1. Check the in-memory revision manager.
@@ -520,11 +507,12 @@ impl RevisionManager {
         }
         drop(by_hash);
 
-        // 2. Default empty-trie short-circuit.
+        // 2. Default empty-trie short-circuit. An empty trie has no on-disk
+        //    root node, so `RootStore` can never produce it; synthesize one
+        //    against the file backing carried by any committed revision.
         if HashKey::default_root_hash().as_ref() == Some(&root_hash) {
-            return Ok(Arc::new(NodeStore::new_empty_committed(
-                self.storage.clone(),
-            )));
+            let storage = self.current_revision().storage().clone();
+            return Ok(Arc::new(NodeStore::new_empty_committed(storage)));
         }
 
         // 3. Check `RootStore` (if it exists).
@@ -1039,8 +1027,6 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    /// Regression test for TOB-FIREWOOD-7.
-    ///
     /// Under `ethhash`, an empty committed revision is exposed via the
     /// Ethereum empty-trie hash but never indexed in `RootStore` (an empty
     /// trie has no on-disk root node, so there is no `LinearAddress` to
@@ -1091,8 +1077,15 @@ mod tests {
             manager.commit(proposal).unwrap();
         }
 
-        // Empty hash should still resolve, even though the revision has been
-        // reaped from the in-memory queue.
+        // Verify the empty revision has actually been evicted from the
+        // in-memory index — otherwise the next assertion would just be
+        // testing the step-1 path again.
+        assert!(
+            !manager.by_hash.read().contains_key(&empty_hash),
+            "precondition: empty-trie revision must have been evicted from by_hash"
+        );
+
+        // Empty hash should still resolve via the default-hash short-circuit.
         let revision = manager
             .revision(empty_hash.clone())
             .expect("empty-trie revision must resolve via the default-hash short-circuit");

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -18,7 +18,7 @@ use firewood_storage::logger::{trace, warn};
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use typed_builder::TypedBuilder;
 
-use crate::api::{self, ArcDynDbView, HashKey, IntoBatchIter, OptionalHashKeyExt};
+use crate::api::{self, ArcDynDbView, HashKey, HashKeyExt, IntoBatchIter, OptionalHashKeyExt};
 use crate::db::{BatchOp, UseParallel};
 use crate::merkle::Merkle;
 use crate::merkle::parallel::ParallelMerkle;
@@ -124,6 +124,15 @@ pub(crate) struct RevisionManager {
 
     /// Worker responsible for persisting revisions to disk.
     persist_worker: PersistWorker,
+
+    /// File backing shared with all nodestores managed here.
+    ///
+    /// Retained so that `revision()` can synthesize an empty committed
+    /// nodestore when the caller requests the default empty-trie hash but no
+    /// in-memory revision matches. An empty trie has no on-disk root node and
+    /// therefore cannot be indexed in `RootStore`, so the lookup must be
+    /// resolved without consulting `RootStore`.
+    storage: Arc<FileBacked>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -229,6 +238,7 @@ impl RevisionManager {
             threadpool: OnceLock::new(),
             root_store,
             persist_worker,
+            storage,
         };
 
         // On startup, we always write the latest revision to RootStore
@@ -490,7 +500,12 @@ impl RevisionManager {
     /// Retrieve a committed revision by its root hash.
     /// To retrieve a revision involves a few steps:
     /// 1. Check the in-memory revision manager.
-    /// 2. Check `RootStore` (if it exists).
+    /// 2. If the caller requested the default empty-trie hash, synthesize an
+    ///    empty committed nodestore. An empty trie has no on-disk root node
+    ///    and therefore no `LinearAddress` to record in `RootStore`, so the
+    ///    persistence layer can never produce this revision and we must not
+    ///    consult `RootStore` for it. (TOB-FIREWOOD-7)
+    /// 3. Check `RootStore` (if it exists).
     pub fn revision(&self, root_hash: HashKey) -> Result<CommittedRevision, RevisionManagerError> {
         // 1. Check the in-memory revision manager.
         // BLOCKING: read lock on `by_hash`. Concurrent writes (commit reap/insert) will pause
@@ -505,7 +520,14 @@ impl RevisionManager {
         }
         drop(by_hash);
 
-        // 2. Check `RootStore` (if it exists).
+        // 2. Default empty-trie short-circuit.
+        if HashKey::default_root_hash().as_ref() == Some(&root_hash) {
+            return Ok(Arc::new(NodeStore::new_empty_committed(
+                self.storage.clone(),
+            )));
+        }
+
+        // 3. Check `RootStore` (if it exists).
         let root_store =
             self.root_store
                 .as_ref()
@@ -1015,5 +1037,65 @@ mod tests {
 
         let result = RevisionManager::new(config);
         assert!(result.is_ok());
+    }
+
+    /// Regression test for TOB-FIREWOOD-7.
+    ///
+    /// Under `ethhash`, an empty committed revision is exposed via the
+    /// Ethereum empty-trie hash but never indexed in `RootStore` (an empty
+    /// trie has no on-disk root node, so there is no `LinearAddress` to
+    /// record). Once the in-memory entry is evicted from `by_hash`,
+    /// `revision()` previously fell through to `RootStore::get` and returned
+    /// `RevisionNotFound`. The fix synthesizes an empty committed nodestore
+    /// when the caller asks for the default empty-trie hash.
+    #[cfg(feature = "ethhash")]
+    #[test]
+    fn test_revision_empty_root_after_eviction() {
+        use firewood_storage::{LeafNode, NibblesIterator, Node, Path};
+
+        let empty_hash =
+            HashKey::default_root_hash().expect("ethhash exposes a default empty-trie hash");
+
+        let db_dir = tempfile::tempdir().unwrap();
+        let config = ConfigManager::builder()
+            .root_dir(db_dir.as_ref().to_path_buf())
+            .node_hash_algorithm(NodeHashAlgorithm::compile_option())
+            .create(true)
+            .manager(
+                // Smallest legal queue: max_revisions must exceed
+                // deferred_persistence_commit_count (default 1). Two slots is
+                // enough for the initial empty revision to be reaped after a
+                // pair of non-empty commits.
+                RevisionManagerConfig::builder().max_revisions(2).build(),
+            )
+            .build();
+
+        let manager = RevisionManager::new(config).unwrap();
+
+        // Sanity: the fresh manager indexes the empty revision under the
+        // default hash.
+        assert!(manager.revision(empty_hash.clone()).is_ok());
+
+        // Commit two non-empty revisions to push the empty one out of the
+        // in-memory queue and out of `by_hash`.
+        for i in 0..2u8 {
+            let base = manager.current_revision();
+            let mut proposal = NodeStore::new(&*base).unwrap();
+            *proposal.root_mut() = Some(Node::Leaf(LeafNode {
+                partial_path: Path::from_nibbles_iterator(NibblesIterator::new(&[i])),
+                value: Box::new([i]),
+            }));
+            let proposal: Arc<NodeStore<Arc<ImmutableProposal>, _>> =
+                Arc::new(proposal.try_into().unwrap());
+            manager.add_proposal(proposal.clone());
+            manager.commit(proposal).unwrap();
+        }
+
+        // Empty hash should still resolve, even though the revision has been
+        // reaped from the in-memory queue.
+        let revision = manager
+            .revision(empty_hash.clone())
+            .expect("empty-trie revision must resolve via the default-hash short-circuit");
+        assert!(revision.root_address().is_none());
     }
 }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -207,10 +207,9 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
 
 impl<S: ReadableStorage> NodeStore<Committed, S> {
     /// Get the underlying storage for a `NodeStore`.
-    #[cfg(any(test, feature = "test_utils"))]
     #[must_use]
-    pub fn get_storage(&self) -> Arc<S> {
-        self.storage.clone()
+    pub const fn storage(&self) -> &Arc<S> {
+        &self.storage
     }
 }
 


### PR DESCRIPTION
## Why this should be merged

Trail of Bits finding TOB-FIREWOOD-7 (low, data validation): under the `ethhash` feature, Firewood advertises the Ethereum empty-trie hash (56e81f17…3b421) as a stable identifier for empty committed revisions through the public API, but the persistence layer never records an entry for those revisions in `RootStore`. An empty trie has no on-disk root node and therefore no `LinearAddress` to map to — both the startup `RootStore` write and the persist worker's `maybe_save_to_root_store` skip revisions whose raw `root_hash()` is `None`.

The result is asymmetric: the in-memory index inserts the empty revision under the default hash, but `RootStore` does not. Once the empty revision is evicted from the in-memory queue (or the database is reopened on a non-empty current state), `RevisionManager::revision` falls through to `RootStore::get`, which has no entry for the empty hash, and returns `RevisionNotFound`. Any consumer that treats the public hash as a stable handle observes a contract violation.

## How this works

In `RevisionManager::revision`, between the `by_hash` lookup and the `RootStore` fallback, short-circuit when the caller requests `HashKey::default_root_hash()`: synthesize a fresh empty `NodeStore<Committed, FileBacked>` against the manager's existing file backing and return it. This is sound because an empty trie is a conceptual revision with no on-disk state — there is nothing for `RootStore` to retrieve, so consulting it is meaningless.

To support this, `RevisionManager` now retains an `Arc<FileBacked>` clone alongside the existing fields. The storage `Arc` was already shared with every nodestore created here; we just hold one more reference for the synthesis path.

Without `ethhash`, `default_root_hash()` returns `None` and the short-circuit is unreachable, so behavior is unchanged for the SHA-256 backend.

This addresses the short-term recommendation in the audit. The long-term recommendation (a single canonical accessor for revision identifiers, enforced by a lint or newtype) is left for a separate change.

## How this was tested

- `cargo build -p firewood --features ethhash,logger` and without features (clean)
- `cargo clippy -p firewood --features ethhash,logger --all-targets` and without features (clean)
- `cargo nextest run -p firewood --features ethhash,logger` — 330 passed (was 329; one new regression test)
- `cargo nextest run -p firewood` — 328 passed

The new regression test `test_revision_empty_root_after_eviction` (gated on `ethhash`) creates a manager with `max_revisions = 2`, commits two non-empty revisions to evict the initial empty revision out of `by_hash`, then asserts that `revision(empty_hash)` still succeeds and yields a nodestore with `root_address() == None`. Without the fix the same call returned `RevisionNotFound`.

## Breaking Changes

None.