### PR TITLE
fix(proofs): simple find_next_key for change proofs

### DIFF
--- a/firewood/src/merkle/tests/change/continuation.rs
+++ b/firewood/src/merkle/tests/change/continuation.rs
@@ -118,11 +118,10 @@ fn test_find_next_key_change_two_round_termination() {
 //
 // The start revision contains `{0x05, 0x80}`; the end revision
 // deletes `0x05`, leaving `{0x80}`. Requesting range `[0x00, 0x10]`
-// produces
-// `batch_ops = [Delete 0x05]` and an `end_proof` whose terminal lies
-// at the (single remaining) `0x80` leaf with value — terminal_key
-// `0x80` differs from `last_key 0x05`, so this is the "Delete +
-// terminal at different key" shape.
+// produces `batch_ops = [Delete 0x05]` and an `end_proof` whose
+// terminal lies at the (single remaining) `0x80` leaf with value —
+// terminal_key `0x80` differs from `last_key 0x05`, so this is the
+// "Delete + terminal at different key" shape.
 //
 // The algorithm cannot tell whether the proof was truncated (an
 // exclusion of `0x05` that landed on `0x80`'s sibling leaf) or

--- a/firewood/src/merkle/tests/change/continuation.rs
+++ b/firewood/src/merkle/tests/change/continuation.rs
@@ -1,0 +1,157 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+//! Real-proof integration tests for `find_next_key_after_change_proof` —
+//! post-verification continuation logic for the syncer's next-range cursor.
+
+use super::*;
+use crate::find_next_key_after_change_proof;
+
+#[test]
+// Real-proof test for `find_next_key_after_change_proof`'s Case 5
+// (Put + terminal at last_key's path with value).
+//
+// Trie at the end revision contains a single key `0x05`. A Put at
+// `0x05` (updating its value from "old" to "new") is the only diff.
+// Requesting range `[0x00, 0x10]` produces `batch_ops = [Put 0x05 "new"]`
+// and an `end_proof` whose terminal lies at `0x05`'s leaf carrying a
+// value — reached because the walk for `0x10` diverges within `0x05`'s
+// compressed path.
+//
+// The function cannot distinguish this Case 5 shape from a truncated
+// inclusion of `0x05`, so it conservatively returns
+// `Some(lex_successor(0x05), 0x10)`. The follow-up fetch returns no
+// diffs (handled by the two-round termination test below).
+fn test_find_next_key_change_put_case5() {
+    let (db, _dir) = setup_db![(b"\x05", b"old")];
+    let (root1, root2) = setup_2nd_commit!(db, [(b"\x05", b"new")]);
+
+    let proof = db
+        .change_proof(root1, root2.clone(), Some(b"\x00"), Some(b"\x10"), None)
+        .unwrap();
+    assert_eq!(proof.batch_ops().len(), 1);
+    assert!(matches!(
+        proof.batch_ops()[0],
+        BatchOp::Put { ref key, .. } if key.as_ref() == b"\x05"
+    ));
+
+    // Structural verification (mirrors the range-proof Layer B test).
+    verify_change_proof_structure(&proof, root2, Some(b"\x00"), Some(b"\x10"), None).unwrap();
+
+    let result = find_next_key_after_change_proof(&proof, Some(b"\x10")).unwrap();
+    let (cursor, returned_end) = result.expect("Case 5 must return Some");
+
+    // Liveness: cursor strictly greater than last_op's key.
+    assert!(
+        cursor.as_ref() > b"\x05".as_slice(),
+        "cursor {:?} must be > 0x05",
+        cursor.as_ref()
+    );
+    // End key echoed back unchanged.
+    assert_eq!(returned_end.as_deref(), Some(b"\x10".as_slice()));
+}
+
+#[test]
+// Real-proof test for two-round termination.
+//
+// Syncer-style flow:
+//   Round 1: change_proof([0x00, 0x10]) yields the Case 5 shape from
+//            `test_find_next_key_change_put_case5`. find_next_key
+//            returns `Some(lex_successor(0x05), 0x10)`.
+//   Round 2: change_proof([lex_successor(0x05), 0x10]) yields no diffs
+//            because no key past `0x05` exists in either revision
+//            within the requested range. find_next_key returns `None`
+//            via Case 1 (empty `batch_ops`).
+//
+// Termination in exactly two rounds confirms forward progress.
+fn test_find_next_key_change_two_round_termination() {
+    let (db, _dir) = setup_db![(b"\x05", b"old")];
+    let (root1, root2) = setup_2nd_commit!(db, [(b"\x05", b"new")]);
+
+    // Round 1.
+    let proof1 = db
+        .change_proof(
+            root1.clone(),
+            root2.clone(),
+            Some(b"\x00"),
+            Some(b"\x10"),
+            None,
+        )
+        .unwrap();
+    verify_change_proof_structure(&proof1, root2.clone(), Some(b"\x00"), Some(b"\x10"), None)
+        .unwrap();
+    let (next_start, next_end) = find_next_key_after_change_proof(&proof1, Some(b"\x10"))
+        .unwrap()
+        .expect("round 1 must return Some for the Case 5 ambiguous shape");
+
+    // Round 2: feed the cursor back as the new range.
+    let proof2 = db
+        .change_proof(
+            root1,
+            root2.clone(),
+            Some(next_start.as_ref()),
+            next_end.as_deref(),
+            None,
+        )
+        .unwrap();
+    assert!(
+        proof2.batch_ops().is_empty(),
+        "no diffs past 0x05 should exist in the requested range"
+    );
+    verify_change_proof_structure(
+        &proof2,
+        root2,
+        Some(next_start.as_ref()),
+        next_end.as_deref(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        find_next_key_after_change_proof(&proof2, next_end.as_deref()).unwrap(),
+        None,
+        "round 2 must return None — Case 1 (empty batch_ops)"
+    );
+}
+
+#[test]
+// Real-proof test for the Delete conservative-continuation path.
+//
+// The start revision contains `{0x05, 0x80}`; the end revision
+// deletes `0x05`, leaving `{0x80}`. Requesting range `[0x00, 0x10]`
+// produces
+// `batch_ops = [Delete 0x05]` and an `end_proof` whose terminal lies
+// at the (single remaining) `0x80` leaf with value — terminal_key
+// `0x80` differs from `last_key 0x05`, so this is the "Delete +
+// terminal at different key" shape.
+//
+// The algorithm cannot tell whether the proof was truncated (an
+// exclusion of `0x05` that landed on `0x80`'s sibling leaf) or
+// exhaustive (an exclusion of `0x10` that landed on the same node).
+// It conservatively returns `Some(lex_successor(0x05), 0x10)`.
+fn test_find_next_key_change_delete_conservative() {
+    let (db, _dir) = setup_db![(b"\x05", b"v0"), (b"\x80", b"v1")];
+    let root1 = db.root_hash().unwrap();
+    let delete_batch: Vec<BatchOp<&[u8], &[u8]>> = vec![BatchOp::Delete { key: b"\x05" }];
+    db.propose(delete_batch).unwrap().commit().unwrap();
+    let root2 = db.root_hash().unwrap();
+
+    let proof = db
+        .change_proof(root1, root2.clone(), Some(b"\x00"), Some(b"\x10"), None)
+        .unwrap();
+    assert_eq!(proof.batch_ops().len(), 1);
+    assert!(matches!(
+        proof.batch_ops()[0],
+        BatchOp::Delete { ref key } if key.as_ref() == b"\x05"
+    ));
+
+    verify_change_proof_structure(&proof, root2, Some(b"\x00"), Some(b"\x10"), None).unwrap();
+
+    let result = find_next_key_after_change_proof(&proof, Some(b"\x10")).unwrap();
+    let (cursor, returned_end) = result.expect("Delete shape must return Some");
+    assert!(
+        cursor.as_ref() > b"\x05".as_slice(),
+        "cursor {:?} must be > 0x05",
+        cursor.as_ref()
+    );
+    assert_eq!(returned_end.as_deref(), Some(b"\x10".as_slice()));
+}

--- a/firewood/src/merkle/tests/change/mod.rs
+++ b/firewood/src/merkle/tests/change/mod.rs
@@ -94,6 +94,7 @@ pub(super) fn verify_and_check(
 
 mod attack;
 mod bounds;
+mod continuation;
 mod edge_cases;
 // Empty start trie tests require ethhash: without it, the empty trie has no
 // root hash, so change proofs from an empty database can't be generated.

--- a/firewood/src/proofs/change.rs
+++ b/firewood/src/proofs/change.rs
@@ -240,12 +240,9 @@ type FrozenBatchOp = BatchOp<Box<[u8]>, Box<[u8]>>;
 /// - [`ProofError::EndProofOperationMismatch`] when `last_op` is
 ///   Delete but the `end_proof`'s terminal carries a value at
 ///   `last_key`'s path — also malformed; verifier should have caught.
-///
-/// # Panics
-///
-/// Panics if `last_op` is a `DeleteRange`. `verify_change_proof_structure`
-/// rejects `DeleteRange` ops, so a verified proof cannot reach this
-/// branch.
+/// - [`ProofError::DeleteRangeFoundInChangeProof`] when `last_op` is
+///   a `DeleteRange`. `verify_change_proof_structure` rejects these
+///   upstream; this is defense in depth.
 pub fn find_next_key_after_change_proof(
     proof: &FrozenChangeProof,
     end_key: Option<&[u8]>,
@@ -301,7 +298,13 @@ pub fn find_next_key_after_change_proof(
             // fall through to conservative continuation.
         }
         BatchOp::DeleteRange { .. } => {
-            unreachable!("DeleteRange is rejected by change-proof verification");
+            // `DeleteRange` ops are rejected by
+            // `verify_change_proof_structure`; a verified proof can't
+            // reach this branch. Surface the same error for defense
+            // in depth.
+            return Err(api::Error::ProofError(
+                ProofError::DeleteRangeFoundInChangeProof,
+            ));
         }
     }
 

--- a/firewood/src/proofs/change.rs
+++ b/firewood/src/proofs/change.rs
@@ -3,11 +3,15 @@
 
 use std::{fmt::Debug, num::NonZeroUsize};
 
+use firewood_storage::{Hashable, PathBuf, TriePath, TriePathFromPackedBytes};
+
 use crate::{
     Proof, ProofCollection, ProofError,
     api::{self, FrozenChangeProof, HashKey},
     db::BatchOp,
 };
+
+use super::lex_successor;
 
 /// A change proof can demonstrate that by applying the provided array of `BatchOp`s to a Merkle
 /// trie with given start root hash, the resulting trie will have the given end root hash. It
@@ -175,42 +179,134 @@ type FrozenBatchOp = BatchOp<Box<[u8]>, Box<[u8]>>;
 
 /// Determine the next key range to fetch after this change proof.
 ///
-/// Inspects the proof structure only — does not require a proposal.
-/// `end_key` is the original requested upper bound passed to the proof
-/// generator.
+/// Returns `None` when the proof's structure proves the requested range
+/// is exhaustively covered. Returns
+/// `Some((lex_successor(last_key), end_key))` for the structurally
+/// ambiguous shape (Case 5 for Put, or any non-malformed Delete shape) —
+/// the conservative continuation strictly advances the cursor past
+/// `last_key` so the next fetch makes guaranteed forward progress.
 ///
-/// Returns `None` if the proof confirms there are no more keys in the
-/// requested range; otherwise returns `Some((last_op.key, end_key))` as
-/// a continuation.
+/// As a preflight, an empty `end_proof` (which signals exhaustive
+/// coverage with no boundary proof emitted) short-circuits to `None`
+/// before the case analysis below.
+///
+/// # Cases
+///
+/// - **Case 1**: `batch_ops` is empty. The proof contains no diffs for
+///   the requested range, so there is nothing more to fetch. → `None`.
+/// - **Case 2**: `last_key == end_key`. The proof's last returned key
+///   reaches the requested upper bound; the range `[start, end_key]`
+///   is fully covered. → `None`.
+///
+/// For Put `last_op` (`last_key` is present in the end revision), the
+/// remaining cases mirror the range-proof analysis:
+///
+/// - **Case 3**: the `end_proof`'s terminal node carries no value (an
+///   exclusion proof). A truncated proof would carry `last_key`'s
+///   value at the terminal, so an exclusion shape means exhaustive.
+///   → `None`.
+/// - **Case 4**: the `end_proof`'s terminal carries a value, but at a
+///   key different from `last_key`. A truncated proof would put
+///   `last_key` itself at the terminal, so a different key there
+///   means exhaustive. → `None`.
+/// - **Case 5**: the `end_proof`'s terminal carries a value at exactly
+///   `last_key`'s path. Structurally ambiguous between a truncated
+///   inclusion of `last_key` and an exhaustive exclusion of `end_key`
+///   whose terminal lies at `last_key`'s node. Conservative
+///   continuation. → `Some((lex_successor(last_key), end_key))`.
+///
+/// For Delete `last_op` (`last_key` is absent from the end revision),
+/// the truncated `end_proof` is an exclusion proof of `last_key` in
+/// the end revision, which is structurally indistinguishable from an
+/// exhaustive exclusion of `end_key` for the non-malformed shapes.
+/// The algorithm collapses these to a single conservative
+/// continuation:
+///
+/// - **Delete malformed**: terminal carries a value at exactly
+///   `last_key`'s path. This contradicts `last_key`'s absence from
+///   the end revision. The change-proof verifier catches this
+///   upstream via the same condition; we surface the same error for
+///   defense in depth.
+///   → `Err(EndProofOperationMismatch)`.
+/// - **Delete other**: any other Delete shape (no value, or value at a
+///   different key) is structurally ambiguous between truncated and
+///   exhaustive. → `Some((lex_successor(last_key), end_key))`.
 ///
 /// # Errors
 ///
-/// Returns [`ProofError::EndKeyLessThanLastKey`] when `last_op.key` is
-/// strictly greater than `end_key` — this indicates the proof was
-/// generated against a different `end_key` than the one supplied here.
+/// - [`ProofError::EndKeyLessThanLastKey`] when `last_key` is strictly
+///   greater than `end_key` — a malformed-proof condition that
+///   verification should have caught upstream.
+/// - [`ProofError::EndProofOperationMismatch`] when `last_op` is
+///   Delete but the `end_proof`'s terminal carries a value at
+///   `last_key`'s path — also malformed; verifier should have caught.
+///
+/// # Panics
+///
+/// Panics if `last_op` is a `DeleteRange`. `verify_change_proof_structure`
+/// rejects `DeleteRange` ops, so a verified proof cannot reach this
+/// branch.
 pub fn find_next_key_after_change_proof(
     proof: &FrozenChangeProof,
     end_key: Option<&[u8]>,
 ) -> Result<Option<super::range::KeyRange>, api::Error> {
+    // Case 1: empty `batch_ops` → no diffs in range; range is exhausted.
     let Some(last_op) = proof.batch_ops().last() else {
-        // No changes in this range. If bounded, continue from end_key.
-        return Ok(end_key.map(|ek| (Box::from(ek), None)));
-    };
-
-    if proof.end_proof().is_empty() {
         return Ok(None);
-    }
+    };
+    let last_key: &[u8] = last_op.key().as_ref();
 
-    if let Some(end_key) = end_key {
-        if **last_op.key() > *end_key {
+    if let Some(ek) = end_key {
+        // Malformed: `last_key > end_key`; verifier should have caught this.
+        if last_key > ek {
             return Err(api::Error::ProofError(ProofError::EndKeyLessThanLastKey));
         }
-        if **last_op.key() == *end_key {
+        // Case 2: `last_key` reaches `end_key`.
+        if last_key == ek {
             return Ok(None);
         }
     }
 
-    Ok(Some((last_op.key().clone(), end_key.map(Box::from))))
+    // Preflight: empty `end_proof` signals exhaustive coverage.
+    let Some(terminal) = proof.end_proof().last() else {
+        return Ok(None);
+    };
+
+    let terminal_at_last_key = terminal
+        .full_path()
+        .path_eq(&PathBuf::path_from_packed_bytes(last_key));
+
+    match last_op {
+        BatchOp::Put { .. } => {
+            // Case 3: terminal has no value → exhaustive.
+            if terminal.value_digest.is_none() {
+                return Ok(None);
+            }
+            // Case 4: terminal at different key → exhaustive.
+            if !terminal_at_last_key {
+                return Ok(None);
+            }
+            // Case 5: ambiguous → fall through to conservative continuation.
+        }
+        BatchOp::Delete { .. } => {
+            // Malformed: Delete `last_key` means `last_key` is absent
+            // from the end revision, so the terminal can't carry a
+            // value at `last_key`'s path.
+            if terminal.value_digest.is_some() && terminal_at_last_key {
+                return Err(api::Error::ProofError(
+                    ProofError::EndProofOperationMismatch,
+                ));
+            }
+            // All other Delete shapes are structurally ambiguous →
+            // fall through to conservative continuation.
+        }
+        BatchOp::DeleteRange { .. } => {
+            unreachable!("DeleteRange is rejected by change-proof verification");
+        }
+    }
+
+    // Conservative continuation: cursor strictly past `last_key`.
+    Ok(Some((lex_successor(last_key), end_key.map(Box::from))))
 }
 
 /// Verify a boundary proof against `end_root` and optionally check that the
@@ -456,8 +552,200 @@ mod tests {
     #![expect(clippy::unwrap_used, reason = "Tests can use unwrap")]
     #![expect(clippy::indexing_slicing, reason = "Tests can use indexing")]
 
+    use firewood_storage::{Children, ValueDigest};
+
     use super::*;
+    use crate::ProofNode;
     use crate::merkle::{Key, Value};
+
+    /// An `end_key` larger than any test key, used when the test should
+    /// not exercise the `last_key == end_key` (Case 2) or `last_key >
+    /// end_key` (malformed) branches.
+    const FAR_END_KEY: &[u8] = b"\xff\xff";
+
+    /// Build a terminal `ProofNode` at the path corresponding to
+    /// `key_bytes`. If `value` is `Some`, the node carries a value
+    /// digest wrapping those bytes; otherwise the node represents an
+    /// exclusion-shaped terminal with no value.
+    fn make_terminal(key_bytes: &[u8], value: Option<&[u8]>) -> ProofNode {
+        ProofNode {
+            key: PathBuf::path_from_packed_bytes(key_bytes),
+            partial_len: 0,
+            value_digest: value.map(|v| ValueDigest::Value(Box::from(v))),
+            child_hashes: Children::new(),
+        }
+    }
+
+    /// Build a `BatchOp::Put` operation for `key` and `value`.
+    fn make_put(key: &[u8], value: &[u8]) -> BatchOp<Key, Value> {
+        BatchOp::Put {
+            key: Box::from(key),
+            value: Box::from(value),
+        }
+    }
+
+    /// Build a `BatchOp::Delete` operation for `key`.
+    fn make_delete(key: &[u8]) -> BatchOp<Key, Value> {
+        BatchOp::Delete {
+            key: Box::from(key),
+        }
+    }
+
+    /// Build a `FrozenChangeProof` from explicit batch ops and an
+    /// optional terminal node for the `end_proof`. The `start_proof`
+    /// is always empty (irrelevant to `find_next_key`'s decisions).
+    fn make_change_proof(
+        batch_ops: Vec<BatchOp<Key, Value>>,
+        end_terminal: Option<ProofNode>,
+    ) -> FrozenChangeProof {
+        ChangeProof::new(
+            Proof::new(Box::default()),
+            Proof::new(end_terminal.into_iter().collect()),
+            batch_ops.into_boxed_slice(),
+        )
+    }
+
+    #[test]
+    fn test_find_next_key_change_empty_batch_ops() {
+        // Case 1: empty `batch_ops` → no diffs in range.
+        let proof = make_change_proof(vec![], None);
+        assert_eq!(
+            find_next_key_after_change_proof(&proof, Some(FAR_END_KEY)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_next_key_change_empty_end_proof() {
+        // Empty `end_proof` → exhaustive.
+        let proof = make_change_proof(vec![make_put(b"key1", b"v1")], None);
+        assert_eq!(
+            find_next_key_after_change_proof(&proof, Some(FAR_END_KEY)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_next_key_change_last_equals_end() {
+        // Case 2: last_key reaches end_key.
+        let proof = make_change_proof(
+            vec![make_put(b"key1", b"v1")],
+            Some(make_terminal(b"key1", Some(b"v"))),
+        );
+        assert_eq!(
+            find_next_key_after_change_proof(&proof, Some(b"key1")).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_next_key_change_last_greater_than_end() {
+        // Malformed: last_key > end_key → Err.
+        let proof = make_change_proof(
+            vec![make_put(b"key2", b"v2")],
+            Some(make_terminal(b"key2", Some(b"v"))),
+        );
+        assert!(matches!(
+            find_next_key_after_change_proof(&proof, Some(b"key1")),
+            Err(api::Error::ProofError(ProofError::EndKeyLessThanLastKey))
+        ));
+    }
+
+    #[test]
+    fn test_find_next_key_change_put_terminal_no_value() {
+        // Case 3 (Put): terminal has no value → exhaustive.
+        let proof = make_change_proof(
+            vec![make_put(b"key1", b"v1")],
+            Some(make_terminal(b"key1", None)),
+        );
+        assert_eq!(
+            find_next_key_after_change_proof(&proof, Some(FAR_END_KEY)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_next_key_change_put_terminal_value_different_key() {
+        // Case 4 (Put): terminal at a key different from last_key.
+        let proof = make_change_proof(
+            vec![make_put(b"key1", b"v1")],
+            Some(make_terminal(b"key9", Some(b"v"))),
+        );
+        assert_eq!(
+            find_next_key_after_change_proof(&proof, Some(FAR_END_KEY)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_find_next_key_change_put_terminal_value_at_last_key() {
+        // Case 5 (Put): ambiguous shape → conservative continuation.
+        let last_key: &[u8] = b"key1";
+        let proof = make_change_proof(
+            vec![make_put(last_key, b"v1")],
+            Some(make_terminal(last_key, Some(b"v"))),
+        );
+        let result = find_next_key_after_change_proof(&proof, Some(FAR_END_KEY)).unwrap();
+        let (cursor, returned_end) = result.expect("ambiguous shape must return Some");
+        assert!(
+            cursor.as_ref() > last_key,
+            "cursor {cursor:?} must be > {last_key:?}"
+        );
+        assert_eq!(returned_end.as_deref(), Some(FAR_END_KEY));
+    }
+
+    #[test]
+    fn test_find_next_key_change_delete_terminal_no_value() {
+        // Delete with terminal carrying no value: structurally
+        // ambiguous between truncated and exhaustive → conservative.
+        let last_key: &[u8] = b"key1";
+        let proof = make_change_proof(
+            vec![make_delete(last_key)],
+            Some(make_terminal(last_key, None)),
+        );
+        let result = find_next_key_after_change_proof(&proof, Some(FAR_END_KEY)).unwrap();
+        let (cursor, returned_end) = result.expect("Delete must return Some");
+        assert!(
+            cursor.as_ref() > last_key,
+            "cursor {cursor:?} must be > {last_key:?}"
+        );
+        assert_eq!(returned_end.as_deref(), Some(FAR_END_KEY));
+    }
+
+    #[test]
+    fn test_find_next_key_change_delete_terminal_value_different_key() {
+        // Delete with terminal at a sibling leaf carrying a value:
+        // structurally ambiguous → conservative.
+        let last_key: &[u8] = b"key1";
+        let proof = make_change_proof(
+            vec![make_delete(last_key)],
+            Some(make_terminal(b"key9", Some(b"v"))),
+        );
+        let result = find_next_key_after_change_proof(&proof, Some(FAR_END_KEY)).unwrap();
+        let (cursor, returned_end) = result.expect("Delete must return Some");
+        assert!(
+            cursor.as_ref() > last_key,
+            "cursor {cursor:?} must be > {last_key:?}"
+        );
+        assert_eq!(returned_end.as_deref(), Some(FAR_END_KEY));
+    }
+
+    #[test]
+    fn test_find_next_key_change_delete_terminal_value_at_last_key() {
+        // Malformed Delete: terminal carries a value at last_key's
+        // path, contradicting last_key's absence from the end revision.
+        // Should surface the same error the verifier raises.
+        let proof = make_change_proof(
+            vec![make_delete(b"key1")],
+            Some(make_terminal(b"key1", Some(b"v"))),
+        );
+        assert!(matches!(
+            find_next_key_after_change_proof(&proof, Some(FAR_END_KEY)),
+            Err(api::Error::ProofError(
+                ProofError::EndProofOperationMismatch
+            ))
+        ));
+    }
 
     #[test]
     fn test_change_proof_iterator() {


### PR DESCRIPTION
  ## Why this should be merged

  Companion to the range-proof PR. The previous `find_next_key_after_change_proof`
  had the same cursor-non-advance pattern that caused issue #1989's
  infinite loop on the range-proof side, plus an empty-`batch_ops`
  branch that incorrectly returned `Some((end_key, None))` for bounded
  requests.

  ## How this works

  Mirrors the range-proof algorithm for Put `last_op` (preflight + Cases
  3–5 on the `end_proof` terminal: no value, value at different key,
  value at `last_key`'s path).

  For Delete `last_op`, the algorithm cannot tell from the terminal
  whether the proof was truncated (more keys remain) or exhaustive
  (range complete), so it always returns the conservative
  `Some((lex_successor(last_key), end_key))`. This costs one extra
  round-trip when the proof was actually exhaustive, but never loses
  data. The one malformed shape (terminal carries a value at
  `last_key`'s path, which contradicts a Delete) returns
  `Err(EndProofOperationMismatch)`.

  `DeleteRange` ops are rejected by `verify_change_proof_structure`;
  defensive `unreachable!()` covers the path. Reuses `lex_successor`
  from the range-proof PR. No new `ProofError` variants. No FFI changes.

  **Behavioral change:** empty `batch_ops` now returns `None`
  unconditionally (was `Some((end_key, None))` for bounded). Mirrors the
  range-proof PR's analogous correction.

  ## How this was tested

  - **Unit tests** (`firewood/src/proofs/change.rs`)
  - **Integration tests**
    (`firewood/src/merkle/tests/change/continuation.rs`)

  ## Breaking Changes
  
  `find_next_key_after_change_proof` signature unchanged. Callers that
  relied on the empty-`batch_ops` returning `Some((end_key, None))` will
  see `None` instead — the correct termination signal.