### PR TITLE
fix(proofs): hash single storage child proofs as root

### DIFF
--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -369,9 +369,18 @@ fn compute_root_hash_with_proofs(
     path_prefix: &[PathComponent],
     proof_nodes: &HashMap<PathBuf, &ProofNode>,
     outside_children: &HashMap<PathBuf, ChildMask>,
+    fake_root: bool,
 ) -> HashType {
     let branch = match node {
-        Node::Leaf(_) => return HashableShunt::from_node(path_prefix, node).to_hash(),
+        Node::Leaf(leaf) => {
+            return hash_proof_node_parts(
+                path_prefix,
+                leaf.partial_path.as_components(),
+                Some(ValueDigest::Value(&leaf.value)),
+                Children::new(),
+                fake_root,
+            );
+        }
         Node::Branch(branch) => branch,
     };
 
@@ -385,6 +394,13 @@ fn compute_root_hash_with_proofs(
     let mut child_hashes: Children<Option<HashType>> = Children::new();
 
     let outside_mask = outside_children.get(&full_key);
+    #[cfg(feature = "ethhash")]
+    let single_account_child = single_effective_account_child(
+        &full_key,
+        branch,
+        proof_nodes.get(&full_key).copied(),
+        outside_mask,
+    );
 
     // For children inside the proven range, compute hashes recursively.
     // For children outside the range, use proof node hashes (set below).
@@ -404,8 +420,22 @@ fn compute_root_hash_with_proofs(
             unreachable!()
         };
         child_prefix.push(nibble);
-        let child_hash =
-            compute_root_hash_with_proofs(child_node, &child_prefix, proof_nodes, outside_children);
+        let child_hash = compute_root_hash_with_proofs(
+            child_node,
+            &child_prefix,
+            proof_nodes,
+            outside_children,
+            {
+                #[cfg(feature = "ethhash")]
+                {
+                    single_account_child == Some(nibble)
+                }
+                #[cfg(not(feature = "ethhash"))]
+                {
+                    false
+                }
+            },
+        );
         child_hashes[nibble] = Some(child_hash);
         child_prefix.pop();
     }
@@ -430,13 +460,73 @@ fn compute_root_hash_with_proofs(
             .get(&full_key)
             .and_then(|pn| pn.value_digest.as_ref().map(ValueDigest::as_ref))
     });
-    HashableShunt::new(
+    hash_proof_node_parts(
         path_prefix,
         branch.partial_path.as_components(),
         value_digest,
         child_hashes,
+        fake_root,
     )
-    .to_hash()
+}
+
+fn hash_proof_node_parts<'a>(
+    path_prefix: &'a [PathComponent],
+    partial_path: &'a [PathComponent],
+    value_digest: Option<ValueDigest<&'a [u8]>>,
+    child_hashes: Children<Option<HashType>>,
+    fake_root: bool,
+) -> HashType {
+    #[cfg(feature = "ethhash")]
+    if fake_root && let Some((nibble, prefix)) = path_prefix.split_last() {
+        // Match ethhash account hashing for a single storage child: the child
+        // becomes the storage-trie root, with the account child nibble folded
+        // into its partial path.
+        let fake_partial: PathBuf = once(*nibble).chain(partial_path.iter().copied()).collect();
+        return HashableShunt::new(prefix, fake_partial.as_slice(), value_digest, child_hashes)
+            .to_hash();
+    }
+
+    let _ = fake_root;
+    HashableShunt::new(path_prefix, partial_path, value_digest, child_hashes).to_hash()
+}
+
+#[cfg(feature = "ethhash")]
+fn single_effective_account_child(
+    full_key: &[PathComponent],
+    branch: &BranchNode,
+    proof_node: Option<&ProofNode>,
+    outside_mask: Option<&ChildMask>,
+) -> Option<PathComponent> {
+    if full_key.len() != 64 {
+        return None;
+    }
+
+    // Count the child set after merging reconstructed in-range children with
+    // out-of-range hashes supplied by proof nodes.
+    let mut only_child = None;
+    let mut count = 0usize;
+    let mut record = |nibble| {
+        if only_child != Some(nibble) {
+            only_child = Some(nibble);
+            count = count.saturating_add(1);
+        }
+    };
+
+    for (nibble, child) in &branch.children {
+        if child.is_some() && !outside_mask.is_some_and(|mask| mask.is_set(nibble.0)) {
+            record(nibble);
+        }
+    }
+
+    if let (Some(proof_node), Some(outside_mask)) = (proof_node, outside_mask) {
+        for (nibble, _) in proof_node.child_hashes.iter_present() {
+            if outside_mask.is_set(nibble.0) {
+                record(nibble);
+            }
+        }
+    }
+
+    if count == 1 { only_child } else { None }
 }
 
 /// Reject any proof node that carries a value digest (either
