### PR TITLE
ci: gate canonical-repo workflows on github.repository

### DIFF
--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -29,9 +29,30 @@ concurrency:
 # - aarch64-unknown-linux-gnu
 # - aarch64-apple-darwin
 jobs:
+  # Detect whether the deploy key is configured. On forks without the
+  # secret, the downstream push step cannot run and the multi-arch build
+  # is wasted CI time — so skip the entire workflow there.
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has_secrets: ${{ steps.check.outputs.has_secrets }}
+    steps:
+      - name: Check if FIREWOOD_GO_DEPLOY_KEY is set
+        id: check
+        run: |
+          if [ -z "${{ secrets.FIREWOOD_GO_DEPLOY_KEY }}" ]; then
+            echo "FIREWOOD_GO_DEPLOY_KEY is not set"
+            echo "has_secrets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "FIREWOOD_GO_DEPLOY_KEY is set"
+            echo "has_secrets=true" >> "$GITHUB_OUTPUT"
+          fi
+
   # Build the static libraries for each target architecture and upload
   # them as artifacts to collect and attach in the next job.
   build-firewood-ffi-libs:
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has_secrets == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -43,8 +64,6 @@ jobs:
           - os: macos-26
             target: aarch64-apple-darwin
             pre-build-cmd: echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> "$GITHUB_ENV"
-    outputs:
-      has_secrets: ${{ steps.check_secrets.outputs.has_secrets }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
@@ -73,24 +92,12 @@ jobs:
           path: target/${{ matrix.target }}/maxperf/libfirewood_ffi.a
           if-no-files-found: error
 
-      - name: Check if FIREWOOD_GO_DEPLOY_KEY is set
-        id: check_secrets
-        run: |
-          if [ -z "${{ secrets.FIREWOOD_GO_DEPLOY_KEY }}" ]; then
-            echo "FIREWOOD_GO_DEPLOY_KEY is not set"
-            echo "has_secrets=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "FIREWOOD_GO_DEPLOY_KEY is set"
-            echo "has_secrets=true" >> "$GITHUB_OUTPUT"
-          fi
-
   # Collect all the static libraries built on the previous matrix of jobs
   # and add them into ffi/libs directory.
   # We commit and push this as a new branch with "--force" to overwrite
   # the previous static libs that will not be on our branch.
   push-firewood-ffi-libs:
     needs: build-firewood-ffi-libs
-    if: needs.build-firewood-ffi-libs.outputs.has_secrets == 'true'
     runs-on: ubuntu-24.04
     outputs:
       target_branch: ${{ steps.determine_branch.outputs.target_branch }}

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -24,8 +24,12 @@ env:
 
 jobs:
   build:
-    # Skip if triggered by failed workflow_run
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Only run on the canonical repo — forks don't have GitHub Pages
+    # configured and the deploy step fails.
+    # Also skip if triggered by failed workflow_run.
+    if: |
+      github.repository == 'ava-labs/firewood' &&
+      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -78,8 +82,9 @@ jobs:
           overwrite: true
           include-hidden-files: true
   deploy:
-    # Pull requests only validates the build step but does not actually deploy
-    if: github.event_name != 'pull_request'
+    # Pull requests only validates the build step but does not actually deploy.
+    # Forks don't have Pages configured, so restrict to the canonical repo.
+    if: github.repository == 'ava-labs/firewood' && github.event_name != 'pull_request'
     needs: build
     permissions:
       pages: write

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,8 @@ jobs:
   publish-firewood-crate:
     name: firewood-lib
     runs-on: ubuntu-latest
-    if: startsWith(github.event.release.tag_name, 'v')
+    # Publishing requires CARGO_TOKEN which only the canonical repo has.
+    if: github.repository == 'ava-labs/firewood' && startsWith(github.event.release.tag_name, 'v')
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    # Only cut releases from the canonical repo.
+    if: github.repository == 'ava-labs/firewood'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/track-performance.yml
+++ b/.github/workflows/track-performance.yml
@@ -43,6 +43,10 @@ on:
 
 jobs:
   configure-benchmark:
+    # Triggers AvalancheGo workflows and pushes to benchmark-data —
+    # both require secrets and a repo state that only the canonical
+    # repo has. Skip on forks.
+    if: github.repository == 'ava-labs/firewood'
     runs-on: ubuntu-latest
     outputs:
       name: ${{ steps.resolve.outputs.name }}


### PR DESCRIPTION
## Why this should be merged

Several workflows push to external repos, deploy GitHub Pages, publish crates, or trigger cross-repo workflows. On any fork (or repo without the relevant secrets) these jobs fail noisily on `push`-to-`main` / scheduled / tag triggers. Gating them on `github.repository == 'ava-labs/firewood'` keeps the canonical repo's behavior unchanged while letting forks run a clean subset of CI.

## How this works

Adds `if: github.repository == 'ava-labs/firewood'` to the jobs that require canonical-repo secrets or write to external state:

- `gh-pages.yaml` — build + deploy (Pages not configured on forks)
- `track-performance.yml` — scheduled cron pushes `benchmark-data` and triggers AvalancheGo via `FIREWOOD_AVALANCHEGO_GITHUB_TOKEN`
- `publish.yaml` — needs `CARGO_TOKEN` to publish to crates.io
- `release.yaml` — cuts GitHub releases on tag push

Other workflows already self-gate (`attach-static-libs.yaml` on `has_secrets`, `ffi-nix.yaml` on `vars.CACHIX_CACHE_NAME`, `ci.yaml` on the PR head repo) or are self-contained (`benchmarks`, `devcontainer`, `default-branch-cache`, `verify-go-versions`, `expected-golangci-yaml-diff`, `cache-cleanup`, `label-pull-requests`, `pr-title`) and need no change.

## How this was tested

YAML reviewed locally; no runtime change on `ava-labs/firewood` (the guard evaluates to `true`). Effect is only visible on forks, where the gated jobs become no-ops.

## Breaking Changes

None.