### PR TITLE
docs(changelog): detect breaking-change PR labels in CHANGELOG automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ All notable changes to this project will be documented in this file.
 - *(manager)* Resolve empty-trie revision under ethhash without RootStore (TOB-FIREWOOD-7) ([#1982](https://github.com/ava-labs/firewood/pull/1982))
 - *(range-proof)* Use last_kv_key as right-edge anchor for inclusion-style end_proofs ([#1970](https://github.com/ava-labs/firewood/pull/1970))
 - *(manager)* Hold proposals lock across cleanup and reparent (TOB-FIREWOOD-6) ([#1981](https://github.com/ava-labs/firewood/pull/1981))
-- *(manager)* Use CommittedId for parent identity, skip trivial commits ([#1987](https://github.com/ava-labs/firewood/pull/1987))
-- *(storage)* Pin committed parent in Reconstructed to prevent reaping ([#2000](https://github.com/ava-labs/firewood/pull/2000))
+- *(manager)* [**breaking** firewood-storage] Use CommittedId for parent identity, skip trivial commits ([#1987](https://github.com/ava-labs/firewood/pull/1987))
+- *(storage)* [**breaking** firewood, firewood-ffi, firewood-storage] Pin committed parent in Reconstructed to prevent reaping ([#2000](https://github.com/ava-labs/firewood/pull/2000))
 
 ### 🚜 Refactor
 
@@ -88,10 +88,10 @@ All notable changes to this project will be documented in this file.
 
 ### 🚜 Refactor
 
-- *(metrics)* [**breaking**] Remove histograms ([#1847](https://github.com/ava-labs/firewood/pull/1847))
+- *(metrics)* [**breaking** firewood-go] Remove histograms ([#1847](https://github.com/ava-labs/firewood/pull/1847))
 - *(proofs)* Replace ChildMask [bool; 16] with u16 newtype ([#1849](https://github.com/ava-labs/firewood/pull/1849))
 - *(range-proofs)* Consolidate ChildrenMap into ChildMask ([#1852](https://github.com/ava-labs/firewood/pull/1852))
-- *(merkle)* [**breaking**] Reduce visibility of firewood::merkle module ([#1858](https://github.com/ava-labs/firewood/pull/1858))
+- *(merkle)* [**breaking** firewood] Reduce visibility of firewood::merkle module ([#1858](https://github.com/ava-labs/firewood/pull/1858))
 - Rename verify_root_hash to verify_range_proof_root_hash ([#1887](https://github.com/ava-labs/firewood/pull/1887))
 - *(ffi)* Remove ArcCache from DatabaseHandle ([#1891](https://github.com/ava-labs/firewood/pull/1891))
 - *(metrics)* Consolidate metric registry definitions with macro ([#1867](https://github.com/ava-labs/firewood/pull/1867))

--- a/cliff.toml
+++ b/cliff.toml
@@ -25,7 +25,18 @@ body = """
             {% continue -%}
         {% endif -%}
         - {% if commit.scope %}*({{ commit.scope }})* {% endif -%}
-            {% if commit.breaking %}[**breaking**] {% endif -%}
+            {%- set_global breaking = commit.breaking -%}
+            {%- set_global breaking_scopes = [] -%}
+            {%- if commit.remote.pr_labels is defined -%}
+              {%- for label in commit.remote.pr_labels -%}
+                {%- if label is starting_with("breaking-change/") -%}
+                  {%- set_global breaking = true -%}
+                  {%- set scope = label | trim_start_matches(pat="breaking-change/") -%}
+                  {%- set_global breaking_scopes = breaking_scopes | concat(with=scope) -%}
+                {%- endif -%}
+              {%- endfor -%}
+            {%- endif -%}
+            {% if breaking %}[**breaking**{% if breaking_scopes | length > 0 %} {{ breaking_scopes | sort | join(sep=", ") }}{% endif %}] {% endif -%}
             {{ commit.message | upper_first }}
     {% endfor -%}
 {% endfor %}\n
@@ -80,7 +91,7 @@ commit_preprocessors = [
     { pattern = '\(#([0-9]+)\)', replace = '([#${1}](<REPO>/pull/${1}))' },
 ]
 # Prevent commits that are breaking from being excluded by commit parsers.
-protect_breaking_commits = false
+protect_breaking_commits = true
 # An array of regex based parsers for extracting data from the commit message.
 # Assigns commits to groups.
 # Optionally sets the commit's scope and can decide to exclude commits from further processing.


### PR DESCRIPTION
Closes #1443

## Why this should be merged

A PR may be identified as breaking after it has already been merged — either because the breaking nature wasn't recognized at merge time or because the conventional commit message didn't include a `!` marker. Without a way to attach that metadata retroactively, breaking changes would be silently omitted or mislabeled in the CHANGELOG.

To solve this, per-scope repo labels (`breaking-change/<crate>`) were added so that breaking metadata can be applied to any merged PR after the fact. This change wires those labels into changelog generation: `cliff.toml` now reads `pr_labels` and surfaces the affected crate names directly in each breaking-change entry.

## How this works

`cliff.toml` is updated to scan each commit's `pr_labels` for labels matching the `breaking-change/` prefix. When found, the label suffixes (e.g. `firewood`, `firewood-storage`, `firewood-ffi`, `firewood-go`, `fwdctl`) are collected, sorted, and rendered as `[**breaking** <scope1>, <scope2>]` in the changelog body. A commit is treated as breaking if it carries a `!` in the conventional commit message *or* has at least one `breaking-change/` label, so retroactively labeled PRs are correctly promoted. The `protect_breaking_commits` flag is also enabled so breaking commits are never accidentally excluded by the commit parsers.

Existing breaking-change entries in `CHANGELOG.md` are updated to match the new format, retroactively adding the affected crate names derived from their PR labels.

## How this was tested

Verified by inspecting the rendered diff in `CHANGELOG.md` and confirming the affected crate names match the `breaking-change/` labels on each referenced PR.

## Breaking Changes

N/A