### PR TITLE
chore: bump go to 1.25.10

### DIFF
--- a/ffi/flake.lock
+++ b/ffi/flake.lock
@@ -39,17 +39,17 @@
       },
       "locked": {
         "dir": "nix/go",
-        "lastModified": 1773256574,
-        "narHash": "sha256-bZiyC/Y4LIBdp9RR93rJYqh3Ls+VZap5L0KNyjGo308=",
+        "lastModified": 1780000179,
+        "narHash": "sha256-bwDUHWy4bHO0xmmHPJgYVXIDeP90PQNRYovglGuLybU=",
         "owner": "ava-labs",
         "repo": "avalanchego",
-        "rev": "50585cbbdfe1af02a2c11bdc9fa77fca26e6b838",
+        "rev": "89ac856f87556f8dd38ed93530d10eb92210da35",
         "type": "github"
       },
       "original": {
         "dir": "nix/go",
         "owner": "ava-labs",
-        "ref": "50585cbbdfe1af02a2c11bdc9fa77fca26e6b838",
+        "ref": "89ac856f87556f8dd38ed93530d10eb92210da35",
         "repo": "avalanchego",
         "type": "github"
       }

--- a/ffi/flake.nix
+++ b/ffi/flake.nix
@@ -12,7 +12,7 @@
     rust-overlay.url = "github:oxalica/rust-overlay?ref=40e6ccc06e1245a4837cbbd6bdda64e21cc67379";
     crane.url = "github:ipetkov/crane";
     flake-utils.url = "github:numtide/flake-utils";
-    golang.url = "github:ava-labs/avalanchego?dir=nix/go&ref=50585cbbdfe1af02a2c11bdc9fa77fca26e6b838";
+    golang.url = "github:ava-labs/avalanchego?dir=nix/go&ref=89ac856f87556f8dd38ed93530d10eb92210da35";
   };
 
   outputs = { self, nixpkgs, rust-overlay, crane, flake-utils, golang }:

--- a/ffi/go.mod
+++ b/ffi/go.mod
@@ -4,7 +4,7 @@ module github.com/ava-labs/firewood/ffi
 //   - ffi/go.mod (here)
 //   - ffi/tests/eth/go.mod
 //   - ffi/tests/firewood/go.mod
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/prometheus/client_golang v1.22.0

--- a/ffi/tests/eth/go.mod
+++ b/ffi/tests/eth/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/firewood/ffi/tests/eth
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.0 // this is replaced to use the parent folder

--- a/ffi/tests/firewood/go.mod
+++ b/ffi/tests/firewood/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/firewood/ffi/tests/firewood
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/ava-labs/firewood-go/ffi v0.0.0 // this is replaced to use the parent folder


### PR DESCRIPTION
## Why this should be merged

Bumps go version to `1.25.10`, keeping in line with the version currently used in AvalancheGo.

## How this works

Bumps version of go in `go.mod` + updates Nix flake.

## How this was tested

CI; used https://github.com/ava-labs/firewood/pull/1775 as a reference

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