@@ -893,7 +983,7 @@ fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
     };
 
     let computed =
-        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children);
+        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children, false);
 
     if computed != root_hash.clone().into_hash_type() {
         return Err(api::Error::ProofError(ProofError::UnexpectedHash));
@@ -1082,7 +1172,7 @@ pub fn verify_change_proof_root_hash(
         .expect("a non-empty proof reconciliation always leaves behind a root node");
 
     let computed =
-        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children);
+        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children, false);
 
     if computed != verification.end_root.clone().into_hash_type() {
         return Err(api::Error::ProofError(ProofError::EndRootMismatch));

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -26,9 +26,9 @@ use firewood_metrics::firewood_counter;
 use firewood_storage::MemStore;
 use firewood_storage::{
     BranchNode, Child, Children, FileIoError, HashType, HashableShunt, HashedNodeReader,
-    ImmutableProposal, IntoHashType, LeafNode, MaybePersistedNode, Mutable, MutableKind,
-    NibblesIterator, Node, NodeStore, Path, PathBuf, PathComponent, Propose, ReadableStorage,
-    SharedNode, TrieHash, TrieReader, U4, ValueDigest,
+    ImmutableProposal, IntoHashType, JoinedPath, LeafNode, MaybePersistedNode, Mutable,
+    MutableKind, NibblesIterator, Node, NodeStore, Path, PathBuf, PathComponent, Propose,
+    ReadableStorage, SharedNode, TrieHash, TrieReader, U4, ValueDigest,
 };
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
@@ -394,7 +394,6 @@ fn compute_root_hash_with_proofs(
     let mut child_hashes: Children<Option<HashType>> = Children::new();
 
     let outside_mask = outside_children.get(&full_key);
-    #[cfg(feature = "ethhash")]
     let single_account_child = single_effective_account_child(
         &full_key,
         branch,
@@ -425,16 +424,7 @@ fn compute_root_hash_with_proofs(
             &child_prefix,
             proof_nodes,
             outside_children,
-            {
-                #[cfg(feature = "ethhash")]
-                {
-                    single_account_child == Some(nibble)
-                }
-                #[cfg(not(feature = "ethhash"))]
-                {
-                    false
-                }
-            },
+            single_account_child == Some(nibble),
         );
         child_hashes[nibble] = Some(child_hash);
         child_prefix.pop();
@@ -481,13 +471,22 @@ fn hash_proof_node_parts<'a>(
         // Match ethhash account hashing for a single storage child: the child
         // becomes the storage-trie root, with the account child nibble folded
         // into its partial path.
-        let fake_partial: PathBuf = once(*nibble).chain(partial_path.iter().copied()).collect();
-        return HashableShunt::new(prefix, fake_partial.as_slice(), value_digest, child_hashes)
-            .to_hash();
+        let folded = JoinedPath::new(std::slice::from_ref(nibble), partial_path);
+        return HashableShunt::new(prefix, folded, value_digest, child_hashes).to_hash();
     }
 
     let _ = fake_root;
     HashableShunt::new(path_prefix, partial_path, value_digest, child_hashes).to_hash()
+}
+
+#[cfg(not(feature = "ethhash"))]
+fn single_effective_account_child(
+    _full_key: &[PathComponent],
+    _branch: &BranchNode,
+    _proof_node: Option<&ProofNode>,
+    _outside_mask: Option<&ChildMask>,
+) -> Option<PathComponent> {
+    None
 }
 
 #[cfg(feature = "ethhash")]
@@ -501,32 +500,30 @@ fn single_effective_account_child(
         return None;
     }
 
-    // Count the child set after merging reconstructed in-range children with
-    // out-of-range hashes supplied by proof nodes.
+    // The two scans cover disjoint nibble sets by construction: in-range
+    // children (!outside_mask) and proof-node children (outside_mask).
     let mut only_child = None;
-    let mut count = 0usize;
-    let mut record = |nibble| {
-        if only_child != Some(nibble) {
-            only_child = Some(nibble);
-            count = count.saturating_add(1);
-        }
-    };
-
     for (nibble, child) in &branch.children {
         if child.is_some() && !outside_mask.is_some_and(|mask| mask.is_set(nibble.0)) {
-            record(nibble);
+            if only_child.is_some() {
+                return None;
+            }
+            only_child = Some(nibble);
         }
     }
 
     if let (Some(proof_node), Some(outside_mask)) = (proof_node, outside_mask) {
         for (nibble, _) in proof_node.child_hashes.iter_present() {
             if outside_mask.is_set(nibble.0) {
-                record(nibble);
+                if only_child.is_some() {
+                    return None;
+                }
+                only_child = Some(nibble);
             }
         }
     }
 
-    if count == 1 { only_child } else { None }
+    only_child
 }
 
 /// Reject any proof node that carries a value digest (either

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -23,12 +23,14 @@ use crate::{
     ChangeProofVerificationContext, Proof, ProofCollection, ProofError, ProofNode, RangeProof,
 };
 use firewood_metrics::firewood_counter;
