### PR TITLE
ci(deps): bump golangci/golangci-lint-action from 9.2.0 to 9.2.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -261,7 +261,7 @@ jobs:
           go-version-file: "ffi/go.mod"
           cache-dependency-path: "ffi/go.sum"
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # @v7 -> v9.2.0
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # @v7 -> v9.2.1
         with:
           version: latest
           working-directory: ffi


### PR DESCRIPTION
## Why this should be merged
Preempt dependabot's weekly bump. Picks up `golangci/golangci-lint-action@v9.2.1`, the first immutable release of v9.x.

## How this works
Bump the pinned SHA in `.github/workflows/ci.yaml`, keeping the `@v7 -> v9.2.1` trailing comment in sync.

## Review of v9.2.1 release notes
Reviewed the [v9.2.1 release notes](https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1) — the only changes are downstream version bumps (transitive dependency updates in the action's own `package.json`) and one workflow-chore PR. No behavior changes to the action's surface. The individual downstream bumps themselves were **not** reviewed.