### PR TITLE
fix(proofs): simple find_next_key for range proofs

### DIFF
--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -2170,34 +2170,29 @@ fn test_multi_level_range_proof_with_hashed_values() {
 fn test_find_next_key_exhaustive_divergent_at_last_kv() {
     use crate::{find_next_key_after_range_proof, verify_range_proof_structure};
 
-    let merkle = init_merkle([(&b"\x05"[..], &b"v"[..])]);
+    let merkle = init_merkle([(b"\x05".as_slice(), b"v".as_slice())]);
     let root_hash = merkle.nodestore().root_hash().unwrap();
     let proof = merkle
-        .range_proof(Some(b"\x00".as_slice()), Some(b"\x10".as_slice()), None)
+        .range_proof(Some(b"\x00"), Some(b"\x10"), None)
         .unwrap();
     assert_eq!(proof.key_values().len(), 1);
     assert_eq!(proof.key_values()[0].0.as_ref(), b"\x05");
 
-    let verification = verify_range_proof_structure(
-        &proof,
-        root_hash,
-        Some(b"\x00".as_slice()),
-        Some(b"\x10".as_slice()),
-        None,
-    )
-    .unwrap();
+    let verification =
+        verify_range_proof_structure(&proof, root_hash, Some(b"\x00"), Some(b"\x10"), None)
+            .unwrap();
 
     let result = find_next_key_after_range_proof(&proof, &verification).unwrap();
     let (cursor, returned_end) = result.expect("Case 5 must return Some");
 
     // Liveness: cursor strictly greater than last_kv.
     assert!(
-        cursor.as_ref() > &b"\x05"[..],
+        cursor.as_ref() > b"\x05".as_slice(),
         "cursor {:?} must be > 0x05",
         cursor.as_ref()
     );
     // End key echoed back unchanged.
-    assert_eq!(returned_end.as_deref(), Some(&b"\x10"[..]));
+    assert_eq!(returned_end.as_deref(), Some(b"\x10".as_slice()));
 }
 
 #[test]
@@ -2220,18 +2215,18 @@ fn test_find_next_key_exhaustive_divergent_at_last_kv() {
 fn test_find_next_key_two_round_termination() {
     use crate::{find_next_key_after_range_proof, verify_range_proof_structure};
 
-    let merkle = init_merkle([(&b"\x05"[..], &b"v"[..])]);
+    let merkle = init_merkle([(b"\x05".as_slice(), b"v".as_slice())]);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     // Round 1.
     let proof1 = merkle
-        .range_proof(Some(b"\x00".as_slice()), Some(b"\x10".as_slice()), None)
+        .range_proof(Some(b"\x00"), Some(b"\x10"), None)
         .unwrap();
     let verification1 = verify_range_proof_structure(
         &proof1,
         root_hash.clone(),
-        Some(b"\x00".as_slice()),
-        Some(b"\x10".as_slice()),
+        Some(b"\x00"),
+        Some(b"\x10"),
         None,
     )
     .unwrap();

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -2150,3 +2150,114 @@ fn test_multi_level_range_proof_with_hashed_values() {
     // - "abcdef" in-range: Hash fast path in reconcile_branch_proof_node
     verify_range_proof(Some(b"abc123"), Some(b"\xff"), &root_hash, &deserialized).unwrap();
 }
+
+#[test]
+// Real-proof test for `find_next_key_after_range_proof`'s Case 5.
+//
+// Trie has a single key `0x05`. Requesting range [0x00, 0x10] produces
+// an honest, exhaustive proof: key_values = [(0x05, "v")], and the
+// end_proof's terminal is the trie's single leaf (cumulative key 0x05,
+// carrying the value), reached because the walk for 0x10 diverges
+// within that leaf's compressed path. The terminal therefore carries
+// last_kv's value at last_kv's path — Case 5 (see
+// `find_next_key_after_range_proof`'s docstring).
+//
+// The function cannot distinguish this from a truncated inclusion of
+// 0x05, so it conservatively returns
+// Some(lex_successor(0x05), 0x10). The follow-up fetch then returns
+// no keys (handled by the two-round termination test below),
+// accepting one extra round-trip in exchange for soundness.
+fn test_find_next_key_exhaustive_divergent_at_last_kv() {
+    use crate::{find_next_key_after_range_proof, verify_range_proof_structure};
+
+    let merkle = init_merkle([(&b"\x05"[..], &b"v"[..])]);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+    let proof = merkle
+        .range_proof(Some(b"\x00".as_slice()), Some(b"\x10".as_slice()), None)
+        .unwrap();
+    assert_eq!(proof.key_values().len(), 1);
+    assert_eq!(proof.key_values()[0].0.as_ref(), b"\x05");
+
+    let verification = verify_range_proof_structure(
+        &proof,
+        root_hash,
+        Some(b"\x00".as_slice()),
+        Some(b"\x10".as_slice()),
+        None,
+    )
+    .unwrap();
+
+    let result = find_next_key_after_range_proof(&proof, &verification).unwrap();
+    let (cursor, returned_end) = result.expect("Case 5 must return Some");
+
+    // Liveness: cursor strictly greater than last_kv.
+    assert!(
+        cursor.as_ref() > &b"\x05"[..],
+        "cursor {:?} must be > 0x05",
+        cursor.as_ref()
+    );
+    // End key echoed back unchanged.
+    assert_eq!(returned_end.as_deref(), Some(&b"\x10"[..]));
+}
+
+#[test]
+// Real-proof test for two-round termination.
+//
+// Syncer-style flow:
+//   Round 1: range_proof([0x00, 0x10]) yields the Case 5 shape from
+//            `test_find_next_key_exhaustive_divergent_at_last_kv`.
+//            find_next_key returns Some((lex_successor(0x05), 0x10)).
+//   Round 2: range_proof([lex_successor(0x05), 0x10]) yields no
+//            key_values because nothing past 0x05 exists in the trie
+//            within the requested range. find_next_key returns None
+//            via Case 1.
+//
+// Termination in exactly two rounds confirms forward progress — the
+// `lex_successor`-based cursor advances strictly past last_kv, so the
+// syncer cannot loop on the same response. This is the liveness
+// property the simple algorithm guarantees (and the regression
+// safeguard against issue #1989's infinite-loop bug).
+fn test_find_next_key_two_round_termination() {
+    use crate::{find_next_key_after_range_proof, verify_range_proof_structure};
+
+    let merkle = init_merkle([(&b"\x05"[..], &b"v"[..])]);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    // Round 1.
+    let proof1 = merkle
+        .range_proof(Some(b"\x00".as_slice()), Some(b"\x10".as_slice()), None)
+        .unwrap();
+    let verification1 = verify_range_proof_structure(
+        &proof1,
+        root_hash.clone(),
+        Some(b"\x00".as_slice()),
+        Some(b"\x10".as_slice()),
+        None,
+    )
+    .unwrap();
+    let (next_start, next_end) = find_next_key_after_range_proof(&proof1, &verification1)
+        .unwrap()
+        .expect("round 1 must return Some for the Case 5 ambiguous shape");
+
+    // Round 2: feed the cursor back as the new range.
+    let proof2 = merkle
+        .range_proof(Some(next_start.as_ref()), next_end.as_deref(), None)
+        .unwrap();
+    assert!(
+        proof2.key_values().is_empty(),
+        "no keys past 0x05 should exist in the trie"
+    );
+    let verification2 = verify_range_proof_structure(
+        &proof2,
+        root_hash,
+        Some(next_start.as_ref()),
+        next_end.as_deref(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        find_next_key_after_range_proof(&proof2, &verification2).unwrap(),
+        None,
+        "round 2 must return None — Case 1 (empty key_values)"
+    );
+}

--- a/firewood/src/proofs/mod.rs
+++ b/firewood/src/proofs/mod.rs
@@ -310,6 +310,22 @@ pub use self::types::{
     EmptyProofCollection, Proof, ProofCollection, ProofError, ProofNode, ProofType,
 };
 
+/// Returns the lexicographic successor of `key`: the smallest byte string
+/// strictly greater than `key` under lex ordering on variable-length keys.
+///
+/// The successor is `key` with a single `0x00` byte appended. The empty
+/// key's successor is `[0x00]`. Every byte string has a well-defined
+/// successor under this ordering, so the function is total.
+///
+/// Used by `find_next_key_after_*_proof` to express "the range remaining
+/// after this proof starts strictly above `last_key`."
+pub(crate) fn lex_successor(key: &[u8]) -> Box<[u8]> {
+    let mut succ = Vec::with_capacity(key.len().saturating_add(1));
+    succ.extend_from_slice(key);
+    succ.push(0);
+    succ.into_boxed_slice()
+}
+
 pub(super) mod magic {
     //! Magic constants for proof format identification.
     //!

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -58,6 +58,8 @@
 
 use std::num::NonZeroUsize;
 
+use firewood_storage::{Hashable, NibblesIterator, Path, TriePath};
+
 use crate::api::{self, FrozenRangeProof, HashKey};
 use crate::merkle::verify_range_proof;
 use crate::proofs::ProofError;
@@ -125,37 +127,93 @@ pub fn verify_range_proof_structure(
 
 /// Determine the next key range to fetch after this range proof.
 ///
-/// Returns `None` when the originally-requested range is fully accounted
-/// for; otherwise returns `Some((last_key, end_key))`.
+/// Returns `None` when the proof's structure proves the requested range is
+/// exhaustively covered. Returns `Some((lex_successor(last_key), end_key))`
+/// when the `end_proof`'s terminal carries a value at exactly
+/// `last_key`'s path, which is the structurally ambiguous shape — the
+/// proof is consistent with both a truncated inclusion proof of
+/// `last_key` and an exhaustive exclusion of `end_key` whose terminal
+/// lies at `last_key`'s node. The conservative continuation strictly
+/// advances the cursor past `last_key` so the next fetch makes
+/// guaranteed forward progress.
+///
+/// As a preflight, an empty `end_proof` (which signals exhaustive
+/// coverage with no boundary proof emitted) short-circuits to `None`
+/// before the case analysis below.
+///
+/// # Cases
+///
+/// - **Case 1**: `key_values` is empty. The proof contains no keys for
+///   the requested range, so there is nothing more to fetch. → `None`.
+/// - **Case 2**: `last_key == end_key`. The proof's last returned key
+///   reaches the requested upper bound; the range `[start, end_key]`
+///   is fully covered. → `None`.
+/// - **Case 3**: the `end_proof`'s terminal node carries no value (an
+///   exclusion proof). A truncated proof would carry `last_key`'s
+///   value at the terminal, so an exclusion shape means the prover
+///   produced an exhaustive proof. → `None`.
+/// - **Case 4**: the `end_proof`'s terminal carries a value, but at a
+///   key different from `last_key`. A truncated proof would put
+///   `last_key` itself at the terminal, so a different key there
+///   means the prover produced an exhaustive proof. → `None`.
+/// - **Case 5**: the `end_proof`'s terminal carries a value at exactly
+///   `last_key`'s path. This shape is consistent with both a
+///   truncated proof (inclusion of `last_key`) and an exhaustive
+///   proof (exclusion of `end_key` whose terminal lies at
+///   `last_key`'s node). The implementation cannot distinguish these
+///   from the terminal alone, so it conservatively assumes more data
+///   may remain. → `Some((lex_successor(last_key), end_key))`.
 ///
 /// # Errors
 ///
-/// Currently does not return errors; the signature is `Result` for parity
-/// with the change-proof counterpart and to allow future error paths.
+/// Returns [`ProofError::EndKeyLessThanLastKey`] when `last_key` is
+/// strictly greater than `end_key` — a malformed-proof condition that
+/// verification should have caught upstream.
 pub fn find_next_key_after_range_proof(
     proof: &FrozenRangeProof,
     verification: &RangeProofVerificationContext,
 ) -> Result<Option<KeyRange>, api::Error> {
-    // TODO(#352): proper implementation, this naively returns the last key
-    // in the range, which is correct, but not ideal.
+    // Case 1: empty `key_values` → no keys in range.
     let Some((last_key, _)) = proof.key_values().last() else {
-        // no key-values in the proof, so we are done
         return Ok(None);
     };
 
-    if proof.end_proof().is_empty() {
-        // unbounded, so we are done
+    if let Some(ek) = verification.end_key.as_deref() {
+        // Malformed: `last_key > end_key`; verifier should have caught this.
+        if **last_key > *ek {
+            return Err(api::Error::ProofError(ProofError::EndKeyLessThanLastKey));
+        }
+        // Case 2: `last_key` reaches `end_key`.
+        if **last_key == *ek {
+            return Ok(None);
+        }
+    }
+
+    // Preflight: empty `end_proof` signals exhaustive coverage.
+    let Some(terminal) = proof.end_proof().last() else {
+        return Ok(None);
+    };
+
+    // Case 3: terminal has no value (exclusion proof) → exhaustive.
+    if terminal.value_digest.is_none() {
         return Ok(None);
     }
 
-    if let Some(ref end_key) = verification.end_key
-        && **last_key >= **end_key
+    // Case 4: terminal's key differs from `last_key` → exhaustive.
+    if !terminal
+        .full_path()
+        .path_eq(Path(NibblesIterator::new(last_key.as_ref()).collect()).as_components())
     {
-        // reached or exceeded the end key, so we are done
         return Ok(None);
     }
 
-    Ok(Some((last_key.clone(), verification.end_key.clone())))
+    // Case 5: structurally ambiguous. Conservative continuation via
+    // `lex_successor` ensures the syncer advances even if the prover
+    // replies identically.
+    Ok(Some((
+        super::lex_successor(last_key),
+        verification.end_key.clone(),
+    )))
 }
 
 /// A range proof is a cryptographic proof that demonstrates a contiguous set of key-value pairs
@@ -321,9 +379,192 @@ mod tests {
     #![expect(clippy::unwrap_used, reason = "Tests can use unwrap")]
     #![expect(clippy::indexing_slicing, reason = "Tests can use indexing")]
 
+    use firewood_storage::{Children, PathComponent, TrieHash, U4, ValueDigest};
+
+    use super::super::types::ProofNode;
+    use super::*;
     use crate::api::TryIntoBatch;
 
-    use super::*;
+    /// An `end_key` larger than any test key, used when the test should
+    /// not exercise the `last_key == end_key` (Case 2) or `last_key >
+    /// end_key` (malformed) branches.
+    const FAR_END_KEY: &[u8] = b"\xff\xff";
+
+    /// Convert a byte slice to its nibble representation (high nibble of each
+    /// byte first, then low nibble).
+    fn bytes_to_nibbles(bytes: &[u8]) -> Vec<u8> {
+        let mut nibs = Vec::with_capacity(bytes.len().saturating_mul(2));
+        for b in bytes {
+            nibs.push(b >> 4);
+            nibs.push(b & 0x0F);
+        }
+        nibs
+    }
+
+    /// Build a terminal `ProofNode` at the given nibble path. If `value`
+    /// is `Some`, the node carries a value digest wrapping those bytes;
+    /// otherwise the node represents an exclusion-shaped terminal with
+    /// no value.
+    fn make_terminal(nibbles: &[u8], value: Option<&[u8]>) -> ProofNode {
+        let key = nibbles
+            .iter()
+            .map(|&n| PathComponent(U4::new_masked(n)))
+            .collect();
+        let value_digest = value.map(|v| ValueDigest::Value(Box::from(v)));
+        ProofNode {
+            key,
+            partial_len: 0,
+            value_digest,
+            child_hashes: Children::new(),
+        }
+    }
+
+    /// Build a `FrozenRangeProof` from explicit key-value pairs and an
+    /// optional terminal node for the `end_proof`. The `start_proof` is
+    /// always empty (irrelevant to `find_next_key`'s decisions).
+    fn make_range_proof(
+        key_values: &[(&[u8], &[u8])],
+        end_terminal: Option<ProofNode>,
+    ) -> FrozenRangeProof {
+        let end_proof = match end_terminal {
+            Some(node) => Proof::new(Box::<[ProofNode]>::from([node])),
+            None => Proof::new(Box::<[ProofNode]>::from([])),
+        };
+        FrozenRangeProof::new(
+            Proof::new(Box::<[ProofNode]>::from([])),
+            end_proof,
+            key_values
+                .iter()
+                .map(|(k, v)| (Box::from(*k), Box::from(*v)))
+                .collect(),
+        )
+    }
+
+    /// Build a `RangeProofVerificationContext` with the given `end_key`.
+    /// `root`, `start_key`, and `max_length` are set to values that
+    /// `find_next_key_after_range_proof` does not consult.
+    fn make_verification(end_key: Option<&[u8]>) -> RangeProofVerificationContext {
+        RangeProofVerificationContext {
+            root: TrieHash::from([0u8; 32]),
+            start_key: None,
+            end_key: end_key.map(Box::from),
+            max_length: None,
+        }
+    }
+
+    #[test]
+    fn test_find_next_key_empty_key_values() {
+        // Case 1: empty key_values means the prover returned nothing in
+        // range, so there's nothing more to fetch.
+        let proof = make_range_proof(&[], None);
+        let verification = make_verification(Some(FAR_END_KEY));
+        assert_eq!(
+            find_next_key_after_range_proof(&proof, &verification).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_next_key_empty_end_proof() {
+        // Empty end_proof: the generator emitted no boundary proof,
+        // which signals an exhaustive response. Returns None.
+        let proof = make_range_proof(&[(b"key1", b"v1")], None);
+        let verification = make_verification(Some(FAR_END_KEY));
+        assert_eq!(
+            find_next_key_after_range_proof(&proof, &verification).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_next_key_last_equals_end() {
+        // Case 2: last_key matches the requested end_key exactly, so
+        // the range [start, end_key] is fully covered.
+        let proof = make_range_proof(
+            &[(b"key1", b"v1")],
+            Some(make_terminal(&bytes_to_nibbles(b"key1"), Some(b"v"))),
+        );
+        let verification = make_verification(Some(b"key1"));
+        assert_eq!(
+            find_next_key_after_range_proof(&proof, &verification).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_next_key_last_greater_than_end() {
+        // Malformed input: last_key > end_key. The verifier should
+        // have rejected this; the function surfaces an error.
+        let proof = make_range_proof(
+            &[(b"key2", b"v2")],
+            Some(make_terminal(&bytes_to_nibbles(b"key2"), Some(b"v"))),
+        );
+        let verification = make_verification(Some(b"key1"));
+        let result = find_next_key_after_range_proof(&proof, &verification);
+        assert!(matches!(
+            result,
+            Err(api::Error::ProofError(ProofError::EndKeyLessThanLastKey))
+        ));
+    }
+
+    #[test]
+    fn test_find_next_key_terminal_no_value() {
+        // Case 3: terminal carries no value. A truncated proof would
+        // put last_key's value at the terminal, so an exclusion shape
+        // here means the prover covered the whole range.
+        let proof = make_range_proof(
+            &[(b"key1", b"v1")],
+            Some(make_terminal(&bytes_to_nibbles(b"key1"), None)),
+        );
+        let verification = make_verification(Some(FAR_END_KEY));
+        assert_eq!(
+            find_next_key_after_range_proof(&proof, &verification).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_next_key_terminal_value_different_key() {
+        // Case 4: terminal carries a value but at a key different from
+        // last_key. A truncated proof would put last_key specifically
+        // at the terminal, so this shape implies exhaustive coverage.
+        let proof = make_range_proof(
+            &[(b"key1", b"v1")],
+            Some(make_terminal(&bytes_to_nibbles(b"key9"), Some(b"v"))),
+        );
+        let verification = make_verification(Some(FAR_END_KEY));
+        assert_eq!(
+            find_next_key_after_range_proof(&proof, &verification).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_next_key_terminal_value_at_last_key() {
+        // Case 5: terminal carries last_key's value at last_key's path.
+        // This is the structurally ambiguous shape — it's consistent
+        // with both a truncated inclusion of last_key and an
+        // exhaustive proof whose terminal for end_key lies at
+        // last_key's node. The function cannot distinguish them, so
+        // it conservatively returns Some((lex_successor(last_key),
+        // end_key)) with cursor strictly greater than last_key
+        // (liveness — guarantees the syncer makes forward progress).
+        let last_key: &[u8] = b"key1";
+        let proof = make_range_proof(
+            &[(last_key, b"v1")],
+            Some(make_terminal(&bytes_to_nibbles(last_key), Some(b"v"))),
+        );
+        let verification = make_verification(Some(FAR_END_KEY));
+        let result = find_next_key_after_range_proof(&proof, &verification).unwrap();
+        let (cursor, returned_end) = result.expect("ambiguous shape must return Some");
+        // Liveness: cursor strictly greater than last_key.
+        assert!(
+            cursor.as_ref() > last_key,
+            "cursor {cursor:?} must be > {last_key:?}"
+        );
+        // End key echoed back unchanged.
+        assert_eq!(returned_end.as_deref(), Some(FAR_END_KEY));
+    }
 
     #[test]
     fn test_range_proof_iterator() {

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -58,12 +58,13 @@
 
 use std::num::NonZeroUsize;
 
-use firewood_storage::{Hashable, NibblesIterator, Path, TriePath};
+use firewood_storage::{Hashable, PathBuf, TriePath, TriePathFromPackedBytes};
 
 use crate::api::{self, FrozenRangeProof, HashKey};
 use crate::merkle::verify_range_proof;
 use crate::proofs::ProofError;
 
+use super::lex_successor;
 use super::types::{Proof, ProofCollection};
 
 /// `(start_key, end_key)` describing the next key range to fetch after a
@@ -202,7 +203,7 @@ pub fn find_next_key_after_range_proof(
     // Case 4: terminal's key differs from `last_key` → exhaustive.
     if !terminal
         .full_path()
-        .path_eq(Path(NibblesIterator::new(last_key.as_ref()).collect()).as_components())
+        .path_eq(&PathBuf::path_from_packed_bytes(last_key.as_ref()))
     {
         return Ok(None);
     }
@@ -211,7 +212,7 @@ pub fn find_next_key_after_range_proof(
     // `lex_successor` ensures the syncer advances even if the prover
     // replies identically.
     Ok(Some((
-        super::lex_successor(last_key),
+        lex_successor(last_key),
         verification.end_key.clone(),
     )))
 }
@@ -379,7 +380,7 @@ mod tests {
     #![expect(clippy::unwrap_used, reason = "Tests can use unwrap")]
     #![expect(clippy::indexing_slicing, reason = "Tests can use indexing")]
 
-    use firewood_storage::{Children, PathComponent, TrieHash, U4, ValueDigest};
+    use firewood_storage::{Children, TrieHash, ValueDigest};
 
     use super::super::types::ProofNode;
     use super::*;
@@ -390,31 +391,16 @@ mod tests {
     /// end_key` (malformed) branches.
     const FAR_END_KEY: &[u8] = b"\xff\xff";
 
-    /// Convert a byte slice to its nibble representation (high nibble of each
-    /// byte first, then low nibble).
-    fn bytes_to_nibbles(bytes: &[u8]) -> Vec<u8> {
-        let mut nibs = Vec::with_capacity(bytes.len().saturating_mul(2));
-        for b in bytes {
-            nibs.push(b >> 4);
-            nibs.push(b & 0x0F);
-        }
-        nibs
-    }
-
-    /// Build a terminal `ProofNode` at the given nibble path. If `value`
-    /// is `Some`, the node carries a value digest wrapping those bytes;
-    /// otherwise the node represents an exclusion-shaped terminal with
-    /// no value.
-    fn make_terminal(nibbles: &[u8], value: Option<&[u8]>) -> ProofNode {
-        let key = nibbles
-            .iter()
-            .map(|&n| PathComponent(U4::new_masked(n)))
-            .collect();
-        let value_digest = value.map(|v| ValueDigest::Value(Box::from(v)));
+    /// Build a terminal `ProofNode` at the path corresponding to
+    /// `key_bytes` (bytes are unpacked into nibbles via
+    /// `PathBuf::path_from_packed_bytes`). If `value` is `Some`, the
+    /// node carries a value digest wrapping those bytes; otherwise the
+    /// node represents an exclusion-shaped terminal with no value.
+    fn make_terminal(key_bytes: &[u8], value: Option<&[u8]>) -> ProofNode {
         ProofNode {
-            key,
+            key: PathBuf::path_from_packed_bytes(key_bytes),
             partial_len: 0,
-            value_digest,
+            value_digest: value.map(|v| ValueDigest::Value(Box::from(v))),
             child_hashes: Children::new(),
         }
     }
@@ -482,7 +468,7 @@ mod tests {
         // the range [start, end_key] is fully covered.
         let proof = make_range_proof(
             &[(b"key1", b"v1")],
-            Some(make_terminal(&bytes_to_nibbles(b"key1"), Some(b"v"))),
+            Some(make_terminal(b"key1", Some(b"v"))),
         );
         let verification = make_verification(Some(b"key1"));
         assert_eq!(
@@ -497,7 +483,7 @@ mod tests {
         // have rejected this; the function surfaces an error.
         let proof = make_range_proof(
             &[(b"key2", b"v2")],
-            Some(make_terminal(&bytes_to_nibbles(b"key2"), Some(b"v"))),
+            Some(make_terminal(b"key2", Some(b"v"))),
         );
         let verification = make_verification(Some(b"key1"));
         let result = find_next_key_after_range_proof(&proof, &verification);
@@ -512,10 +498,7 @@ mod tests {
         // Case 3: terminal carries no value. A truncated proof would
         // put last_key's value at the terminal, so an exclusion shape
         // here means the prover covered the whole range.
-        let proof = make_range_proof(
-            &[(b"key1", b"v1")],
-            Some(make_terminal(&bytes_to_nibbles(b"key1"), None)),
-        );
+        let proof = make_range_proof(&[(b"key1", b"v1")], Some(make_terminal(b"key1", None)));
         let verification = make_verification(Some(FAR_END_KEY));
         assert_eq!(
             find_next_key_after_range_proof(&proof, &verification).unwrap(),
@@ -530,7 +513,7 @@ mod tests {
         // at the terminal, so this shape implies exhaustive coverage.
         let proof = make_range_proof(
             &[(b"key1", b"v1")],
-            Some(make_terminal(&bytes_to_nibbles(b"key9"), Some(b"v"))),
+            Some(make_terminal(b"key9", Some(b"v"))),
         );
         let verification = make_verification(Some(FAR_END_KEY));
         assert_eq!(
@@ -552,7 +535,7 @@ mod tests {
         let last_key: &[u8] = b"key1";
         let proof = make_range_proof(
             &[(last_key, b"v1")],
-            Some(make_terminal(&bytes_to_nibbles(last_key), Some(b"v"))),
+            Some(make_terminal(last_key, Some(b"v"))),
         );
         let verification = make_verification(Some(FAR_END_KEY));
         let result = find_next_key_after_range_proof(&proof, &verification).unwrap();

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -175,17 +175,17 @@ pub fn find_next_key_after_range_proof(
     verification: &RangeProofVerificationContext,
 ) -> Result<Option<KeyRange>, api::Error> {
     // Case 1: empty `key_values` → no keys in range.
-    let Some((last_key, _)) = proof.key_values().last() else {
+    let Some(last_key) = proof.key_values().last().map(|(k, _)| k.as_ref()) else {
         return Ok(None);
     };
 
     if let Some(ek) = verification.end_key.as_deref() {
         // Malformed: `last_key > end_key`; verifier should have caught this.
-        if **last_key > *ek {
+        if last_key > ek {
             return Err(api::Error::ProofError(ProofError::EndKeyLessThanLastKey));
         }
         // Case 2: `last_key` reaches `end_key`.
-        if **last_key == *ek {
+        if last_key == ek {
             return Ok(None);
         }
     }
@@ -200,10 +200,11 @@ pub fn find_next_key_after_range_proof(
         return Ok(None);
     }
 
-    // Case 4: terminal's key differs from `last_key` → exhaustive.
+    // Case 4: terminal's nibble path differs from `last_key` unpacked
+    // into nibbles → exhaustive.
     if !terminal
         .full_path()
-        .path_eq(&PathBuf::path_from_packed_bytes(last_key.as_ref()))
+        .path_eq(&PathBuf::path_from_packed_bytes(last_key))
     {
         return Ok(None);
     }
@@ -412,16 +413,12 @@ mod tests {
         key_values: &[(&[u8], &[u8])],
         end_terminal: Option<ProofNode>,
     ) -> FrozenRangeProof {
-        let end_proof = match end_terminal {
-            Some(node) => Proof::new(Box::<[ProofNode]>::from([node])),
-            None => Proof::new(Box::<[ProofNode]>::from([])),
-        };
         FrozenRangeProof::new(
-            Proof::new(Box::<[ProofNode]>::from([])),
-            end_proof,
+            Proof::new(Box::default()),
+            Proof::new(end_terminal.into_iter().collect()),
             key_values
                 .iter()
-                .map(|(k, v)| (Box::from(*k), Box::from(*v)))
+                .map(|&(k, v)| (Box::from(k), Box::from(v)))
                 .collect(),
         )
     }

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -383,8 +383,8 @@ mod tests {
 
     use firewood_storage::{Children, TrieHash, ValueDigest};
 
-    use super::super::types::ProofNode;
     use super::*;
+    use crate::ProofNode;
     use crate::api::TryIntoBatch;
 
     /// An `end_key` larger than any test key, used when the test should

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -12,7 +12,7 @@ use firewood_storage::{
 
 use super::{
     header::InvalidHeader,
-    magic,
+    lex_successor, magic,
     reader::ReadError,
     types::{Proof, ProofNode, ProofType},
 };
@@ -915,4 +915,42 @@ fn test_slow_malformed_proof_fuzz() {
             }
         }
     }
+}
+
+#[test]
+fn test_lex_successor_empty_key() {
+    assert_eq!(&*lex_successor(b""), &[0x00][..]);
+}
+
+#[test]
+fn test_lex_successor_single_byte() {
+    assert_eq!(&*lex_successor(b"\x10"), &[0x10, 0x00][..]);
+}
+
+#[test]
+fn test_lex_successor_max_byte() {
+    // No overflow: `succ([0xff])` is just `[0xff, 0x00]`.
+    assert_eq!(&*lex_successor(b"\xff"), &[0xff, 0x00][..]);
+}
+
+#[test]
+fn test_lex_successor_is_strictly_greater() {
+    let keys: &[&[u8]] = &[b"", b"\x00", b"\x10", b"\xff", b"abc"];
+    for k in keys {
+        let s = lex_successor(k);
+        assert!(s.as_ref() > *k, "succ({k:?}) = {s:?} is not > input");
+    }
+}
+
+#[test]
+fn test_lex_successor_no_key_in_between() {
+    // succ(k) is k with 0x00 appended — the lexicographically smallest
+    // extension. Any other byte string strictly greater than k must
+    // either differ from k in its first len(k) bytes (so it differs
+    // before reaching the appended 0x00 and is therefore >= succ(k))
+    // or extend k with a non-empty suffix whose first byte is >= 0x00
+    // (also >= succ(k)). No byte string lies strictly between k and
+    // succ(k). Exercise on a multi-byte input distinct from
+    // `test_lex_successor_single_byte`.
+    assert_eq!(&*lex_successor(b"abc"), &[b'a', b'b', b'c', 0x00][..]);
 }

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -919,18 +919,18 @@ fn test_slow_malformed_proof_fuzz() {
 
 #[test]
 fn test_lex_successor_empty_key() {
-    assert_eq!(&*lex_successor(b""), &[0x00][..]);
+    assert_eq!(lex_successor(b"").as_ref(), [0x00].as_slice());
 }
 
 #[test]
 fn test_lex_successor_single_byte() {
-    assert_eq!(&*lex_successor(b"\x10"), &[0x10, 0x00][..]);
+    assert_eq!(lex_successor(b"\x10").as_ref(), [0x10, 0x00].as_slice());
 }
 
 #[test]
 fn test_lex_successor_max_byte() {
     // No overflow: `succ([0xff])` is just `[0xff, 0x00]`.
-    assert_eq!(&*lex_successor(b"\xff"), &[0xff, 0x00][..]);
+    assert_eq!(lex_successor(b"\xff").as_ref(), [0xff, 0x00].as_slice());
 }
 
 #[test]
@@ -952,5 +952,8 @@ fn test_lex_successor_no_key_in_between() {
     // (also >= succ(k)). No byte string lies strictly between k and
     // succ(k). Exercise on a multi-byte input distinct from
     // `test_lex_successor_single_byte`.
-    assert_eq!(&*lex_successor(b"abc"), &[b'a', b'b', b'c', 0x00][..]);
+    assert_eq!(
+        lex_successor(b"abc").as_ref(),
+        [b'a', b'b', b'c', 0x00].as_slice()
+    );
 }


### PR DESCRIPTION
  ## Why this should be merged

  `find_next_key_after_range_proof` was a placeholder returning
  `Some((last_key, end_key))` whenever the proof had any keys and a non-empty
  `end_proof`. The returned cursor was `last_key` itself, so when a prover
  re-served the same first key in response to the new range, the syncer
  looped indefinitely.

  This PR replaces the placeholder with a simple, correct, conservative
  implementation. Range proofs only; the change-proof counterpart will
  follow in a separate PR.
  
  ## How this works

  The implementation enumerates five structural cases on the proof's
  `end_proof` terminal node, returning `None` whenever the proof structure
  proves the range is exhaustively covered:

  - Empty `key_values` (Case 1) → `None`.
  - `last_key == end_key` (Case 2) → `None`.
  - Empty `end_proof` (preflight) → `None`.
  - Terminal has no value (Case 3, exclusion proof) → `None`.
  - Terminal has a value at a key ≠ `last_key` (Case 4) → `None`.

  For the one structurally ambiguous case (Case 5 — terminal carries a
  value at exactly `last_key`'s path), the implementation cannot
  distinguish a truncated inclusion of `last_key` from an exhaustive
  exclusion of `end_key` whose terminal happens to lie at `last_key`'s
  node. It conservatively returns
  `Some((lex_successor(last_key), end_key))`, where `lex_successor`
  appends `0x00`. The cursor strictly advances past `last_key`, so the
  syncer cannot loop on identical prover responses — guaranteed forward
  progress.

  ## How this was tested

  - **Unit tests** (`firewood/src/proofs/range.rs`, `firewood/src/proofs/tests.rs`):
    7 hand-built proof tests covering every algorithm branch, plus 5 tests
    for the new `lex_successor` helper.
  - **Integration tests** (`firewood/src/merkle/tests/range.rs`): 2 real-proof
    tests using `init_merkle` + `range_proof`. One exercises the Case 5
    ambiguous shape end-to-end; the other is a two-round syncer flow that
    confirms forward progress.

  ## Breaking Changes

  None. `find_next_key_after_range_proof`'s signature is unchanged; only
  its body changes. The FFI wrapper compiles and runs unchanged.
  `lex_successor` is a new `pub(crate)` helper, so no external API
  surface change.