### PR TITLE
feat: add ability to clone reconstructed revisions

### DIFF
--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -535,6 +535,45 @@ typedef struct ValueResult {
 } ValueResult;
 
 /**
+ * A result type returned from FFI functions that create a reconstructed view.
+ */
+enum ReconstructedResult_Tag {
+  /**
+   * The caller provided a null pointer to an input handle.
+   */
+  ReconstructedResult_NullHandlePointer,
+  /**
+   * Building the reconstructed view was successful and the handle is returned.
+   */
+  ReconstructedResult_Ok,
+  /**
+   * An error occurred and the message is returned as an [`OwnedBytes`].
+   */
+  ReconstructedResult_Err,
+};
+typedef size_t ReconstructedResult_Tag;
+
+typedef struct ReconstructedResult_Ok_Body {
+  /**
+   * An opaque pointer to the [`ReconstructedHandle`].
+   * The value should be freed with [`fwd_free_reconstructed`].
+   *
+   * [`fwd_free_reconstructed`]: crate::fwd_free_reconstructed
+   */
+  struct ReconstructedHandle *handle;
+} ReconstructedResult_Ok_Body;
+
+typedef struct ReconstructedResult {
+  ReconstructedResult_Tag tag;
+  union {
+    ReconstructedResult_Ok_Body ok;
+    struct {
+      OwnedBytes err;
+    };
+  };
+} ReconstructedResult;
+
+/**
  * Arguments for creating a change proof.
  */
 typedef struct CreateChangeProofArgs {
@@ -1366,45 +1405,6 @@ typedef struct CodeIteratorResult {
 } CodeIteratorResult;
 
 /**
- * A result type returned from FFI functions that create a reconstructed view.
- */
-enum ReconstructedResult_Tag {
-  /**
-   * The caller provided a null pointer to an input handle.
-   */
-  ReconstructedResult_NullHandlePointer,
-  /**
-   * Building the reconstructed view was successful and the handle is returned.
-   */
-  ReconstructedResult_Ok,
-  /**
-   * An error occurred and the message is returned as an [`OwnedBytes`].
-   */
-  ReconstructedResult_Err,
-};
-typedef size_t ReconstructedResult_Tag;
-
-typedef struct ReconstructedResult_Ok_Body {
-  /**
-   * An opaque pointer to the [`ReconstructedHandle`].
-   * The value should be freed with [`fwd_free_reconstructed`].
-   *
-   * [`fwd_free_reconstructed`]: crate::fwd_free_reconstructed
-   */
-  struct ReconstructedHandle *handle;
-} ReconstructedResult_Ok_Body;
-
-typedef struct ReconstructedResult {
-  ReconstructedResult_Tag tag;
-  union {
-    ReconstructedResult_Ok_Body ok;
-    struct {
-      OwnedBytes err;
-    };
-  };
-} ReconstructedResult;
-
-/**
  * Arguments for initializing logging for the Firewood FFI.
  */
 typedef struct LogArgs {
@@ -1513,6 +1513,33 @@ struct ChangeProofResult fwd_change_proof_from_bytes(BorrowedBytes bytes);
  * - [`ValueResult::Err`] if serialization failed.
  */
 struct ValueResult fwd_change_proof_to_bytes(const struct ChangeProofContext *proof);
+
+/**
+ * Produces an independent reconstructed handle that shares the underlying
+ * view with the input handle. Both handles can be used and freed independently.
+ *
+ * # Arguments
+ *
+ * * `handle` - The reconstructed handle returned by [`fwd_reconstruct_on_revision`] or
+ *   [`fwd_reconstruct_on_reconstructed`].
+ *
+ * # Returns
+ *
+ * - [`ReconstructedResult::NullHandlePointer`] if the provided handle is null.
+ * - [`ReconstructedResult::Ok`] with a new [`ReconstructedHandle`] that
+ *   shares the underlying view with the input handle.
+ *
+ * # Safety
+ *
+ * The caller must:
+ * * ensure that `handle` is a valid pointer to a [`ReconstructedHandle`].
+ * * call [`fwd_free_reconstructed`] to free the returned handle when it is
+ *   no longer needed.
+ * * ensure that the underlying [`DatabaseHandle`] remains valid (not closed
+ *   via [`fwd_close_db`]) for as long as the returned [`ReconstructedHandle`]
+ *   is in use.
+ */
+struct ReconstructedResult fwd_clone_reconstructed(const struct ReconstructedHandle *handle);
 
 /**
  * Close and free the memory for a database handle

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1527,8 +1527,8 @@ struct ValueResult fwd_change_proof_to_bytes(const struct ChangeProofContext *pr
  *
  * # Arguments
  *
- * * `handle` - The reconstructed handle returned by [`fwd_reconstruct_on_revision`] or
- *   [`fwd_reconstruct_on_reconstructed`].
+ * * `handle` - The reconstructed handle returned by [`fwd_reconstruct_on_revision`],
+ *   [`fwd_reconstruct_on_reconstructed`], or a previous call to [`fwd_clone_reconstructed`].
  *
  * # Returns
  *

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1516,13 +1516,14 @@ struct ValueResult fwd_change_proof_to_bytes(const struct ChangeProofContext *pr
 
 /**
  * Produces an independent reconstructed handle that shares the underlying
- * view with the input handle. Both handles can be used and freed independently.
+ * view with the input handle. Both handles can be used, reconstructed, and
+ * freed independently.
  *
- * Callers should only perform read operations on the cloned handle and free
- * it before performing further writes. Calling
- * [`fwd_reconstruct_on_reconstructed`] on the clone (or on any sibling)
- * while another clone is alive is expensive: it forces a deep clone of the
- * root node instead of the zero-copy move that the uncloned path takes.
+ * Calling [`fwd_reconstruct_on_reconstructed`] on either handle while another
+ * handle shares the same reconstructed state is supported but expensive: it
+ * forces a deep clone of the root node instead of the zero-copy move used when
+ * the handle is uniquely owned. Free unneeded clones before reconstructing
+ * when write performance matters.
  *
  * # Arguments
  *

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1518,6 +1518,12 @@ struct ValueResult fwd_change_proof_to_bytes(const struct ChangeProofContext *pr
  * Produces an independent reconstructed handle that shares the underlying
  * view with the input handle. Both handles can be used and freed independently.
  *
+ * Callers should only perform read operations on the cloned handle and free
+ * it before performing further writes. Calling
+ * [`fwd_reconstruct_on_reconstructed`] on the clone (or on any sibling)
+ * while another clone is alive is expensive: it forces a deep clone of the
+ * root node instead of the zero-copy move that the uncloned path takes.
+ *
  * # Arguments
  *
  * * `handle` - The reconstructed handle returned by [`fwd_reconstruct_on_revision`] or

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1519,12 +1519,6 @@ struct ValueResult fwd_change_proof_to_bytes(const struct ChangeProofContext *pr
  * view with the input handle. Both handles can be used, reconstructed, and
  * freed independently.
  *
- * Calling [`fwd_reconstruct_on_reconstructed`] on either handle while another
- * handle shares the same reconstructed state is supported but expensive: it
- * forces a deep clone of the root node instead of the zero-copy move used when
- * the handle is uniquely owned. Free unneeded clones before reconstructing
- * when write performance matters.
- *
  * # Arguments
  *
  * * `handle` - The reconstructed handle returned by [`fwd_reconstruct_on_revision`],

--- a/ffi/reconstructed.go
+++ b/ffi/reconstructed.go
@@ -13,6 +13,8 @@ package ffi
 // #cgo nocallback fwd_iter_on_reconstructed
 // #cgo noescape fwd_reconstruct_on_reconstructed
 // #cgo nocallback fwd_reconstruct_on_reconstructed
+// #cgo noescape fwd_clone_reconstructed
+// #cgo nocallback fwd_clone_reconstructed
 // #cgo noescape fwd_reconstructed_dump
 // #cgo nocallback fwd_reconstructed_dump
 // #cgo noescape fwd_free_reconstructed
@@ -169,6 +171,21 @@ func (r *Reconstructed) Reconstruct(batch []BatchOp) error {
 	r.rootMu.Unlock()
 
 	return nil
+}
+
+// Clone returns an independent [Reconstructed] handle that shares the
+// underlying view with the receiver. The two handles can be used and
+// freed independently.
+func (r *Reconstructed) Clone() (*Reconstructed, error) {
+	r.keepAliveHandle.mu.RLock()
+	defer r.keepAliveHandle.mu.RUnlock()
+
+	if r.dropped {
+		return nil, ErrDroppedReconstructed
+	}
+
+	result := C.fwd_clone_reconstructed(r.ptr)
+	return getReconstructedFromResult(result, r.keepAliveHandle.outstandingHandles)
 }
 
 // Dump returns a DOT (Graphviz) representation of this reconstructed view.

--- a/ffi/reconstructed.go
+++ b/ffi/reconstructed.go
@@ -176,12 +176,6 @@ func (r *Reconstructed) Reconstruct(batch []BatchOp) error {
 // Clone returns an independent [Reconstructed] handle that shares the
 // underlying view with the receiver. The two handles can be used, reconstructed,
 // and freed independently.
-//
-// Calling [Reconstructed.Reconstruct] on either handle while another handle
-// shares the same reconstructed state is supported but expensive: it forces a
-// deep clone of the root node instead of the zero-copy move used when the
-// handle is uniquely owned. Drop unneeded clones before reconstructing when
-// write performance matters.
 func (r *Reconstructed) Clone() (*Reconstructed, error) {
 	r.keepAliveHandle.mu.RLock()
 	defer r.keepAliveHandle.mu.RUnlock()

--- a/ffi/reconstructed.go
+++ b/ffi/reconstructed.go
@@ -174,14 +174,14 @@ func (r *Reconstructed) Reconstruct(batch []BatchOp) error {
 }
 
 // Clone returns an independent [Reconstructed] handle that shares the
-// underlying view with the receiver. The two handles can be used and
-// freed independently.
+// underlying view with the receiver. The two handles can be used, reconstructed,
+// and freed independently.
 //
-// Callers should only perform read operations on the clone and drop it
-// before performing further writes. Calling [Reconstructed.Reconstruct]
-// on the clone (or on any sibling) while another clone is alive is
-// expensive: it forces a deep clone of the root node instead of the
-// zero-copy move that the uncloned path takes.
+// Calling [Reconstructed.Reconstruct] on either handle while another handle
+// shares the same reconstructed state is supported but expensive: it forces a
+// deep clone of the root node instead of the zero-copy move used when the
+// handle is uniquely owned. Drop unneeded clones before reconstructing when
+// write performance matters.
 func (r *Reconstructed) Clone() (*Reconstructed, error) {
 	r.keepAliveHandle.mu.RLock()
 	defer r.keepAliveHandle.mu.RUnlock()

--- a/ffi/reconstructed.go
+++ b/ffi/reconstructed.go
@@ -176,6 +176,12 @@ func (r *Reconstructed) Reconstruct(batch []BatchOp) error {
 // Clone returns an independent [Reconstructed] handle that shares the
 // underlying view with the receiver. The two handles can be used and
 // freed independently.
+//
+// Callers should only perform read operations on the clone and drop it
+// before performing further writes. Calling [Reconstructed.Reconstruct]
+// on the clone (or on any sibling) while another clone is alive is
+// expensive: it forces a deep clone of the root node instead of the
+// zero-copy move that the uncloned path takes.
 func (r *Reconstructed) Clone() (*Reconstructed, error) {
 	r.keepAliveHandle.mu.RLock()
 	defer r.keepAliveHandle.mu.RUnlock()

--- a/ffi/reconstructed_test.go
+++ b/ffi/reconstructed_test.go
@@ -187,6 +187,100 @@ func TestReconstructedDropThenUse(t *testing.T) {
 	r.ErrorIs(err, ErrDroppedReconstructed)
 }
 
+// TestReconstructedClone verifies that a Reconstruct call on a clone does
+// not affect the original handle's view of the same key.
+func TestReconstructedClone(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	// A reconstructed view must be built from a committed revision.
+	root, err := db.Update([]BatchOp{Put([]byte("foo"), []byte("bar"))})
+	r.NoError(err)
+	rev, err := db.Revision(root)
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(rev.Drop()) })
+
+	var (
+		key      = []byte("k")
+		value    = []byte("v")
+		newValue = []byte("newV")
+	)
+
+	original, err := rev.Reconstruct([]BatchOp{Put(key, value)})
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(original.Drop()) })
+
+	cloned, err := original.Clone()
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(cloned.Drop()) })
+
+	r.NoError(cloned.Reconstruct([]BatchOp{Put(key, newValue)}))
+
+	got, err := original.Get(key)
+	r.NoError(err)
+	r.Equal(value, got)
+}
+
+// TestReconstructedCloneOutlivesOriginal verifies that dropping the original
+// reconstructed handle does not invalidate the clone.
+func TestReconstructedCloneOutlivesOriginal(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	const (
+		keysPerBatch = 2
+		numKeys      = 2 * keysPerBatch
+	)
+
+	keys, vals, batch := kvForTest(numKeys)
+	root, err := db.Update(batch[:keysPerBatch])
+	r.NoError(err)
+
+	rev, err := db.Revision(root)
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(rev.Drop()) })
+
+	original, err := rev.Reconstruct(batch[keysPerBatch:])
+	r.NoError(err)
+
+	cloned, err := original.Clone()
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(cloned.Drop()) })
+
+	expectedRoot := original.Root()
+	r.NoError(original.Drop())
+
+	// Clone remains fully functional after the original is dropped.
+	r.Equal(expectedRoot, cloned.Root())
+	for i := range len(keys) {
+		got, err := cloned.Get(keys[i])
+		r.NoError(err)
+		r.Equal(vals[i], got)
+	}
+}
+
+// TestReconstructedCloneAfterDrop verifies that Clone cannot be called on a
+// dropped reconstructed handle.
+func TestReconstructedCloneAfterDrop(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	_, _, batch := kvForTest(4)
+	root, err := db.Update(batch[:2])
+	r.NoError(err)
+
+	rev, err := db.Revision(root)
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(rev.Drop()) })
+
+	reconstructed, err := rev.Reconstruct(nil)
+	r.NoError(err)
+	r.NoError(reconstructed.Drop())
+
+	_, err = reconstructed.Clone()
+	r.ErrorIs(err, ErrDroppedReconstructed)
+}
+
 // TestReconstructedConcurrentGetAndDrop verifies that concurrent Get and Drop
 // calls do not panic or return unexpected errors. Every goroutine must see
 // either a successful result or ErrDroppedReconstructed.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -625,12 +625,6 @@ pub extern "C" fn fwd_reconstruct_on_reconstructed<'db>(
 /// view with the input handle. Both handles can be used, reconstructed, and
 /// freed independently.
 ///
-/// Calling [`fwd_reconstruct_on_reconstructed`] on either handle while another
-/// handle shares the same reconstructed state is supported but expensive: it
-/// forces a deep clone of the root node instead of the zero-copy move used when
-/// the handle is uniquely owned. Free unneeded clones before reconstructing
-/// when write performance matters.
-///
 /// # Arguments
 ///
 /// * `handle` - The reconstructed handle returned by [`fwd_reconstruct_on_revision`],

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -622,13 +622,14 @@ pub extern "C" fn fwd_reconstruct_on_reconstructed<'db>(
 }
 
 /// Produces an independent reconstructed handle that shares the underlying
-/// view with the input handle. Both handles can be used and freed independently.
+/// view with the input handle. Both handles can be used, reconstructed, and
+/// freed independently.
 ///
-/// Callers should only perform read operations on the cloned handle and free
-/// it before performing further writes. Calling
-/// [`fwd_reconstruct_on_reconstructed`] on the clone (or on any sibling)
-/// while another clone is alive is expensive: it forces a deep clone of the
-/// root node instead of the zero-copy move that the uncloned path takes.
+/// Calling [`fwd_reconstruct_on_reconstructed`] on either handle while another
+/// handle shares the same reconstructed state is supported but expensive: it
+/// forces a deep clone of the root node instead of the zero-copy move used when
+/// the handle is uniquely owned. Free unneeded clones before reconstructing
+/// when write performance matters.
 ///
 /// # Arguments
 ///

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -621,6 +621,38 @@ pub extern "C" fn fwd_reconstruct_on_reconstructed<'db>(
     invoke_with_handle(handle, move |h| h.reconstruct(values))
 }
 
+/// Produces an independent reconstructed handle that shares the underlying
+/// view with the input handle. Both handles can be used and freed independently.
+///
+/// # Arguments
+///
+/// * `handle` - The reconstructed handle returned by [`fwd_reconstruct_on_revision`] or
+///   [`fwd_reconstruct_on_reconstructed`].
+///
+/// # Returns
+///
+/// - [`ReconstructedResult::NullHandlePointer`] if the provided handle is null.
+/// - [`ReconstructedResult::Ok`] with a new [`ReconstructedHandle`] that
+///   shares the underlying view with the input handle.
+///
+/// # Safety
+///
+/// The caller must:
+/// * ensure that `handle` is a valid pointer to a [`ReconstructedHandle`].
+/// * call [`fwd_free_reconstructed`] to free the returned handle when it is
+///   no longer needed.
+/// * ensure that the underlying [`DatabaseHandle`] remains valid (not closed
+///   via [`fwd_close_db`]) for as long as the returned [`ReconstructedHandle`]
+///   is in use.
+#[unsafe(no_mangle)]
+pub extern "C" fn fwd_clone_reconstructed<'db>(
+    handle: Option<&ReconstructedHandle<'db>>,
+) -> ReconstructedResult<'db> {
+    invoke_with_handle(handle, move |h| {
+        Ok::<_, firewood::api::Error>(h.clone_view())
+    })
+}
+
 /// Commits a proposal to the database.
 ///
 /// This function will consume the proposal regardless of whether the commit

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -624,6 +624,12 @@ pub extern "C" fn fwd_reconstruct_on_reconstructed<'db>(
 /// Produces an independent reconstructed handle that shares the underlying
 /// view with the input handle. Both handles can be used and freed independently.
 ///
+/// Callers should only perform read operations on the cloned handle and free
+/// it before performing further writes. Calling
+/// [`fwd_reconstruct_on_reconstructed`] on the clone (or on any sibling)
+/// while another clone is alive is expensive: it forces a deep clone of the
+/// root node instead of the zero-copy move that the uncloned path takes.
+///
 /// # Arguments
 ///
 /// * `handle` - The reconstructed handle returned by [`fwd_reconstruct_on_revision`] or

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -633,8 +633,8 @@ pub extern "C" fn fwd_reconstruct_on_reconstructed<'db>(
 ///
 /// # Arguments
 ///
-/// * `handle` - The reconstructed handle returned by [`fwd_reconstruct_on_revision`] or
-///   [`fwd_reconstruct_on_reconstructed`].
+/// * `handle` - The reconstructed handle returned by [`fwd_reconstruct_on_revision`],
+///   [`fwd_reconstruct_on_reconstructed`], or a previous call to [`fwd_clone_reconstructed`].
 ///
 /// # Returns
 ///

--- a/ffi/src/reconstructed.rs
+++ b/ffi/src/reconstructed.rs
@@ -91,12 +91,6 @@ impl<'db> ReconstructedHandle<'db> {
     ///
     /// Each clone owns its own handle and may be dropped independently. The
     /// two distinct handles may be used independently.
-    ///
-    /// Calling [`Self::reconstruct`] on either handle while another handle
-    /// shares the same reconstructed state is supported but expensive: it
-    /// forces a deep clone of the root node instead of the zero-copy move used
-    /// when the handle is uniquely owned. Drop unneeded clones before
-    /// reconstructing when write performance matters.
     #[must_use]
     pub fn clone_view(&self) -> Self {
         Self::new(self.reconstructed.clone(), self.handle)

--- a/ffi/src/reconstructed.rs
+++ b/ffi/src/reconstructed.rs
@@ -92,11 +92,11 @@ impl<'db> ReconstructedHandle<'db> {
     /// Each clone owns its own handle and may be dropped independently. The
     /// two distinct handles may be used independently.
     ///
-    /// Callers should only perform read operations on the clone and drop it
-    /// before performing further writes. Calling [`Self::reconstruct`] on the
-    /// clone (or on any sibling) while another clone is alive is expensive: it
-    /// forces a deep clone of the root node instead of the zero-copy move that
-    /// the uncloned path takes.
+    /// Calling [`Self::reconstruct`] on either handle while another handle
+    /// shares the same reconstructed state is supported but expensive: it
+    /// forces a deep clone of the root node instead of the zero-copy move used
+    /// when the handle is uniquely owned. Drop unneeded clones before
+    /// reconstructing when write performance matters.
     #[must_use]
     pub fn clone_view(&self) -> Self {
         Self::new(self.reconstructed.clone(), self.handle)

--- a/ffi/src/reconstructed.rs
+++ b/ffi/src/reconstructed.rs
@@ -91,6 +91,12 @@ impl<'db> ReconstructedHandle<'db> {
     ///
     /// Each clone owns its own handle and may be dropped independently. The
     /// two distinct handles may be used independently.
+    ///
+    /// Callers should only perform read operations on the clone and drop it
+    /// before performing further writes. Calling [`Self::reconstruct`] on the
+    /// clone (or on any sibling) while another clone is alive is expensive: it
+    /// forces a deep clone of the root node instead of the zero-copy move that
+    /// the uncloned path takes.
     #[must_use]
     pub fn clone_view(&self) -> Self {
         Self::new(self.reconstructed.clone(), self.handle)

--- a/ffi/src/reconstructed.rs
+++ b/ffi/src/reconstructed.rs
@@ -86,6 +86,15 @@ impl<'db> ReconstructedHandle<'db> {
         let next = self.reconstructed.reconstruct(values)?;
         Ok(Self::new(next, self.handle))
     }
+
+    /// Produces an independent handle backed by the same underlying state.
+    ///
+    /// Each clone owns its own handle and may be dropped independently. The
+    /// two distinct handles may be used independently.
+    #[must_use]
+    pub fn clone_view(&self) -> Self {
+        Self::new(self.reconstructed.clone(), self.handle)
+    }
 }
 
 impl crate::MetricsContextExt for ReconstructedHandle<'_> {

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -455,6 +455,17 @@ impl ReconstructedView<'_> {
     }
 }
 
+impl Clone for ReconstructedView<'_> {
+    /// Produces an independent view that shares the underlying `NodeStore` via
+    /// the inner `Arc`. The returned view can be used independently of this one.
+    fn clone(&self) -> Self {
+        Self {
+            nodestore: self.nodestore.clone(),
+            db: self.db,
+        }
+    }
+}
+
 impl api::DbView for Proposal<'_> {
     type Iter<'view>
         = MerkleKeyValueIter<'view, NodeStore<Arc<ImmutableProposal>, FileBacked>>
@@ -823,6 +834,89 @@ mod test {
 
         assert_eq!(&*reconstructed.val(b"base").unwrap().unwrap(), b"v1");
         assert_eq!(&*reconstructed.val(b"next").unwrap().unwrap(), b"v2");
+    }
+
+    #[test]
+    fn test_reconstruct_clone_is_independent() {
+        let db = TestDb::new();
+
+        // Build a base committed revision.
+        let initial = db
+            .propose(vec![BatchOp::Put {
+                key: b"base",
+                value: b"v0",
+            }])
+            .unwrap();
+        initial.commit().unwrap();
+        let historical_hash = db.root_hash().unwrap();
+        let historical = db.revision(historical_hash).unwrap();
+
+        // Build a reconstructed view on top of the historical revision.
+        let original = db
+            .reconstruct_from_view(
+                historical.as_ref(),
+                vec![BatchOp::Put {
+                    key: b"shared",
+                    value: b"v1",
+                }],
+            )
+            .unwrap();
+        let original_root = original.root_hash();
+
+        // Verify that a cloned reconstructed revision has the same state as the original.
+        let cloned = original.clone();
+        assert_eq!(cloned.root_hash(), original_root);
+        assert_eq!(&*cloned.val(b"base").unwrap().unwrap(), b"v0");
+        assert_eq!(&*cloned.val(b"shared").unwrap().unwrap(), b"v1");
+
+        // Mutating the clone via reconstruct does not affect the original.
+        let new_cloned = cloned
+            .reconstruct(vec![BatchOp::Put {
+                key: b"clone_only",
+                value: b"v2",
+            }])
+            .unwrap();
+        assert_eq!(&*new_cloned.val(b"clone_only").unwrap().unwrap(), b"v2");
+        assert_eq!(original.val(b"clone_only").unwrap(), None);
+        assert_eq!(original.root_hash(), original_root);
+
+        // Mutating the original via reconstruct does not affect the clone.
+        let original_next = original
+            .reconstruct(vec![BatchOp::Put {
+                key: b"original_only",
+                value: b"v3",
+            }])
+            .unwrap();
+        assert_eq!(
+            &*original_next.val(b"original_only").unwrap().unwrap(),
+            b"v3"
+        );
+        assert_eq!(new_cloned.val(b"original_only").unwrap(), None);
+    }
+
+    #[test]
+    fn test_reconstruct_clone_outlives_original() {
+        let db = TestDb::new();
+
+        let key = b"k";
+        let value = b"v";
+        let initial = db.propose(vec![BatchOp::Put { key, value }]).unwrap();
+        initial.commit().unwrap();
+
+        let historical_hash = db.root_hash().unwrap();
+        let historical = db.revision(historical_hash).unwrap();
+
+        let original = db
+            .reconstruct_from_view(historical.as_ref(), Vec::<BatchOp<&[u8], &[u8]>>::new())
+            .unwrap();
+        let cloned = original.clone();
+        let expected_root = original.root_hash();
+
+        drop(original);
+
+        // The clone is fully functional after the original is dropped.
+        assert_eq!(cloned.root_hash(), expected_root);
+        assert_eq!(&*cloned.val(b"k").unwrap().unwrap(), b"v");
     }
 
     #[test]

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -459,11 +459,11 @@ impl Clone for ReconstructedView<'_> {
     /// Produces an independent view that shares the underlying `NodeStore` via
     /// the inner `Arc`. The returned view can be used independently of this one.
     ///
-    /// Callers should only perform read operations on the clone and drop it
-    /// before performing further writes. Calling [`api::Reconstructible::reconstruct`]
-    /// on the clone (or on any sibling) while another clone is alive is
-    /// expensive: it forfeits the zero-copy move on the reconstructed parent
-    /// and forces a deep clone of the root node.
+    /// Calling [`api::Reconstructible::reconstruct`] on either view while
+    /// another view shares the same reconstructed state is supported but
+    /// expensive: it forces a deep clone of the root node instead of the
+    /// zero-copy move used when the view is uniquely owned. Drop unneeded
+    /// clones before reconstructing when write performance matters.
     fn clone(&self) -> Self {
         Self {
             nodestore: self.nodestore.clone(),

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -884,6 +884,41 @@ mod test {
     }
 
     #[test]
+    fn test_reconstruct_clone_of_clone() {
+        let db = TestDb::new();
+
+        // Build a base committed revision.
+        let initial = db
+            .propose(vec![BatchOp::Put {
+                key: b"base",
+                value: b"v0",
+            }])
+            .unwrap();
+        initial.commit().unwrap();
+        let historical_hash = db.root_hash().unwrap();
+        let historical = db.revision(historical_hash).unwrap();
+
+        // Build a reconstructed view on top of the historical revision.
+        let original = db
+            .reconstruct_from_view(
+                &historical,
+                vec![BatchOp::Put {
+                    key: b"shared",
+                    value: b"v1",
+                }],
+            )
+            .unwrap();
+        let original_root = original.root_hash();
+
+        let first_clone = original.clone();
+        let second_clone = first_clone.clone();
+
+        // Verify that the first and second clones are usable
+        assert_eq!(original_root, first_clone.root_hash());
+        assert_eq!(original_root, second_clone.root_hash());
+    }
+
+    #[test]
     fn test_reconstruct_clone_outlives_original() {
         let db = TestDb::new();
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -458,6 +458,12 @@ impl ReconstructedView<'_> {
 impl Clone for ReconstructedView<'_> {
     /// Produces an independent view that shares the underlying `NodeStore` via
     /// the inner `Arc`. The returned view can be used independently of this one.
+    ///
+    /// Callers should only perform read operations on the clone and drop it
+    /// before performing further writes. Calling [`api::Reconstructible::reconstruct`]
+    /// on the clone (or on any sibling) while another clone is alive is
+    /// expensive: it forfeits the zero-copy move on the reconstructed parent
+    /// and forces a deep clone of the root node.
     fn clone(&self) -> Self {
         Self {
             nodestore: self.nodestore.clone(),

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -440,7 +440,7 @@ pub struct Proposal<'db> {
     db: &'db Db,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 /// A user-visible reconstructed view.
 pub struct ReconstructedView<'db> {
     nodestore: Arc<NodeStore<Reconstructed<FileBacked>, FileBacked>>,
@@ -452,23 +452,6 @@ impl ReconstructedView<'_> {
     #[must_use]
     pub fn view(&self) -> ArcDynDbView {
         self.nodestore.clone()
-    }
-}
-
-impl Clone for ReconstructedView<'_> {
-    /// Produces an independent view that shares the underlying `NodeStore` via
-    /// the inner `Arc`. The returned view can be used independently of this one.
-    ///
-    /// Calling [`api::Reconstructible::reconstruct`] on either view while
-    /// another view shares the same reconstructed state is supported but
-    /// expensive: it forces a deep clone of the root node instead of the
-    /// zero-copy move used when the view is uniquely owned. Drop unneeded
-    /// clones before reconstructing when write performance matters.
-    fn clone(&self) -> Self {
-        Self {
-            nodestore: self.nodestore.clone(),
-            db: self.db,
-        }
     }
 }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -843,7 +843,7 @@ mod test {
         // Build a reconstructed view on top of the historical revision.
         let original = db
             .reconstruct_from_view(
-                historical.as_ref(),
+                &historical,
                 vec![BatchOp::Put {
                     key: b"shared",
                     value: b"v1",
@@ -896,7 +896,7 @@ mod test {
         let historical = db.revision(historical_hash).unwrap();
 
         let original = db
-            .reconstruct_from_view(historical.as_ref(), Vec::<BatchOp<&[u8], &[u8]>>::new())
+            .reconstruct_from_view(&historical, Vec::<BatchOp<&[u8], &[u8]>>::new())
             .unwrap();
         let cloned = original.clone();
         let expected_root = original.root_hash();

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -955,9 +955,7 @@ impl<S: ReadableStorage> From<Arc<NodeStore<Reconstructed<S>, S>>>
         // reconstructed root out without cloning.
         // The fallback (shared-Arc) path is reachable in two ways:
         //   1. A caller produced sibling views via `ReconstructedView::clone` and is keeping
-        //      another sibling alive across this call. This is a supported pattern for handing
-        //      out independent read-only views, but reconstructing while a sibling is alive
-        //      lands here; callers are documented to drop the clone before writing.
+        //      another sibling alive across this call.
         //   2. A caller is iterating over the reconstructed view (the iterator holds an Arc
         //      clone via `ReconstructedView::view`) while also deriving the next reconstructed
         //      state.
@@ -965,10 +963,6 @@ impl<S: ReadableStorage> From<Arc<NodeStore<Reconstructed<S>, S>>>
         // cloning the in-memory subtree attached to it. We accept this fallback so callers
         // don't have to guarantee uniqueness, while still exploiting the cheaper move path
         // whenever possible.
-        if Arc::strong_count(&val) > 1 {
-            debug!("Reconstruct fell back to shared-Arc clone path");
-        }
-
         Self::from(Arc::unwrap_or_clone(val))
     }
 }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -953,15 +953,18 @@ impl<S: ReadableStorage> From<Arc<NodeStore<Reconstructed<S>, S>>>
     fn from(val: Arc<NodeStore<Reconstructed<S>, S>>) -> Self {
         // Fast path: if this Arc is uniquely owned, `try_unwrap` is O(1) and lets us move the
         // reconstructed root out without cloning.
-        // Why this Arc might be shared: a caller could keep another handle alive (e.g. iterating
-        // over a reconstructed view while also deriving the next reconstructed state), which makes
-        // `try_unwrap` fail even though conversion is still valid.
-        // Fallback cost: when shared, we must clone the `NodeStore<Reconstructed, S>`, which
-        // clones the root `SharedNode` arc and then `Arc::unwrap_or_clone` extracts the `Node`.
-        // This shared-Arc fallback does not match our known reconstruction use cases, where the
-        // previous reconstructed handle is typically consumed before building the next one.
-        // We do this to avoid forcing callers to guarantee uniqueness while still exploiting the
-        // cheaper move path whenever possible.
+        // The fallback (shared-Arc) path is reachable in two ways:
+        //   1. A caller produced sibling views via `ReconstructedView::clone` and is keeping
+        //      another sibling alive across this call. This is a supported pattern for handing
+        //      out independent read-only views, but reconstructing while a sibling is alive
+        //      lands here; callers are documented to drop the clone before writing.
+        //   2. A caller is iterating over the reconstructed view (the iterator holds an Arc
+        //      clone via `ReconstructedView::view`) while also deriving the next reconstructed
+        //      state.
+        // Fallback cost: producing an owned root from the shared Arc requires recursively
+        // cloning the in-memory subtree attached to it. We accept this fallback so callers
+        // don't have to guarantee uniqueness, while still exploiting the cheaper move path
+        // whenever possible.
         Self::from(Arc::unwrap_or_clone(val))
     }
 }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -965,6 +965,10 @@ impl<S: ReadableStorage> From<Arc<NodeStore<Reconstructed<S>, S>>>
         // cloning the in-memory subtree attached to it. We accept this fallback so callers
         // don't have to guarantee uniqueness, while still exploiting the cheaper move path
         // whenever possible.
+        if Arc::strong_count(&val) > 1 {
+            debug!("Reconstruct fell back to shared-Arc clone path");
+        }
+
         Self::from(Arc::unwrap_or_clone(val))
     }
 }


### PR DESCRIPTION
## Why this should be merged

While benchmarking our Firewood archival nodes, we came across an error when making an `eth_estimateGas` API call that required block reexecution. After some investigation, the root cause was determined to be triggered by the following code:

https://github.com/ava-labs/avalanchego/blob/c5d4e6c31db451fb2e6d8a7fd178c19004985765/graft/evm/firewood/reconstructed_state.go#L73-L77

We currently return `nil` because reconstructed revisions cannot be shared while `state.Database` (the interface that `reconstructedStateAccessor` satisfies) has the following documentation for `CopyTrie`:

```go
// CopyTrie returns an independent copy of the given trie.
CopyTrie(Trie) Trie
```

Given that `eth_estimateGas` and similar methods call on `CopyTrie()`, there should be a way to create a new `reconstructedAccountTrie` while also not having two tries share the same reconstructed revision.

## How this works

Adds a `Clone()` method to the reconstructed pointer type, which returns a new, independent reconstructed revision. This independent reconstructed revision can then be used for the implementation of `CopyTrie()`.

*Note*: an alternative approach that was suggested was to just return a new instance of `reconstructedAccountTrie` via copy-by-reference. While this approach also solves the bug fix, this explicitly violates the invariant set in `CopyTrie()`, setting up a footgun I would **strongly prefer** not to introduce into AvalancheGo.

## How this was tested

CI + added additional UTs in Go and Rust verifying that cloned reconstructed revisions are independent of the reconstructed revision they are cloned from.

I also have a PoC in AvalancheGo which utilizes this fix, and have verified that all usages of `CopyTrie()` are read-only.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
