### PR TITLE
fix(ffi): avoid false close error and stranded lease on panic

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -485,9 +485,10 @@ type closeConfig struct {
 // [RangeProof.Free] before Close can complete.
 //
 // Each handle is dropped once even if its underlying free errors, so a
-// failing free cannot stall the close. Any drop errors are joined and
-// returned, and the underlying database close is still attempted on a
-// best-effort basis.
+// failing free cannot stall the close. Drops run sequentially under each
+// handle's lock, so an in-flight reader can delay the close past the
+// deadline. Drop errors are joined and returned, and the database close
+// is still attempted on a best-effort basis.
 //
 // While force-close is in progress, attempts to construct derived handles
 // (for example via [Proposal.Propose] or [Revision.Iter]) fail with an
@@ -538,16 +539,11 @@ func (db *Database) Close(ctx context.Context, opts ...CloseOption) error {
 	var forcedDropErr error
 	if cfg.forceCloseHandles {
 		forcedDropErr = db.keepAlives.closeAndForceDrop(ctx)
-		if ctx.Err() != nil {
-			// Force-drop bailed early because ctx expired. The registry
-			// may still contain live handles, so calling fwd_close_db
-			// would free the Db out from under their Rust-side
-			// counterparts. Surface the error and leave the Db open;
-			// the caller can retry Close with a fresh context.
-			return errors.Join(forcedDropErr, fmt.Errorf("%w: %w", ErrActiveKeepAliveHandles, ctx.Err()))
-		}
 	}
 
+	// waitForKeepAlives decides whether handles remain: nil once the count
+	// drains (even if ctx is already cancelled), ErrActiveKeepAliveHandles
+	// otherwise.
 	if err := db.waitForKeepAlives(ctx); err != nil {
 		// Graceful path: bookkeeping says handles are still live. Don't
 		// touch fwd_close_db — we'd be freeing the Db out from under

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -1659,17 +1659,34 @@ func TestCloseForceDropsOutstandingHandles(t *testing.T) {
 	// Force close should succeed even though nothing was dropped.
 	r.NoError(db.Close(oneSecCtx(t), WithForceCloseHandles()))
 
-	// All handles should now report as dropped on subsequent use.
-	_, err = proposal.Get([]byte("k"))
-	r.ErrorIs(err, errDroppedProposal)
-	_, err = revision.Get([]byte("k"))
-	r.ErrorIs(err, ErrDroppedRevision)
-	_, err = reconstructed.Get([]byte("k"))
-	r.ErrorIs(err, ErrDroppedReconstructed)
-	r.False(revIter.Next())
-	r.ErrorIs(revIter.Err(), errDroppedIterator)
-	r.False(propIter.Next())
-	r.ErrorIs(propIter.Err(), errDroppedIterator)
+	type view interface {
+		Get([]byte) ([]byte, error)
+	}
+	tests := []struct {
+		name   string
+		handle view
+		want   error
+	}{
+		{"proposal", proposal, errDroppedProposal},
+		{"revision", revision, ErrDroppedRevision},
+		{"reconstructed", reconstructed, ErrDroppedReconstructed},
+	}
+	for _, tc := range tests {
+		_, got := tc.handle.Get([]byte("k"))
+		r.ErrorIs(got, tc.want, tc.name)
+	}
+
+	iters := []struct {
+		name string
+		it   *Iterator
+	}{
+		{"revIter", revIter},
+		{"propIter", propIter},
+	}
+	for _, tc := range iters {
+		r.False(tc.it.Next(), tc.name)
+		r.ErrorIs(tc.it.Err(), errDroppedIterator, tc.name)
+	}
 }
 
 // TestCloseForceWithCancelledContextThenRetry verifies the retry path
@@ -1781,6 +1798,208 @@ func TestCloseForceDropsConcurrentReader(t *testing.T) {
 	if iterErr != nil {
 		r.ErrorIs(iterErr, errDroppedIterator)
 	}
+}
+
+// TestCloseForceNoHandlesCancelledCtx checks that force-close with no
+// outstanding handles succeeds even under an already-cancelled context.
+func TestCloseForceNoHandlesCancelledCtx(t *testing.T) {
+	db, err := newDatabase(t.TempDir())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.NoError(t, db.Close(ctx, WithForceCloseHandles()))
+}
+
+// TestLeaseReleaseRecoversPanic checks that a panic in the release callback
+// still drops the lease and re-raises, so a panicking free cannot block Close.
+func TestLeaseReleaseRecoversPanic(t *testing.T) {
+	reg := newKeepAliveRegistry()
+
+	var l lease
+	require.NoError(t, l.attach(reg, func() error { return nil }))
+	require.Equal(t, 1, reg.count)
+
+	const panicVal = "boom"
+	func() {
+		defer func() {
+			require.Equal(t, panicVal, recover())
+		}()
+		_ = l.release(true, func() error {
+			panic(panicVal)
+		})
+	}()
+
+	require.Zero(t, reg.count, "lease must be released even when the callback panics")
+}
+
+// TestKeepAliveRegistryAttachAfterClose checks that attaching to a closed
+// registry runs the drop callback, returns errDBClosed, and leaves the count
+// unchanged. The callback's own error is joined when present.
+func TestKeepAliveRegistryAttachAfterClose(t *testing.T) {
+	freeErr := errors.New("free failed")
+	tests := []struct {
+		name    string
+		dropErr error
+	}{
+		{"drop succeeds", nil},
+		{"drop fails", freeErr},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := newKeepAliveRegistry()
+			require.NoError(t, reg.closeAndForceDrop(t.Context()))
+
+			var (
+				l       lease
+				dropped bool
+			)
+			err := l.attach(reg, func() error {
+				dropped = true
+				return tc.dropErr
+			})
+			require.ErrorIs(t, err, errDBClosed)
+			if tc.dropErr != nil {
+				require.ErrorIs(t, err, tc.dropErr)
+			}
+			require.True(t, dropped, "attach must run the drop callback on a closed registry")
+			require.Zero(t, reg.count, "attach must not increment count on a closed registry")
+		})
+	}
+}
+
+// TestIteratorFreesImplicitly checks that an undropped iterator is released by
+// its finalizer, unblocking Close. Covered on its own because Iterator has a
+// distinct AddCleanup wiring (iteratorCleanup bound to the inner handle).
+func TestIteratorFreesImplicitly(t *testing.T) {
+	db, err := newDatabase(t.TempDir())
+	require.NoError(t, err)
+
+	_, err = db.Update([]BatchOp{Put(keyForTest(1), valForTest(1))})
+	require.NoError(t, err)
+	rev, err := db.LatestRevision()
+	require.NoError(t, err)
+	it, err := rev.Iter(nil)
+	require.NoError(t, err)
+	// Drop the revision so the iterator is the only outstanding handle.
+	require.NoError(t, rev.Drop())
+
+	done := make(chan struct{})
+	go func() {
+		require.NoError(t, db.Close(oneSecCtx(t)))
+		close(done)
+	}()
+
+	// Close must block while the iterator is still reachable.
+	select {
+	case <-done:
+		require.FailNow(t, "Close returned while the iterator was still reachable")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	// Drop the only reference and let the finalizer release the iterator.
+	runtime.KeepAlive(it)
+	it = nil //nolint:ineffassign // drop the reference so GC can reap it
+	runtime.GC()
+
+	<-done
+}
+
+// TestReconstructedFreesImplicitly checks that an undropped reconstructed view
+// is released by its finalizer, unblocking Close.
+func TestReconstructedFreesImplicitly(t *testing.T) {
+	db, err := newDatabase(t.TempDir())
+	require.NoError(t, err)
+
+	_, _, batch := kvForTest(2)
+	root, err := db.Update(batch[:1])
+	require.NoError(t, err)
+	rev, err := db.Revision(root)
+	require.NoError(t, err)
+	recon, err := rev.Reconstruct(batch[1:2])
+	require.NoError(t, err)
+	// Drop the revision so the reconstructed view is the only outstanding handle.
+	require.NoError(t, rev.Drop())
+
+	done := make(chan struct{})
+	go func() {
+		require.NoError(t, db.Close(oneSecCtx(t)))
+		close(done)
+	}()
+
+	// Close must block while the reconstructed view is still reachable.
+	select {
+	case <-done:
+		require.FailNow(t, "Close returned while the reconstructed view was still reachable")
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	// Drop the only reference and let the finalizer release the view.
+	runtime.KeepAlive(recon)
+	recon = nil //nolint:ineffassign // drop the reference so GC can reap it
+	runtime.GC()
+
+	<-done
+}
+
+// TestCloseForceDoesNotDropRangeProof pins the documented limitation that
+// force-close does not auto-drop a verified RangeProof. The proof is counted
+// but not in the drop map, so Close blocks until the proof is freed.
+func TestCloseForceDoesNotDropRangeProof(t *testing.T) {
+	db := newTestDatabase(t)
+	_, _, batch := kvForTest(50)
+	root, err := db.Update(batch)
+	require.NoError(t, err)
+
+	proof := newVerifiedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenTruncated)
+	require.NoError(t, db.VerifyRangeProof(proof, nothing(), nothing(), root, rangeProofLenTruncated))
+
+	require.ErrorIs(t,
+		db.Close(oneSecCtx(t), WithForceCloseHandles()),
+		ErrActiveKeepAliveHandles,
+		"force-close must not auto-drop a verified RangeProof",
+	)
+
+	// Freeing the proof releases the count and unblocks Close.
+	require.NoError(t, proof.Free())
+	require.NoError(t, db.Close(oneSecCtx(t), WithForceCloseHandles()))
+}
+
+// TestCloseAndForceDropPartialThenRetry exercises the partial-drain path: a
+// context that cancels mid-drain leaves the rest registered, and a retry with a
+// fresh context drains them. Driven at the registry level for determinism.
+func TestCloseAndForceDropPartialThenRetry(t *testing.T) {
+	reg := newKeepAliveRegistry()
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	const n = 3
+	var dropped int
+	for range n {
+		l := &lease{}
+		require.NoError(t, l.attach(reg, func() error {
+			return l.release(true, func() error {
+				dropped++
+				// Cancel after the first drop so closeAndForceDrop stops with
+				// the remaining leases still registered.
+				cancel()
+				return nil
+			})
+		}))
+	}
+	require.Equal(t, n, reg.count)
+
+	// First pass drops one handle, then bails on the cancelled context.
+	require.NoError(t, reg.closeAndForceDrop(ctx))
+	require.Equal(t, 1, dropped, "only one handle drops before ctx cancels")
+	require.Equal(t, n-1, reg.count, "remaining handles stay registered")
+	require.True(t, reg.closed, "registry stays closed across the partial drain")
+
+	// Retry with a fresh context drains the rest.
+	require.NoError(t, reg.closeAndForceDrop(t.Context()))
+	require.Equal(t, n, dropped)
+	require.Zero(t, reg.count)
 }
 
 func TestDump(t *testing.T) {

--- a/ffi/iterator.go
+++ b/ffi/iterator.go
@@ -31,10 +31,11 @@ import (
 // forget to Drop. With the iterator-specific state owned by this inner
 // type, the registry's dropFn is bound to *iteratorHandle, the wrapper is
 // independently reclaimable, and the cleanup path works as advertised.
+
 // freer is the contract for an FFI-owned pair or batch returned by
 // fwd_iter_next / fwd_iter_next_n: a single free() that releases the
 // underlying Rust allocation. The concrete types are [ownedKeyValue]
-// and [ownedKeyValueBatch], both file-private to the FFI package.
+// and [ownedKeyValueBatch], both unexported in the ffi package.
 type freer interface {
 	free() error
 }
@@ -74,14 +75,14 @@ func (ih *iteratorHandle) Drop() error {
 		if ih.dropped {
 			return err
 		}
-		// Always free the iterator even if releasing the current KV/batch
-		// failed. The iterator holds a NodeStore ref that must be released.
-		if e := getErrorFromVoidResult(ih.free(ih.ptr)); e != nil {
+		// Mark dropped before freeing so a panic in free cannot leave a
+		// retry able to double-free ptr.
+		ptr := ih.ptr
+		ih.ptr = nil
+		ih.dropped = true
+		if e := getErrorFromVoidResult(ih.free(ptr)); e != nil {
 			err = errors.Join(err, fmt.Errorf("%w: %w", errFreeingValue, e))
 		}
-		var zero *C.IteratorHandle
-		ih.ptr = zero
-		ih.dropped = true
 		return err
 	})
 }
@@ -109,6 +110,10 @@ func iteratorCleanup(ih *iteratorHandle) {
 // the key and value into Go-managed memory. [Iterator.NextBorrowed] returns slices
 // that borrow Rust-owned memory, which is faster but the slices are only valid until
 // the next call to Next, NextBorrowed, or [Iterator.Drop].
+//
+// An Iterator is single-reader: Next, NextBorrowed, Key, Value, and Err must
+// not be called concurrently. Drop is the exception and is safe from another
+// goroutine, including force-close.
 type Iterator struct {
 	// iteratorHandle owns the Rust iterator pointer, the keep-alive handle on
 	// the parent database, and the currently-borrowed FFI batch/KV. Calls
@@ -223,7 +228,6 @@ func (it *Iterator) NextBorrowed() bool {
 	}
 	it.currentKey = it.currentPair.key.BorrowedBytes()
 	it.currentValue = it.currentPair.value.BorrowedBytes()
-	it.err = nil
 	return true
 }
 

--- a/ffi/keepalive.go
+++ b/ffi/keepalive.go
@@ -10,6 +10,7 @@ import "C"
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 )
 
@@ -88,7 +89,7 @@ func (h *handle[T]) Drop() error {
 		h.dropped = true
 
 		if err := getErrorFromVoidResult(h.free(ptr)); err != nil {
-			return errors.Join(errFreeingValue, err)
+			return fmt.Errorf("%w: %w", errFreeingValue, err)
 		}
 		return nil
 	})
@@ -140,9 +141,9 @@ func newKeepAliveRegistry() *keepAliveRegistry {
 // waiters are released. Called from [lease.releaseLocked] on disown.
 func (r *keepAliveRegistry) removeAndDecr(l *lease) {
 	r.mu.Lock()
+	defer r.mu.Unlock()
 	delete(r.handles, l)
 	r.decrLocked()
-	r.mu.Unlock()
 }
 
 // decrLocked decrements the outstanding-handle count and releases any
@@ -339,11 +340,19 @@ func (l *lease) attachUnregistered(registry *keepAliveRegistry) {
 // Safe to call multiple times; subsequent calls after the first continue
 // to invoke attemptDisown but do not double-decrement the count unless
 // [attach] or [attachUnregistered] runs again in between.
-func (l *lease) release(releaseOnError bool, attemptDisown func() error) error {
+func (l *lease) release(releaseOnError bool, attemptDisown func() error) (err error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	err := attemptDisown()
+	// Release on panic too, so a panicking callback cannot strand the
+	// lease and block Close forever.
+	defer func() {
+		if p := recover(); p != nil {
+			l.releaseLocked()
+			panic(p)
+		}
+	}()
+	err = attemptDisown()
 	if err == nil || releaseOnError {
 		l.releaseLocked()
 	}

--- a/ffi/memory.go
+++ b/ffi/memory.go
@@ -169,7 +169,7 @@ func (b *ownedBytes) Free() error {
 	}
 
 	if err := getErrorFromVoidResult(C.fwd_free_owned_bytes(b.owned)); err != nil {
-		return errors.Join(errFreeingValue, err)
+		return fmt.Errorf("%w: %w", errFreeingValue, err)
 	}
 
 	b.owned = C.OwnedBytes{}
@@ -310,7 +310,7 @@ func getValueFromValueResult(result C.ValueResult) ([]byte, error) {
 		ownedBytes := newOwnedBytes(*(*C.OwnedBytes)(unsafe.Pointer(&result.anon0)))
 		bytes := ownedBytes.CopiedBytes()
 		if err := ownedBytes.Free(); err != nil {
-			return nil, errors.Join(errFreeingValue, err)
+			return nil, fmt.Errorf("%w: %w", errFreeingValue, err)
 		}
 		return bytes, nil
 	case C.ValueResult_Err:
@@ -352,7 +352,7 @@ func (b *ownedKeyValueBatch) free() error {
 	}
 
 	if err := getErrorFromVoidResult(C.fwd_free_owned_key_value_batch(b.owned)); err != nil {
-		return errors.Join(errFreeingValue, err)
+		return fmt.Errorf("%w: %w", errFreeingValue, err)
 	}
 
 	b.owned = C.OwnedKeyValueBatch{}
@@ -391,7 +391,7 @@ func (kv *ownedKeyValue) free() error {
 		return nil
 	}
 	if err := getErrorFromVoidResult(C.fwd_free_owned_kv_pair(kv.owned)); err != nil {
-		return errors.Join(errFreeingValue, err)
+		return fmt.Errorf("%w: %w", errFreeingValue, err)
 	}
 	// zero out fields to avoid accidental reuse/double free
 	kv.owned = C.OwnedKeyValuePair{}

--- a/ffi/metrics.go
+++ b/ffi/metrics.go
@@ -16,7 +16,6 @@ package ffi
 import "C"
 
 import (
-	"errors"
 	"fmt"
 	"runtime"
 	"unsafe"
@@ -88,7 +87,7 @@ func gatherFromRust() ([]*dto.MetricFamily, error) {
 		owned := *(*C.OwnedRenderedMetrics)(unsafe.Pointer(&result.anon0))
 		families := convertRenderedMetrics(owned)
 		if freeErr := getErrorFromVoidResult(C.fwd_free_rendered_metrics(owned)); freeErr != nil {
-			return nil, errors.Join(errFreeingValue, freeErr)
+			return nil, fmt.Errorf("%w: %w", errFreeingValue, freeErr)
 		}
 		return families, nil
 	case C.RenderedMetricsResult_Err:

--- a/ffi/proposal.go
+++ b/ffi/proposal.go
@@ -138,7 +138,7 @@ func (p *Proposal) Propose(batch []BatchOp) (*Proposal, error) {
 // operations that access it (such as [Database.Get] and [Database.Propose]) will
 // block until this function returns.
 func (p *Proposal) Commit() error {
-	return p.lease.release(true /* evenOnError */, func() error {
+	return p.lease.release(true /* releaseOnError */, func() error {
 		if p.dropped {
 			return errDroppedProposal
 		}
@@ -170,7 +170,7 @@ func (p *Proposal) Commit() error {
 // block until this function returns.
 func (p *Proposal) CommitWithRebase() (Hash, error) {
 	var hash Hash
-	err := p.lease.release(true /* evenOnError */, func() error {
+	err := p.lease.release(true /* releaseOnError */, func() error {
 		if p.dropped {
 			return errDroppedProposal
 		}

--- a/ffi/revision.go
+++ b/ffi/revision.go
@@ -166,7 +166,7 @@ func getRevisionFromResult(result C.RevisionResult, registry *keepAliveRegistry)
 		if err := rev.lease.attach(registry, rev.Drop); err != nil {
 			return nil, err
 		}
-		runtime.AddCleanup(rev, drop, rev.handle)
+		runtime.AddCleanup(rev, drop[*C.RevisionHandle], rev.handle)
 		return rev, nil
 	case C.RevisionResult_Err:
 		err := newOwnedBytes(*(*C.OwnedBytes)(unsafe.Pointer(&result.anon0))).intoError()


### PR DESCRIPTION
## Why this should be merged

Should be merged in #1976 or parts of it that resolve correctness issues and/or introduce better coverage for regressions.

## How this works

Resolve correctness issues found while reviewing the force-close work:

- `Database.Close` no longer returns `ErrActiveKeepAliveHandles` when force-closing with no live handles under an already-cancelled context. `waitForKeepAlives` is now the sole check for remaining handles and returns nil once the count drains, regardless of ctx state.
- `lease.release` releases the lease even when its callback panics, so a panicking free can no longer strand the lease and block `Close` forever.
- `iteratorHandle.Drop` marks the handle dropped before freeing, matching `handle[T].Drop`, so a panic in free cannot leave a retry able to double-free.
- `removeAndDecr` defers its unlock, matching `attachUnregistered` and preventing a stranded registry lock on panic.
- Restore `fmt.Errorf` for `errFreeingValue` wraps where the inner error is the cause rather than an independent error.
- Document the `Iterator` single-reader contract and that force-close does not auto-drop verified `RangeProof`s.

## How this was tested

Add tests for the force-close edge cases, panic-safe release, closed-registry attach, `Iterator`/`Reconstructed` finalizer back-stops, a live `RangeProof` under force-close, and partial-drain-then-retry.

## Breaking Changes
none

Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov@avalabs.org)