### PR TITLE
fix(proofs): correct ethhash range/change proof verification

### DIFF
--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -30,6 +30,10 @@ use firewood_storage::{
     NibblesIterator, Node, NodeStore, Path, PathBuf, PathComponent, Propose, ReadableStorage,
     SharedNode, TrieHash, TrieReader, U4, ValueDigest,
 };
+#[cfg(feature = "ethhash")]
+use firewood_storage::{
+    hash_node_as_storage_trie_root_for_node, hash_node_as_storage_trie_root_parts,
+};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
@@ -364,14 +368,33 @@ fn compute_outside_children(
 /// are hashed recursively. Persisted children (`AddressWithHash`,
 /// `MaybePersisted`) already carry their hash and are used directly.
 /// Out-of-range children get their hash from the corresponding proof node.
+///
+/// `fake_root` is set by the parent when this node is the single storage
+/// child of an account at depth 64; its hash must be computed as a
+/// standalone storage-trie root via the shared fold helper, matching what
+/// live hashing did when the node was first written.
 fn compute_root_hash_with_proofs(
     node: &Node,
     path_prefix: &[PathComponent],
     proof_nodes: &HashMap<PathBuf, &ProofNode>,
     outside_children: &HashMap<PathBuf, ChildMask>,
-) -> HashType {
+    #[cfg(feature = "ethhash")] fake_root: bool,
+) -> Result<HashType, ProofError> {
     let branch = match node {
-        Node::Leaf(_) => return HashableShunt::from_node(path_prefix, node).to_hash(),
+        Node::Leaf(_) => {
+            #[cfg(feature = "ethhash")]
+            if fake_root {
+                let (branch_nibble, account_prefix) = path_prefix
+                    .split_last()
+                    .ok_or(ProofError::InvalidStorageTrieRootPath)?;
+                return Ok(hash_node_as_storage_trie_root_for_node(
+                    account_prefix,
+                    *branch_nibble,
+                    node,
+                ));
+            }
+            return Ok(HashableShunt::from_node(path_prefix, node).to_hash());
+        }
         Node::Branch(branch) => branch,
     };
 
@@ -382,9 +405,14 @@ fn compute_root_hash_with_proofs(
         .copied()
         .collect();
 
-    let mut child_hashes: Children<Option<HashType>> = Children::new();
-
     let outside_mask = outside_children.get(&full_key);
+    let proof_node = proof_nodes.get(&full_key);
+
+    #[cfg(feature = "ethhash")]
+    let single_storage_child =
+        single_effective_account_child(&full_key, branch, proof_node.copied(), outside_mask);
+
+    let mut child_hashes: Children<Option<HashType>> = Children::new();
 
     // For children inside the proven range, compute hashes recursively.
     // For children outside the range, use proof node hashes (set below).
@@ -404,15 +432,30 @@ fn compute_root_hash_with_proofs(
             unreachable!()
         };
         child_prefix.push(nibble);
-        let child_hash =
-            compute_root_hash_with_proofs(child_node, &child_prefix, proof_nodes, outside_children);
+        #[cfg(feature = "ethhash")]
+        let child_hash = compute_root_hash_with_proofs(
+            child_node,
+            &child_prefix,
+            proof_nodes,
+            outside_children,
+            // Apply the storage-trie-root fold iff this child is the
+            // account's lone storage child.
+            single_storage_child == Some(nibble),
+        )?;
+        #[cfg(not(feature = "ethhash"))]
+        let child_hash = compute_root_hash_with_proofs(
+            child_node,
+            &child_prefix,
+            proof_nodes,
+            outside_children,
+        )?;
         child_hashes[nibble] = Some(child_hash);
         child_prefix.pop();
     }
 
     // For children outside the proven range, use proof node hashes.
-    if let (Some(proof_node), Some(outside)) = (proof_nodes.get(&full_key), outside_mask) {
-        for (nibble, hash) in proof_node.child_hashes.iter_present() {
+    if let (Some(pn), Some(outside)) = (proof_node, outside_mask) {
+        for (nibble, hash) in pn.child_hashes.iter_present() {
             if outside.is_set(nibble.0) {
                 child_hashes[nibble] = Some(hash.clone());
             }
@@ -425,18 +468,79 @@ fn compute_root_hash_with_proofs(
     // hash chain was verified by `value_digest()` during boundary proof
     // validation, and `reconcile_branch_proof_node` verified the hash
     // against the branch value when present. The digest is trusted.
-    let value_digest = branch.value.as_deref().map(ValueDigest::Value).or_else(|| {
-        proof_nodes
-            .get(&full_key)
-            .and_then(|pn| pn.value_digest.as_ref().map(ValueDigest::as_ref))
-    });
-    HashableShunt::new(
+    let value_digest =
+        branch.value.as_deref().map(ValueDigest::Value).or_else(|| {
+            proof_node.and_then(|pn| pn.value_digest.as_ref().map(ValueDigest::as_ref))
+        });
+
+    #[cfg(feature = "ethhash")]
+    if fake_root {
+        let (branch_nibble, account_prefix) = path_prefix
+            .split_last()
+            .ok_or(ProofError::InvalidStorageTrieRootPath)?;
+        return Ok(hash_node_as_storage_trie_root_parts(
+            account_prefix,
+            *branch_nibble,
+            branch.partial_path.as_components(),
+            value_digest,
+            child_hashes,
+        ));
+    }
+
+    Ok(HashableShunt::new(
         path_prefix,
         branch.partial_path.as_components(),
         value_digest,
         child_hashes,
     )
-    .to_hash()
+    .to_hash())
+}
+
+/// At a depth-64 account branch, return the slot of the single effective
+/// storage child (the fake-root case live hashing applies), or `None`.
+///
+/// An "effective" child is either an in-range branch child or an
+/// out-of-range child carried by the proof node — together they reflect
+/// the true on-disk shape. Proof verification only; live hashing has its
+/// own detection in `hash_helper_inner`.
+#[cfg(feature = "ethhash")]
+fn single_effective_account_child(
+    full_key: &[PathComponent],
+    branch: &BranchNode,
+    proof_node: Option<&ProofNode>,
+    outside_mask: Option<&ChildMask>,
+) -> Option<PathComponent> {
+    if full_key.len() != 64 {
+        return None;
+    }
+
+    let mut only_child: Option<PathComponent> = None;
+    let mut set_one = |nibble: PathComponent| -> Result<(), ()> {
+        if only_child.is_some() {
+            Err(())
+        } else {
+            only_child = Some(nibble);
+            Ok(())
+        }
+    };
+
+    // In-range branch children (those NOT marked as outside).
+    for (nibble, child) in &branch.children {
+        let in_range = !outside_mask.is_some_and(|m| m.is_set(nibble.0));
+        if child.is_some() && in_range && set_one(nibble).is_err() {
+            return None;
+        }
+    }
+    // Out-of-range children, taken from the proof node.
+    if let (Some(pn), Some(mask)) = (proof_node, outside_mask) {
+        for (nibble, _) in pn.child_hashes.iter_present() {
+            if mask.is_set(nibble.0) && set_one(nibble).is_err() {
+                return None;
+            }
+        }
+    }
+
+    only_child
 }
 
 /// Reject any proof node that carries a value digest (either
@@ -892,8 +996,12 @@ fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
         return Err(api::Error::ProofError(ProofError::Empty));
     };
 
+    #[cfg(feature = "ethhash")]
     let computed =
-        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children);
+        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children, false)?;
+    #[cfg(not(feature = "ethhash"))]
+    let computed =
+        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children)?;
 
     if computed != root_hash.clone().into_hash_type() {
         return Err(api::Error::ProofError(ProofError::UnexpectedHash));
@@ -1081,8 +1189,12 @@ pub fn verify_change_proof_root_hash(
         .root()
         .expect("a non-empty proof reconciliation always leaves behind a root node");
 
+    #[cfg(feature = "ethhash")]
     let computed =
-        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children);
+        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children, false)?;
+    #[cfg(not(feature = "ethhash"))]
+    let computed =
+        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children)?;
 
     if computed != verification.end_root.clone().into_hash_type() {
         return Err(api::Error::ProofError(ProofError::EndRootMismatch));

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -19,6 +19,8 @@ use crate::api::{
 use crate::iter::{MerkleKeyValueIter, PathIterator};
 use crate::merkle::changes::DiffMerkleNodeStream;
 use crate::proofs::change::ChangeProof;
+#[cfg(feature = "ethhash")]
+use crate::proofs::eth::ACCOUNT_DEPTH_NIBBLES;
 use crate::{
     ChangeProofVerificationContext, Proof, ProofCollection, ProofError, ProofNode, RangeProof,
 };
@@ -510,7 +512,7 @@ fn single_effective_account_child(
     proof_node: Option<&ProofNode>,
     outside_mask: Option<&ChildMask>,
 ) -> Option<PathComponent> {
-    if full_key.len() != 64 {
+    if full_key.len() != ACCOUNT_DEPTH_NIBBLES {
         return None;
     }
 

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -363,43 +363,96 @@ fn compute_outside_children(
     Ok(result)
 }
 
-/// Recursively computes the hash of a node in the proving trie, merging
-/// child hashes from proof nodes for subtrees outside the proven range.
+/// Compute the hash of a node in the proving trie, merging child hashes
+/// from proof nodes for subtrees outside the proven range.
 ///
 /// For branch nodes, in-range children that are in-memory (`Child::Node`)
 /// are hashed recursively. Persisted children (`AddressWithHash`,
 /// `MaybePersisted`) already carry their hash and are used directly.
 /// Out-of-range children get their hash from the corresponding proof node.
 ///
-/// `fake_root` is set by the parent when this node is the single storage
-/// child of an account at depth 64; its hash must be computed as a
-/// standalone storage-trie root via the shared fold helper, matching what
-/// live hashing did when the node was first written.
+/// Hashes the node as a normal trie node. Under `ethhash`, when this node
+/// is the single storage child of an account at depth 64, the parent
+/// instead invokes `compute_root_hash_as_storage_trie_root` to apply the
+/// storage-trie-root fold.
 fn compute_root_hash_with_proofs(
     node: &Node,
     path_prefix: &[PathComponent],
     proof_nodes: &HashMap<PathBuf, &ProofNode>,
     outside_children: &HashMap<PathBuf, ChildMask>,
-    #[cfg(feature = "ethhash")] fake_root: bool,
 ) -> Result<HashType, ProofError> {
-    let branch = match node {
-        Node::Leaf(_) => {
-            #[cfg(feature = "ethhash")]
-            if fake_root {
-                let (branch_nibble, account_prefix) = path_prefix
-                    .split_last()
-                    .ok_or(ProofError::InvalidStorageTrieRootPath)?;
-                return Ok(hash_node_as_storage_trie_root_for_node(
-                    account_prefix,
-                    *branch_nibble,
-                    node,
-                ));
-            }
-            return Ok(HashableShunt::from_node(path_prefix, node).to_hash());
+    match node {
+        Node::Leaf(_) => Ok(HashableShunt::from_node(path_prefix, node).to_hash()),
+        Node::Branch(branch) => {
+            let parts = build_branch_parts(branch, path_prefix, proof_nodes, outside_children)?;
+            Ok(HashableShunt::new(
+                path_prefix,
+                parts.partial_path,
+                parts.value_digest,
+                parts.child_hashes,
+            )
+            .to_hash())
         }
-        Node::Branch(branch) => branch,
-    };
+    }
+}
 
+/// Compute the hash of a node as a standalone storage-trie root, applying
+/// the account-branch-nibble fold. Invoked by the parent at depth-64
+/// account boundaries when this node is the account's lone storage child;
+/// the fold matches what live hashing produced when the storage trie was
+/// first written.
+#[cfg(feature = "ethhash")]
+fn compute_root_hash_as_storage_trie_root(
+    node: &Node,
+    account_prefix: &[PathComponent],
+    branch_nibble: PathComponent,
+    proof_nodes: &HashMap<PathBuf, &ProofNode>,
+    outside_children: &HashMap<PathBuf, ChildMask>,
+) -> Result<HashType, ProofError> {
+    match node {
+        Node::Leaf(_) => Ok(hash_node_as_storage_trie_root_for_node(
+            account_prefix,
+            branch_nibble,
+            node,
+        )),
+        Node::Branch(branch) => {
+            let path_prefix: PathBuf = account_prefix
+                .iter()
+                .copied()
+                .chain(once(branch_nibble))
+                .collect();
+            let parts = build_branch_parts(branch, &path_prefix, proof_nodes, outside_children)?;
+            Ok(hash_node_as_storage_trie_root_parts(
+                account_prefix,
+                branch_nibble,
+                parts.partial_path,
+                parts.value_digest,
+                parts.child_hashes,
+            ))
+        }
+    }
+}
+
+/// Hashable parts of a branch node assembled by `build_branch_parts`. The
+/// caller applies the final hash via either `HashableShunt::new` (normal)
+/// or `hash_node_as_storage_trie_root_parts` (the single-storage-child
+/// fold used at depth-64 account boundaries under `ethhash`).
+struct BranchParts<'b> {
+    partial_path: &'b [PathComponent],
+    value_digest: Option<ValueDigest<&'b [u8]>>,
+    child_hashes: Children<Option<HashType>>,
+}
+
+/// Recursive worker for the two `compute_root_hash_with_proofs` entry
+/// points. Walks `branch`'s children (recursing into in-range subtrees,
+/// copying proof-node hashes for out-of-range slots) and returns the parts
+/// the caller needs to hash this node by either terminal helper.
+fn build_branch_parts<'b>(
+    branch: &'b BranchNode,
+    path_prefix: &[PathComponent],
+    proof_nodes: &HashMap<PathBuf, &'b ProofNode>,
+    outside_children: &HashMap<PathBuf, ChildMask>,
+) -> Result<BranchParts<'b>, ProofError> {
     // Build full key for this node: path_prefix ++ partial_path
     let full_key: PathBuf = path_prefix
         .iter()
@@ -435,15 +488,20 @@ fn compute_root_hash_with_proofs(
         };
         child_prefix.push(nibble);
         #[cfg(feature = "ethhash")]
-        let child_hash = compute_root_hash_with_proofs(
-            child_node,
-            &child_prefix,
-            proof_nodes,
-            outside_children,
-            // Apply the storage-trie-root fold iff this child is the
-            // account's lone storage child.
-            single_storage_child == Some(nibble),
-        )?;
+        let child_hash = if single_storage_child == Some(nibble) {
+            // Apply the storage-trie-root fold for the account's lone
+            // storage child; the dispatch lives here at the parent so the
+            // child's recursive call doesn't need to carry a flag.
+            compute_root_hash_as_storage_trie_root(
+                child_node,
+                &full_key,
+                nibble,
+                proof_nodes,
+                outside_children,
+            )?
+        } else {
+            compute_root_hash_with_proofs(child_node, &child_prefix, proof_nodes, outside_children)?
+        };
         #[cfg(not(feature = "ethhash"))]
         let child_hash = compute_root_hash_with_proofs(
             child_node,
@@ -475,27 +533,11 @@ fn compute_root_hash_with_proofs(
             proof_node.and_then(|pn| pn.value_digest.as_ref().map(ValueDigest::as_ref))
         });
 
-    #[cfg(feature = "ethhash")]
-    if fake_root {
-        let (branch_nibble, account_prefix) = path_prefix
-            .split_last()
-            .ok_or(ProofError::InvalidStorageTrieRootPath)?;
-        return Ok(hash_node_as_storage_trie_root_parts(
-            account_prefix,
-            *branch_nibble,
-            branch.partial_path.as_components(),
-            value_digest,
-            child_hashes,
-        ));
-    }
-
-    Ok(HashableShunt::new(
-        path_prefix,
-        branch.partial_path.as_components(),
+    Ok(BranchParts {
+        partial_path: branch.partial_path.as_components(),
         value_digest,
         child_hashes,
-    )
-    .to_hash())
+    })
 }
 
 /// At a depth-64 account branch, return the slot of the single effective
@@ -998,10 +1040,6 @@ fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
         return Err(api::Error::ProofError(ProofError::Empty));
     };
 
-    #[cfg(feature = "ethhash")]
-    let computed =
-        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children, false)?;
-    #[cfg(not(feature = "ethhash"))]
     let computed =
         compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children)?;
 
@@ -1191,10 +1229,6 @@ pub fn verify_change_proof_root_hash(
         .root()
         .expect("a non-empty proof reconciliation always leaves behind a root node");
 
-    #[cfg(feature = "ethhash")]
-    let computed =
-        compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children, false)?;
-    #[cfg(not(feature = "ethhash"))]
     let computed =
         compute_root_hash_with_proofs(&root_node, &[], &proof_node_map, &outside_children)?;
 

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -559,27 +559,23 @@ fn single_effective_account_child(
     }
 
     let mut only_child: Option<PathComponent> = None;
-    let mut set_one = |nibble: PathComponent| -> Result<(), ()> {
-        if only_child.is_some() {
-            Err(())
-        } else {
-            only_child = Some(nibble);
-            Ok(())
-        }
-    };
-
     // In-range branch children (those NOT marked as outside).
     for (nibble, child) in &branch.children {
-        let in_range = !outside_mask.is_some_and(|m| m.is_set(nibble.0));
-        if child.is_some() && in_range && set_one(nibble).is_err() {
-            return None;
+        if child.is_some() && !outside_mask.is_some_and(|m| m.is_set(nibble.0)) {
+            if only_child.is_some() {
+                return None;
+            }
+            only_child = Some(nibble);
         }
     }
     // Out-of-range children, taken from the proof node.
     if let (Some(pn), Some(mask)) = (proof_node, outside_mask) {
         for (nibble, _) in pn.child_hashes.iter_present() {
-            if mask.is_set(nibble.0) && set_one(nibble).is_err() {
-                return None;
+            if mask.is_set(nibble.0) {
+                if only_child.is_some() {
+                    return None;
+                }
+                only_child = Some(nibble);
             }
         }
     }

--- a/firewood/src/merkle/reconcile.rs
+++ b/firewood/src/merkle/reconcile.rs
@@ -4,6 +4,8 @@
 use firewood_storage::{Mutable, NodeStore, Propose, ReadableStorage, ValueDigest};
 
 use crate::{ProofError, ProofNode, Value, merkle::Merkle};
+#[cfg(feature = "ethhash")]
+use crate::proofs::eth::ACCOUNT_DEPTH_NIBBLES;
 
 impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
     /// Reconciles a branch proof node against the in-memory proving merkle.
@@ -81,7 +83,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
         // `Preimage::write` always recomputes storageRoot from the current
         // children at hash time, but byte equality fails.
         #[cfg(feature = "ethhash")]
-        if proof_node.key.len() == 64
+        if proof_node.key.len() == ACCOUNT_DEPTH_NIBBLES
             && let (Some(pv), Some(bv)) = (proof_value, branch.value.as_deref())
             && account_values_equal_except_storage_root(pv, bv)
         {

--- a/firewood/src/merkle/reconcile.rs
+++ b/firewood/src/merkle/reconcile.rs
@@ -3,9 +3,9 @@
 
 use firewood_storage::{Mutable, NodeStore, Propose, ReadableStorage, ValueDigest};
 
-use crate::{ProofError, ProofNode, Value, merkle::Merkle};
 #[cfg(feature = "ethhash")]
 use crate::proofs::eth::ACCOUNT_DEPTH_NIBBLES;
+use crate::{ProofError, ProofNode, Value, merkle::Merkle};
 
 impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
     /// Reconciles a branch proof node against the in-memory proving merkle.

--- a/firewood/src/merkle/reconcile.rs
+++ b/firewood/src/merkle/reconcile.rs
@@ -73,8 +73,54 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             return Ok(());
         }
 
+        // Ethhash account values may differ from the proof's value in just
+        // the `storageRoot` field. This happens when the proposal was built
+        // from a subset of the account's storage children — live hashing
+        // splices in a partial storageRoot, while the proof carries the
+        // full on-disk value. Both produce the same final hash because
+        // `Preimage::write` always recomputes storageRoot from the current
+        // children at hash time, but byte equality fails.
+        #[cfg(feature = "ethhash")]
+        if proof_node.key.len() == 64
+            && let (Some(pv), Some(bv)) = (proof_value, branch.value.as_deref())
+            && account_values_equal_except_storage_root(pv, bv)
+        {
+            return Ok(());
+        }
+
         // Values differ — let the caller decide what to do.
         branch.value = on_conflict(proof_node)?;
         Ok(())
+    }
+}
+
+/// Two ethhash account RLP values are equivalent for hashing if they agree
+/// on every field except `storageRoot` (index 2). `Preimage::write` always
+/// recomputes that field from the current children, so the on-disk byte
+/// difference is invisible in the final hash.
+///
+/// Logs a warning when either side fails to parse as account RLP — the
+/// resulting `false` return falls through to `on_conflict`, which surfaces
+/// the conflict as `UnexpectedValue`. The warning gives operators a clearer
+/// signal that the underlying cause is malformed data, not a value
+/// mismatch.
+#[cfg(feature = "ethhash")]
+fn account_values_equal_except_storage_root(a: &[u8], b: &[u8]) -> bool {
+    use firewood_storage::logger::warn;
+    use firewood_storage::replace_list_field;
+    let zeros = [0u8; 32];
+    match (
+        replace_list_field(a, 2, &zeros),
+        replace_list_field(b, 2, &zeros),
+    ) {
+        (Ok(na), Ok(nb)) => na == nb,
+        (a_res, b_res) => {
+            warn!(
+                "malformed account RLP at depth 64 during reconcile: proof={:?} branch={:?}",
+                a_res.err(),
+                b_res.err(),
+            );
+            false
+        }
     }
 }

--- a/firewood/src/merkle/tests/change/empty.rs
+++ b/firewood/src/merkle/tests/change/empty.rs
@@ -153,7 +153,7 @@ fn test_empty_start_trie_prefix_keys() {
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
 }
 
-use super::super::ethhash::{empty_code_hash, rlp_encode_account, rlp_encode_storage};
+use crate::merkle::tests::ethhash::{empty_code_hash, rlp_encode_account, rlp_encode_storage};
 
 /// Build a 64-byte key whose first 32 bytes are `account_key` and whose
 /// 33rd byte is `byte_32` (the rest zero). Used to construct storage keys

--- a/firewood/src/merkle/tests/change/empty.rs
+++ b/firewood/src/merkle/tests/change/empty.rs
@@ -8,6 +8,7 @@
 //! and the divergent child / value skip logic.
 
 use super::*;
+use test_case::test_case;
 
 /// Empty start trie, single key inserted. Complete proof (no bounds).
 #[test]
@@ -150,4 +151,220 @@ fn test_empty_start_trie_prefix_keys() {
     )
     .unwrap();
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
+}
+
+use super::super::ethhash::{empty_code_hash, rlp_encode_account, rlp_encode_storage};
+
+/// Build a 64-byte key whose first 32 bytes are `account_key` and whose
+/// 33rd byte is `byte_32` (the rest zero). Used to construct storage keys
+/// and range boundaries under a fixed account.
+fn key_under_account(account_key: &[u8; 32], byte_32: u8) -> [u8; 64] {
+    std::array::from_fn(|i| match i {
+        0..=31 => account_key[i],
+        32 => byte_32,
+        _ => 0,
+    })
+}
+
+/// Bound choice for the parameterized partial-storage-children test below.
+/// Resolved to an `Option<&[u8]>` against the test's fixed `account_key`
+/// and a fixed mid-storage probe (`0x40`, between `storage_keys[1]` at
+/// 0x30 and `storage_keys[2]` at 0x60).
+#[derive(Debug, Clone, Copy)]
+enum Bound {
+    /// No bound on this side of the range.
+    None,
+    /// Bound exactly at `account_key` (32 bytes; the start-proof
+    /// terminates at the account branch itself).
+    AtAccount,
+    /// Bound in the middle of the account's storage children, between
+    /// storage[1] and storage[2] (64 bytes; the proof reconciliation
+    /// runs through the storage trie).
+    MidStorage,
+}
+
+/// Change proof from empty to a single account with four storage children
+/// (at distinct first nibbles 0x10, 0x30, 0x60, 0xC0), bounded so the
+/// `batch_ops` cover only a subset of the storage children. Verified against
+/// an empty target.
+///
+/// Each case exercises a different reconciliation path:
+/// - `left_half_end_bound_only`: end-proof in-range path.
+/// - `left_edge_both_bounds`: start-proof in-range path at the account
+///   itself + end-proof in-range path in storage.
+/// - `right_half_start_bound_only`: start-proof reconciliation but the
+///   account is out-of-range (proof carries it as a boundary node).
+///
+/// All three triggered `UnexpectedValue` before the
+/// `account_values_equal_except_storage_root` relaxation in
+/// `reconcile_branch_proof_node`, because the proposal's account value
+/// has a partial-state storageRoot while the proof carries the
+/// full-state value.
+#[test_case(Bound::None, Bound::MidStorage ; "left_half_end_bound_only")]
+#[test_case(Bound::AtAccount, Bound::MidStorage ; "left_edge_both_bounds")]
+#[test_case(Bound::MidStorage, Bound::None ; "right_half_start_bound_only")]
+fn test_change_proof_partial_storage_children_against_empty(start_bound: Bound, end_bound: Bound) {
+    let dummy_storage_root = [0u8; 32];
+    let account_key: [u8; 32] = [0x10u8; 32];
+
+    let storage_keys: Vec<[u8; 64]> = [0x10u8, 0x30, 0x60, 0xC0]
+        .iter()
+        .map(|&p| key_under_account(&account_key, p))
+        .collect();
+    let storage_values: Vec<Box<[u8]>> = (1u8..=4)
+        .map(|i| rlp_encode_storage(&[i; 32]).into_boxed_slice())
+        .collect();
+    let account_value = rlp_encode_account(1, 100, &dummy_storage_root, &empty_code_hash());
+
+    let (source, _dir_source) = setup_db![];
+    let (empty_root, root2) = setup_2nd_commit!(
+        source,
+        [
+            (account_key.as_ref(), account_value.as_ref()),
+            (storage_keys[0].as_ref(), storage_values[0].as_ref()),
+            (storage_keys[1].as_ref(), storage_values[1].as_ref()),
+            (storage_keys[2].as_ref(), storage_values[2].as_ref()),
+            (storage_keys[3].as_ref(), storage_values[3].as_ref()),
+        ]
+    );
+
+    // Mid-storage probe — between storage_keys[1] (suffix 0x30) and
+    // storage_keys[2] (suffix 0x60).
+    let mid_storage = key_under_account(&account_key, 0x40);
+    let resolve = |bound: Bound| -> Option<&[u8]> {
+        match bound {
+            Bound::None => None,
+            Bound::AtAccount => Some(account_key.as_ref()),
+            Bound::MidStorage => Some(mid_storage.as_ref()),
+        }
+    };
+    let start_key = resolve(start_bound);
+    let end_key = resolve(end_bound);
+
+    let proof = source
+        .change_proof(empty_root.clone(), root2.clone(), start_key, end_key, None)
+        .unwrap();
+    let ctx =
+        verify_change_proof_structure(&proof, root2.clone(), start_key, end_key, None).unwrap();
+
+    let (target, _dir_target) = setup_db![];
+    let empty_root_target = target.root_hash().unwrap();
+    verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
+}
+
+/// Cross-batch ordering: apply the RIGHT half first, then the LEFT half.
+/// State sync receives batches in arbitrary order. When the right-side
+/// batch lands first, the target's depth-64 branch has storage children
+/// but no account value (the account is in the left-side batch). When the
+/// left batch arrives later, the account value is added to the existing
+/// branch and live hashing recomputes storageRoot from the full child set.
+/// Final root must match the source's root.
+///
+/// Note: this test passes both with and without the reconcile-side fix
+/// for partial-vs-full storageRoot conflicts. By the time the LEFT batch
+/// is applied, the cumulative children in the local DB are complete, so
+/// the proposal's storageRoot matches the proof's. The single-batch
+/// `test_change_proof_left_half_*` tests are what actually exercise the
+/// reconcile fix. This test guards convergence across batches.
+#[test]
+fn test_change_proof_arbitrary_order_right_then_left_converges() {
+    let dummy_storage_root = [0u8; 32];
+    let account_key: [u8; 32] = [0x10u8; 32];
+
+    let storage_keys: Vec<[u8; 64]> = [0x10u8, 0x30, 0x60, 0xC0]
+        .iter()
+        .map(|&p| key_under_account(&account_key, p))
+        .collect();
+    let storage_values: Vec<Box<[u8]>> = (1u8..=4)
+        .map(|i| rlp_encode_storage(&[i; 32]).into_boxed_slice())
+        .collect();
+    let account_value = rlp_encode_account(1, 100, &dummy_storage_root, &empty_code_hash());
+
+    // Source: empty → account + 4 storage children.
+    let (source, _dir_source) = setup_db![];
+    let (empty_root, full_root) = setup_2nd_commit!(
+        source,
+        [
+            (account_key.as_ref(), account_value.as_ref()),
+            (storage_keys[0].as_ref(), storage_values[0].as_ref()),
+            (storage_keys[1].as_ref(), storage_values[1].as_ref()),
+            (storage_keys[2].as_ref(), storage_values[2].as_ref()),
+            (storage_keys[3].as_ref(), storage_values[3].as_ref()),
+        ]
+    );
+
+    // mid_key sits between storage[1] and storage[2].
+    let mid_key = key_under_account(&account_key, 0x40);
+
+    let proof_left = source
+        .change_proof(
+            empty_root.clone(),
+            full_root.clone(),
+            None,
+            Some(mid_key.as_ref()),
+            None,
+        )
+        .unwrap();
+    let ctx_left = verify_change_proof_structure(
+        &proof_left,
+        full_root.clone(),
+        None,
+        Some(mid_key.as_ref()),
+        None,
+    )
+    .unwrap();
+
+    let proof_right = source
+        .change_proof(
+            empty_root.clone(),
+            full_root.clone(),
+            Some(mid_key.as_ref()),
+            None,
+            None,
+        )
+        .unwrap();
+    let ctx_right = verify_change_proof_structure(
+        &proof_right,
+        full_root.clone(),
+        Some(mid_key.as_ref()),
+        None,
+        None,
+    )
+    .unwrap();
+
+    // Apply RIGHT first, then LEFT, to an empty target.
+    let (target, _dir_target) = setup_db![];
+    let target_empty_root = target.root_hash().unwrap();
+
+    // Step 1: apply RIGHT half. Verifies, then commits.
+    let parent = target.revision(target_empty_root.clone()).unwrap();
+    let proposal_right = target
+        .apply_change_proof_to_parent(&proof_right, &*parent)
+        .unwrap();
+    crate::merkle::verify_change_proof_root_hash(&proof_right, &ctx_right, &proposal_right)
+        .unwrap();
+    proposal_right.commit().unwrap();
+    let after_right_root = target.root_hash().unwrap();
+    assert_ne!(
+        after_right_root, full_root,
+        "intermediate state should differ from full state"
+    );
+
+    // Step 2: apply LEFT half on top. The account value is in this batch's
+    // batch_ops — gets added to the existing depth-64 branch (which already
+    // has S2/S3/S4 from the right batch), live hashing recomputes storageRoot
+    // from the now-full child set.
+    let parent = target.revision(after_right_root).unwrap();
+    let proposal_left = target
+        .apply_change_proof_to_parent(&proof_left, &*parent)
+        .unwrap();
+    crate::merkle::verify_change_proof_root_hash(&proof_left, &ctx_left, &proposal_left).unwrap();
+    proposal_left.commit().unwrap();
+    let final_root = target.root_hash().unwrap();
+
+    // Final root must match the source's full-state root.
+    assert_eq!(
+        final_root, full_root,
+        "final root after applying both batches should match source"
+    );
 }

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -184,7 +184,7 @@ fn test_root_hash_random_deletions() {
 }
 
 /// Keccak256 of empty bytes — the codeHash for accounts with no contract code.
