### PR TITLE
chore: fix nightly clippy warnings

### DIFF
--- a/ffi/src/proofs/change.rs
+++ b/ffi/src/proofs/change.rs
@@ -241,7 +241,7 @@ pub extern "C" fn fwd_db_verify_change_proof<'db>(
     proof: Option<&ChangeProofContext>,
     args: CreateChangeProofArgs<'_>,
 ) -> crate::ProposalResult<'db> {
-    let handle = db.and_then(|db| proof.map(|p| (db, p)));
+    let handle = db.zip(proof);
     crate::invoke_with_handle(handle, |(db, ctx)| {
         let proof = ctx
             .proof()
@@ -277,7 +277,7 @@ pub extern "C" fn fwd_db_verify_and_commit_change_proof(
     proof: Option<&ChangeProofContext>,
     args: CreateChangeProofArgs<'_>,
 ) -> HashResult {
-    let handle = db.and_then(|db| proof.map(|p| (db, p)));
+    let handle = db.zip(proof);
     crate::invoke_with_handle(handle, |(db, ctx)| {
         let proof = ctx
             .proof()

--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -381,7 +381,7 @@ pub extern "C" fn fwd_db_verify_range_proof<'db>(
         max_length,
     } = args;
 
-    let handle = db.and_then(|db| proof.map(|p| (db, p)));
+    let handle = db.zip(proof);
 
     crate::invoke_with_handle(handle, |(db, ctx)| {
         let start_key = start_key.into_option();
@@ -439,7 +439,7 @@ pub extern "C" fn fwd_db_verify_and_commit_range_proof<'db>(
         max_length,
     } = args;
 
-    let handle = db.and_then(|db| proof.map(|p| (db, p)));
+    let handle = db.zip(proof);
 
     crate::invoke_with_handle(handle, |(db, ctx)| {
         let start_key = start_key.into_option();

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -971,7 +971,7 @@ mod test {
         let db = db.replace();
         let final_root = db.root_hash();
         println!("{final_root:?}");
-        assert!(final_root == initial_root);
+        assert_eq!(final_root, initial_root);
     }
 
     #[test]

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -852,7 +852,7 @@ mod tests {
                 index += 1;
             }
         }
-        assert!(index == batch_sorted.len());
+        assert_eq!(index, batch_sorted.len());
 
         // Third test that just skips the children after calling `next` once. This should skip all of
         // the children of the root node, causing the next call to `next` to return None.

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -217,7 +217,7 @@ fn test_missing_key_proof() {
     for key in ["a", "j", "l", "z"] {
         let proof = merkle.prove(key.as_ref()).unwrap();
         assert!(!proof.is_empty());
-        assert!(proof.len() == 1);
+        assert_eq!(proof.len(), 1);
 
         proof.verify(key, None::<&[u8]>, &root_hash).unwrap();
     }

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -199,7 +199,7 @@ where
         }
         let trie_stats = self
             .root_as_maybe_persisted_node()
-            .and_then(|node| self.root_hash().map(|root_hash| (node, root_hash)))
+            .zip(self.root_hash())
             .and_then(|(root, root_hash)| {
                 if let Some(root_address) = root.as_linear_address() {
                     let (trie_stats, trie_errors) = self.visit_trie(
@@ -722,7 +722,7 @@ where
         }
 
         // we assume that all areas are aligned to `MIN_AREA_SIZE`, in which case leaked ranges can always be split into free areas perfectly
-        debug_assert!(current_addr == *leaked_range.end);
+        debug_assert_eq!(current_addr, *leaked_range.end);
         leaked
     }
 }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -1531,7 +1531,7 @@ mod tests {
 
         let err = node_store.persist(&mut header).unwrap_err();
         let err_ctx = err.context();
-        assert!(err_ctx == Some("allocate_node"));
+        assert_eq!(err_ctx, Some("allocate_node"));
 
         let io_err = err
             .source()


### PR DESCRIPTION
## Summary
- Applied `cargo +nightly clippy --fix` across the workspace.
- Replaced `assert!(a == b)` / `debug_assert!(a == b)` with `assert_eq!` / `debug_assert_eq!` (`manual_assert_eq`).
- Replaced manual `Option`-zipping (`.and_then(|x| y.map(|y| (x, y)))`) with `Option::zip` (`manual_option_zip`).

## How this was tested
- `cargo +nightly clippy --workspace --features ethhash,logger --all-targets` — no warnings
- `cargo nextest run --workspace --features ethhash,logger --all-targets` — 732 passed
- `cargo doc --no-deps`
- `cargo fmt`