### PR TITLE
refactor(proofs): move range/change proof verification helpers from FFI to firewood

### DIFF
--- a/ffi/src/proofs.rs
+++ b/ffi/src/proofs.rs
@@ -6,3 +6,8 @@ mod range;
 
 pub use self::change::*;
 pub use self::range::*;
+
+// Re-export firewood-side types that used to be defined in this crate, so
+// downstream FFI code (e.g. `crate::value::results`) can keep importing
+// them via `crate::KeyRange`.
+pub use firewood::KeyRange;

--- a/ffi/src/proofs/change.rs
+++ b/ffi/src/proofs/change.rs
@@ -77,29 +77,11 @@ impl ChangeProofContext {
     /// `end_key` is the original requested end key passed to the proof
     /// generator.
     fn find_next_key(&self, end_key: Option<&[u8]>) -> Result<Option<KeyRange>, api::Error> {
-        let Some(proof) = &self.proof else {
-            return Err(api::Error::ProofError(ProofError::ProofIsNone));
-        };
-
-        let Some(last_op) = proof.batch_ops().last() else {
-            // No changes in this range. If bounded, continue from end_key.
-            return Ok(end_key.map(|ek| (Box::from(ek), None)));
-        };
-
-        if proof.end_proof().is_empty() {
-            return Ok(None);
-        }
-
-        if let Some(end_key) = end_key {
-            if **last_op.key() > *end_key {
-                return Err(api::Error::ProofError(ProofError::EndKeyLessThanLastKey));
-            }
-            if **last_op.key() == *end_key {
-                return Ok(None);
-            }
-        }
-
-        Ok(Some((last_op.key().clone(), end_key.map(Box::from))))
+        let proof = self
+            .proof
+            .as_ref()
+            .ok_or(api::Error::ProofError(ProofError::ProofIsNone))?;
+        firewood::find_next_key_after_change_proof(proof, end_key)
     }
 }
 

--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -4,9 +4,8 @@
 use std::num::NonZeroUsize;
 
 use firewood::{
-    ProofError,
+    KeyRange, ProofError, RangeProofVerificationContext,
     api::{self, DbView, FrozenRangeProof, HashKey},
-    logger::warn,
 };
 use firewood_metrics::{MetricsContext, firewood_counter};
 
@@ -14,9 +13,6 @@ use crate::{
     BorrowedBytes, CodeIteratorHandle, CodeIteratorResult, DatabaseHandle, HashResult, Maybe,
     NextKeyRangeResult, RangeProofResult, ValueResult, VoidResult,
 };
-
-/// A key range represented by a start key and an optional end key.
-pub type KeyRange = (Box<[u8]>, Option<Box<[u8]>>);
 
 /// Arguments for creating a range proof.
 #[derive(Debug)]
@@ -75,16 +71,8 @@ pub struct VerifyRangeProofArgs<'a, 'db> {
 #[derive(Debug)]
 pub struct RangeProofContext<'db> {
     proof: FrozenRangeProof,
-    verification: Option<VerificationContext>,
+    verification: Option<RangeProofVerificationContext>,
     proposal_state: Option<ProposalState<'db>>,
-}
-
-#[derive(Debug)]
-struct VerificationContext {
-    root: HashKey,
-    start_key: Option<Box<[u8]>>,
-    end_key: Option<Box<[u8]>>,
-    max_length: Option<NonZeroUsize>,
 }
 
 #[derive(Debug)]