+#[cfg(feature = "ethhash")]
+use firewood_storage::JoinedPath;
 use firewood_storage::MemStore;
 use firewood_storage::{
     BranchNode, Child, Children, FileIoError, HashType, HashableShunt, HashedNodeReader,
-    ImmutableProposal, IntoHashType, JoinedPath, LeafNode, MaybePersistedNode, Mutable,
-    MutableKind, NibblesIterator, Node, NodeStore, Path, PathBuf, PathComponent, Propose,
-    ReadableStorage, SharedNode, TrieHash, TrieReader, U4, ValueDigest,
+    ImmutableProposal, IntoHashType, LeafNode, MaybePersistedNode, Mutable, MutableKind,
+    NibblesIterator, Node, NodeStore, Path, PathBuf, PathComponent, Propose, ReadableStorage,
+    SharedNode, TrieHash, TrieReader, U4, ValueDigest,
 };
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
@@ -480,7 +482,7 @@ fn hash_proof_node_parts<'a>(
 }
 
 #[cfg(not(feature = "ethhash"))]
-fn single_effective_account_child(
+const fn single_effective_account_child(
     _full_key: &[PathComponent],
     _branch: &BranchNode,
     _proof_node: Option<&ProofNode>,

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -648,3 +648,77 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
     )
     .unwrap();
 }
