### PR TITLE
refactor(storage): lift nibbles_to_eth_compact into eth_encoding module

### DIFF
--- a/storage/src/eth_encoding.rs
+++ b/storage/src/eth_encoding.rs
@@ -1,0 +1,85 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+//! # Ethereum MPT path encoding
+//!
+//! Encoding primitives for the Ethereum Modified Merkle Patricia Trie that are
+//! needed by both the ethhash hasher and the `eth_getProof`-compatible proof
+//! emitter. These helpers are unconditionally compiled so the proof emitter
+//! (which is itself always compiled) can call them without pulling in the
+//! `ethhash` feature gate.
+
+use crate::TriePath;
+use bitfield::bitfield;
+use smallvec::SmallVec;
+use std::iter::once;
+
+/// Hex-prefix encoding of a nibble path (Ethereum Yellow Paper, appendix C).
+///
+/// Produces the byte sequence used as the first element of leaf and extension
+/// nodes when RLP-encoding an MPT node. The first output byte is a header of
+/// the form `00ABCCCC`:
+///
+/// - `A` is 1 iff `is_leaf` — distinguishes leaf (`2x`/`3x`) from extension
+///   (`0x`/`1x`) nodes.
+/// - `B` is 1 iff the input has an odd number of nibbles, in which case
+///   `CCCC` is the first (orphan) nibble.
+/// - If `B` is 0, `CCCC` is zero and the remaining nibbles pack evenly into
+///   bytes.
+///
+/// Remaining nibble pairs are packed high-nibble-first into subsequent bytes.
+/// This must match geth's `hexToCompact` exactly; any deviation breaks root
+/// hash compatibility.
+pub fn nibbles_to_eth_compact<T: TriePath>(nibbles: T, is_leaf: bool) -> SmallVec<[u8; 32]> {
+    // This is a bitfield that represents the first byte of the output, documented above
+    bitfield! {
+        struct CompactFirstByte(u8);
+        impl Debug;
+        impl new;
+        u8;
+        is_leaf, set_is_leaf: 5;
+        odd_nibbles, set_odd_nibbles: 4;
+        low_nibble, set_low_nibble: 3, 0;
+    }
+
+    let nibbles = nibbles.as_component_slice();
+
+    let mut first_byte = CompactFirstByte(0);
+    first_byte.set_is_leaf(is_leaf);
+
+    let (maybe_low_nibble, nibble_pairs) = nibbles.as_rchunks::<2>();
+    if let &[low_nibble] = maybe_low_nibble {
+        // we have an odd number of nibbles
+        first_byte.set_odd_nibbles(true);
+        first_byte.set_low_nibble(low_nibble.as_u8());
+    } else {
+        // as_rchunks can only return 0 or 1 element in the first slice if N is 2
+        debug_assert!(maybe_low_nibble.is_empty());
+    }
+
+    // now assemble everything: the first byte, and the nibble pairs compacted back together
+    once(first_byte.0)
+        .chain(nibble_pairs.iter().map(|&[hi, lo]| hi.join(lo)))
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use test_case::test_case;
+
+    use crate::{PathComponent, TriePathFromUnpackedBytes};
+
+    #[test_case(&[], false, &[0x00])]
+    #[test_case(&[], true, &[0x20])]
+    #[test_case(&[1, 2, 3, 4, 5], false, &[0x11, 0x23, 0x45])]
+    #[test_case(&[0, 1, 2, 3, 4, 5], false, &[0x00, 0x01, 0x23, 0x45])]
+    #[test_case(&[15, 1, 12, 11, 8], true, &[0x3f, 0x1c, 0xb8])]
+    #[test_case(&[0, 15, 1, 12, 11, 8], true, &[0x20, 0x0f, 0x1c, 0xb8])]
+    fn test_hex_to_compact(hex: &[u8], has_value: bool, expected_compact: &[u8]) {
+        let path = <&[PathComponent]>::path_from_unpacked_bytes(hex).expect("valid path");
+        assert_eq!(
+            &*super::nibbles_to_eth_compact(path, has_value),
+            expected_compact
+        );
+    }
+}

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -101,70 +101,20 @@
 //!   beyond the standard 4, so [`replace_list_field`](crate::rlp::replace_list_field)
 //!   only touches index 2 and leaves any trailing fields intact.
 
+use crate::eth_encoding::nibbles_to_eth_compact;
 use crate::logger::warn;
 use crate::rlp::{NULL_RLP, RlpItem, encode_list, replace_list_field};
 use crate::{
     BranchNode, HashType, Hashable, Preimage, TrieHash, TriePath, ValueDigest,
     hashednode::HasUpdate, logger::trace,
 };
-use bitfield::bitfield;
 use sha3::{Digest, Keccak256};
 use smallvec::SmallVec;
