### PR TITLE
chore: add 33m-33.5m benchmark

### DIFF
--- a/.github/workflows/track-performance.yml
+++ b/.github/workflows/track-performance.yml
@@ -7,6 +7,8 @@ on:
     # These cron expressions are matched exactly in configure-benchmark to set parameters
     # Weekdays at 05:00 UTC (00:00 ET) - 1M blocks: 40M → 41M
     - cron: '0 5 * * 1-5'
+    # Weekdays at 05:05 UTC - 500k blocks: 33M -> 33.5M
+    - cron: '5 5 * * 1-5'
   workflow_dispatch:
     inputs:
       firewood:
@@ -83,6 +85,12 @@ jobs:
                 echo "::notice::Schedule: daily-40m-41m"
                 echo "name=daily-40m-41m" >> "$GITHUB_OUTPUT"
                 echo "test=firewood-40m-41m" >> "$GITHUB_OUTPUT"
+                echo "timeout-minutes=720" >> "$GITHUB_OUTPUT"
+                ;;
+              "5 5 * * 1-5")  # Weekdays at 05:05 UTC: firewood-33m-33m500k
+                echo "::notice::Schedule: daily-33m-33m500k"
+                echo "name=daily-33m-33m500k" >> "$GITHUB_OUTPUT"
+                echo "test=firewood-33m-33m500k" >> "$GITHUB_OUTPUT"
                 echo "timeout-minutes=720" >> "$GITHUB_OUTPUT"
                 ;;
               *)

--- a/benchmark/docs/cchain-reexecution.md
+++ b/benchmark/docs/cchain-reexecution.md
@@ -137,6 +137,7 @@ For long tests, trigger directly:
 | Schedule | Test | ~Duration |
 | --- | --- | --- |
 | Weekdays 05:00 UTC | `firewood-40m-41m` (blocks 40M–41M) | <2h |
+| Weekdays 05:05 UTC | `firewood-33m-33m500k` (blocks 33M–33.5M) | <2h |
 
 ## Finding S3 Data
 


### PR DESCRIPTION
## Why this should be merged

AvalancheGo uses the 33m-33.5m block range for their reexecution tests. We should stick to this standard as it allows us to compare the performance of Firewood to HashDB and PathDB (assuming the mismatched GH runner types get fixed in a follow-up PR). 

Existing `firewood-33m-33m500k` test: https://github.com/ava-labs/avalanchego/blob/89ac856f87556f8dd38ed93530d10eb92210da35/scripts/benchmark_cchain_range.sh#L78

## How this was tested

CI.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