@@ -119,11 +107,6 @@ impl<'db> RangeProofContext<'db> {
     /// [`RangeProofContext::verify_and_propose`] to prepare a proposal against
     /// a specific database and [`RangeProofContext::verify_and_commit`] to
     /// commit the proof to a database.
-    ///
-    /// ## ⚠️ Unimplemented ⚠️
-    ///
-    /// Currently, this is a stub implementation that does not perform any
-    /// verification steps.
     fn verify(
         &mut self,
         root: HashKey,
@@ -146,13 +129,13 @@ impl<'db> RangeProofContext<'db> {
 
         debug_assert!(self.verification.is_none());
 
-        warn!("range proof verification not yet implemented");
-        self.verification = Some(VerificationContext {
+        self.verification = Some(firewood::verify_range_proof_structure(
+            &self.proof,
             root,
-            start_key: start_key.map(Box::from),
-            end_key: end_key.map(Box::from),
+            start_key,
+            end_key,
             max_length,
-        });
+        )?);
         Ok(())
     }
 
@@ -257,41 +240,24 @@ impl<'db> RangeProofContext<'db> {
     /// we are able to inspect the database and provide a more accurate value
     /// for `finalKey` than simply the last key in the set of key-value pairs.
     fn find_next_key(&mut self) -> Result<Option<KeyRange>, api::Error> {
-        // TODO(#352): proper implementation, this naively returns the last key in
-        // in the range, which is correct, but not ideal.
         let verification = self
             .verification
             .as_ref()
             .ok_or(api::Error::ProofError(ProofError::Unverified))?;
 
-        let Some((last_key, _)) = self.proof.key_values().last() else {
-            // no key-values in the proof, so we are done
-            return Ok(None);
-        };
-
+        // FFI-only optimization: if a proposal has been prepared/committed
+        // and its root already matches the verification target, the receiver
+        // is up-to-date and no further fetching is needed.
         let root_hash = match self.proposal_state {
             Some(ProposalState::Committed(ref hash)) => Ok(hash.clone()),
             Some(ProposalState::Proposed(ref proposal)) => Ok(proposal.root_hash()),
             None => Err(api::Error::ProofError(ProofError::Unverified)),
         }?;
         if root_hash.as_ref() == Some(&verification.root) {
-            // already at the target root, so we are done
             return Ok(None);
         }
 
-        if self.proof.end_proof().is_empty() {
-            // unbounded, so we are done
-            return Ok(None);
-        }
-
-        if let Some(ref end_key) = verification.end_key
-            && **last_key >= **end_key
-        {
-            // reached or exceeded the end key, so we are done
-            return Ok(None);
-        }
-
-        Ok(Some((last_key.clone(), verification.end_key.clone())))
+        firewood::find_next_key_after_range_proof(&self.proof, verification)
     }
 
     fn code_hash_iter(&self) -> Result<CodeIteratorHandle<'_>, api::Error> {

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -156,9 +156,10 @@ pub mod proofs;
 // Re-export commonly used proof types at the crate root for ergonomic access
 pub use merkle::{Key, Value, verify_change_proof_root_hash, verify_range_proof};
 pub use proofs::{
-    ChangeProof, ChangeProofVerificationContext, EmptyProofCollection, InvalidHeader, Proof,
-    ProofCollection, ProofError, ProofNode, ProofType, RangeProof, ReadError,
-    verify_change_proof_structure,
+    ChangeProof, ChangeProofVerificationContext, EmptyProofCollection, InvalidHeader, KeyRange,
+    Proof, ProofCollection, ProofError, ProofNode, ProofType, RangeProof,
+    RangeProofVerificationContext, ReadError, find_next_key_after_change_proof,
+    find_next_key_after_range_proof, verify_change_proof_structure, verify_range_proof_structure,
 };
 
 // Re-export the proc macro from firewood-macros

--- a/firewood/src/proofs/change.rs
+++ b/firewood/src/proofs/change.rs
@@ -158,6 +158,46 @@ pub struct ChangeProofVerificationContext {
 
 type FrozenBatchOp = BatchOp<Box<[u8]>, Box<[u8]>>;
 
+/// Determine the next key range to fetch after this change proof.
+///
+/// Inspects the proof structure only — does not require a proposal.
+/// `end_key` is the original requested upper bound passed to the proof
+/// generator.
+///
+/// Returns `None` if the proof confirms there are no more keys in the
+/// requested range; otherwise returns `Some((last_op.key, end_key))` as
+/// a continuation.
+///
+/// # Errors
+///
+/// Returns [`ProofError::EndKeyLessThanLastKey`] when `last_op.key` is
+/// strictly greater than `end_key` — this indicates the proof was
+/// generated against a different `end_key` than the one supplied here.
+pub fn find_next_key_after_change_proof(
+    proof: &FrozenChangeProof,
+    end_key: Option<&[u8]>,
+) -> Result<Option<super::range::KeyRange>, api::Error> {
+    let Some(last_op) = proof.batch_ops().last() else {
+        // No changes in this range. If bounded, continue from end_key.
+        return Ok(end_key.map(|ek| (Box::from(ek), None)));
+    };
+
+    if proof.end_proof().is_empty() {
+        return Ok(None);
+    }
+
+    if let Some(end_key) = end_key {
+        if **last_op.key() > *end_key {
+            return Err(api::Error::ProofError(ProofError::EndKeyLessThanLastKey));
+        }
+        if **last_op.key() == *end_key {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some((last_op.key().clone(), end_key.map(Box::from))))
+}
+
 /// Verify a boundary proof against `end_root` and optionally check that the
 /// proof's inclusion/exclusion result is consistent with `boundary_op`.
 ///

--- a/firewood/src/proofs/mod.rs
+++ b/firewood/src/proofs/mod.rs
@@ -296,11 +296,15 @@ mod tests;
 pub(crate) mod types;
 
 pub use self::change::{
-    ChangeProof, ChangeProofVerificationContext, verify_change_proof_structure,
+    ChangeProof, ChangeProofVerificationContext, find_next_key_after_change_proof,
+    verify_change_proof_structure,
 };
 
 pub use self::header::InvalidHeader;
-pub use self::range::RangeProof;
+pub use self::range::{
+    KeyRange, RangeProof, RangeProofVerificationContext, find_next_key_after_range_proof,
+    verify_range_proof_structure,
+};
 pub use self::reader::ReadError;
 pub use self::types::{
     EmptyProofCollection, Proof, ProofCollection, ProofError, ProofNode, ProofType,

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -116,8 +116,7 @@ pub fn verify_range_proof_structure(
 /// Determine the next key range to fetch after this range proof.
 ///
 /// Returns `None` when the originally-requested range is fully accounted
-/// for; otherwise returns `Some((last_key, end_key))`. See the plan in
-/// `dazzling-prefix-walrus.md` for the rule this function implements.
+/// for; otherwise returns `Some((last_key, end_key))`.
 ///
 /// # Errors
 ///
@@ -143,19 +142,6 @@ pub fn find_next_key_after_range_proof(
         && **last_key >= **end_key
     {
         // reached or exceeded the end key, so we are done
-        return Ok(None);
-    }
-
-    // A non-empty end_proof alone doesn't mean the proof was truncated:
-    // a bounded request always carries an end_proof for the requested
-    // end_key, even when the limit wasn't hit. The unambiguous signal is
-    // whether the number of key/value pairs reached the requested limit.
-    // If it didn't (or no limit was specified), the proof is exhaustive
-    // within [last_key, end_key] and there's nothing more to fetch.
-    let truncated = verification
-        .max_length
-        .is_some_and(|max| proof.key_values().len() >= max.get());
-    if !truncated {
         return Ok(None);
     }
 

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -56,7 +56,111 @@
 //! }
 //! ```
 
+use std::num::NonZeroUsize;
+
+use crate::api::{self, FrozenRangeProof, HashKey};
+use firewood_storage::logger::warn;
+
 use super::types::{Proof, ProofCollection};
+
+/// `(start_key, end_key)` describing the next key range to fetch after a
+/// range or change proof. Returned by `find_next_key_after_*_proof`.
+pub type KeyRange = (Box<[u8]>, Option<Box<[u8]>>);
+
+/// Verification context captured after structural validation of a range proof.
+/// Stored so that downstream logic (root hash verification, `find_next_key`)
+/// can reference the original verification parameters without re-validating.
+#[derive(Debug)]
+pub struct RangeProofVerificationContext {
+    /// The expected root hash of the trie.
+    pub root: HashKey,
+    /// The lower bound of the verified key range, if any.
+    pub start_key: Option<Box<[u8]>>,
+    /// The upper bound of the verified key range, if any.
+    pub end_key: Option<Box<[u8]>>,
+    /// The maximum number of key/value pairs the proof was permitted to
+    /// contain. `None` means no limit.
+    pub max_length: Option<NonZeroUsize>,
+}
+
+/// Verify structural properties of a range proof and produce a
+/// [`RangeProofVerificationContext`] capturing the verification parameters
+/// for use by downstream logic.
+///
+/// ## ⚠️ Unimplemented ⚠️
+///
+/// Currently a stub: structural verification is not yet implemented. The
+/// returned context records the supplied parameters so that callers
+/// downstream of `verify_*` can still consume them. Tracked separately.
+///
+/// # Errors
+///
+/// Reserved for the implemented form; the current stub does not return
+/// errors.
+pub fn verify_range_proof_structure(
+    _proof: &FrozenRangeProof,
+    root: HashKey,
+    start_key: Option<&[u8]>,
+    end_key: Option<&[u8]>,
+    max_length: Option<NonZeroUsize>,
+) -> Result<RangeProofVerificationContext, api::Error> {
+    warn!("range proof verification not yet implemented");
+    Ok(RangeProofVerificationContext {
+        root,
+        start_key: start_key.map(Box::from),
+        end_key: end_key.map(Box::from),
+        max_length,
+    })
+}
+
+/// Determine the next key range to fetch after this range proof.
+///
+/// Returns `None` when the originally-requested range is fully accounted
+/// for; otherwise returns `Some((last_key, end_key))`. See the plan in
+/// `dazzling-prefix-walrus.md` for the rule this function implements.
+///
+/// # Errors
+///
+/// Currently does not return errors; the signature is `Result` for parity
+/// with the change-proof counterpart and to allow future error paths.
+pub fn find_next_key_after_range_proof(
+    proof: &FrozenRangeProof,
+    verification: &RangeProofVerificationContext,
+) -> Result<Option<KeyRange>, api::Error> {
+    // TODO(#352): proper implementation, this naively returns the last key
+    // in the range, which is correct, but not ideal.
+    let Some((last_key, _)) = proof.key_values().last() else {
+        // no key-values in the proof, so we are done
+        return Ok(None);
+    };
+
+    if proof.end_proof().is_empty() {
+        // unbounded, so we are done
+        return Ok(None);
+    }
+
+    if let Some(ref end_key) = verification.end_key
+        && **last_key >= **end_key
+    {
+        // reached or exceeded the end key, so we are done
+        return Ok(None);
+    }
+
+    // A non-empty end_proof alone doesn't mean the proof was truncated:
+    // a bounded request always carries an end_proof for the requested
+    // end_key, even when the limit wasn't hit. The unambiguous signal is
+    // whether the number of key/value pairs reached the requested limit.
+    // If it didn't (or no limit was specified), the proof is exhaustive
+    // within [last_key, end_key] and there's nothing more to fetch.
+    let truncated = verification
+        .max_length
+        .is_some_and(|max| proof.key_values().len() >= max.get());
+    if !truncated {
+        return Ok(None);
+    }
+
+    Ok(Some((last_key.clone(), verification.end_key.clone())))
+}
 
 /// A range proof is a cryptographic proof that demonstrates a contiguous set of key-value pairs
 /// exists within a Merkle trie with a given root hash.


### PR DESCRIPTION
## Why this should be merged

ffi should just be doing marshaling to C/go.

## How this works

Pure relocation, no logic changes. Centralizes verification-context types and `find_next_key` core logic in the firewood crate so the FFI layer can stay focused on handle management and C-interop concerns.

Specifically:

* Move `KeyRange` typedef from `ffi/src/proofs/range.rs` to `firewood::proofs::range`. Re-exported at firewood crate root and from `firewood_ffi::proofs` for backward-compatible imports.
* Move FFI's private `VerificationContext` to firewood as `RangeProofVerificationContext`, mirroring the existing `ChangeProofVerificationContext` shape.
* Move the range-proof structural-verify stub (`warn!(...)`) into firewood as `verify_range_proof_structure`, mirroring `verify_change_proof_structure`.
* Move the bodies of `RangeProofContext::find_next_key` and `ChangeProofContext::find_next_key` into firewood as `find_next_key_after_range_proof` and `find_next_key_after_change_proof`. FFI methods now delegate; the range-proof side keeps an FFI-only proposal-state early-return optimization wrapper.

## How this was tested

No test changes. All existing tests pass at 664/664. This is a preparatory move for the upcoming `find_next_key` correctness fix (see issue #1989).

## Breaking Changes

None