### PR TITLE
fix(ffi): return None from find_next_key when no keys remain in requested range

### DIFF
--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -670,6 +670,100 @@ func TestChangeProofFindNextKey(t *testing.T) {
 	r.NoError(nextRange.Free())
 }
 
+// TestChangeProofFindNextKeyBoundedNoDiffs verifies that when a bounded
+// change-proof request covers a range with zero diffs, FindNextKey returns
+// nil rather than echoing the requested end key as the next start key. The
+// caller would have no forward progress otherwise.
+func TestChangeProofFindNextKeyBoundedNoDiffs(t *testing.T) {
+	r := require.New(t)
+	dbA := newTestDatabase(t)
+	dbB := newTestDatabase(t)
+
+	keys, _, batch := kvForTest(100)
+	rootA, err := dbA.Update(batch[:50])
+	r.NoError(err)
+	_, err = dbB.Update(batch[:50])
+	r.NoError(err)
+
+	// All diffs between rootA and rootAUpdated live in keys[50:].
+	rootAUpdated, err := dbA.Update(batch[50:])
+	r.NoError(err)
+
+	// Request a change proof bounded entirely within keys[:50] — there are
+	// no diffs in this range.
+	startKey := something(keys[10])
+	endKey := something(keys[20])
+	proof, err := dbA.ChangeProof(rootA, rootAUpdated, startKey, endKey, changeProofLenUnbounded)
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(proof.Free()) })
+
+	_, err = dbB.VerifyChangeProof(proof, rootAUpdated, startKey, endKey, changeProofLenUnbounded)
+	r.NoError(err)
+
+	nextRange, err := proof.FindNextKey(endKey)
+	r.NoError(err)
+	r.Nil(nextRange, "FindNextKey should return nil for a bounded range with zero diffs")
+}
+
+// TestChangeProofFindNextKeyEndAtRightmost verifies that when the requested
+// end key equals the rightmost key actually delivered by the proof,
+// FindNextKey returns nil.
+func TestChangeProofFindNextKeyEndAtRightmost(t *testing.T) {
+	r := require.New(t)
+	dbA := newTestDatabase(t)
+	dbB := newTestDatabase(t)
+
+	keys, _, batch := kvForTest(100)
+	rootA, err := dbA.Update(batch[:50])
+	r.NoError(err)
+	_, err = dbB.Update(batch[:50])
+	r.NoError(err)
+
+	rootAUpdated, err := dbA.Update(batch[50:])
+	r.NoError(err)
+
+	// Bound the request at the rightmost diff key (keys[99] in sorted order).
+	endKey := something(keys[len(keys)-1])
+	proof, err := dbA.ChangeProof(rootA, rootAUpdated, nothing(), endKey, changeProofLenUnbounded)
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(proof.Free()) })
+
+	_, err = dbB.VerifyChangeProof(proof, rootAUpdated, nothing(), endKey, changeProofLenUnbounded)
+	r.NoError(err)
+
+	nextRange, err := proof.FindNextKey(endKey)
+	r.NoError(err)
+	r.Nil(nextRange, "FindNextKey should return nil when last_op == end_key")
+}
+
+// TestRangeProofFindNextKeyEndPastTrie verifies that a bounded range proof
+// whose end key sits past the actual rightmost trie key reports no further
+// keys to fetch — the proof is exhaustive within the requested range, so
+// FindNextKey must not fabricate a continuation past the end.
+func TestRangeProofFindNextKeyEndPastTrie(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	_, _, batch := kvForTest(10)
+	root, err := db.Update(batch)
+	r.NoError(err)
+
+	// End key past any real key in the trie.
+	endKey := something([]byte{0xFF, 0xFF, 0xFF, 0xFF})
+
+	// Use a generous limit so it isn't hit. With 10 keys and a limit of 100,
+	// the proof covers the full trie and its end_proof is a non-existence
+	// proof for endKey.
+	proof := newVerifiedRangeProof(t, db, root, nothing(), endKey, 100)
+
+	// FindNextKey requires a prepared proposal or commit.
+	r.NoError(db.VerifyRangeProof(proof, nothing(), endKey, root, 100))
+
+	nextRange, err := proof.FindNextKey()
+	r.NoError(err)
+	r.Nil(nextRange, "FindNextKey should return nil when the proof exhausted the trie within the requested range")
+}
+
 func TestChangeProofProposalKeepAlive(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/ffi/src/proofs/change.rs
+++ b/ffi/src/proofs/change.rs
@@ -82,8 +82,11 @@ impl ChangeProofContext {
         };
 
         let Some(last_op) = proof.batch_ops().last() else {
-            // No changes in this range. If bounded, continue from end_key.
-            return Ok(end_key.map(|ek| (Box::from(ek), None)));
+            // Zero diffs across the requested range — the proof confirms the
+            // range is fully accounted for, so there's nothing more to fetch.
+            // Returning `end_key` here would expand scope past the original
+            // request and has no forward-progress meaning to the caller.
+            return Ok(None);
         };
 
         if proof.end_proof().is_empty() {

--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -291,6 +291,19 @@ impl<'db> RangeProofContext<'db> {
             return Ok(None);
         }
 
+        // A non-empty end_proof alone doesn't mean the proof was truncated:
+        // a bounded request always carries an end_proof for the requested
+        // end_key, even when the limit wasn't hit. The unambiguous signal is
+        // whether the number of key/value pairs reached the requested limit.
+        // If it didn't (or no limit was specified), the proof is exhaustive
+        // within [last_key, end_key] and there's nothing more to fetch.
+        let truncated = verification
+            .max_length
+            .is_some_and(|max| self.proof.key_values().len() >= max.get());
+        if !truncated {
+            return Ok(None);
+        }
+
         Ok(Some((last_key.clone(), verification.end_key.clone())))
     }
 


### PR DESCRIPTION
## Why this should be merged

`FindNextKey` returns `end_key` as the next start key even if the next key is outside
the range requested.

Suppose a proof is generated that contains all keys in the range A-D, and that only
A-C and E-Z exist in the database. The returned right edge proof is likely to be an
exclusion proof of D, indicating that no keys to the right of C in the requested range
exist.

The current scheme always returns C as the "find_next_key" value. A subsequent
call for a range proof from C-D will again return a proof that C exists and will only
contain C. The caller has no way of knowing if the returned proof was just truncated
(that is, only one key was provided) or there are no other keys between C and D.

## How this works

When the caller asks for a bounded range and the proof confirms there are no
more keys to fetch within that range, `find_next_key` should return `None`.

Two paths produced the buggy behavior:

- **Change proof** (`ffi/src/proofs/change.rs`): when `batch_ops` was empty
  and the request was bounded, the function returned `(end_key, None)`. An
  empty diff over the requested range means the proof is complete — return
  `None`.

- **Range proof** (`ffi/src/proofs/range.rs`): a bounded range proof always
  carries a non-empty `end_proof` for `end_key` (even when the limit isn't
  hit), so `end_proof().is_empty()` can't distinguish "truncated" from
  "exhausted within range." Use `max_length` as the unambiguous truncation
  signal: if `key_values.len() < max_length` (or no limit was specified),
  the proof is exhaustive within the requested range and there's nothing
  more to fetch.

## How this was tested

- `cargo fmt`
- `cargo clippy --workspace --features ethhash,logger --all-targets` — clean
- `cargo nextest run --workspace --features ethhash,logger --all-targets` — 664 passed
- `cargo doc --no-deps` — clean
- `go test ./...` in `ffi/` — passes

Three Go FFI regression tests added in `ffi/proofs_test.go`:
- `TestChangeProofFindNextKeyBoundedNoDiffs` — bounded request over a range with zero diffs
- `TestChangeProofFindNextKeyEndAtRightmost` — bounded request where last_op equals end_key
- `TestRangeProofFindNextKeyEndPastTrie` — end_key past the rightmost trie key

## Breaking Changes

`firewood-ffi`/`firewood-go`: `FindNextKey` now returns `nil` rather than a
zero-progress continuation in the cases described above.