### PR TITLE
feat(storage): add NodeHashAlgorithm::is_ethereum predicate

### DIFF
--- a/firewood/src/proofs/eth.rs
+++ b/firewood/src/proofs/eth.rs
@@ -71,7 +71,8 @@ pub fn proof_node_to_mpt_rlp(node: &ProofNode) -> SmallVec<[Box<[u8]>; 2]> {
     // The account-node concept only exists in ethhash mode. Without that
     // feature, depth-64 nodes are plain MPT nodes and no special handling
     // fires.
-    let is_account = cfg!(feature = "ethhash") && key.len() == ACCOUNT_DEPTH_NIBBLES;
+    let is_account = firewood_storage::NodeHashAlgorithm::compile_option().is_ethereum()
+        && key.len() == ACCOUNT_DEPTH_NIBBLES;
     let value_bytes = node.value_digest.as_ref().and_then(ValueDigest::value);
 
     if node.child_hashes.count() == 0 {

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -30,7 +30,7 @@ pub enum NodeHashAlgorithm {
 
 impl Default for NodeHashAlgorithm {
     fn default() -> Self {
-        if cfg!(feature = "ethhash") {
+        if firewood_storage::NodeHashAlgorithm::compile_option().is_ethereum() {
             NodeHashAlgorithm::Ethereum
         } else {
             NodeHashAlgorithm::MerkleDB

--- a/storage/src/nodestore/hash_algo.rs
+++ b/storage/src/nodestore/hash_algo.rs
@@ -21,33 +21,40 @@ pub enum NodeHashAlgorithm {
     Ethereum,
 }
 
-// This is used in `validate_init` regardless of whether test code is being built.
-#[inline]
-const fn compile_option() -> NodeHashAlgorithm {
-    if cfg!(feature = "ethhash") {
-        NodeHashAlgorithm::Ethereum
-    } else {
-        NodeHashAlgorithm::MerkleDB
-    }
-}
-
 impl NodeHashAlgorithm {
-    /// Returns the hash algorithm that matches the compile-time option.
+    /// Returns the hash algorithm selected by the current build.
     ///
-    /// Note: This function is only available in test builds or when the
-    /// `test_utils` feature is enabled (for upstream testing purposes).
+    /// Today this is decided at compile time by the `ethhash` feature; when
+    /// the algorithm becomes runtime-selectable (issue #1088), this is the
+    /// single function that switches over and every caller picks up the new
+    /// behavior automatically.
     #[must_use]
+    #[inline]
     pub const fn compile_option() -> Self {
-        compile_option()
+        if cfg!(feature = "ethhash") {
+            NodeHashAlgorithm::Ethereum
+        } else {
+            NodeHashAlgorithm::MerkleDB
+        }
     }
 
-    /// Returns whether this hash algorithm matches the compile-time option.
+    /// Returns whether this hash algorithm matches the one selected by the
+    /// current build (see [`Self::compile_option`]).
     #[must_use]
     pub const fn matches_compile_option(self) -> bool {
-        match self {
-            NodeHashAlgorithm::MerkleDB => !cfg!(feature = "ethhash"),
-            NodeHashAlgorithm::Ethereum => cfg!(feature = "ethhash"),
-        }
+        self.is_ethereum() == Self::compile_option().is_ethereum()
+    }
+
+    /// Returns whether this is the Ethereum hash algorithm (Keccak-256,
+    /// account-aware nodes).
+    ///
+    /// Callers that need to gate ethereum-mode proofs or encoding should
+    /// read `NodeHashAlgorithm::compile_option().is_ethereum()` instead of
+    /// checking the `ethhash` feature directly. When this enum becomes
+    /// runtime-selectable, every caller picks up the new behavior for free.
+    #[must_use]
+    pub const fn is_ethereum(self) -> bool {
+        matches!(self, NodeHashAlgorithm::Ethereum)
     }
 
     pub(crate) const fn name(self) -> &'static str {
@@ -68,7 +75,7 @@ impl NodeHashAlgorithm {
                     "node store hash algorithm mismatch: want to initialize with {}, \
                      but build option is for {}",
                     self.name(),
-                    compile_option().name()
+                    Self::compile_option().name()
                 ),
             ))
         }


### PR DESCRIPTION
## Why this should be merged

The Rust-side \`eth_getProof\` work (issue #2001) wants to gate ethereum-mode
behavior at runtime without scattering \`#[cfg(feature = \"ethhash\")]\` walls
through new code. This PR sets up the seam by giving \`NodeHashAlgorithm\` a
single predicate callers consult — when the algorithm eventually becomes
runtime-selectable (#1088), every caller picks up the new behavior with no
further changes.

Along the way, the existing \`compile_option\` / \`matches_compile_option\`
plumbing in \`storage/src/nodestore/hash_algo.rs\` had drifted: a free
function shadowed the inherent method (intended to allow gating the inherent
method to \`test_utils\`, a plan that was never carried out), and the
inherent method's doc claimed it was only available under \`test_utils\`,
which is false today (it's load-bearing in production paths like
\`MemStore::default\`, \`validate_init\`'s error formatting, the benchmark
binary, fwdctl, and examples).

## How this works

In \`storage/src/nodestore/hash_algo.rs\`:

- Add \`NodeHashAlgorithm::is_ethereum(self) -> bool\` next to the existing
  \`compile_option\` and \`matches_compile_option\`.
- Delete the free module-level \`compile_option\` shadow and fold its
  \`cfg!(feature = \"ethhash\")\` body into the inherent method.
- Drop the stale \"only available in test builds / test_utils\" doc note.
- Rewrite \`matches_compile_option\` as
  \`self.is_ethereum() == Self::compile_option().is_ethereum()\` — stays
  \`const fn\`, reads as \"do these agree.\"

Route two existing call sites through the new predicate to validate the
seam:

- \`firewood::proofs::eth::proof_node_to_mpt_rlp\` — the account-leaf branch
- \`fwdctl::NodeHashAlgorithm::default\` — picks the default CLI hash mode

Other \`cfg!(feature = \"ethhash\")\` sites are deliberately left alone:
- \`storage/src/nodestore/hash_algo.rs\` itself owns the underlying seam.
- \`fwdctl/build.rs\` runs at compile time where a runtime predicate doesn't
  apply.

## How this was tested

- \`cargo clippy --workspace --all-targets\` — clean
- \`cargo clippy --workspace --features ethhash,logger --all-targets\` — clean
- \`cargo nextest run -p firewood-storage --features ethhash\` — 302/302 pass
- \`cargo doc --no-deps\` — clean

## Breaking Changes

None. The public method shape on \`NodeHashAlgorithm\` is purely additive
(\`is_ethereum\` is new; \`compile_option\` and \`matches_compile_option\`
retain their existing signatures and semantics).