### PR TITLE
perf(storage): avoid deep Node::clone on shared-Arc reconstructed advance

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -944,6 +944,147 @@ mod test {
     }
 
     #[test]
+    fn test_reconstruct_clone_is_independent_branching_trie() {
+        // Exercises the fork-then-advance path on a wide, deep trie where the
+        // shared-Arc fallback in `From<Arc<NodeStore<Reconstructed, _>>>`
+        // would deep-clone via `Node::clone` if the optimization regressed.
+        // The trivial-trie variant `test_reconstruct_clone_is_independent`
+        // wouldn't notice a regression in that walk; this one would.
+        let db = TestDb::new();
+
+        // Build a base committed revision with two entries per top-level
+        // nibble so the root is a 16-way branch with depth in every subtree.
+        let mut base_batch = Vec::new();
+        for hi in 0..16u8 {
+            for lo in 0..2u8 {
+                let key = vec![hi << 4, lo];
+                let value = vec![hi, lo, 0xaa];
+                base_batch.push(BatchOp::Put { key, value });
+            }
+        }
+        let initial = db.propose(base_batch).unwrap();
+        initial.commit().unwrap();
+        let historical_hash = db.root_hash().unwrap();
+        let historical = db.revision(historical_hash).unwrap();
+
+        let original = db
+            .reconstruct_from_view(
+                &historical,
+                vec![BatchOp::Put {
+                    key: b"shared".to_vec(),
+                    value: b"v_shared".to_vec(),
+                }],
+            )
+            .unwrap();
+        let original_root = original.root_hash();
+
+        let cloned = original.clone();
+        assert_eq!(cloned.root_hash(), original_root);
+
+        // Each side mutates a distinct suffix in every top-level subtree, so
+        // both reconstructs touch the full breadth of branches.
+        let mut clone_batch = Vec::new();
+        let mut orig_batch = Vec::new();
+        for hi in 0..16u8 {
+            clone_batch.push(BatchOp::Put {
+                key: vec![hi << 4, 0x99],
+                value: vec![hi, 0xcc],
+            });
+            orig_batch.push(BatchOp::Put {
+                key: vec![hi << 4, 0x88],
+                value: vec![hi, 0xdd],
+            });
+        }
+        let new_cloned = cloned.reconstruct(clone_batch).unwrap();
+        let original_next = original.reconstruct(orig_batch).unwrap();
+
+        // Each side sees only its own mutations, across every subtree.
+        for hi in 0..16u8 {
+            let clone_only = [hi << 4, 0x99];
+            let orig_only = [hi << 4, 0x88];
+            assert_eq!(
+                &*new_cloned.val(&clone_only[..]).unwrap().unwrap(),
+                &[hi, 0xcc][..]
+            );
+            assert_eq!(new_cloned.val(&orig_only[..]).unwrap(), None);
+            assert_eq!(
+                &*original_next.val(&orig_only[..]).unwrap().unwrap(),
+                &[hi, 0xdd][..]
+            );
+            assert_eq!(original_next.val(&clone_only[..]).unwrap(), None);
+        }
+
+        // Both sides retain every base entry.
+        for hi in 0..16u8 {
+            for lo in 0..2u8 {
+                let key = [hi << 4, lo];
+                let expected = [hi, lo, 0xaa];
+                assert_eq!(&*new_cloned.val(&key[..]).unwrap().unwrap(), &expected[..]);
+                assert_eq!(
+                    &*original_next.val(&key[..]).unwrap().unwrap(),
+                    &expected[..]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_reconstruct_with_held_view_arc() {
+        // The shared-Arc advance path is reachable two ways: explicit
+        // `clone()` (covered by the other tests) and an FFI iterator that
+        // pinned the inner nodestore via `view()`. This test exercises the
+        // second case: hold an `ArcDynDbView` over the original, then
+        // advance the original. The advance must succeed and produce
+        // correct reads; the pinned share must continue to see the
+        // pre-advance snapshot.
+        let db = TestDb::new();
+
+        let initial = db
+            .propose(vec![BatchOp::Put {
+                key: b"base",
+                value: b"v0",
+            }])
+            .unwrap();
+        initial.commit().unwrap();
+        let historical_hash = db.root_hash().unwrap();
+        let historical = db.revision(historical_hash).unwrap();
+
+        let original = db
+            .reconstruct_from_view(
+                &historical,
+                vec![BatchOp::Put {
+                    key: b"shared",
+                    value: b"v1",
+                }],
+            )
+            .unwrap();
+        let original_root = original.root_hash();
+
+        // Pin the inner nodestore via `view()`. While `pinned` is alive the
+        // underlying Arc has strong_count > 1, so the advance below takes
+        // the shared-Arc path.
+        let pinned = original.view();
+
+        let advanced = original
+            .reconstruct(vec![BatchOp::Put {
+                key: b"after",
+                value: b"v2",
+            }])
+            .unwrap();
+
+        // Advance is correct: sees base, shared, and the new entry.
+        assert_eq!(&*advanced.val(b"base").unwrap().unwrap(), b"v0");
+        assert_eq!(&*advanced.val(b"shared").unwrap().unwrap(), b"v1");
+        assert_eq!(&*advanced.val(b"after").unwrap().unwrap(), b"v2");
+
+        // The pinned share still reads the pre-advance snapshot.
+        assert_eq!(pinned.root_hash(), Some(original_root.unwrap()));
+        assert_eq!(&*pinned.val(b"base").unwrap().unwrap(), b"v0");
+        assert_eq!(&*pinned.val(b"shared").unwrap().unwrap(), b"v1");
+        assert_eq!(pinned.val(b"after").unwrap(), None);
+    }
+
+    #[test]
     fn reopen_test() {
         let db = TestDb::new();
         let initial_root = db.root_hash();

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -957,21 +957,31 @@ impl<S: ReadableStorage> From<NodeStore<Mutable<Recon<S>>, S>> for NodeStore<Rec
 
 impl<S: ReadableStorage> From<Arc<NodeStore<Reconstructed<S>, S>>>
     for NodeStore<Mutable<Recon<S>>, S>
+where
+    NodeStore<Reconstructed<S>, S>: TrieReader,
 {
     fn from(val: Arc<NodeStore<Reconstructed<S>, S>>) -> Self {
-        // Fast path: if this Arc is uniquely owned, `try_unwrap` is O(1) and lets us move the
-        // reconstructed root out without cloning.
-        // The fallback (shared-Arc) path is reachable in two ways:
+        // Fast path: `try_unwrap` moves the reconstructed root out without cloning
+        // when the Arc is uniquely owned.
+        //
+        // The shared-Arc path is reachable in two ways:
         //   1. A caller produced sibling views via `ReconstructedView::clone` and is keeping
         //      another sibling alive across this call.
         //   2. A caller is iterating over the reconstructed view (the iterator holds an Arc
         //      clone via `ReconstructedView::view`) while also deriving the next reconstructed
         //      state.
-        // Fallback cost: producing an owned root from the shared Arc requires recursively
-        // cloning the in-memory subtree attached to it. We accept this fallback so callers
-        // don't have to guarantee uniqueness, while still exploiting the cheaper move path
-        // whenever possible.
-        Self::from(Arc::unwrap_or_clone(val))
+        // In the shared case, `unwrap_or_clone` on the root `SharedNode` deep-clones every
+        // `Child::Node` subtree via `Node::clone`. Forcing `root_hash` first rewrites those
+        // children to `Child::MaybePersisted` (Arc-shared), turning the deep walk into a
+        // per-level Arc bump.
+        let inner = match Arc::try_unwrap(val) {
+            Ok(owned) => owned,
+            Err(arc) => {
+                let _ = arc.root_hash();
+                Arc::unwrap_or_clone(arc)
+            }
+        };
+        Self::from(inner)
     }
 }
 
@@ -979,6 +989,9 @@ impl<S: ReadableStorage> From<Arc<NodeStore<Reconstructed<S>, S>>>
 ///
 /// This clones the [`SharedNode`] arc (cheap ref-count bump) and the
 /// [`OnceLock`] hash (cloned if already computed, empty otherwise).
+///
+/// Not derived because only `Reconstructed` T may be cloned; others are
+/// not safe.
 impl<S> Clone for NodeStore<Reconstructed<S>, S> {
     fn clone(&self) -> Self {
         NodeStore {
@@ -1837,6 +1850,56 @@ mod tests {
             assert!(
                 !matches!(child, Child::Node(_)),
                 "root child still Child::Node after root_hash: {child:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn shared_arc_advance_forces_hash_for_sibling() {
+        // When `From<Arc<NodeStore<Reconstructed, _>>>` is called on a shared
+        // Arc (strong_count > 1), the impl forces `root_hash()` before
+        // `unwrap_or_clone` so the deep `Node::clone` fallback becomes a
+        // per-level Arc bump. Verify the *sibling* Arc holder observes the
+        // hashed state (children rewritten to `Child::MaybePersisted`,
+        // OnceLock populated).
+        let storage = Arc::new(MemStore::default());
+        let mut recon = NodeStore::new_empty_recon(Arc::clone(&storage));
+
+        let mut children = Children::new();
+        children[PathComponent::ALL[0x0]] = Some(Child::Node(Node::Leaf(LeafNode {
+            partial_path: Path::from_nibbles_iterator(NibblesIterator::new(b"abc")),
+            value: b"v0".to_vec().into_boxed_slice(),
+        })));
+        children[PathComponent::ALL[0xF]] = Some(Child::Node(Node::Leaf(LeafNode {
+            partial_path: Path::from_nibbles_iterator(NibblesIterator::new(b"xyz")),
+            value: b"vf".to_vec().into_boxed_slice(),
+        })));
+        recon.root_mut().replace(Node::Branch(Box::new(BranchNode {
+            partial_path: Path::new(),
+            value: None,
+            children,
+        })));
+
+        let reconstructed: Arc<NodeStore<Reconstructed<_>, _>> = Arc::new(recon.into());
+        let sibling = Arc::clone(&reconstructed);
+        assert!(reconstructed.kind.hash.get().is_none());
+
+        // Advance one Arc; the other (sibling) stays alive, so strong_count == 2.
+        let _mutable: NodeStore<Mutable<Recon<_>>, _> = reconstructed.into();
+
+        // Sibling now sees the forced hash and the rewritten children.
+        assert!(
+            sibling.kind.hash.get().is_some(),
+            "sibling OnceLock must be populated after shared-Arc advance"
+        );
+        let root = sibling.root_node().expect("sibling root present");
+        let Node::Branch(b) = &*root else {
+            panic!("sibling root must be a branch");
+        };
+        for (_, child) in b.children.iter_present() {
+            assert!(
+                !matches!(child, Child::Node(_)),
+                "sibling child still Child::Node after shared-Arc advance: {child:?}"
             );
         }
     }


### PR DESCRIPTION
## Why this should be merged

Advancing a `NodeStore<Reconstructed<S>, S>` from a shared `Arc` falls through `Arc::unwrap_or_clone` → `Node::clone`, which recursively deep-clones every `Child::Node` subtree. Two callers hit this path:

1. Explicit sibling clones via `ReconstructedView::clone` (Go: `Reconstructed.Clone()`, used by AvalancheGo's `CopyTrie`).
2. An iterator pinning the inner nodestore via `view()` while the caller advances the reconstructed.

The CopyTrie path in (1) is read-only, so the *deep clone* itself doesn't usually fire there — but path (2), and any future caller that advances a clone, eats the full O(N) walk.

## How this works

`From<Arc<NodeStore<Reconstructed<S>, S>>>` now uses `Arc::try_unwrap` to distinguish the unique-owner case from the shared case atomically:

```rust
let inner = match Arc::try_unwrap(val) {
    Ok(owned) => owned,
    Err(arc) => {
        let _ = arc.root_hash();
        Arc::unwrap_or_clone(arc)
    }
};
```

- **Unique** → move, no hash, no clone. The dominant `CopyTrie` read-only-clone path is unchanged.
- **Shared** → force `root_hash()`, which rewrites the tree's children from `Child::Node` (owned) to `Child::MaybePersisted` (Arc-shared). The subsequent `unwrap_or_clone` walks an Arc-shared tree: per-level Arc bump instead of a recursive `Node::clone`.

`Clone for NodeStore<Reconstructed<S>, S>` is **unchanged from main**. The optimization is purely in the advance path.

### Race story

`try_unwrap` closes the TOCTOU window of a `strong_count > 1` check. The only remaining race is benign: if a drop lands between our `root_hash` and `unwrap_or_clone`, the unwrap succeeds as a move and we did the hash for nothing. Correct result, slightly wasted work.

### TrieReader bound

`From<Arc<NodeStore<Reconstructed<S>, S>>>` gains a `where NodeStore<Reconstructed<S>, S>: TrieReader` bound (needed to call `root_hash`). The bound is satisfied by all in-tree call sites and stays local to this impl.

## How this was tested

New tests:

- **`shared_arc_advance_forces_hash_for_sibling`** (`storage/src/nodestore/mod.rs`): structural check — clone an Arc, advance one, assert the sibling sees a populated `OnceLock` and that no `Child::Node` remains at the root.
- **`test_reconstruct_clone_is_independent_branching_trie`** (`firewood/src/db.rs`): clone-then-advance on a 16-way branching trie with depth. Each side mutates a distinct suffix in every subtree; cross-asserts read isolation. The existing trivial-trie variant `test_reconstruct_clone_is_independent` wouldn't notice a regression in the deep-walk path; this one would.
- **`test_reconstruct_with_held_view_arc`** (`firewood/src/db.rs`): exercises scenario (2). Hold a `view()` Arc, advance the original, verify the advance succeeds and the pinned share still reads the pre-advance snapshot.

Plus the standard suite:

- `cargo fmt`
- `cargo nextest run --workspace --features ethhash,logger --all-targets` (735 passed)
- `cargo clippy --workspace --features ethhash,logger --all-targets` (clean)
- `cargo doc --no-deps` (clean)

## Breaking Changes

None at the public-API level. The `TrieReader` bound on `From<Arc<...>>` is satisfied by all in-tree call sites.