+
+#[test]
+fn test_limit_truncated_range_proof_inside_single_storage_child_account() {
+    let dummy_storage_root = [0u8; 32];
+    let account_key: Box<[u8]> = [0x10u8; 32].into();
+    let storage_key: Box<[u8]> = [account_key.as_ref(), &[0xAAu8; 32]].concat().into();
+    let following_key: Box<[u8]> = [0xFFu8; 32].into();
+
+    let account_value = rlp_encode_account(1, 100, &dummy_storage_root, &empty_code_hash());
+    let storage_value: Box<[u8]> = rlp_encode_storage(&[0x42u8; 32]).into();
+    let following_value = rlp_encode_account(2, 200, &dummy_storage_root, &empty_code_hash());
+
+    let merkle = init_merkle([
+        (account_key.as_ref(), account_value.as_ref()),
+        (storage_key.as_ref(), storage_value.as_ref()),
+        (following_key.as_ref(), following_value.as_ref()),
+    ]);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let range_proof = merkle
+        .range_proof(None, None, std::num::NonZeroUsize::new(2))
+        .unwrap();
+    assert_eq!(range_proof.key_values().len(), 2);
+    assert_eq!(range_proof.key_values()[0].0.as_ref(), account_key.as_ref());
+    assert_eq!(range_proof.key_values()[1].0.as_ref(), storage_key.as_ref());
+    assert!(!range_proof.end_proof().is_empty());
+
+    verify_range_proof::<_>(None::<&[u8]>, None::<&[u8]>, &root_hash, &range_proof).unwrap();
+
+    let mut serialized = Vec::new();
+    range_proof.write_to_vec(&mut serialized);
+    let deserialized = crate::api::FrozenRangeProof::from_slice(&serialized).unwrap();
+    verify_range_proof::<_>(None::<&[u8]>, None::<&[u8]>, &root_hash, &deserialized).unwrap();
+}
+
+#[test]
+fn test_limit_truncated_range_proof_inside_multi_storage_child_account() {
+    let dummy_storage_root = [0u8; 32];
+    let account_key: Box<[u8]> = [0x10u8; 32].into();
+    let storage_key_a: Box<[u8]> = [account_key.as_ref(), &[0x10u8; 32]].concat().into();
+    let storage_key_b: Box<[u8]> = [account_key.as_ref(), &[0x20u8; 32]].concat().into();
+    let following_key: Box<[u8]> = [0xFFu8; 32].into();
+
+    let account_value = rlp_encode_account(1, 100, &dummy_storage_root, &empty_code_hash());
+    let storage_value_a: Box<[u8]> = rlp_encode_storage(&[0x42u8; 32]).into();
+    let storage_value_b: Box<[u8]> = rlp_encode_storage(&[0x43u8; 32]).into();
+    let following_value = rlp_encode_account(2, 200, &dummy_storage_root, &empty_code_hash());
+
+    let merkle = init_merkle([
+        (account_key.as_ref(), account_value.as_ref()),
+        (storage_key_a.as_ref(), storage_value_a.as_ref()),
+        (storage_key_b.as_ref(), storage_value_b.as_ref()),
+        (following_key.as_ref(), following_value.as_ref()),
+    ]);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let range_proof = merkle
+        .range_proof(None, None, std::num::NonZeroUsize::new(2))
+        .unwrap();
+    assert_eq!(range_proof.key_values().len(), 2);
+    assert_eq!(range_proof.key_values()[0].0.as_ref(), account_key.as_ref());
+    assert_eq!(
+        range_proof.key_values()[1].0.as_ref(),
+        storage_key_a.as_ref()
+    );
+    assert!(!range_proof.end_proof().is_empty());
+
+    verify_range_proof::<_>(None::<&[u8]>, None::<&[u8]>, &root_hash, &range_proof).unwrap();
+
+    let mut serialized = Vec::new();
+    range_proof.write_to_vec(&mut serialized);
+    let deserialized = crate::api::FrozenRangeProof::from_slice(&serialized).unwrap();
+    verify_range_proof::<_>(None::<&[u8]>, None::<&[u8]>, &root_hash, &deserialized).unwrap();
+}

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -48,7 +48,7 @@
 )]
 
 #[cfg(feature = "ethhash")]
