### PR TITLE
perf(storage): retain hashed root in Reconstructed for cheap forks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +1884,7 @@ name = "firewood-storage"
 version = "0.4.0"
 dependencies = [
  "aquamarine",
+ "arc-swap",
  "bitfield",
  "bitflags 2.11.1",
  "bumpalo",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -50,6 +50,7 @@ io-uring = { version = "0.7.12", optional = true }
 log = { version = "0.4.29", optional = true }
 sha3 = { version = "0.10.9", optional = true }
 bumpalo = { version = "3.20.2", features = ["collections", "std"] }
+arc-swap = "1.9.1"
 
 [dev-dependencies]
 cfg-if = "1.0.4"

--- a/storage/src/arc_swap_triomphe.rs
+++ b/storage/src/arc_swap_triomphe.rs
@@ -1,0 +1,91 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+//! `RefCnt` bridge so that `arc_swap` can swap `triomphe::Arc` values.
+//!
+//! `arc-swap` ships `RefCnt` impls for `std::sync::Arc` and `std::rc::Rc` but
+//! not for `triomphe::Arc`, which is what `SharedNode` is built on. The orphan
+//! rule prevents us from implementing `RefCnt` for `triomphe::Arc` directly,
+//! so this module exposes a transparent newtype, [`TriompheArc`], that wraps
+//! it and implements `RefCnt` itself.
+//!
+//! This module is the *only* place in the storage crate that opts out of
+//! `deny(unsafe_code)`. The unsafe surface is intentionally minimal: each
+//! `RefCnt` method forwards to the matching `triomphe::Arc` raw-pointer API.
+//!
+//! Soundness rests on three properties that `triomphe::Arc` shares with
+//! `std::sync::Arc`:
+//!
+//! 1. `into_raw` consumes the `Arc` without touching the refcount and returns
+//!    a stable pointer to the inner `T`.
+//! 2. `from_raw(p)` rehydrates ownership of the same refcount slot, given a
+//!    pointer that came from a prior `into_raw`.
+//! 3. `as_ptr` returns the same pointer `into_raw` would, without affecting
+//!    the refcount.
+//!
+//! The pointer is non-null for any sized `T` we use here (`Node` is non-ZST),
+//! which is what `arc_swap`'s `RefCnt for Option<T>` relies on to distinguish
+//! `Some` from `None`.
+
+#![allow(
+    unsafe_code,
+    reason = "arc_swap::RefCnt requires unsafe trait methods; sealed bridge for triomphe::Arc"
+)]
+
+use std::ops::Deref;
+
+use arc_swap::RefCnt;
+
+/// Transparent wrapper around `triomphe::Arc<T>` that implements
+/// [`arc_swap::RefCnt`] so the value can live inside an `ArcSwapAny`.
+#[repr(transparent)]
+pub(crate) struct TriompheArc<T>(triomphe::Arc<T>);
+
+impl<T> TriompheArc<T> {
+    pub(crate) const fn new(arc: triomphe::Arc<T>) -> Self {
+        Self(arc)
+    }
+
+    pub(crate) fn into_inner(self) -> triomphe::Arc<T> {
+        self.0
+    }
+}
+
+impl<T> Clone for TriompheArc<T> {
+    fn clone(&self) -> Self {
+        Self(triomphe::Arc::clone(&self.0))
+    }
+}
+
+impl<T> Deref for TriompheArc<T> {
+    type Target = triomphe::Arc<T>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for TriompheArc<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// SAFETY: forwards to triomphe::Arc's raw-pointer API, which provides the same
+// refcount-stable, ABI-stable guarantees that std::sync::Arc does (see module docs).
+unsafe impl<T> RefCnt for TriompheArc<T> {
+    type Base = T;
+
+    fn into_ptr(me: Self) -> *mut Self::Base {
+        triomphe::Arc::into_raw(me.0).cast_mut()
+    }
+
+    fn as_ptr(me: &Self) -> *mut Self::Base {
+        triomphe::Arc::as_ptr(&me.0).cast_mut()
+    }
+
+    unsafe fn from_ptr(ptr: *const Self::Base) -> Self {
+        // SAFETY: `ptr` originated from `Self::into_ptr` (i.e. `triomphe::Arc::into_raw`)
+        // per the `RefCnt::from_ptr` contract.
+        Self(unsafe { triomphe::Arc::from_raw(ptr) })
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -22,6 +22,7 @@
 use std::fmt::{Display, Formatter, LowerHex, Result};
 use std::ops::Range;
 
+mod arc_swap_triomphe;
 mod checker;
 mod hashednode;
 mod hashedshunt;

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -49,6 +49,7 @@ pub(crate) mod persist;
 pub(crate) mod primitives;
 
 use crate::IntoHashType;
+use crate::arc_swap_triomphe::TriompheArc;
 use crate::linear::{OffsetReader, ReadableNodeMode};
 use crate::logger::{debug, trace};
 use crate::node::branch::ReadSerializable as _;
@@ -675,16 +676,31 @@ pub struct NodeStore<T, S> {
 /// Contains state for a reconstructed revision of the trie.
 /// These are unparented, and only contain an in-memory root.
 ///
-/// The root node is stored as a [`SharedNode`] at construction time.
-/// The root hash is computed lazily on the first call to
-/// [`HashedNodeReader::root_hash`] and cached in a [`OnceLock`] for
-/// lock-free access on subsequent reads.
-#[derive(Debug, Clone)]
+/// The root node is held in an [`arc_swap::ArcSwapAny`] so that
+/// [`HashedNodeReader::root_hash`] can replace it atomically with the
+/// fully-hashed version produced by hashing (children rewritten from
+/// `Child::Node` to `Child::MaybePersisted`). Reconstruction chains that
+/// never request the hash never pay for the swap.
+#[derive(Debug)]
 pub struct Reconstructed {
-    /// The root node, wrapped in a [`SharedNode`] at construction.
-    node: Option<SharedNode>,
+    /// The current root node. `None` for an empty trie; otherwise an
+    /// atomically-swappable `SharedNode`. After the first `root_hash` call
+    /// the swapped-in value's children are all `Child::MaybePersisted`.
+    root: Option<arc_swap::ArcSwapAny<TriompheArc<Node>>>,
     /// Lazily computed root hash (write-once, then lock-free reads).
     hash: OnceLock<TrieHash>,
+}
+
+impl Clone for Reconstructed {
+    fn clone(&self) -> Self {
+        Self {
+            root: self
+                .root
+                .as_ref()
+                .map(|swap| arc_swap::ArcSwapAny::new(swap.load_full())),
+            hash: self.hash.clone(),
+        }
+    }
 }
 
 /// Proposal-specific fields for a mutable nodestore.
@@ -748,11 +764,15 @@ pub struct Mutable<Kind> {
 /// For reconstruct on reconstruct, this avoids cloning
 impl<S: ReadableStorage> From<NodeStore<Reconstructed, S>> for NodeStore<Mutable<Recon>, S> {
     fn from(val: NodeStore<Reconstructed, S>) -> Self {
+        // Consume the ArcSwap to get back the SharedNode, then unwrap_or_clone to extract
+        // an owned Node. In the linear M->R->M->R chain the SharedNode is uniquely held,
+        // so this is a free move.
+        let root = val
+            .kind
+            .root
+            .map(|swap| triomphe::Arc::unwrap_or_clone(swap.into_inner().into_inner()));
         NodeStore {
-            kind: Mutable {
-                root: val.kind.node.map(triomphe::Arc::unwrap_or_clone),
-                inner: Recon,
-            },
+            kind: Mutable { root, inner: Recon },
             storage: val.storage,
             must_recompute_storage_hash: val.must_recompute_storage_hash,
         }
@@ -763,7 +783,10 @@ impl<S: ReadableStorage> From<NodeStore<Mutable<Recon>, S>> for NodeStore<Recons
     fn from(val: NodeStore<Mutable<Recon>, S>) -> Self {
         NodeStore {
             kind: Reconstructed {
-                node: val.kind.root.map(triomphe::Arc::new),
+                root: val
+                    .kind
+                    .root
+                    .map(|n| arc_swap::ArcSwapAny::new(TriompheArc::new(triomphe::Arc::new(n)))),
                 hash: OnceLock::new(),
             },
             storage: val.storage,
@@ -969,7 +992,10 @@ impl<S: ReadableStorage> RootReader for NodeStore<Arc<ImmutableProposal>, S> {
 
 impl<S: ReadableStorage> RootReader for NodeStore<Reconstructed, S> {
     fn root_node(&self) -> Option<SharedNode> {
-        self.kind.node.clone()
+        self.kind
+            .root
+            .as_ref()
+            .map(|swap| swap.load_full().into_inner())
     }
 
     fn root_as_maybe_persisted_node(&self) -> Option<MaybePersistedNode> {
@@ -1003,22 +1029,33 @@ where
         None
     }
 
-    // Lazily compute and cache the hash. We don't use parallel hash
-    // calculations here because reconstructed views don't benefit as much
-    // from spinning up multiple threads.
+    // Lazily compute and cache the hash. The hashed root (with children rewritten
+    // to `Child::MaybePersisted`) is swapped back into `self.kind.root` so any
+    // subsequent fork-then-reconstruct walks Arc-shared children instead of
+    // deep-cloning every `Child::Node` subtree. We don't parallelise the hash
+    // because reconstructed views don't benefit much from multiple threads.
     fn root_hash(&self) -> Option<TrieHash> {
-        let node = self.kind.node.as_ref()?;
         if let Some(hash) = self.kind.hash.get() {
             return Some(hash.clone());
         }
-        let node_val: Node = Node::clone(node);
+        let swap = self.kind.root.as_ref()?;
+        let current = swap.load_full();
+        let node_val: Node = Node::clone(&current);
         #[cfg(feature = "ethhash")]
-        let (_, hash) = self.hash_helper(node_val, Path::new()).ok()?;
+        let (hashed_mp, hash) = self.hash_helper(node_val, Path::new()).ok()?;
         #[cfg(not(feature = "ethhash"))]
-        let (_, hash) =
+        let (hashed_mp, hash) =
             NodeStore::<Mutable<Propose>, S>::hash_helper(node_val, Path::new()).ok()?;
+        // Extract the in-memory SharedNode from the freshly-built MaybePersistedNode
+        // (always the `Unpersisted` variant here, so this is a Mutex lock + Arc clone,
+        // no I/O). Replace the unhashed root with the fully-hashed one. If another
+        // thread raced us, the loser's swap overwrites with an equivalent tree; both
+        // contain the same trie content, only the children's form differs
+        // (`Child::Node` vs `Child::MaybePersisted`) and both are valid reads.
+        let hashed_shared = hashed_mp.as_shared_node(self).ok()?;
+        swap.store(TriompheArc::new(hashed_shared));
         let hash = hash.into_triehash();
-        // If another thread raced us, discard ours — both computed the same value.
+        // If another thread raced us on the hash too, discard ours — same value.
         let _ = self.kind.hash.set(hash.clone());
         Some(hash)
     }
@@ -1575,5 +1612,58 @@ mod tests {
         let reconstructed: NodeStore<Reconstructed, _> = recon.into();
 
         assert_eq!(reconstructed.root_hash(), None);
+    }
+
+    #[test]
+    fn reconstructed_root_hash_rewrites_root_children() {
+        // After root_hash() runs, the swapped-in root must have no Child::Node
+        // children — they should all be Child::MaybePersisted. hash_helper works
+        // bottom-up, so if no Child::Node remains at the root, none remains below.
+        let storage = Arc::new(MemStore::default());
+        let mut recon = NodeStore::new_empty_recon(Arc::clone(&storage));
+
+        let mut children = Children::new();
+        children[PathComponent::ALL[0x0]] = Some(Child::Node(Node::Leaf(LeafNode {
+            partial_path: Path::from_nibbles_iterator(NibblesIterator::new(b"abc")),
+            value: b"v0".to_vec().into_boxed_slice(),
+        })));
+        children[PathComponent::ALL[0xF]] = Some(Child::Node(Node::Leaf(LeafNode {
+            partial_path: Path::from_nibbles_iterator(NibblesIterator::new(b"xyz")),
+            value: b"vf".to_vec().into_boxed_slice(),
+        })));
+        recon.root_mut().replace(Node::Branch(Box::new(BranchNode {
+            partial_path: Path::new(),
+            value: None,
+            children,
+        })));
+
+        let reconstructed: NodeStore<Reconstructed, _> = recon.into();
+
+        // Sanity: pre-hash, the root branch has at least one Child::Node.
+        let before = reconstructed.root_node().expect("root present");
+        let Node::Branch(b) = &*before else {
+            panic!("root must be a branch");
+        };
+        assert!(
+            b.children
+                .iter_present()
+                .any(|(_, c)| matches!(c, Child::Node(_))),
+            "fixture must start with at least one Child::Node"
+        );
+        drop(before);
+
+        assert!(reconstructed.root_hash().is_some());
+
+        // After root_hash, no Child::Node remains at the root.
+        let after = reconstructed.root_node().expect("root present");
+        let Node::Branch(b) = &*after else {
+            panic!("root must still be a branch");
+        };
+        for (_, child) in b.children.iter_present() {
+            assert!(
+                !matches!(child, Child::Node(_)),
+                "root child still Child::Node after root_hash: {child:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Why this should be merged

`HashedNodeReader::root_hash` on a `Reconstructed` nodestore called `hash_helper`, which builds a fully-hashed in-memory tree (every `Child::Node` rewritten to `Child::MaybePersisted` over an `Arc`-shared subtree), and then threw that tree away. Only the resulting `TrieHash` was cached in a `OnceLock`. The next fork-and-reconstruct off the same `Reconstructed` still saw `Child::Node` children and paid for a full deep clone of the trie structure.

Now the hashed tree is kept: `root_hash` swaps the new `SharedNode` into the root via `ArcSwapAny`, so any subsequent
`From<NodeStore<Reconstructed>> for NodeStore<Mutable<Recon>>` walks `Arc`-shared `MaybePersisted` children rather than recursively copying `Child::Node` subtrees. The unhashed `M -> R -> M -> R` reconstruction chain is unaffected — it never invokes `root_hash`, so the swap never fires.

## How this works

- `Reconstructed::root` changes from `Option<SharedNode>` to `Option<ArcSwapAny<TriompheArc<Node>>>`. The `OnceLock<TrieHash>` next to it is unchanged.
- A new sealed module `storage/src/arc_swap_triomphe.rs` provides `TriompheArc<T>`, a `#[repr(transparent)]` newtype around `triomphe::Arc<T>`. It implements `arc_swap::RefCnt` by forwarding to `triomphe::Arc`'s raw-pointer API. This is the only place in the storage crate that opts out of `deny(unsafe_code)`; the unsafe surface is three forwarded methods with documented soundness.
- `root_hash` now stores the hashed `SharedNode` (extracted from the `MaybePersistedNode` returned by `hash_helper`) back into the `ArcSwap`, then caches the `TrieHash` in the existing `OnceLock`.
- `From<NodeStore<Mutable<Recon>>> for NodeStore<Reconstructed>` wraps the root in an `ArcSwapAny` without computing the hash, preserving the cheap-chain path.
- `RootReader::root_node` and the `Clone` impl for `Reconstructed` load from the `ArcSwap` rather than cloning a stored `SharedNode`.

## A note on arc-swap

We've used `arc-swap` in firewood before, on hot paths with hundreds of concurrently-swapping nodes, and it caused performance problems there. This use is different: a `Reconstructed` has exactly one `ArcSwapAny`, the swap fires at most once per `Reconstructed` lifetime (when `root_hash` is first computed), and the number of live `Reconstructed` instances is small. None of the conditions that hurt us last time apply.

## How this was tested

- `cargo nextest run --workspace --features ethhash,logger --all-targets` (710 tests, all pass).
- `cargo clippy --workspace --features ethhash,logger --all-targets` (clean).
- `cargo doc --no-deps` (clean).
- New unit test `reconstructed_root_hash_rewrites_root_children` builds a `Reconstructed` whose root is a branch with `Child::Node` children, calls `root_hash`, then asserts the root branch returned by `RootReader::root_node` no longer contains any `Child::Node` child. `hash_helper` works bottom-up, so the root assertion implies the whole subtree was rewritten.

## Breaking Changes

None. The change is internal to `firewood-storage`; no public API signatures change.