-fn empty_code_hash() -> [u8; 32] {
+pub(super) fn empty_code_hash() -> [u8; 32] {
     Keccak256::digest([]).into()
 }
 
@@ -194,7 +194,7 @@ fn empty_trie_root() -> [u8; 32] {
 }
 
 /// RLP-encode an Ethereum account value: [nonce, balance, storageRoot, codeHash].
-fn rlp_encode_account(
+pub(super) fn rlp_encode_account(
     nonce: u64,
     balance: u64,
     storage_root: &[u8; 32],
@@ -211,7 +211,7 @@ fn rlp_encode_account(
 }
 
 /// RLP-encode a 32-byte storage slot value.
-fn rlp_encode_storage(value: &[u8; 32]) -> Vec<u8> {
+pub(super) fn rlp_encode_storage(value: &[u8; 32]) -> Vec<u8> {
     use rlp::RlpStream;
 
     let mut rlp = RlpStream::new();
@@ -647,4 +647,93 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
         &range_proof,
     )
     .unwrap();
+}
+
+/// A limit-truncated range proof bounded inside an account's storage trie,
+/// covering the account + the first storage child. Truncation creates an
+/// out-of-range tail handled by the end-proof.
+///
+/// Runs for both:
+/// - One storage child (verifier must apply the storage-trie-root fold to
+///   match the on-disk hash).
+/// - Two storage children (verifier must NOT apply the fold even though
+///   only one storage child is in-range; the boundary detection has to
+///   count both in-range and out-of-range proof children).
+#[test_case(&[0xAAu8] ; "single_storage_child")]
+#[test_case(&[0x10u8, 0x20u8] ; "multi_storage_child")]
+fn test_limit_truncated_range_proof_inside_account_with_storage_children(
+    storage_suffix_first_bytes: &[u8],
+) {
+    let dummy_storage_root = [0u8; 32];
+    let account_key: Box<[u8]> = [0x10u8; 32].into();
+    let storage_keys: Vec<Box<[u8]>> = storage_suffix_first_bytes
+        .iter()
+        .map(|&first| {
+            let mut suffix = [0u8; 32];
+            suffix[0] = first;
+            [account_key.as_ref(), &suffix].concat().into()
+        })
+        .collect();
+    let following_key: Box<[u8]> = [0xFFu8; 32].into();
+
+    let account_value = rlp_encode_account(1, 100, &dummy_storage_root, &empty_code_hash());
+    let storage_values: Vec<Box<[u8]>> = (0u8..)
+        .take(storage_keys.len())
+        .map(|i| rlp_encode_storage(&[0x42u8.saturating_add(i); 32]).into())
+        .collect();
+    let following_value = rlp_encode_account(2, 200, &dummy_storage_root, &empty_code_hash());
+
+    let mut items: Vec<(&[u8], &[u8])> = vec![(account_key.as_ref(), account_value.as_ref())];
+    for (k, v) in storage_keys.iter().zip(storage_values.iter()) {
+        items.push((k.as_ref(), v.as_ref()));
+    }
+    items.push((following_key.as_ref(), following_value.as_ref()));
+
+    let merkle = init_merkle(items);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    let range_proof = merkle
+        .range_proof(None, None, std::num::NonZeroUsize::new(2))
+        .unwrap();
+    assert_eq!(range_proof.key_values().len(), 2);
+    assert_eq!(range_proof.key_values()[0].0.as_ref(), account_key.as_ref());
+    assert_eq!(
+        range_proof.key_values()[1].0.as_ref(),
+        storage_keys[0].as_ref()
+    );
+    assert!(!range_proof.end_proof().is_empty());
+
+    verify_range_proof::<_>(None::<&[u8]>, None::<&[u8]>, &root_hash, &range_proof).unwrap();
+
+    let mut serialized = Vec::new();
+    range_proof.write_to_vec(&mut serialized);
+    let deserialized = crate::api::FrozenRangeProof::from_slice(&serialized).unwrap();
+    verify_range_proof::<_>(None::<&[u8]>, None::<&[u8]>, &root_hash, &deserialized).unwrap();
+}
+
+/// A full unbounded range proof over a single-storage-child account. No
+/// truncation — exercises the fold path whenever the verifier rebuilds the
+/// storage child in-range, not only when a limit truncates the proof.
+#[test]
+fn test_full_range_proof_single_storage_child_account_no_truncation() {
+    let dummy_storage_root = [0u8; 32];
+    let account_key: Box<[u8]> = [0x10u8; 32].into();
+    let storage_key: Box<[u8]> = [account_key.as_ref(), &[0xAAu8; 32]].concat().into();
+
+    let account_value = rlp_encode_account(1, 100, &dummy_storage_root, &empty_code_hash());
+    let storage_value: Box<[u8]> = rlp_encode_storage(&[0x42u8; 32]).into();
+
+    let merkle = init_merkle([
+        (account_key.as_ref(), account_value.as_ref()),
+        (storage_key.as_ref(), storage_value.as_ref()),
+    ]);
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    // Full, unbounded range proof with no key limit.
+    let range_proof = merkle.range_proof(None, None, None).unwrap();
+    assert_eq!(range_proof.key_values().len(), 2);
+    assert_eq!(range_proof.key_values()[0].0.as_ref(), account_key.as_ref());
+    assert_eq!(range_proof.key_values()[1].0.as_ref(), storage_key.as_ref());
+
+    verify_range_proof::<_>(None::<&[u8]>, None::<&[u8]>, &root_hash, &range_proof).unwrap();
 }

--- a/firewood/src/proofs/eth.rs
+++ b/firewood/src/proofs/eth.rs
@@ -38,7 +38,7 @@ use crate::proofs::types::ProofNode;
 
 /// Path length in nibbles at which a node is treated as an Ethereum account
 /// (Keccak-256 of a 20-byte address).
-const ACCOUNT_DEPTH_NIBBLES: usize = 64;
+pub(crate) const ACCOUNT_DEPTH_NIBBLES: usize = 64;
 
 /// Emit one or two canonical MPT-RLP nodes for `node`.
 ///

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -47,6 +47,8 @@
     reason = "Found 1 occurrences after enabling the lint."
 )]
 
+#[cfg(feature = "ethhash")]
+use firewood_storage::hash_node_as_storage_trie_root_parts;
 use firewood_storage::{
     Children, FileIoError, HashType, Hashable, IntoHashType, IntoSplitPath, NibblesIterator, Path,
     PathBuf, PathComponent, PathIterItem, Preimage, SplitPath, TrieHash, TriePath, ValueDigest,
@@ -244,6 +246,16 @@ pub enum ProofError {
     /// boundary index, so the proof must include that child.
     #[error("exclusion proof missing child at boundary index")]
     ExclusionProofMissingChild,
+
+    /// A node was flagged for the storage-trie-root fold (i.e., it is the
+    /// single storage child of a depth-64 account branch) but its path
+    /// prefix is too short to contain the account's 64-nibble key plus the
+    /// child's 1-nibble slot. This indicates either a malformed proof
+    /// (`partial_len` of a storage child doesn't match its depth) or an
+    /// internal invariant violation in the verifier.
+    #[cfg(feature = "ethhash")]
+    #[error("invalid storage-trie-root path: prefix shorter than expected")]
+    InvalidStorageTrieRootPath,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -323,6 +335,33 @@ impl Hashable for ProofNode {
     fn children(&self) -> Children<Option<HashType>> {
         self.child_hashes.clone()
     }
+}
+
+/// Compute the hash a proof-walk expects for a node. When
+/// `as_storage_trie_root` is true, the node is hashed via the shared
+/// storage-trie-root fold helper — used for the storage child of an
+/// account branch at depth 64 with exactly one storage child. Otherwise
+/// the default `Hashable::to_hash` is used.
+fn compute_node_hash_for_proof<N: Hashable>(
+    node: &N,
+    #[cfg(feature = "ethhash")] as_storage_trie_root: bool,
+) -> Result<HashType, ProofError> {
+    #[cfg(feature = "ethhash")]
+    if as_storage_trie_root {
+        let (branch_nibble, account_prefix) = node
+            .parent_prefix_path()
+            .into_split_path()
+            .split_last()
+            .ok_or(ProofError::InvalidStorageTrieRootPath)?;
+        return Ok(hash_node_as_storage_trie_root_parts(
+            account_prefix,
+            branch_nibble,
+            node.partial_path().into_split_path(),
+            node.value_digest(),
+            node.children(),
+        ));
+    }
+    Ok(node.to_hash())
 }
 
 impl From<PathIterItem> for ProofNode {
@@ -456,11 +495,26 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
         };
 
         let mut expected_hash = root_hash.clone().into_hash_type();
+        // True when the previous iteration's node was a depth-64 account
+        // branch with exactly one storage child. The current node's hash
+        // must be computed as a standalone storage-trie root via the shared
+        // fold helper, matching what live hashing did when the node was
+        // first written.
+        #[cfg(feature = "ethhash")]
+        let mut hash_as_storage_root = false;
 
         let mut iter = self.0.as_ref().iter().peekable();
         while let Some(node) = iter.next() {
-            if node.to_hash() != expected_hash {
+            #[cfg(feature = "ethhash")]
+            let actual_hash = compute_node_hash_for_proof(node, hash_as_storage_root)?;
+            #[cfg(not(feature = "ethhash"))]
+            let actual_hash = compute_node_hash_for_proof(node)?;
+            if actual_hash != expected_hash {
                 return Err(ProofError::UnexpectedHash);
+            }
+            #[cfg(feature = "ethhash")]
+            {
+                hash_as_storage_root = false;
             }
 
             // Assert that only nodes whose keys are an even number of nibbles
@@ -482,10 +536,20 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
                     return Err(ProofError::ShouldBePrefixOfNextKey);
                 }
 
-                expected_hash = node.children()[key_nibble]
+                let children = node.children();
+                expected_hash = children[key_nibble]
                     .as_ref()
                     .ok_or(ProofError::NodeNotInTrie)?
                     .clone();
+
+                // If this node is a depth-64 account branch with exactly one
+                // storage child, the next node IS that storage child and must
+                // be hashed as a standalone storage-trie root on the next
+                // iteration.
+                #[cfg(feature = "ethhash")]
+                {
+                    hash_as_storage_root = node.full_path().len() == 64 && children.count() == 1;
+                }
             }
         }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -63,12 +63,15 @@ pub use hashtype::{HashType, IntoHashType, InvalidTrieHashLength, TrieHash};
 pub use linear::{FileIoError, ReadableStorage, WritableStorage};
 pub use node::path::{NibblesIterator, Path};
 pub use node::{BranchNode, Child, Children, ChildrenSlots, LeafNode, Node, PathIterItem};
-pub use nodestore::fix_account_storage_root_value;
 pub use nodestore::{
     AreaIndex, Committed, CommittedId, CommittedParentHash, HashedNodeReader, ImmutableProposal,
     LinearAddress, Mutable, MutableKind, NodeHashAlgorithm, NodeHashAlgorithmTryFromIntError,
     NodeReader, NodeStore, NodeStoreHeader, Parentable, Propose, Recon, Reconstructed,
-    ReconstructionSource, RootReader, TrieReader,
+    ReconstructionSource, RootReader, TrieReader, fix_account_storage_root_value,
+};
+#[cfg(feature = "ethhash")]
+pub use nodestore::{
+    hash_node_as_storage_trie_root_for_node, hash_node_as_storage_trie_root_parts,
 };
 pub use path::{
     ComponentIter, IntoSplitPath, JoinedPath, PackedBytes, PackedPathComponents, PackedPathRef,

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -298,9 +298,9 @@ pub fn hash_node_as_storage_trie_root_for_node(
 ///
 /// - 0 children → empty trie root (`keccak256(0x80)`)
 /// - 1 child → that child's hash directly. The caller is responsible for having
-///   produced that hash via [`hash_node_as_storage_trie_root_parts`] (which folds
+///   produced that hash via `hash_node_as_storage_trie_root_parts` (which folds
 ///   the account's branch nibble into the child's partial path so the child hashes
-///   as a standalone storage-trie root).
+///   as a standalone storage-trie root). Only relevant under the `ethhash` feature.
 /// - ≥2 children → the 17-element branch RLP, hashed.
 ///
 /// At account depth (64 nibbles) storage keys are 32 bytes, so every child

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -6,15 +6,16 @@
 //! This module contains all node hashing functionality for the nodestore, including
 //! specialized support for Ethereum-compatible hash processing.
 
-#[cfg(feature = "ethhash")]
-use crate::PathComponent;
 use crate::hashednode::hash_node;
 use crate::linear::FileIoError;
 use crate::logger::trace;
 use crate::node::Node;
 use crate::{
     Child, Children, HashType, MaybePersistedNode, NodeStore, Path, ReadableStorage, SharedNode,
+    TrieHash,
 };
+#[cfg(feature = "ethhash")]
+use crate::{HashableShunt, JoinedPath, PathComponent, SplitPath, ValueDigest};
 
 use super::NodeReader;
 
@@ -133,7 +134,7 @@ where
         #[cfg(feature = "ethhash")] &self,
         mut node: Node,
         mut path_prefix: PathGuard<'_>,
-        #[cfg(feature = "ethhash")] fake_root_extra_nibble: Option<u8>,
+        #[cfg(feature = "ethhash")] fake_root_extra_nibble: Option<PathComponent>,
     ) -> Result<(MaybePersistedNode, HashType), FileIoError> {
         // If this is a branch, find all unhashed children and recursively hash them.
         trace!("hashing {node:?} at {path_prefix:?}");
@@ -152,26 +153,26 @@ where
                 trace!("hashed {hashed:?} unhashed {unhashed:?}");
                 // we were left with one hashed node that must be rehashed
                 if let [(child_idx, (child_node, child_hash))] = &mut hashed[..] {
-                    // read MaybePersistedNode as a SharedNode so we can hash and update it
-                    let mut hashable_node = child_node.as_shared_node(&self)?.deref().clone();
+                    let shared = child_node.as_shared_node(&self)?;
                     let hash = {
                         let mut path_guard = PathGuard::new(&mut path_prefix);
                         path_guard.0.extend(b.partial_path.0.iter().copied());
                         if unhashed.is_empty() {
-                            hashable_node.update_partial_path(Path::from_nibbles_iterator(
-                                std::iter::once(child_idx.as_u8())
-                                    .chain(hashable_node.partial_path().0.iter().copied()),
-                            ));
+                            hash_node_as_storage_trie_root_for_node(
+                                path_guard.as_components(),
+                                *child_idx,
+                                &shared,
+                            )
                         } else {
                             path_guard.0.push(child_idx.as_u8());
+                            hash_node(&shared, &path_guard)
                         }
-                        hash_node(&hashable_node, &path_guard)
                     };
                     **child_hash = hash;
                 }
                 // handle the single-child case for an account special below
                 if hashed.is_empty() && unhashed.len() == 1 {
-                    Some(unhashed.last().expect("only one").0.as_u8())
+                    Some(unhashed.last().expect("only one").0)
                 } else {
                     None
                 }
@@ -236,16 +237,8 @@ where
         // if the encoded child hash <32 bytes then we use that RLP
 
         #[cfg(feature = "ethhash")]
-        // if we have a child that is the only child of an account branch, we will hash this child as if it
-        // is a root node. This means we have to take the nibble from the parent and prefix it to the partial path
         let hash = if let Some(nibble) = fake_root_extra_nibble {
-            let mut fake_root = node.clone();
-            trace!("old node: {fake_root:?}");
-            fake_root.update_partial_path(Path::from_nibbles_iterator(
-                std::iter::once(nibble).chain(fake_root.partial_path().0.iter().copied()),
-            ));
-            trace!("new node: {fake_root:?}");
-            hash_node(&fake_root, &path_prefix)
+            hash_node_as_storage_trie_root_for_node(path_prefix.as_components(), nibble, &node)
         } else {
             hash_node(&node, &path_prefix)
         };
@@ -262,23 +255,77 @@ where
         path_prefix: &Path,
         have_peers: bool,
     ) -> HashType {
-        if path_prefix.0.len() == 65 && !have_peers {
-            // This is the special case when this node is the only child of an account
-            //  - 64 nibbles for account + 1 nibble for its position in account branch node
-            let mut fake_root = node.clone();
-            fake_root.update_partial_path(Path::from_nibbles_iterator(
-                path_prefix
-                    .0
-                    .last()
-                    .into_iter()
-                    .chain(fake_root.partial_path().0.iter())
-                    .copied(),
-            ));
-            hash_node(&fake_root, path_prefix)
+        let components = path_prefix.as_components();
+        // 64 nibbles for the account prefix + 1 for this node's slot in the
+        // account branch = 65. !have_peers means this is the only storage child.
+        if components.len() == 65 && !have_peers {
+            let (branch_nibble, account_prefix) = components
+                .split_last()
+                .expect("len == 65 implies non-empty");
+            hash_node_as_storage_trie_root_for_node(account_prefix, *branch_nibble, node)
         } else {
             hash_node(node, path_prefix)
         }
     }
+}
+
+/// Convenience wrapper around [`hash_node_as_storage_trie_root_parts`] that
+/// extracts the parts from a [`Node`] directly.
+#[cfg(feature = "ethhash")]
+pub fn hash_node_as_storage_trie_root_for_node(
+    account_full_prefix: &[PathComponent],
+    branch_nibble: PathComponent,
+    node: &Node,
+) -> HashType {
+    let (value_digest, children) = match node {
+        Node::Branch(b) => (
+            b.value.as_deref().map(ValueDigest::Value),
+            b.children_hashes(),
+        ),
+        Node::Leaf(l) => (Some(ValueDigest::Value(l.value.as_ref())), Children::new()),
+    };
+    hash_node_as_storage_trie_root_parts(
+        account_full_prefix,
+        branch_nibble,
+        node.partial_path().as_components(),
+        value_digest,
+        children,
+    )
+}
+
+/// Compute the root hash of an Ethereum storage trie from an account branch's
+/// already-hashed children.
+///
+/// - 0 children → empty trie root (`keccak256(0x80)`)
+/// - 1 child → that child's hash directly. The caller is responsible for having
+///   produced that hash via [`hash_node_as_storage_trie_root_parts`] (which folds
+///   the account's branch nibble into the child's partial path so the child hashes
+///   as a standalone storage-trie root).
+/// - ≥2 children → the 17-element branch RLP, hashed.
+///
+/// At account depth (64 nibbles) storage keys are 32 bytes, so every child
+/// encoding exceeds 32 bytes and the inline-RLP variant of [`HashType`] cannot
+/// occur. Without `ethhash`, `HashType` is `TrieHash` and the single-child case
+/// returns the child hash unchanged.
+#[must_use]
+pub(crate) fn compute_storage_trie_root(child_hashes: &Children<Option<HashType>>) -> TrieHash {
+    use crate::node::BranchNode;
+    use crate::rlp::{NULL_RLP, RlpItem, encode_list};
+    use sha3::{Digest, Keccak256};
+
+    if child_hashes.count() == 0 {
+        return TrieHash::from(Keccak256::digest(NULL_RLP));
+    }
+    let mut child_hashes = child_hashes.clone();
+    if let Some((_, child)) = child_hashes.take_only_child() {
+        return single_child_storage_root(child);
+    }
+    let mut items: [RlpItem<'_>; BranchNode::MAX_CHILDREN + 1] =
+        [RlpItem::Empty; BranchNode::MAX_CHILDREN + 1];
+    for ((_, child), slot) in (&child_hashes).into_iter().zip(items.iter_mut()) {
+        *slot = child_to_rlp_item(child.as_ref());
+    }
+    TrieHash::from(Keccak256::digest(encode_list(&items)))
 }
 
 /// Given an account node's value and its children's hashes, return the value with the
@@ -288,36 +335,38 @@ where
 /// For branch accounts, the storage root is computed from the children's hashes.
 ///
 /// Returns `None` if the value is not well-formed account RLP.
-///
-/// At account depth (64 nibbles), storage keys are 32 bytes, so every child
-/// encoding exceeds 32 bytes and is stored as a `HashType::Hash` — `Rlp`
-/// children are impossible here.
 #[must_use]
 pub fn fix_account_storage_root_value(
     value: &[u8],
     child_hashes: &Children<Option<HashType>>,
 ) -> Option<Box<[u8]>> {
-    use crate::node::BranchNode;
-    use crate::rlp::{NULL_RLP, RlpItem, encode_list, replace_list_field};
-    use sha3::{Digest, Keccak256};
-
-    let storage_root = if child_hashes.count() == 0 {
-        crate::TrieHash::from(Keccak256::digest(NULL_RLP))
-    } else {
-        let mut child_hashes = child_hashes.clone();
-        if let Some((_, child)) = child_hashes.take_only_child() {
-            single_child_storage_root(child)
-        } else {
-            let mut items: [RlpItem<'_>; BranchNode::MAX_CHILDREN + 1] =
-                [RlpItem::Empty; BranchNode::MAX_CHILDREN + 1];
-            for ((_, child), slot) in (&child_hashes).into_iter().zip(items.iter_mut()) {
-                *slot = child_to_rlp_item(child.as_ref());
-            }
-            crate::TrieHash::from(Keccak256::digest(encode_list(&items)))
-        }
-    };
-
+    use crate::rlp::replace_list_field;
+    let storage_root = compute_storage_trie_root(child_hashes);
     replace_list_field(value, 2, storage_root.as_slice()).ok()
+}
+
+/// Hash a node as the standalone root of an Ethereum storage trie.
+///
+/// In Ethereum, an account with exactly one storage entry has a storage trie
+/// consisting of just that leaf, whose partial path is the full 64-nibble
+/// storage key. Firewood stores that leaf as a child of the account branch
+/// at depth 64, with only 63 nibbles of partial path — the first nibble is
+/// the parent's child-slot index. This function folds the missing nibble
+/// back onto the front of the child's partial path and hashes the result as
+/// if the child were a standalone root.
+///
+/// Single source of truth for the storage-trie-root fold; prefer this over
+/// inline folding so live hashing and proof verification cannot drift.
+#[cfg(feature = "ethhash")]
+pub fn hash_node_as_storage_trie_root_parts<Prefix: SplitPath, Partial: SplitPath>(
+    account_full_prefix: Prefix,
+    branch_nibble: PathComponent,
+    partial_path: Partial,
+    value_digest: Option<ValueDigest<&[u8]>>,
+    children: Children<Option<HashType>>,
+) -> HashType {
+    let folded = JoinedPath::new(std::slice::from_ref(&branch_nibble), partial_path);
+    HashableShunt::new(account_full_prefix, folded, value_digest, children).to_hash()
 }
 
 /// Persist the computed storageRoot into an account node's RLP-encoded value,

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -63,10 +63,12 @@ use std::time::Instant;
 
 // Re-export types from alloc module
 pub use alloc::NodeAllocator;
+pub use hash::fix_account_storage_root_value;
+#[cfg(feature = "ethhash")]
+pub use hash::{hash_node_as_storage_trie_root_for_node, hash_node_as_storage_trie_root_parts};
 pub use hash_algo::{NodeHashAlgorithm, NodeHashAlgorithmTryFromIntError};
 pub use primitives::{AreaIndex, LinearAddress};
 // Re-export types from header module
-pub use hash::fix_account_storage_root_value;
 pub use header::NodeStoreHeader;
 
 /// The [`NodeStore`] handles the serialization of nodes and

--- a/storage/src/path/split.rs
+++ b/storage/src/path/split.rs
@@ -24,6 +24,18 @@ pub trait SplitPath: TriePath + Default + Copy {
     /// Returns [`None`] if the path is empty.
     fn split_first(self) -> Option<(PathComponent, Self)>;
 
+    /// Splits the last path component off of this path, returning it along with
+    /// the remaining path.
+    ///
+    /// Returns [`None`] if the path is empty.
+    fn split_last(self) -> Option<(PathComponent, Self)> {
+        let prefix_len = self.len().checked_sub(1)?;
+        let (prefix, last) = self.split_at(prefix_len);
+        // `last` has exactly one component because we split at `len - 1`.
+        let (component, _) = last.split_first()?;
+        Some((component, prefix))
+    }
+
     /// Computes the longest common prefix of this path and another path, along
     /// with their respective suffixes.
     fn longest_common_prefix<T: SplitPath>(self, other: T) -> PathCommonPrefix<Self, T> {


### PR DESCRIPTION
## Why this should be merged
  
Avalanche C-Chain state sync against firewood v0.5.0 fails with `ProofError::UnexpectedHash` on honest range proofs. Root cause: *bug 1* ethhash proof verification diverges from live hashing whenever a verifier has to recompute the hash of a "fake-root" boundary node (an account at depth 64 with exactly one storage child). A second, related defect surfaces in bounded change proofs as `UnexpectedValue` whenever an account's storage children are only partially in range *bug 2*.
  
PR #2030 was correct for bug 1 and fixed this in a different way, by duplicating some code. This fix eliminates that duplication.
  
**Bug 1** — single-storage-child fake-root divergence. Live hashing applies a fold at account-storage boundaries (depth 64, accounts with exactly one storage child) that proof verification didn't. Reproducible without truncation. 

Fix: one shared helper used by every hashing site (live hashing, checker, range/change-proof verification, single-key proof). Previously the fold lived inline in two places and the verifier didn't have it at all.
  
**Bug 2** — partial-storage change proofs. reconcile_branch_proof_node byte-compared the storageRoot field, which Preimage::write recomputes from children at hash time. The check rejected valid proofs because the proposal's recomputed storageRoot differed from the source's full-state storageRoot when batch_ops covered only a subset of an account's storage children. 

Fix: ignore that field when comparing account values at depth 64. The final root-hash check (computed_root == claimed_end_root) is unchanged and remains the security gate. The storageRoot bytes are functionally write-only on the wire because Preimage::write strips and recomputes them.

Range proofs aren't affected: their proving trie is built fresh from key_values, so reconcile compares source bytes against source bytes. Only change proofs fork an already-hashed proposal where update_account_storage_root has already mutated the storageRoot field.
 
## Out of scope
  
  - #2007 (UnexpectedValue in change-proof reconciliation): the documented seed no longer reproduces on current branches, so the relationship can't be confirmed. Bug 2 may or may not be this issue.
  - #2008-class (false-acceptance of dropped batch ops): different code path; one instance (M2_omit_delete) reproduced during this investigation's fuzz runs on main.
  
## Follow-ups to file
  
  1. Strip storageRoot field from account values in proofs (wire-format proposal — coordinated with avalanchego state syncer).
  2. Unify the recursive trie walkers (hash_helper_inner and compute_root_hash_with_proofs are conceptually the same walk over different child resolvers; a ChildResolver trait would close the remaining structural duplication).
  
## Breaking changes
  
  - None. Unit tests pass under both feature configs. The original symptom is only observable against C-Chain reexecution, so state-sync validation against production shape is needed before merge.