-use std::iter::once;
 
 impl HasUpdate for Keccak256 {
     fn update<T: AsRef<[u8]>>(&mut self, data: T) {
         sha3::Digest::update(self, data);
     }
-}
-
-/// Hex-prefix encoding of a nibble path (Ethereum Yellow Paper, appendix C).
-///
-/// Produces the byte sequence used as the first element of leaf and extension
-/// nodes when RLP-encoding an MPT node. The first output byte is a header of
-/// the form `00ABCCCC`:
-///
-/// - `A` is 1 iff `is_leaf` — distinguishes leaf (`2x`/`3x`) from extension
-///   (`0x`/`1x`) nodes.
-/// - `B` is 1 iff the input has an odd number of nibbles, in which case
-///   `CCCC` is the first (orphan) nibble.
-/// - If `B` is 0, `CCCC` is zero and the remaining nibbles pack evenly into
-///   bytes.
-///
-/// Remaining nibble pairs are packed high-nibble-first into subsequent bytes.
-/// This must match geth's `hexToCompact` exactly; any deviation breaks root
-/// hash compatibility.
-fn nibbles_to_eth_compact<T: TriePath>(nibbles: T, is_leaf: bool) -> SmallVec<[u8; 32]> {
-    // This is a bitfield that represents the first byte of the output, documented above
-    bitfield! {
-        struct CompactFirstByte(u8);
-        impl Debug;
-        impl new;
-        u8;
-        is_leaf, set_is_leaf: 5;
-        odd_nibbles, set_odd_nibbles: 4;
-        low_nibble, set_low_nibble: 3, 0;
-    }
-
-    let nibbles = nibbles.as_component_slice();
-
-    let mut first_byte = CompactFirstByte(0);
-    first_byte.set_is_leaf(is_leaf);
-
-    let (maybe_low_nibble, nibble_pairs) = nibbles.as_rchunks::<2>();
-    if let &[low_nibble] = maybe_low_nibble {
-        // we have an odd number of nibbles
-        first_byte.set_odd_nibbles(true);
-        first_byte.set_low_nibble(low_nibble.as_u8());
-    } else {
-        // as_rchunks can only return 0 or 1 element in the first slice if N is 2
-        debug_assert!(maybe_low_nibble.is_empty());
-    }
-
-    // now assemble everything: the first byte, and the nibble pairs compacted back together
-    once(first_byte.0)
-        .chain(nibble_pairs.iter().map(|&[hi, lo]| hi.join(lo)))
-        .collect()
 }
 
 impl<T: Hashable> Preimage for T {
@@ -323,26 +273,5 @@ impl<T: Hashable> Preimage for T {
                 buf.update(&final_bytes);
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use test_case::test_case;
-
-    use crate::{PathComponent, TriePathFromUnpackedBytes};
-
-    #[test_case(&[], false, &[0x00])]
-    #[test_case(&[], true, &[0x20])]
-    #[test_case(&[1, 2, 3, 4, 5], false, &[0x11, 0x23, 0x45])]
-    #[test_case(&[0, 1, 2, 3, 4, 5], false, &[0x00, 0x01, 0x23, 0x45])]
-    #[test_case(&[15, 1, 12, 11, 8], true, &[0x3f, 0x1c, 0xb8])]
-    #[test_case(&[0, 15, 1, 12, 11, 8], true, &[0x20, 0x0f, 0x1c, 0xb8])]
-    fn test_hex_to_compact(hex: &[u8], has_value: bool, expected_compact: &[u8]) {
-        let path = <&[PathComponent]>::path_from_unpacked_bytes(hex).expect("valid path");
-        assert_eq!(
-            &*super::nibbles_to_eth_compact(path, has_value),
-            expected_compact
-        );
     }
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -42,6 +42,10 @@ mod u4;
 /// Logger module for handling logging functionality
 pub mod logger;
 
+/// Ethereum MPT path encoding primitives shared by the ethhash hasher and the
+/// `eth_getProof`-compatible proof emitter.
+pub mod eth_encoding;
+
 /// Minimal in-tree RLP encoder/decoder used by ethhash and account-value handling.
 pub(crate) mod rlp;
 


### PR DESCRIPTION
## Why this should be merged

Move the hex-prefix (compact) path encoder out of the `ethhash`-gated
hasher and into a new unconditionally compiled `storage::eth_encoding`
module. The function is pure and has no feature-specific dependencies;
its previous gating was incidental to where it lived.

This is groundwork for an `eth_getProof`-compatible proof emitter, which
needs to emit canonical MPT-RLP node bytes regardless of which hasher
the underlying trie was built with. Forcing the emitter to live behind
`#[cfg(feature = \"ethhash\")]` just to reach this helper would add walls
we'd then have to tear down.

It also lines up with the broader direction of replacing the `ethhash`
compile-time feature flag with a runtime mode knob: pulling pure
encoding helpers out of the gated module shrinks what the feature
actually has to guard, so the eventual flag removal is a smaller change.

## How this works

- New `storage/src/eth_encoding.rs` holds `nibbles_to_eth_compact` and
  its existing unit tests.
- `storage/src/lib.rs` registers `pub mod eth_encoding`.
- `storage/src/hashers/ethhash.rs` imports the helper from its new
  location and drops the local copy and tests.

No behavior change.

## How this was tested

- ``cargo build -p firewood-storage`` (default features)
- ``cargo build -p firewood-storage --features ethhash``
- ``cargo nextest run -p firewood-storage --features ethhash,logger eth_encoding`` — all 6 lifted test cases pass.
- ``cargo clippy -p firewood-storage --features ethhash,logger --all-targets`` — clean.
- ``cargo fmt --check`` — clean.

## Breaking Changes

None.