-use firewood_storage::HashableShunt;
+use firewood_storage::{HashableShunt, JoinedPath};
 use firewood_storage::{
     Children, FileIoError, HashType, Hashable, IntoHashType, IntoSplitPath, NibblesIterator, Path,
     PathBuf, PathComponent, PathIterItem, Preimage, SplitPath, TrieHash, TriePath, ValueDigest,
@@ -333,26 +333,12 @@ fn proof_node_hash<N: Hashable>(node: &N, fake_root: bool) -> HashType {
         // A single storage child under an account is hashed as the storage-trie
         // root, so the account child nibble moves from the parent prefix into
         // this node's partial path.
-        let parent_prefix: PathBuf = node.parent_prefix_path().components().collect();
-        if let Some(fake_partial_start) = parent_prefix.len().checked_sub(1) {
-            let (Some(prefix), Some(suffix)) = (
-                parent_prefix.get(..fake_partial_start),
-                parent_prefix.get(fake_partial_start..),
-            ) else {
-                return node.to_hash();
-            };
-            let fake_partial: PathBuf = suffix
-                .iter()
-                .copied()
-                .chain(node.partial_path().components())
-                .collect();
-            return HashableShunt::new(
-                prefix,
-                fake_partial.as_slice(),
-                node.value_digest(),
-                node.children(),
-            )
-            .to_hash();
+        let parent = node.parent_prefix_path().into_split_path();
+        if let Some(prefix_len) = parent.len().checked_sub(1) {
+            let (prefix, last) = parent.split_at(prefix_len);
+            let folded = JoinedPath::new(last, node.partial_path().into_split_path());
+            return HashableShunt::new(prefix, folded, node.value_digest(), node.children())
+                .to_hash();
         }
     }
 

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -47,6 +47,8 @@
     reason = "Found 1 occurrences after enabling the lint."
 )]
 
+#[cfg(feature = "ethhash")]
+use firewood_storage::HashableShunt;
 use firewood_storage::{
     Children, FileIoError, HashType, Hashable, IntoHashType, IntoSplitPath, NibblesIterator, Path,
     PathBuf, PathComponent, PathIterItem, Preimage, SplitPath, TrieHash, TriePath, ValueDigest,
@@ -325,6 +327,47 @@ impl Hashable for ProofNode {
     }
 }
 
+fn proof_node_hash<N: Hashable>(node: &N, fake_root: bool) -> HashType {
+    #[cfg(feature = "ethhash")]
+    if fake_root {
+        // A single storage child under an account is hashed as the storage-trie
+        // root, so the account child nibble moves from the parent prefix into
+        // this node's partial path.
+        let parent_prefix: PathBuf = node.parent_prefix_path().components().collect();
+        if let Some(fake_partial_start) = parent_prefix.len().checked_sub(1) {
+            let (Some(prefix), Some(suffix)) = (
+                parent_prefix.get(..fake_partial_start),
+                parent_prefix.get(fake_partial_start..),
+            ) else {
+                return node.to_hash();
+            };
+            let fake_partial: PathBuf = suffix
+                .iter()
+                .copied()
+                .chain(node.partial_path().components())
+                .collect();
+            return HashableShunt::new(
+                prefix,
+                fake_partial.as_slice(),
+                node.value_digest(),
+                node.children(),
+            )
+            .to_hash();
+        }
+    }
+
+    let _ = fake_root;
+    node.to_hash()
+}
+
+#[cfg(feature = "ethhash")]
+fn is_single_child_account_node<N: Hashable>(
+    node: &N,
+    children: &Children<Option<HashType>>,
+) -> bool {
+    node.full_path().len() == 64 && children.count() == 1
+}
+
 impl From<PathIterItem> for ProofNode {
     fn from(item: PathIterItem) -> Self {
         let child_hashes = if let Some(branch) = item.node.as_branch() {
@@ -456,12 +499,14 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
         };
 
         let mut expected_hash = root_hash.clone().into_hash_type();
+        let mut fake_root = false;
 
         let mut iter = self.0.as_ref().iter().peekable();
         while let Some(node) = iter.next() {
-            if node.to_hash() != expected_hash {
+            if proof_node_hash(node, fake_root) != expected_hash {
                 return Err(ProofError::UnexpectedHash);
             }
+            fake_root = false;
 
             // Assert that only nodes whose keys are an even number of nibbles
             // have a `value_digest`.
@@ -482,10 +527,16 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
                     return Err(ProofError::ShouldBePrefixOfNextKey);
                 }
 
-                expected_hash = node.children()[key_nibble]
+                let children = node.children();
+                expected_hash = children[key_nibble]
                     .as_ref()
                     .ok_or(ProofError::NodeNotInTrie)?
                     .clone();
+
+                #[cfg(feature = "ethhash")]
+                {
+                    fake_root = is_single_child_account_node(node, &children);
+                }
             }
         }
 

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -47,12 +47,12 @@
     reason = "Found 1 occurrences after enabling the lint."
 )]
 
