### PR TITLE
chore(release): prepare for v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,53 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.0] - 2026-04-28
+## [0.5.0] - 2026-05-19
+
+### 🚀 Features
+
+- Add pathdb config + 33m block option ([#1959](https://github.com/ava-labs/firewood/pull/1959))
+- *(ffi)* Implement range proof verification (Trail of Bits finding TOB-FIREWOOD-2) ([#1971](https://github.com/ava-labs/firewood/pull/1971))
+- Add ability to clone reconstructed revisions ([#1991](https://github.com/ava-labs/firewood/pull/1991))
+
+### 🐛 Bug Fixes
+
+- Resolve false rejection at straddling nibbles in collapse_strip ([#1952](https://github.com/ava-labs/firewood/pull/1952))
+- Remove duplicate children loop in compute_root_hash_with_proofs ([#1948](https://github.com/ava-labs/firewood/pull/1948))
+- *(fwdctl)* Drop legacy rustls feature to clear GHSA-82j2-j2ch-gfr8 ([#1956](https://github.com/ava-labs/firewood/pull/1956))
+- *(manager)* Resolve empty-trie revision under ethhash without RootStore (TOB-FIREWOOD-7) ([#1982](https://github.com/ava-labs/firewood/pull/1982))
+- *(range-proof)* Use last_kv_key as right-edge anchor for inclusion-style end_proofs ([#1970](https://github.com/ava-labs/firewood/pull/1970))
+- *(manager)* Hold proposals lock across cleanup and reparent (TOB-FIREWOOD-6) ([#1981](https://github.com/ava-labs/firewood/pull/1981))
+- *(manager)* Use CommittedId for parent identity, skip trivial commits ([#1987](https://github.com/ava-labs/firewood/pull/1987))
+- *(storage)* Pin committed parent in Reconstructed to prevent reaping ([#2000](https://github.com/ava-labs/firewood/pull/2000))
+
+### 🚜 Refactor
+
+- *(ffi)* Simplify change proof interface with unified Proposal type ([#1966](https://github.com/ava-labs/firewood/pull/1966))
+- *(proofs)* Move range/change proof verification helpers from FFI to firewood ([#1990](https://github.com/ava-labs/firewood/pull/1990))
+- *(storage)* Lift nibbles_to_eth_compact into eth_encoding module ([#2003](https://github.com/ava-labs/firewood/pull/2003))
+
+### ⚡ Performance
+
+- *(storage)* Add in-tree `crate::rlp` module + benchmark ([#1957](https://github.com/ava-labs/firewood/pull/1957))
+- Migrate firewood off the upstream `rlp` crate ([#1958](https://github.com/ava-labs/firewood/pull/1958))
+- *(storage)* Retain hashed root in Reconstructed for cheap forks ([#1999](https://github.com/ava-labs/firewood/pull/1999))
+
+### 🧪 Testing
+
+- Add edge case tests for change proof verification ([#1946](https://github.com/ava-labs/firewood/pull/1946))
+- Add adversarial attack tests for change proof verification ([#1947](https://github.com/ava-labs/firewood/pull/1947))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(deps)* Bump DavidAnson/markdownlint-cli2-action from 23.0.0 to 23.1.0 in the github-actions group ([#1954](https://github.com/ava-labs/firewood/pull/1954))
+- *(deps)* Bump the github-actions group with 2 updates ([#1977](https://github.com/ava-labs/firewood/pull/1977))
+- Remove weekly 50m-60m job ([#1983](https://github.com/ava-labs/firewood/pull/1983))
+- Export errRevisionNotFound ([#1955](https://github.com/ava-labs/firewood/pull/1955))
+- Update workflow to use macOS 26, drop x86_64 mac target ([#1996](https://github.com/ava-labs/firewood/pull/1996))
+- *(deps)* Bump cachix/cachix-action from 1eb2ef646ac0255473d23a5907ad7b04ce94065c to 5f2d7c5294214f71b873db4b969586b980625e71 in the github-actions group ([#1995](https://github.com/ava-labs/firewood/pull/1995))
+- Use deploy key instead of pat ([#2002](https://github.com/ava-labs/firewood/pull/2002))
+
+## [0.4.0] - 2026-04-29
 
 ### 🚀 Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,14 +218,14 @@ dependencies = [
  "serde",
  "serde_derive",
  "unicode-ident",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ec2"
-version = "1.223.0"
+version = "1.226.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c051cf4af033cea16c4eeb73b9c3c07f61fe747ae0d4119aabd45fa0288c19b"
+checksum = "27ef215366676d2392accd5a5f964e891f7a97d210b34ccabe775510ccfd0302"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -799,6 +799,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1040,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1325,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1396,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1734,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "firewood"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aquamarine",
  "bytemuck",
@@ -1769,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-benchmark"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1796,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cbindgen",
  "env_logger",
@@ -1814,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-fwdctl"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "askama",
  "assert_cmd",
@@ -1848,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "firewood-metrics",
  "proc-macro2",
@@ -1859,14 +1868,14 @@ dependencies = [
 
 [[package]]
 name = "firewood-metrics"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "metrics",
 ]
 
 [[package]]
 name = "firewood-replay"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "firewood",
  "firewood-metrics",
@@ -1881,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-storage"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aquamarine",
  "arc-swap",
@@ -2198,9 +2207,9 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2285,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2328,7 +2337,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2400,9 +2409,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2695,7 +2704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2762,16 +2771,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -2859,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3202,9 +3201,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -3471,18 +3470,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3778,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
+checksum = "d1c821816e9b928e20e92ed59bb3ac4aab321d16ca2316871c9fe7ca739cd477"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -4421,11 +4420,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4440,9 +4440,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4493,7 +4493,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4620,9 +4620,9 @@ checksum = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
 
 [[package]]
 name = "str_stack"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "strsim"
@@ -4884,10 +4884,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.52.1"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4960,7 +4975,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4990,7 +5005,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -4999,7 +5014,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5010,9 +5025,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64",
@@ -5036,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -5066,20 +5081,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -5411,9 +5426,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5424,9 +5439,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5434,9 +5449,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5444,9 +5459,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5457,9 +5472,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -5506,9 +5521,9 @@ checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5704,9 +5719,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -5877,9 +5892,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,12 @@ metrics-exporter-prometheus = { git = "https://github.com/demosdemon/metrics.git
 
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.4.0" }
-firewood-macros = { path = "firewood-macros", version = "0.3.0" }
-firewood-storage = { path = "storage", version = "0.4.0" }
-firewood-ffi = { path = "ffi", version = "0.4.0" }
-firewood-metrics = { path = "metrics", version = "0.4.0" }
-firewood-replay = { path = "replay", version = "0.4.0" }
+firewood = { path = "firewood", version = "0.5.0" }
+firewood-macros = { path = "firewood-macros", version = "0.4.0" }
+firewood-storage = { path = "storage", version = "0.5.0" }
+firewood-ffi = { path = "ffi", version = "0.5.0" }
+firewood-metrics = { path = "metrics", version = "0.5.0" }
+firewood-replay = { path = "replay", version = "0.5.0" }
 
 # no longer bumping with workspace
 firewood-triehash = { path = "triehash", version = "0.0.16" }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-benchmark"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 authors = [
      "Aaron Buchwald <aaron.buchwald56@gmail.com>",
@@ -46,7 +46,7 @@ tikv-jemallocator = "0.6.1"
 
 [dependencies.tokio]
 optional = true
-version = "1.52.1"
+version = "1.52.3"
 features = ["mio", "net", "parking_lot", "rt", "time"]
 
 [features]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-ffi"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors = [
      "Aaron Buchwald <aaron.buchwald56@gmail.com>",

--- a/firewood-macros/Cargo.toml
+++ b/firewood-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-macros"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 authors = [
      "Ron Kuris <ron.kuris@avalabs.org>",

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors = [
      "Angel Leon <gubatron@gmail.com>",

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-fwdctl"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors = [
      "Dan Laine <daniel.laine@avalabs.org>",
@@ -38,7 +38,7 @@ indicatif = "0.18.4"
 askama = "0.15.6"
 num-format = "0.4.4"
 aws-config = { version = "1.8", optional = true }
-aws-sdk-ec2 = { version = "1.223", default-features = false, features = ["default-https-client", "rt-tokio"], optional = true }
+aws-sdk-ec2 = { version = "1.226", default-features = false, features = ["default-https-client", "rt-tokio"], optional = true }
 aws-sdk-ssm = { version = "1.109", default-features = false, features = ["default-https-client", "rt-tokio"], optional = true }
 aws-sdk-sts = { version = "1.103.0", default-features = false, features = ["sigv4a", "default-https-client", "rt-tokio"], optional = true }
 aws-smithy-runtime-api = { version = "1.12", optional = true }
@@ -76,7 +76,7 @@ firewood-storage = { workspace = true, features = ["test_utils"] }
 rand.workspace = true
 tempfile.workspace = true
 # Regular dependencies
-assert_cmd = "2.2.1"
+assert_cmd = "2.2.2"
 predicates = "3.1.4"
 
 [lints]

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-metrics"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 license-file.workspace = true
 homepage.workspace = true

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-replay"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 license-file.workspace = true
 homepage.workspace = true
@@ -16,7 +16,7 @@ firewood-storage.workspace = true
 rmp-serde = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
-serde_with = "3.18"
+serde_with = "3.20"
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-storage"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors = [
      "Aaron Buchwald <aaron.buchwald56@gmail.com>",


### PR DESCRIPTION
Bumps from `v0.4.0` to `v0.5.0`.

## How this works

Followed instructions in RELEASE.md.

**Note**: similar to the `v0.4.0` release, the `release-step-update-rust-dependencies` just command was modified for this release to work. In addition to commenting out `cargo upgrade --incompatible`, I also replaced `cargo upgrade` with `cargo upgrade --exclude metrics --exclude metrics-util --exclude metrics-exporter-prometheus` in order to keep using our patched fork versions of these crates. All compatible dependency upgrades were applied, with the following exceptions: 

  - `metrics`, `metrics-util`, and `metrics-exporter-prometheus` remain on the repo’s patched fork versions.
  - `sha2`/`sha3` remain on 0.10.9 because upgrading to `0.11.x` requires follow-up code changes in the hashing layer.

## How this was tested

CI.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
