### PR TITLE
ci: disable bin cache for rust-cache

### DIFF
--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -51,6 +51,10 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:
           shared-key: ${{ matrix.target }}
+          # TEMP:
+          # see: https://github.com/rust-lang/rustup/issues/4856
+          # see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: false
 
       - name: Add target for cross-compilation
         run: rustup target add ${{ matrix.target }}

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -20,6 +20,10 @@ jobs:
           shared-key: "maxperf-ethhash-logger-test_utils"
           cache-all-crates: true
           cache-workspace-crates: true
+          # TEMP:
+          # see: https://github.com/rust-lang/rustup/issues/4856
+          # see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: false
       - name: Cargo Fetch (run `cargo generate-lockfile` if this fails)
         run: cargo fetch --locked --verbose
       - name: Build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,10 @@ jobs:
           shared-key: ${{ matrix.profile-key }}
           cache-all-crates: true
           cache-workspace-crates: true
+          # TEMP:
+          # see: https://github.com/rust-lang/rustup/issues/4856
+          # see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: false
       # Require Cargo.lock to be up to date and ensure the registry cache is populated
       - name: Cargo Fetch (run `cargo generate-lockfile` if this fails)
         run: cargo fetch --locked --verbose


### PR DESCRIPTION
## Why this should be merged

This is a temporary workaround until the upstream issue is resolved or until alternative cache is setup.

- https://github.com/Swatinem/rust-cache/issues/341

## How this works

This applies the recommended change to disable `cache-bin`. This will cause CI to take longer as any installed bins will need to be rebuilt each time.

## How this was tested

CI

## Breaking Changes

n/a