-#[cfg(feature = "ethhash")]
-use firewood_storage::{HashableShunt, JoinedPath};
 use firewood_storage::{
     Children, FileIoError, HashType, Hashable, IntoHashType, IntoSplitPath, NibblesIterator, Path,
     PathBuf, PathComponent, PathIterItem, Preimage, SplitPath, TrieHash, TriePath, ValueDigest,
 };
+#[cfg(feature = "ethhash")]
+use firewood_storage::{HashableShunt, JoinedPath};
 use thiserror::Error;
 
 use crate::merkle::Value;


### PR DESCRIPTION
## Why this should be merged

**Note: This probably should not be merged, and is most likely AI slop. I hope it's still useful to some extent. @claude  wrote the below and the code, but I had fun with this haha.**

In ethhash mode, an account branch with exactly one storage child is hashed using the "fake root" trick documented in `storage/src/hashers/ethhash.rs`: the account-child nibble folds into the child's partial path, and the child is re-hashed as a standalone storage-trie root. Live hashing applies this in `nodestore::hash::hash_helper_inner`, but range/change proof verification did not — so when a range proof was truncated such that only a single storage child of an account remained visible, the computed root mismatched the on-disk root and verification spuriously failed with `UnexpectedHash`.

This surfaces on real C-Chain workloads any time a `range_proof` `limit` lands inside an account whose storage subtree (post-truncation) collapses to a single child.

## How this works

- `compute_root_hash_with_proofs` now takes a `fake_root` flag. Before recursing into each branch child, `single_effective_account_child` checks whether the parent is a depth-64 (account) branch whose in-range live children plus outside-range proof-node children together resolve to exactly one child; if so, that one child is recursed into with `fake_root = true`.
- The new `hash_proof_node_parts` helper centralizes the leaf/branch hash construction and, when `fake_root` is set, splits the last nibble off `path_prefix` and folds it into the partial path via `JoinedPath` before hashing — exactly mirroring `hash_helper_inner`'s `fake_root_extra_nibble` path.
- `Proof::verify` does the analogous rewrite on the linear proof walk: after stepping through a depth-64 node whose own child mask is a singleton, the next proof node is hashed via `proof_node_hash(..., fake_root = true)`. The `is_single_child_account_node` predicate counts the node's own children directly because the proof walk sees the authoritative child mask at each step (no range-visibility bookkeeping needed, unlike the recursive computation above).
- Both behaviors are `#[cfg(feature = "ethhash")]`-gated; in non-ethhash builds `fake_root` is threaded through but never set, and the hash math is byte-identical to before.

## How this was tested

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings` (no features and `--features ethhash,logger`)
- `cargo doc --no-deps --workspace --features ethhash,logger`
- Two new range-proof regression tests in `firewood/src/merkle/tests/ethhash.rs`:
  - `test_limit_truncated_range_proof_inside_single_storage_child_account` — limit lands inside an account with one storage slot; verifies both the live proof and a serialization round-trip.
  - `test_limit_truncated_range_proof_inside_multi_storage_child_account` — limit lands inside an account with two storage slots, confirming the fake-root rewrite does *not* kick in when it shouldn't.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
