### PR TITLE
chore!: clarify deferred persistence terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To do this, a new root is always created for each revision that can reference ei
 When creating a revision,
 a list of nodes that are no longer needed are computed and saved to disk in a future-delete log (FDL) as well as kept in memory.
 When a revision expires, the nodes that were deleted when it was created are returned to the free space.
-Firewood also supports archival mode via `RootStore`, which retains all historical revisions and allows lookup of any past state by its root hash.
+Firewood also supports archival mode via `RootStore`, which retains persisted historical revisions for lookup by root hash.
 
 Hashes are not used to determine where a node is stored on disk in the database file.
 Instead space for nodes may be allocated from the end of the file,
@@ -43,6 +43,11 @@ as well as carefully managing the free list during the creation and expiration o
 
 ## Terminology
 
+- `Commit` - Makes a proposal's state the latest committed state. Success does
+  not guarantee that the state has been persisted.
+- `Persist` - Writes committed state to the database files.
+- `Maximum persistence gap` - The maximum number of committed revisions to go
+  back from the latest committed state to reach the last persisted state.
 - `Revision` - A historical point-in-time state/version of the trie. This
   represents the entire trie, including all `Key`/`Value`s at that point
   in time, and all `Node`s.
@@ -81,8 +86,6 @@ as well as carefully managing the free list during the creation and expiration o
     uncommitted branches and do not participate in proposal-parent branching.
 - `Reconstructible` - Either a `Historical` or `Reconstructed` state, which supports
   building new `Reconstructed` states by applying a `Batch`.
-- `Commit` - The operation of applying one or more `Proposal`s to the most recent
-  `Revision`.
 
 ## Metrics
 

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -124,7 +124,7 @@ type config struct {
 	// revisions is the maximum number of historical revisions to keep in memory.
 	// If rootStoreDir is set, then any revisions removed from memory will still be kept on disk.
 	// Otherwise, any revisions removed from memory will no longer be kept on disk.
-	// Must be >= 2 and > deferredPersistenceCommitCount.
+	// Must be >= 2 and > maxRevisionRecoveryLag.
 	revisions uint
 	// readCacheStrategy is the caching strategy used for the node cache.
 	readCacheStrategy CacheStrategy
@@ -132,19 +132,19 @@ type config struct {
 	rootStore bool
 	// expensiveMetricsEnabled controls whether expensive metrics recording is enabled.
 	expensiveMetricsEnabled bool
-	// deferredPersistenceCommitCount determines the maximum number of unpersisted
-	// revisions that can exist at a given time.
-	// Note: revisions must be > deferredPersistenceCommitCount
-	deferredPersistenceCommitCount uint64
+	// maxRevisionRecoveryLag determines the maximum number of latest committed
+	// revisions that may need to be recommitted after a crash.
+	// Note: revisions must be > maxRevisionRecoveryLag
+	maxRevisionRecoveryLag uint64
 }
 
 func defaultConfig() *config {
 	return &config{
-		nodeCacheSizeInBytes:           128_000_000,
-		freeListCacheEntries:           1_000_000,
-		revisions:                      100,
-		readCacheStrategy:              OnlyCacheWrites,
-		deferredPersistenceCommitCount: 1,
+		nodeCacheSizeInBytes:   128_000_000,
+		freeListCacheEntries:   1_000_000,
+		revisions:              100,
+		readCacheStrategy:      OnlyCacheWrites,
+		maxRevisionRecoveryLag: 1,
 	}
 }
 
@@ -181,7 +181,7 @@ func WithFreeListCacheEntries(entries uint) Option {
 // WithRevisions sets the maximum number of historical revisions to keep in memory.
 // If RootStoreDir is set, then any revisions removed from memory will still be kept on disk.
 // Otherwise, any revisions removed from memory will no longer be kept on disk.
-// Must be >= 2 and > WithDeferredPersistenceCommitCount.
+// Must be >= 2 and > WithMaxRevisionRecoveryLag.
 // Default: 100
 func WithRevisions(revisions uint) Option {
 	return func(c *config) {
@@ -216,13 +216,18 @@ func WithExpensiveMetrics() Option {
 	}
 }
 
-// WithDeferredPersistenceCommitCount sets the maximum number of unpersisted revisions
-// that can exist at a time. Note: `commitCount` must be greater than 0 and WithRevisions
-// must be greater than `commitCount`.
+// WithMaxRevisionRecoveryLag sets the maximum number of latest committed
+// revisions that may need to be recommitted after a crash. This bounds the lag
+// between the latest committed revision and the latest revision recoverable from
+// disk.
+//
+// Note: `maxRevisionRecoveryLag` must be greater than 0 and WithRevisions
+// must be greater than `maxRevisionRecoveryLag`.
+//
 // Default: 1
-func WithDeferredPersistenceCommitCount(commitCount uint64) Option {
+func WithMaxRevisionRecoveryLag(maxRevisionRecoveryLag uint64) Option {
 	return func(c *config) {
-		c.deferredPersistenceCommitCount = commitCount
+		c.maxRevisionRecoveryLag = maxRevisionRecoveryLag
 	}
 }
 
@@ -283,16 +288,16 @@ func New(dbDir string, nodeHashAlgorithm NodeHashAlgorithm, opts ...Option) (*Da
 	defer pinner.Unpin()
 
 	args := C.struct_DatabaseHandleArgs{
-		dir:                               newBorrowedBytes([]byte(dbDir), &pinner),
-		node_cache_memory_limit:           C.size_t(conf.nodeCacheSizeInBytes),
-		free_list_cache_size:              C.size_t(conf.freeListCacheEntries),
-		revisions:                         C.size_t(conf.revisions),
-		strategy:                          C.uint8_t(conf.readCacheStrategy),
-		truncate:                          C.bool(conf.truncate),
-		root_store:                        C.bool(conf.rootStore),
-		expensive_metrics:                 C.bool(conf.expensiveMetricsEnabled),
-		node_hash_algorithm:               C.enum_NodeHashAlgorithm(nodeHashAlgorithm),
-		deferred_persistence_commit_count: C.uint64_t(conf.deferredPersistenceCommitCount),
+		dir:                       newBorrowedBytes([]byte(dbDir), &pinner),
+		node_cache_memory_limit:   C.size_t(conf.nodeCacheSizeInBytes),
+		free_list_cache_size:      C.size_t(conf.freeListCacheEntries),
+		revisions:                 C.size_t(conf.revisions),
+		strategy:                  C.uint8_t(conf.readCacheStrategy),
+		truncate:                  C.bool(conf.truncate),
+		root_store:                C.bool(conf.rootStore),
+		expensive_metrics:         C.bool(conf.expensiveMetricsEnabled),
+		node_hash_algorithm:       C.enum_NodeHashAlgorithm(nodeHashAlgorithm),
+		max_revision_recovery_lag: C.uint64_t(conf.maxRevisionRecoveryLag),
 	}
 
 	return getDatabaseFromHandleResult(C.fwd_open_db(args))

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -139,7 +139,7 @@ type config struct {
 	// revisions is the maximum number of historical revisions to keep in memory.
 	// If rootStoreDir is set, then any revisions removed from memory will still be kept on disk.
 	// Otherwise, any revisions removed from memory will no longer be kept on disk.
-	// Must be >= 2 and > deferredPersistenceCommitCount.
+	// Must be >= 2 and > maxPersistenceGap.
 	revisions uint
 	// readCacheStrategy is the caching strategy used for the node cache.
 	readCacheStrategy CacheStrategy
@@ -149,19 +149,17 @@ type config struct {
 	expensiveMetricsEnabled bool
 	// metricsTag separates metrics and logs by database handle.
 	metricsTag string
-	// deferredPersistenceCommitCount determines the maximum number of unpersisted
-	// revisions that can exist at a given time.
-	// Note: revisions must be > deferredPersistenceCommitCount
-	deferredPersistenceCommitCount uint64
+	// maxPersistenceGap is configured by WithMaxPersistenceGap.
+	maxPersistenceGap uint64
 }
 
 func defaultConfig() *config {
 	return &config{
-		nodeCacheSizeInBytes:           128_000_000,
-		freeListMemoryLimitKB:          4096,
-		revisions:                      100,
-		readCacheStrategy:              OnlyCacheWrites,
-		deferredPersistenceCommitCount: 1,
+		nodeCacheSizeInBytes:  128_000_000,
+		freeListMemoryLimitKB: 4096,
+		revisions:             100,
+		readCacheStrategy:     OnlyCacheWrites,
+		maxPersistenceGap:     1,
 	}
 }
 
@@ -199,7 +197,7 @@ func WithFreeListMemoryLimitKB(memoryLimitKB uint) Option {
 // WithRevisions sets the maximum number of historical revisions to keep in memory.
 // If RootStoreDir is set, then any revisions removed from memory will still be kept on disk.
 // Otherwise, any revisions removed from memory will no longer be kept on disk.
-// Must be >= 2 and > WithDeferredPersistenceCommitCount.
+// Must be >= 2 and > WithMaxPersistenceGap.
 // Default: 100
 func WithRevisions(revisions uint) Option {
 	return func(c *config) {
@@ -242,13 +240,34 @@ func WithMetricsTag(tag string) Option {
 	}
 }
 
-// WithDeferredPersistenceCommitCount sets the maximum number of unpersisted revisions
-// that can exist at a time. Note: `commitCount` must be greater than 0 and WithRevisions
-// must be greater than `commitCount`.
-// Default: 1
-func WithDeferredPersistenceCommitCount(commitCount uint64) Option {
+// WithMaxPersistenceGap sets the maximum number of committed revisions by which
+// the latest persisted state may lag behind the latest committed state.
+//
+// Committing makes a revision current, while persistence writes its state
+// to the database files asynchronously, without a fixed schedule. A commit
+// can therefore return before its state is persisted, even when this value
+// is 1, and subsequent commits may wait for persistence to maintain the
+// configured bound. Only commits that change the current root count toward
+// this limit; uncommitted proposals do not.
+//
+// Set this value to 1 to persist every committed revision before the next
+// state-changing commit completes. Values greater than 1 allow persistence
+// to skip intermediate revisions, so not every revision is guaranteed to be
+// written to disk.
+//
+// A successful [Database.Close] persists the latest committed state.
+//
+// Examples:
+//
+//   - With a value of 1, the latest persisted state is either the latest committed
+//     revision or its parent.
+//   - With a value of 2, it may also be its grandparent: at most two revisions
+//     back, among three possible states.
+//
+// Defaults to 1. Must be positive and less than the value set by [WithRevisions].
+func WithMaxPersistenceGap(maxPersistenceGap uint64) Option {
 	return func(c *config) {
-		c.deferredPersistenceCommitCount = commitCount
+		c.maxPersistenceGap = maxPersistenceGap
 	}
 }
 
@@ -308,17 +327,17 @@ func New(dbDir string, nodeHashAlgorithm NodeHashAlgorithm, opts ...Option) (*Da
 	defer pinner.Unpin()
 
 	args := C.struct_DatabaseHandleArgs{
-		dir:                               newBorrowedBytes([]byte(dbDir), &pinner),
-		node_cache_memory_limit:           C.size_t(conf.nodeCacheSizeInBytes),
-		freelist_memory_limit_kb:          C.size_t(conf.freeListMemoryLimitKB),
-		revisions:                         C.size_t(conf.revisions),
-		strategy:                          C.uint8_t(conf.readCacheStrategy),
-		truncate:                          C.bool(conf.truncate),
-		root_store:                        C.bool(conf.rootStore),
-		expensive_metrics:                 C.bool(conf.expensiveMetricsEnabled),
-		node_hash_algorithm:               C.enum_NodeHashAlgorithm(nodeHashAlgorithm),
-		db_tag:                            newBorrowedBytes([]byte(conf.metricsTag), &pinner),
-		deferred_persistence_commit_count: C.uint64_t(conf.deferredPersistenceCommitCount),
+		dir:                      newBorrowedBytes([]byte(dbDir), &pinner),
+		node_cache_memory_limit:  C.size_t(conf.nodeCacheSizeInBytes),
+		freelist_memory_limit_kb: C.size_t(conf.freeListMemoryLimitKB),
+		revisions:                C.size_t(conf.revisions),
+		strategy:                 C.uint8_t(conf.readCacheStrategy),
+		truncate:                 C.bool(conf.truncate),
+		root_store:               C.bool(conf.rootStore),
+		expensive_metrics:        C.bool(conf.expensiveMetricsEnabled),
+		node_hash_algorithm:      C.enum_NodeHashAlgorithm(nodeHashAlgorithm),
+		db_tag:                   newBorrowedBytes([]byte(conf.metricsTag), &pinner),
+		max_persistence_gap:      C.uint64_t(conf.maxPersistenceGap),
 	}
 
 	return getDatabaseFromHandleResult(C.fwd_open_db(args))

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -255,14 +255,9 @@ func WithMetricsTag(tag string) Option {
 // to skip intermediate revisions, so not every revision is guaranteed to be
 // written to disk.
 //
-// A successful [Database.Close] persists the latest committed state.
-//
-// Examples:
-//
-//   - With a value of 1, the latest persisted state is either the latest committed
-//     revision or its parent.
-//   - With a value of 2, it may also be its grandparent: at most two revisions
-//     back, among three possible states.
+// A successful [Database.Close] persists the latest committed state. If the
+// process exits without a successful Close, the recovered state is at most
+// maxPersistenceGap commits behind the latest committed revision.
 //
 // Defaults to 1. Must be positive and less than the value set by [WithRevisions].
 func WithMaxPersistenceGap(maxPersistenceGap uint64) Option {

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1361,7 +1361,7 @@ typedef struct DatabaseHandleArgs {
   /**
    * The maximum number of revisions to keep.
    *
-   * Must be > `deferred_persistence_commit_count`.
+   * Must be > `max_revision_recovery_lag`.
    */
   size_t revisions;
   /**
@@ -1397,11 +1397,12 @@ typedef struct DatabaseHandleArgs {
    */
   enum NodeHashAlgorithm node_hash_algorithm;
   /**
-   * The maximum number of unpersisted revisions that can exist at a given time.
+   * The maximum number of latest committed revisions that may need to be
+   * recommitted after a crash.
    *
-   * Note: `revisions` must be > `deferred_persistence_commit_count`.
+   * Note: `revisions` must be > `max_revision_recovery_lag`.
    */
-  uint64_t deferred_persistence_commit_count;
+  uint64_t max_revision_recovery_lag;
 } DatabaseHandleArgs;
 
 /**

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1752,14 +1752,10 @@ typedef struct DatabaseHandleArgs {
    * to skip intermediate revisions, so not every revision is guaranteed to be
    * written to disk.
    *
-   * A successful explicit close persists the latest committed state.
-   *
-   * Examples:
-   *
-   * - With a value of 1, the latest persisted state is either the latest
-   *   committed revision or its parent.
-   * - With a value of 2, it may also be its grandparent: at most two revisions
-   *   back, among three possible states.
+   * A successful explicit close persists the latest committed state. If the
+   * process exits without a successful close, the recovered state is at
+   * most `max_persistence_gap` commits behind the latest committed
+   * revision.
    *
    * Must be positive and less than `revisions`.
    */

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1691,7 +1691,7 @@ typedef struct DatabaseHandleArgs {
   /**
    * The maximum number of revisions to keep.
    *
-   * Must be > `deferred_persistence_commit_count`.
+   * Must be > `max_persistence_gap`.
    */
   size_t revisions;
   /**
@@ -1737,11 +1737,33 @@ typedef struct DatabaseHandleArgs {
    */
   enum NodeHashAlgorithm node_hash_algorithm;
   /**
-   * The maximum number of unpersisted revisions that can exist at a given time.
+   * The maximum number of committed revisions by which the latest persisted
+   * state may lag behind the latest committed state.
    *
-   * Note: `revisions` must be > `deferred_persistence_commit_count`.
+   * Committing makes a revision current, while persistence writes its state
+   * to the database files asynchronously, without a fixed schedule. A commit
+   * can therefore return before its state is persisted, even when this value
+   * is 1, and subsequent commits may wait for persistence to maintain the
+   * configured bound. Only commits that change the current root count toward
+   * this limit; uncommitted proposals do not.
+   *
+   * Set this value to 1 to persist every committed revision before the next
+   * state-changing commit completes. Values greater than 1 allow persistence
+   * to skip intermediate revisions, so not every revision is guaranteed to be
+   * written to disk.
+   *
+   * A successful explicit close persists the latest committed state.
+   *
+   * Examples:
+   *
+   * - With a value of 1, the latest persisted state is either the latest
+   *   committed revision or its parent.
+   * - With a value of 2, it may also be its grandparent: at most two revisions
+   *   back, among three possible states.
+   *
+   * Must be positive and less than `revisions`.
    */
-  uint64_t deferred_persistence_commit_count;
+  uint64_t max_persistence_gap;
 } DatabaseHandleArgs;
 
 /**

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -73,7 +73,7 @@ pub struct DatabaseHandleArgs<'a> {
 
     /// The maximum number of revisions to keep.
     ///
-    /// Must be > `deferred_persistence_commit_count`.
+    /// Must be > `max_revision_recovery_lag`.
     pub revisions: usize,
 
     /// The cache read strategy to use.
@@ -104,10 +104,11 @@ pub struct DatabaseHandleArgs<'a> {
     /// Opening returns an error if this does not match the compile-time feature.
     pub node_hash_algorithm: NodeHashAlgorithm,
 
-    /// The maximum number of unpersisted revisions that can exist at a given time.
+    /// The maximum number of latest committed revisions that may need to be
+    /// recommitted after a crash.
     ///
-    /// Note: `revisions` must be > `deferred_persistence_commit_count`.
-    pub deferred_persistence_commit_count: u64,
+    /// Note: `revisions` must be > `max_revision_recovery_lag`.
+    pub max_revision_recovery_lag: u64,
 }
 
 impl DatabaseHandleArgs<'_> {
@@ -120,8 +121,8 @@ impl DatabaseHandleArgs<'_> {
         };
         let free_list_cache_size = NonZeroUsize::new(self.free_list_cache_size)
             .ok_or_else(|| invalid_data("free list cache size should be non-zero"))?;
-        let commit_count = NonZeroU64::new(self.deferred_persistence_commit_count)
-            .ok_or(api::Error::ZeroCommitCount)?;
+        let max_revision_recovery_lag = NonZeroU64::new(self.max_revision_recovery_lag)
+            .ok_or(api::Error::ZeroRevisionRecoveryLag)?;
 
         let memory_limit = NonZeroUsize::new(self.node_cache_memory_limit);
 
@@ -130,7 +131,7 @@ impl DatabaseHandleArgs<'_> {
                 .max_revisions(self.revisions)
                 .cache_read_strategy(cache_read_strategy)
                 .free_list_cache_size(free_list_cache_size)
-                .deferred_persistence_commit_count(commit_count);
+                .max_revision_recovery_lag(max_revision_recovery_lag);
 
             if let Some(memory_limit) = memory_limit {
                 builder.node_cache_memory_limit(memory_limit).build()

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -73,7 +73,7 @@ pub struct DatabaseHandleArgs<'a> {
 
     /// The maximum number of revisions to keep.
     ///
-    /// Must be > `deferred_persistence_commit_count`.
+    /// Must be > `max_persistence_gap`.
     pub revisions: usize,
 
     /// The cache read strategy to use.
@@ -113,10 +113,32 @@ pub struct DatabaseHandleArgs<'a> {
     /// databases regardless of the database's runtime hash mode.
     pub node_hash_algorithm: NodeHashAlgorithm,
 
-    /// The maximum number of unpersisted revisions that can exist at a given time.
+    /// The maximum number of committed revisions by which the latest persisted
+    /// state may lag behind the latest committed state.
     ///
-    /// Note: `revisions` must be > `deferred_persistence_commit_count`.
-    pub deferred_persistence_commit_count: u64,
+    /// Committing makes a revision current, while persistence writes its state
+    /// to the database files asynchronously, without a fixed schedule. A commit
+    /// can therefore return before its state is persisted, even when this value
+    /// is 1, and subsequent commits may wait for persistence to maintain the
+    /// configured bound. Only commits that change the current root count toward
+    /// this limit; uncommitted proposals do not.
+    ///
+    /// Set this value to 1 to persist every committed revision before the next
+    /// state-changing commit completes. Values greater than 1 allow persistence
+    /// to skip intermediate revisions, so not every revision is guaranteed to be
+    /// written to disk.
+    ///
+    /// A successful explicit close persists the latest committed state.
+    ///
+    /// Examples:
+    ///
+    /// - With a value of 1, the latest persisted state is either the latest
+    ///   committed revision or its parent.
+    /// - With a value of 2, it may also be its grandparent: at most two revisions
+    ///   back, among three possible states.
+    ///
+    /// Must be positive and less than `revisions`.
+    pub max_persistence_gap: u64,
 }
 
 impl DatabaseHandleArgs<'_> {
@@ -129,8 +151,8 @@ impl DatabaseHandleArgs<'_> {
         };
         let freelist_memory_limit_kb = NonZeroUsize::new(self.freelist_memory_limit_kb)
             .ok_or_else(|| invalid_data("freelist memory limit should be non-zero"))?;
-        let commit_count = NonZeroU64::new(self.deferred_persistence_commit_count)
-            .ok_or(api::Error::ZeroCommitCount)?;
+        let max_persistence_gap =
+            NonZeroU64::new(self.max_persistence_gap).ok_or(api::Error::ZeroMaxPersistenceGap)?;
 
         let memory_limit = NonZeroUsize::new(self.node_cache_memory_limit);
 
@@ -139,7 +161,7 @@ impl DatabaseHandleArgs<'_> {
                 .max_revisions(self.revisions)
                 .cache_read_strategy(cache_read_strategy)
                 .freelist_memory_limit_kb(freelist_memory_limit_kb)
-                .deferred_persistence_commit_count(commit_count);
+                .max_persistence_gap(max_persistence_gap);
 
             if let Some(memory_limit) = memory_limit {
                 builder.node_cache_memory_limit(memory_limit).build()

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -128,14 +128,10 @@ pub struct DatabaseHandleArgs<'a> {
     /// to skip intermediate revisions, so not every revision is guaranteed to be
     /// written to disk.
     ///
-    /// A successful explicit close persists the latest committed state.
-    ///
-    /// Examples:
-    ///
-    /// - With a value of 1, the latest persisted state is either the latest
-    ///   committed revision or its parent.
-    /// - With a value of 2, it may also be its grandparent: at most two revisions
-    ///   back, among three possible states.
+    /// A successful explicit close persists the latest committed state. If the
+    /// process exits without a successful close, the recovered state is at
+    /// most `max_persistence_gap` commits behind the latest committed
+    /// revision.
     ///
     /// Must be positive and less than `revisions`.
     pub max_persistence_gap: u64,

--- a/firewood/benches/defer_persist.rs
+++ b/firewood/benches/defer_persist.rs
@@ -11,54 +11,59 @@ use std::iter::repeat_with;
 use std::num::NonZeroU64;
 
 #[expect(clippy::unwrap_used)]
-fn bench_deferred_persistence<const N: usize, const COMMIT_COUNT: u64>(criterion: &mut Criterion) {
+fn bench_deferred_persistence<const N: usize, const MAX_REVISION_RECOVERY_LAG: u64>(
+    criterion: &mut Criterion,
+) {
     const KEY_LEN: usize = 4;
     let rng = &firewood_storage::SeededRng::from_option(Some(1234));
-    let commit_count = NonZeroU64::new(COMMIT_COUNT).unwrap();
-    let max_revisions = commit_count.get().wrapping_add(1) as usize;
+    let max_revision_recovery_lag = NonZeroU64::new(MAX_REVISION_RECOVERY_LAG).unwrap();
+    let max_revisions = max_revision_recovery_lag.get().wrapping_add(1) as usize;
 
     criterion
         .benchmark_group("deferred_persistence")
         .sample_size(20)
-        .bench_function(format!("commit_count_{COMMIT_COUNT}"), |b| {
-            b.iter_batched(
-                || {
-                    let batch_ops: Vec<_> =
-                        repeat_with(|| rng.sample_iter(&Alphanumeric).take(KEY_LEN).collect())
-                            .map(|key: Vec<_>| BatchOp::Put {
-                                key,
-                                value: vec![b'v'],
-                            })
-                            .take(N)
-                            .collect();
-                    batch_ops
-                },
-                |batch_ops| {
-                    let tmpdir = tempfile::tempdir().unwrap();
-                    let dbcfg = DbConfig::builder()
-                        .node_hash_algorithm(NodeHashAlgorithm::compile_option())
-                        .manager(
-                            RevisionManagerConfig::builder()
-                                .max_revisions(max_revisions)
-                                .deferred_persistence_commit_count(commit_count)
-                                .build(),
-                        )
-                        .build();
-                    let db = Db::new(tmpdir, dbcfg).unwrap();
+        .bench_function(
+            format!("max_revision_recovery_lag_{MAX_REVISION_RECOVERY_LAG}"),
+            |b| {
+                b.iter_batched(
+                    || {
+                        let batch_ops: Vec<_> =
+                            repeat_with(|| rng.sample_iter(&Alphanumeric).take(KEY_LEN).collect())
+                                .map(|key: Vec<_>| BatchOp::Put {
+                                    key,
+                                    value: vec![b'v'],
+                                })
+                                .take(N)
+                                .collect();
+                        batch_ops
+                    },
+                    |batch_ops| {
+                        let tmpdir = tempfile::tempdir().unwrap();
+                        let dbcfg = DbConfig::builder()
+                            .node_hash_algorithm(NodeHashAlgorithm::compile_option())
+                            .manager(
+                                RevisionManagerConfig::builder()
+                                    .max_revisions(max_revisions)
+                                    .max_revision_recovery_lag(max_revision_recovery_lag)
+                                    .build(),
+                            )
+                            .build();
+                        let db = Db::new(tmpdir, dbcfg).unwrap();
 
-                    for op in batch_ops {
-                        let proposal = db.propose(vec![op]).unwrap();
-                        proposal.commit().unwrap();
-                    }
+                        for op in batch_ops {
+                            let proposal = db.propose(vec![op]).unwrap();
+                            proposal.commit().unwrap();
+                        }
 
-                    db.close().unwrap();
-                },
-                criterion::BatchSize::SmallInput,
-            );
-        });
+                        db.close().unwrap();
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
 }
 
-// Commit count values span powers of 10 (1, 10, 100, 1_000) to show the
+// Recovery lag values span powers of 10 (1, 10, 100, 1_000) to show the
 // performance curve from persisting every commit to persisting just once.
 criterion_group! {
     name = benches;

--- a/firewood/benches/defer_persist.rs
+++ b/firewood/benches/defer_persist.rs
@@ -12,16 +12,18 @@ use std::iter::repeat_with;
 use std::num::NonZeroU64;
 
 #[expect(clippy::unwrap_used)]
-fn bench_deferred_persistence<const N: usize, const COMMIT_COUNT: u64>(criterion: &mut Criterion) {
+fn bench_deferred_persistence<const N: usize, const MAX_PERSISTENCE_GAP: u64>(
+    criterion: &mut Criterion,
+) {
     const KEY_LEN: usize = 4;
     let rng = &firewood_storage::SeededRng::from_option(Some(1234));
-    let commit_count = NonZeroU64::new(COMMIT_COUNT).unwrap();
-    let max_revisions = commit_count.get().wrapping_add(1) as usize;
+    let max_persistence_gap = NonZeroU64::new(MAX_PERSISTENCE_GAP).unwrap();
+    let max_revisions = max_persistence_gap.get().wrapping_add(1) as usize;
 
     criterion
         .benchmark_group("deferred_persistence")
         .sample_size(20)
-        .bench_function(format!("commit_count_{COMMIT_COUNT}"), |b| {
+        .bench_function(format!("max_persistence_gap_{MAX_PERSISTENCE_GAP}"), |b| {
             b.iter_batched(
                 || {
                     let batch_ops: Vec<_> =
@@ -41,7 +43,7 @@ fn bench_deferred_persistence<const N: usize, const COMMIT_COUNT: u64>(criterion
                         .manager(
                             RevisionManagerConfig::builder()
                                 .max_revisions(max_revisions)
-                                .deferred_persistence_commit_count(commit_count)
+                                .max_persistence_gap(max_persistence_gap)
                                 .build(),
                         )
                         .build();
@@ -60,8 +62,8 @@ fn bench_deferred_persistence<const N: usize, const COMMIT_COUNT: u64>(criterion
         });
 }
 
-// Commit count values span powers of 10 (1, 10, 100, 1_000) to show the
-// performance curve from persisting every commit to persisting just once.
+// Persistence gap limits span powers of 10 (1, 10, 100, 1_000) to measure
+// throughput as more revisions may accumulate before persistence completes.
 criterion_group! {
     name = benches;
     config = Criterion::default();

--- a/firewood/src/api.rs
+++ b/firewood/src/api.rs
@@ -202,15 +202,15 @@ pub enum Error {
     #[error("feature not supported in this build: {0}")]
     FeatureNotSupported(String),
 
-    #[error("commit count must be positive")]
-    ZeroCommitCount,
+    #[error("max revision recovery lag must be positive")]
+    ZeroRevisionRecoveryLag,
 
     #[error(
-        "max_revisions ({max_revisions}) must be > deferred_persistence_commit_count ({commit_count})"
+        "max_revisions ({max_revisions}) must be > max_revision_recovery_lag ({max_revision_recovery_lag})"
     )]
     InsufficientRevisions {
         max_revisions: usize,
-        commit_count: u64,
+        max_revision_recovery_lag: u64,
     },
 }
 
@@ -238,10 +238,10 @@ impl From<RevisionManagerError> for Error {
             PersistError(err) => Self::DeferredPersistenceError(err),
             InsufficientRevisions {
                 max_revisions,
-                commit_count,
+                max_revision_recovery_lag,
             } => Self::InsufficientRevisions {
                 max_revisions,
-                commit_count,
+                max_revision_recovery_lag,
             },
         }
     }

--- a/firewood/src/api.rs
+++ b/firewood/src/api.rs
@@ -187,15 +187,15 @@ pub enum Error {
     #[error("feature not supported in this build: {0}")]
     FeatureNotSupported(String),
 
-    #[error("commit count must be positive")]
-    ZeroCommitCount,
+    #[error("max_persistence_gap must be positive")]
+    ZeroMaxPersistenceGap,
 
     #[error(
-        "max_revisions ({max_revisions}) must be > deferred_persistence_commit_count ({commit_count})"
+        "max_revisions ({max_revisions}) must be > max_persistence_gap ({max_persistence_gap})"
     )]
     InsufficientRevisions {
         max_revisions: usize,
-        commit_count: u64,
+        max_persistence_gap: u64,
     },
 
     #[error(
@@ -231,10 +231,10 @@ impl From<RevisionManagerError> for Error {
             PersistError(err) => Self::DeferredPersistenceError(err),
             InsufficientRevisions {
                 max_revisions,
-                commit_count,
+                max_persistence_gap,
             } => Self::InsufficientRevisions {
                 max_revisions,
-                commit_count,
+                max_persistence_gap,
             },
         }
     }

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -1941,16 +1941,16 @@ mod test {
 
     #[test]
     fn test_deferred_persist_close_with_high_commit_count() {
-        const HIGH_COMMIT_COUNT: NonZeroU64 = nonzero!(1_000_000u64);
-        const MAX_REVISIONS: usize = HIGH_COMMIT_COUNT.get() as usize + 1;
+        const HIGH_RECOVERY_LAG: NonZeroU64 = nonzero!(1_000_000u64);
+        const MAX_REVISIONS: usize = HIGH_RECOVERY_LAG.get() as usize + 1;
 
-        // Set commit count to an arbitrarily high number so persist happens
-        // only on shutdown
+        // Set the recovery lag to an arbitrarily high number so persist happens
+        // only on shutdown.
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(MAX_REVISIONS)
-                    .deferred_persistence_commit_count(HIGH_COMMIT_COUNT)
+                    .max_revision_recovery_lag(HIGH_RECOVERY_LAG)
                     .build(),
             )
             .build();
@@ -1975,13 +1975,13 @@ mod test {
 
     #[test]
     fn test_deferred_persist_with_multiple_commit_count() {
-        const COMMIT_COUNT: NonZeroU64 = nonzero!(5u64);
-        const NUM_REVISIONS: u64 = COMMIT_COUNT.get() + 1;
+        const MAX_REVISION_RECOVERY_LAG: NonZeroU64 = nonzero!(5u64);
+        const NUM_REVISIONS: u64 = MAX_REVISION_RECOVERY_LAG.get() + 1;
 
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
-                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .max_revision_recovery_lag(MAX_REVISION_RECOVERY_LAG)
                     .build(),
             )
             .build();
@@ -2000,17 +2000,17 @@ mod test {
             proposal.commit().unwrap();
         }
 
-        // Verify that at least one of the last COMMIT_COUNT revisions is persisted.
-        let commit_count = COMMIT_COUNT.get() as usize;
+        // Verify that at least one of the last MAX_REVISION_RECOVERY_LAG revisions is persisted.
+        let max_revision_recovery_lag = MAX_REVISION_RECOVERY_LAG.get() as usize;
         let any_persisted = root_hashes
             .iter()
             .rev()
-            .take(commit_count)
+            .take(max_revision_recovery_lag)
             .any(|hash| db.manager.revision_persist_status(hash.clone()).unwrap());
 
         assert!(
             any_persisted,
-            "At least one of the last {COMMIT_COUNT} revisions should be persisted"
+            "At least one of the last {MAX_REVISION_RECOVERY_LAG} revisions should be persisted"
         );
     }
 
@@ -2018,20 +2018,20 @@ mod test {
     /// persisted when the database closes.
     #[test]
     fn test_deferred_persistence_closing_on_empty_trie() {
-        const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
+        const MAX_REVISION_RECOVERY_LAG: NonZeroU64 = nonzero!(10u64);
 
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
-                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .max_revision_recovery_lag(MAX_REVISION_RECOVERY_LAG)
                     .build(),
             )
             .build();
 
         let db = TestDb::new_with_config(dbcfg);
 
-        // Commit COMMIT_COUNT proposals to trigger the first persist
-        for i in 0..COMMIT_COUNT.get() {
+        // Commit MAX_REVISION_RECOVERY_LAG proposals to trigger the first persist.
+        for i in 0..MAX_REVISION_RECOVERY_LAG.get() {
             let batch = vec![BatchOp::Put {
                 key: format!("key{i}").as_bytes().to_vec(),
                 value: format!("value{i}").as_bytes().to_vec(),
@@ -2055,14 +2055,14 @@ mod test {
     #[test]
     fn test_deferred_persistence_root_store() {
         const NUM_COMMITS: usize = 20;
-        const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
-        const MAX_REVISIONS: usize = COMMIT_COUNT.get() as usize + 1;
+        const MAX_REVISION_RECOVERY_LAG: NonZeroU64 = nonzero!(10u64);
+        const MAX_REVISIONS: usize = MAX_REVISION_RECOVERY_LAG.get() as usize + 1;
 
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(MAX_REVISIONS)
-                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .max_revision_recovery_lag(MAX_REVISION_RECOVERY_LAG)
                     .build(),
             )
             .root_store(true)
@@ -2085,9 +2085,9 @@ mod test {
 
         let db = db.reopen();
 
-        // Verify that we never went more than COMMIT_COUNT revisions without
+        // Verify that we never went more than MAX_REVISION_RECOVERY_LAG revisions without
         // persisting.
-        let commit_count = COMMIT_COUNT.get() as usize;
+        let max_revision_recovery_lag = MAX_REVISION_RECOVERY_LAG.get() as usize;
         let mut last_persisted: Option<usize> = None;
 
         for (i, hash) in root_hashes.iter().enumerate() {
@@ -2102,8 +2102,8 @@ mod test {
                     None => i.wrapping_add(1),
                 };
                 assert!(
-                    gap <= commit_count,
-                    "Gap of {gap} between persisted revisions exceeds COMMIT_COUNT of {commit_count}"
+                    gap <= max_revision_recovery_lag,
+                    "Gap of {gap} between persisted revisions exceeds MAX_REVISION_RECOVERY_LAG of {max_revision_recovery_lag}"
                 );
                 last_persisted = Some(i);
             }
@@ -2118,12 +2118,12 @@ mod test {
     /// Verifies that non-persisted revisions are lost after reopening the database.
     #[test]
     fn test_deferred_persistence_unpersisted_revisions() {
-        const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
+        const MAX_REVISION_RECOVERY_LAG: NonZeroU64 = nonzero!(10u64);
 
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
-                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .max_revision_recovery_lag(MAX_REVISION_RECOVERY_LAG)
                     .build(),
             )
             .root_store(true)
@@ -2134,7 +2134,7 @@ mod test {
         let mut root_hashes = Vec::new();
 
         let key = b"key";
-        for i in 0..COMMIT_COUNT.get() {
+        for i in 0..MAX_REVISION_RECOVERY_LAG.get() {
             let batch = vec![BatchOp::Put {
                 key,
                 value: format!("{i}").as_bytes().to_vec(),

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -2487,7 +2487,7 @@ mod test {
     }
 
     #[test]
-    fn test_deferred_persist_multiple_commits_with_commit_count_one() {
+    fn test_deferred_persist_multiple_commits_with_max_persistence_gap_one() {
         const NUM_REVISIONS: usize = 20;
 
         let dbcfg = DbConfig::builder()
@@ -2532,7 +2532,7 @@ mod test {
     }
 
     #[test]
-    fn test_deferred_persist_close_with_commit_count_one() {
+    fn test_deferred_persist_close_with_max_persistence_gap_one() {
         let dbcfg = DbConfig::builder().build();
 
         let db = TestDb::new_with_config(dbcfg);
@@ -2554,17 +2554,17 @@ mod test {
     }
 
     #[test]
-    fn test_deferred_persist_close_with_high_commit_count() {
-        const HIGH_COMMIT_COUNT: NonZeroU64 = nonzero!(1_000_000u64);
-        const MAX_REVISIONS: usize = HIGH_COMMIT_COUNT.get() as usize + 1;
+    fn test_deferred_persist_close_with_high_max_persistence_gap() {
+        const HIGH_MAX_PERSISTENCE_GAP: NonZeroU64 = nonzero!(1_000_000u64);
+        const MAX_REVISIONS: usize = HIGH_MAX_PERSISTENCE_GAP.get() as usize + 1;
 
-        // Set commit count to an arbitrarily high number so persist happens
+        // Set the persistence gap limit high enough so persistence happens
         // only on shutdown
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(MAX_REVISIONS)
-                    .deferred_persistence_commit_count(HIGH_COMMIT_COUNT)
+                    .max_persistence_gap(HIGH_MAX_PERSISTENCE_GAP)
                     .build(),
             )
             .build();
@@ -2588,14 +2588,14 @@ mod test {
     }
 
     #[test]
-    fn test_deferred_persist_with_multiple_commit_count() {
-        const COMMIT_COUNT: NonZeroU64 = nonzero!(5u64);
-        const NUM_REVISIONS: u64 = COMMIT_COUNT.get() + 1;
+    fn test_persisted_state_within_max_persistence_gap() {
+        const MAX_PERSISTENCE_GAP: NonZeroU64 = nonzero!(5u64);
+        const NUM_REVISIONS: u64 = MAX_PERSISTENCE_GAP.get() + 1;
 
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
-                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .max_persistence_gap(MAX_PERSISTENCE_GAP)
                     .build(),
             )
             .build();
@@ -2614,17 +2614,17 @@ mod test {
             proposal.commit().unwrap();
         }
 
-        // Verify that at least one of the last COMMIT_COUNT revisions is persisted.
-        let commit_count = COMMIT_COUNT.get() as usize;
+        // Going back at most MAX_PERSISTENCE_GAP revisions includes the current state.
+        let max_persistence_gap = MAX_PERSISTENCE_GAP.get() as usize;
         let any_persisted = root_hashes
             .iter()
             .rev()
-            .take(commit_count)
+            .take(max_persistence_gap.saturating_add(1))
             .any(|hash| db.manager.revision_persist_status(hash.clone()).unwrap());
 
         assert!(
             any_persisted,
-            "At least one of the last {COMMIT_COUNT} revisions should be persisted"
+            "A persisted state should be at most {MAX_PERSISTENCE_GAP} revisions behind"
         );
     }
 
@@ -2632,20 +2632,20 @@ mod test {
     /// persisted when the database closes.
     #[test]
     fn test_deferred_persistence_closing_on_empty_trie() {
-        const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
+        const MAX_PERSISTENCE_GAP: NonZeroU64 = nonzero!(10u64);
 
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
-                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .max_persistence_gap(MAX_PERSISTENCE_GAP)
                     .build(),
             )
             .build();
 
         let db = TestDb::new_with_config(dbcfg);
 
-        // Commit COMMIT_COUNT proposals to trigger the first persist
-        for i in 0..COMMIT_COUNT.get() {
+        // Reach the gap limit before committing the empty state below.
+        for i in 0..MAX_PERSISTENCE_GAP.get() {
             let batch = vec![BatchOp::Put {
                 key: format!("key{i}").as_bytes().to_vec(),
                 value: format!("value{i}").as_bytes().to_vec(),
@@ -2669,14 +2669,14 @@ mod test {
     #[test]
     fn test_deferred_persistence_root_store() {
         const NUM_COMMITS: usize = 20;
-        const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
-        const MAX_REVISIONS: usize = COMMIT_COUNT.get() as usize + 1;
+        const MAX_PERSISTENCE_GAP: NonZeroU64 = nonzero!(10u64);
+        const MAX_REVISIONS: usize = MAX_PERSISTENCE_GAP.get() as usize + 1;
 
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(MAX_REVISIONS)
-                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .max_persistence_gap(MAX_PERSISTENCE_GAP)
                     .build(),
             )
             .root_store(true)
@@ -2699,9 +2699,9 @@ mod test {
 
         let db = db.reopen();
 
-        // Verify that we never went more than COMMIT_COUNT revisions without
+        // Verify that we never went more than MAX_PERSISTENCE_GAP revisions without
         // persisting.
-        let commit_count = COMMIT_COUNT.get() as usize;
+        let max_persistence_gap = MAX_PERSISTENCE_GAP.get() as usize;
         let mut last_persisted: Option<usize> = None;
 
         for (i, hash) in root_hashes.iter().enumerate() {
@@ -2716,8 +2716,8 @@ mod test {
                     None => i.wrapping_add(1),
                 };
                 assert!(
-                    gap <= commit_count,
-                    "Gap of {gap} between persisted revisions exceeds COMMIT_COUNT of {commit_count}"
+                    gap <= max_persistence_gap,
+                    "Gap of {gap} between persisted revisions exceeds MAX_PERSISTENCE_GAP of {max_persistence_gap}"
                 );
                 last_persisted = Some(i);
             }
@@ -2732,12 +2732,12 @@ mod test {
     /// Verifies that non-persisted revisions are lost after reopening the database.
     #[test]
     fn test_deferred_persistence_unpersisted_revisions() {
-        const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
+        const MAX_PERSISTENCE_GAP: NonZeroU64 = nonzero!(10u64);
 
         let dbcfg = DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
-                    .deferred_persistence_commit_count(COMMIT_COUNT)
+                    .max_persistence_gap(MAX_PERSISTENCE_GAP)
                     .build(),
             )
             .root_store(true)
@@ -2748,7 +2748,7 @@ mod test {
         let mut root_hashes = Vec::new();
 
         let key = b"key";
-        for i in 0..COMMIT_COUNT.get() {
+        for i in 0..MAX_PERSISTENCE_GAP.get() {
             let batch = vec![BatchOp::Put {
                 key,
                 value: format!("{i}").as_bytes().to_vec(),

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -39,7 +39,7 @@ pub(crate) const DB_FILE_NAME: &str = "firewood.db";
 pub struct RevisionManagerConfig {
     /// The number of committed revisions to keep in memory.
     ///
-    /// Must be > `deferred_persistence_commit_count`.
+    /// Must be > `max_revision_recovery_lag`.
     #[builder(default = 128)]
     max_revisions: usize,
 
@@ -55,11 +55,12 @@ pub struct RevisionManagerConfig {
     #[builder(default = CacheReadStrategy::WritesOnly)]
     cache_read_strategy: CacheReadStrategy,
 
-    /// The maximum number of unpersisted revisions that can exist at a given time.
+    /// The maximum number of latest committed revisions that may need to be
+    /// recommitted after a crash.
     ///
     /// Must be < `max_revisions`.
     #[builder(default = nonzero!(1u64))]
-    deferred_persistence_commit_count: NonZeroU64,
+    max_revision_recovery_lag: NonZeroU64,
 }
 
 #[derive(Clone, Debug, TypedBuilder)]
@@ -149,21 +150,21 @@ pub(crate) enum RevisionManagerError {
     #[error("A deferred persistence error occurred: {0}")]
     PersistError(#[source] PersistError),
     #[error(
-        "max_revisions ({max_revisions}) must be > deferred_persistence_commit_count ({commit_count})"
+        "max_revisions ({max_revisions}) must be > max_revision_recovery_lag ({max_revision_recovery_lag})"
     )]
     InsufficientRevisions {
         max_revisions: usize,
-        commit_count: u64,
+        max_revision_recovery_lag: u64,
     },
 }
 
 impl RevisionManager {
     pub fn new(config: ConfigManager) -> Result<Self, RevisionManagerError> {
-        let commit_count = config.manager.deferred_persistence_commit_count.get();
-        if (config.manager.max_revisions as u64) <= commit_count {
+        let max_revision_recovery_lag = config.manager.max_revision_recovery_lag.get();
+        if (config.manager.max_revisions as u64) <= max_revision_recovery_lag {
             return Err(RevisionManagerError::InsufficientRevisions {
                 max_revisions: config.manager.max_revisions,
-                commit_count,
+                max_revision_recovery_lag,
             });
         }
 
@@ -217,7 +218,7 @@ impl RevisionManager {
         }
 
         let persist_worker = PersistWorker::new(
-            config.manager.deferred_persistence_commit_count,
+            config.manager.max_revision_recovery_lag,
             header,
             root_store.clone(),
         );
@@ -1004,9 +1005,9 @@ mod tests {
     #[test]
     fn test_revision_count() {
         let db_dir = tempfile::tempdir().unwrap();
-        let commit_count = nonzero!(10u64);
+        let max_revision_recovery_lag = nonzero!(10u64);
 
-        // `max_revisions` < `commit_count`
+        // `max_revisions` < `max_revision_recovery_lag`
         let config = ConfigManager::builder()
             .root_dir(db_dir.as_ref().to_path_buf())
             .node_hash_algorithm(NodeHashAlgorithm::compile_option())
@@ -1014,7 +1015,7 @@ mod tests {
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(5)
-                    .deferred_persistence_commit_count(commit_count)
+                    .max_revision_recovery_lag(max_revision_recovery_lag)
                     .build(),
             )
             .build();
@@ -1022,14 +1023,14 @@ mod tests {
         let result = RevisionManager::new(config);
         assert!(result.is_err());
 
-        // `max_revisions` == `commit_count`
+        // `max_revisions` == `max_revision_recovery_lag`
         let config = ConfigManager::builder()
             .root_dir(db_dir.as_ref().to_path_buf())
             .node_hash_algorithm(NodeHashAlgorithm::compile_option())
             .manager(
                 RevisionManagerConfig::builder()
-                    .max_revisions(commit_count.get() as usize)
-                    .deferred_persistence_commit_count(commit_count)
+                    .max_revisions(max_revision_recovery_lag.get() as usize)
+                    .max_revision_recovery_lag(max_revision_recovery_lag)
                     .build(),
             )
             .build();
@@ -1037,15 +1038,15 @@ mod tests {
         let result = RevisionManager::new(config);
         assert!(result.is_err());
 
-        // `max_revisions` > `commit_count`
-        let max_revisions = commit_count.get().wrapping_add(1) as usize;
+        // `max_revisions` > `max_revision_recovery_lag`
+        let max_revisions = max_revision_recovery_lag.get().wrapping_add(1) as usize;
         let config = ConfigManager::builder()
             .root_dir(db_dir.as_ref().to_path_buf())
             .node_hash_algorithm(NodeHashAlgorithm::compile_option())
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(max_revisions)
-                    .deferred_persistence_commit_count(commit_count)
+                    .max_revision_recovery_lag(max_revision_recovery_lag)
                     .build(),
             )
             .build();
@@ -1076,7 +1077,7 @@ mod tests {
             .create(true)
             .manager(
                 // Smallest legal queue: max_revisions must exceed
-                // deferred_persistence_commit_count (default 1). Two slots is
+                // max_revision_recovery_lag (default 1). Two slots is
                 // enough for the initial empty revision to be reaped after a
                 // pair of non-empty commits.
                 RevisionManagerConfig::builder().max_revisions(2).build(),

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -39,7 +39,7 @@ pub(crate) const DB_FILE_NAME: &str = "firewood.db";
 pub struct RevisionManagerConfig {
     /// The number of committed revisions to keep in memory.
     ///
-    /// Must be > `deferred_persistence_commit_count`.
+    /// Must be > `max_persistence_gap`.
     #[builder(default = 128)]
     max_revisions: usize,
 
@@ -63,11 +63,33 @@ pub struct RevisionManagerConfig {
     #[builder(default = CacheReadStrategy::WritesOnly)]
     cache_read_strategy: CacheReadStrategy,
 
-    /// The maximum number of unpersisted revisions that can exist at a given time.
+    /// The maximum number of committed revisions by which the latest persisted
+    /// state may lag behind the latest committed state.
     ///
-    /// Must be < `max_revisions`.
+    /// Committing makes a revision current, while persistence writes its state
+    /// to the database files asynchronously, without a fixed schedule. A commit
+    /// can therefore return before its state is persisted, even when this value
+    /// is 1, and subsequent commits may wait for persistence to maintain the
+    /// configured bound. Only commits that change the current root count toward
+    /// this limit; uncommitted proposals do not.
+    ///
+    /// Set this value to 1 to persist every committed revision before the next
+    /// state-changing commit completes. Values greater than 1 allow persistence
+    /// to skip intermediate revisions, so not every revision is guaranteed to be
+    /// written to disk.
+    ///
+    /// A successful explicit database close persists the latest committed state.
+    ///
+    /// Examples:
+    ///
+    /// - With a value of 1, the latest persisted state is either the latest
+    ///   committed revision or its parent.
+    /// - With a value of 2, it may also be its grandparent: at most two revisions
+    ///   back, among three possible states.
+    ///
+    /// Defaults to 1. Must be positive and less than `max_revisions`.
     #[builder(default = nonzero!(1u64))]
-    deferred_persistence_commit_count: NonZeroU64,
+    max_persistence_gap: NonZeroU64,
 }
 
 #[derive(Clone, Debug, TypedBuilder)]
@@ -160,21 +182,21 @@ pub(crate) enum RevisionManagerError {
     #[error("A deferred persistence error occurred: {0}")]
     PersistError(#[source] PersistError),
     #[error(
-        "max_revisions ({max_revisions}) must be > deferred_persistence_commit_count ({commit_count})"
+        "max_revisions ({max_revisions}) must be > max_persistence_gap ({max_persistence_gap})"
     )]
     InsufficientRevisions {
         max_revisions: usize,
-        commit_count: u64,
+        max_persistence_gap: u64,
     },
 }
 
 impl<H: HashMode> RevisionManager<H> {
     pub fn new(config: ConfigManager) -> Result<Self, RevisionManagerError> {
-        let commit_count = config.manager.deferred_persistence_commit_count.get();
-        if (config.manager.max_revisions as u64) <= commit_count {
+        let max_persistence_gap = config.manager.max_persistence_gap.get();
+        if (config.manager.max_revisions as u64) <= max_persistence_gap {
             return Err(RevisionManagerError::InsufficientRevisions {
                 max_revisions: config.manager.max_revisions,
-                commit_count,
+                max_persistence_gap,
             });
         }
 
@@ -237,7 +259,7 @@ impl<H: HashMode> RevisionManager<H> {
         }
 
         let persist_worker = PersistWorker::new(
-            config.manager.deferred_persistence_commit_count,
+            config.manager.max_persistence_gap,
             header,
             root_store.clone(),
         );
@@ -411,7 +433,7 @@ impl<H: HashMode> RevisionManager<H> {
         let committed: CommittedRevision<H> = committed.into();
         let __submit_start = ::std::time::Instant::now();
         self.persist_worker
-            .persist(committed.clone())
+            .submit_revision(committed.clone())
             .map_err(RevisionManagerError::PersistError)?;
         firewood_histogram!(cheap: PERSIST_SUBMIT_DURATION_SECONDS)
             .record(__submit_start.elapsed().as_secs_f64());
@@ -1031,16 +1053,16 @@ mod tests {
     #[test]
     fn test_revision_count() {
         let db_dir = tempfile::tempdir().unwrap();
-        let commit_count = nonzero!(10u64);
+        let max_persistence_gap = nonzero!(10u64);
 
-        // `max_revisions` < `commit_count`
+        // `max_revisions` < `max_persistence_gap`
         let config = ConfigManager::builder()
             .root_dir(db_dir.as_ref().to_path_buf())
             .create(true)
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(5)
-                    .deferred_persistence_commit_count(commit_count)
+                    .max_persistence_gap(max_persistence_gap)
                     .build(),
             )
             .build();
@@ -1048,13 +1070,13 @@ mod tests {
         let result = RevisionManager::<DefaultHashMode>::new(config);
         assert!(result.is_err());
 
-        // `max_revisions` == `commit_count`
+        // `max_revisions` == `max_persistence_gap`
         let config = ConfigManager::builder()
             .root_dir(db_dir.as_ref().to_path_buf())
             .manager(
                 RevisionManagerConfig::builder()
-                    .max_revisions(commit_count.get() as usize)
-                    .deferred_persistence_commit_count(commit_count)
+                    .max_revisions(max_persistence_gap.get() as usize)
+                    .max_persistence_gap(max_persistence_gap)
                     .build(),
             )
             .build();
@@ -1062,14 +1084,14 @@ mod tests {
         let result = RevisionManager::<DefaultHashMode>::new(config);
         assert!(result.is_err());
 
-        // `max_revisions` > `commit_count`
-        let max_revisions = commit_count.get().wrapping_add(1) as usize;
+        // `max_revisions` > `max_persistence_gap`
+        let max_revisions = max_persistence_gap.get().wrapping_add(1) as usize;
         let config = ConfigManager::builder()
             .root_dir(db_dir.as_ref().to_path_buf())
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(max_revisions)
-                    .deferred_persistence_commit_count(commit_count)
+                    .max_persistence_gap(max_persistence_gap)
                     .build(),
             )
             .build();
@@ -1099,7 +1121,7 @@ mod tests {
             .create(true)
             .manager(
                 // Smallest legal queue: max_revisions must exceed
-                // deferred_persistence_commit_count (default 1). Two slots is
+                // max_persistence_gap (default 1). Two slots is
                 // enough for the initial empty revision to be reaped after a
                 // pair of non-empty commits.
                 RevisionManagerConfig::builder().max_revisions(2).build(),

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -78,14 +78,10 @@ pub struct RevisionManagerConfig {
     /// to skip intermediate revisions, so not every revision is guaranteed to be
     /// written to disk.
     ///
-    /// A successful explicit database close persists the latest committed state.
-    ///
-    /// Examples:
-    ///
-    /// - With a value of 1, the latest persisted state is either the latest
-    ///   committed revision or its parent.
-    /// - With a value of 2, it may also be its grandparent: at most two revisions
-    ///   back, among three possible states.
+    /// A successful explicit database close persists the latest committed
+    /// state. If the process exits without a successful close, the recovered
+    /// state is at most `max_persistence_gap` commits behind the latest
+    /// committed revision.
     ///
     /// Defaults to 1. Must be positive and less than `max_revisions`.
     #[builder(default = nonzero!(1u64))]

--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -331,7 +331,7 @@ impl PersistChannel {
         state.emit_permits();
 
         // BLOCKING: condvar wait. The commit thread parks here when all permits are consumed
-        // (i.e. `deferred_persistence_commit_count` commits have accumulated without a persist).
+        // (i.e. `max_revision_recovery_lag` commits have accumulated without a persist).
         // It wakes when the background persist loop calls `commit_not_full.notify_all()` after
         // releasing permits. Duration is bounded by how fast the background thread can write a
         // revision to disk. Under slow I/O this can stall commits for hundreds of milliseconds.

--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -4,8 +4,8 @@
 //! Deferred persistence for committed revisions.
 //!
 //! This module decouples commit operations from disk I/O by offloading persistence
-//! to a background thread. Commits return immediately after updating in-memory state,
-//! while disk writes happen asynchronously.
+//! to a background thread. Commits may wait for capacity before updating in-memory
+//! state; disk writes happen asynchronously.
 //!
 //! [`PersistWorker`] is the main entry point. It spawns a background thread and provides
 //! methods to send revisions for persistence, with built-in backpressure to limit
@@ -13,25 +13,27 @@
 //!
 //! # Permit model
 //!
-//! Backpressure is managed through a fixed pool of **permits**, sized by `commit_count`
+//! Backpressure is managed through a fixed pool of **permits**, sized by `max_persistence_gap`
 //! (the maximum number of unpersisted commits allowed at any time).
 //!
-//! - **Commits consume permits.** Each call to [`PersistWorker::persist`] stores the
+//! - **Commits consume permits.** Each call to [`PersistWorker::submit_revision`] stores the
 //!   latest committed revision and consumes one permit. If no permits remain, the
 //!   caller blocks until the background thread releases some.
 //!
 //! - **Persists release permits.** When the background thread writes a revision to disk,
-//!   all permits consumed since the last persist are released at once, unblocking any
-//!   waiting committers.
+//!   the permits associated with that revision and its predecessors are released,
+//!   unblocking waiting committers. Commits submitted during the write retain their
+//!   permits until a later persistence operation completes.
 //!
 //! - **A threshold triggers persistence.** The background thread wakes when the number
-//!   of available permits drops to `persist_threshold` (equal to `commit_count / 2`,
+//!   of available permits drops to `persist_permits_threshold` (equal to `max_persistence_gap / 2`,
 //!   rounded down). It then persists the most recent revision and releases the consumed
 //!   permits in bulk. Only the latest revision is persisted because persisting a revision
 //!   implicitly includes the effects of all prior revisions.
+//!   It does not preserve each prior revision as a separately queryable state.
 //!
-//! For example, with `commit_count = 10` the pool starts with 10 permits and
-//! `persist_threshold = 5`. After 5 commits the available permits drop to 5,
+//! For example, with `max_persistence_gap = 10` the pool starts with 10 permits and
+//! `persist_permits_threshold = 5`. After 5 commits the available permits drop to 5,
 //! triggering a persist that releases all 5 consumed permits back to the pool.
 //!
 //! See [`PersistWorker`] for a sequence diagram illustrating this flow.
@@ -73,7 +75,7 @@ pub enum PersistError {
 ///
 /// # Sequence diagram
 ///
-/// Below is an example when `commit_count` is set to 10:
+/// Below is an example when `max_persistence_gap` is set to 10:
 ///
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// ```mermaid
@@ -127,20 +129,22 @@ impl<H: HashMode> PersistWorker<H> {
     /// Returns the worker for sending messages to the background thread.
     #[expect(clippy::large_types_passed_by_value)]
     pub(crate) fn new(
-        commit_count: NonZeroU64,
+        max_persistence_gap: NonZeroU64,
         header: NodeStoreHeader,
         root_store: Option<Arc<RootStore<H>>>,
     ) -> Self {
-        let persist_interval = NonZeroU64::new(commit_count.get().div_ceil(2))
+        let persist_interval = NonZeroU64::new(max_persistence_gap.get().div_ceil(2))
             .expect("a nonzero div_ceil(2) is always positive");
-        let persist_threshold = commit_count.get().wrapping_sub(persist_interval.get());
+        let persist_permits_threshold = max_persistence_gap
+            .get()
+            .wrapping_sub(persist_interval.get());
 
         let shared = Arc::new(SharedState {
             error: OnceLock::new(),
             root_store,
             header: Mutex::new(header),
             persist_on_shutdown: OnceLock::new(),
-            channel: PersistChannel::new(commit_count, persist_threshold),
+            channel: PersistChannel::new(max_persistence_gap, persist_permits_threshold),
         });
 
         let bg_shared = shared.clone();
@@ -167,7 +171,10 @@ impl<H: HashMode> PersistWorker<H> {
     /// ## Panics
     ///
     /// Propagates any panic from the background thread.
-    pub(crate) fn persist(&self, committed: CommittedRevision<H>) -> Result<(), PersistError> {
+    pub(crate) fn submit_revision(
+        &self,
+        committed: CommittedRevision<H>,
+    ) -> Result<(), PersistError> {
         // BLOCKING: `push` will block the calling thread (i.e. the commit path) if all permits
         // are consumed — meaning the background persist thread has fallen behind. This is the
         // primary backpressure mechanism: excessive commit rates are slowed down here until the
@@ -252,7 +259,7 @@ impl<H: HashMode> PersistWorker<H> {
         // BLOCKING: `handle.lock()` acquires the JoinHandle mutex (fast). `handle.join()` then
         // blocks until the background thread exits — which can be an arbitrarily long wait if
         // the thread is mid-persist or mid-reap with slow disk I/O. This is only called from
-        // `persist()` on a channel shutdown or from `close()`, so normal operation is unaffected.
+        // `submit_revision()` on a channel shutdown or from `close()`, so normal operation is unaffected.
         if let Some(handle) = self.handle.lock().take()
             && let Err(payload) = handle.join()
         {
@@ -279,7 +286,7 @@ struct PersistChannel<H> {
 }
 
 impl<H> PersistChannel<H> {
-    fn new(max_permits: NonZeroU64, persist_threshold: u64) -> Self {
+    fn new(max_permits: NonZeroU64, persist_permits_threshold: u64) -> Self {
         // Emit once at construction since `max_permits` is constant.
         firewood_gauge!(MAX_PERMITS).set_integer(max_permits.get());
 
@@ -287,7 +294,7 @@ impl<H> PersistChannel<H> {
             state: Mutex::new(PersistChannelState {
                 permits_available: max_permits.get(),
                 max_permits,
-                persist_threshold,
+                persist_permits_threshold,
                 shutdown: false,
                 pending_reaps: Vec::new(),
                 latest_committed: None,
@@ -331,7 +338,7 @@ impl<H> PersistChannel<H> {
         state.emit_permits();
 
         // BLOCKING: condvar wait. The commit thread parks here when all permits are consumed
-        // (i.e. `deferred_persistence_commit_count` commits have accumulated without a persist).
+        // (i.e. `max_persistence_gap` commits have accumulated without a persist).
         // It wakes when the background persist loop calls `commit_not_full.notify_all()` after
         // releasing permits. Duration is bounded by how fast the background thread can write a
         // revision to disk. Under slow I/O this can stall commits for hundreds of milliseconds.
@@ -348,7 +355,7 @@ impl<H> PersistChannel<H> {
         state.permits_available = state.permits_available.wrapping_sub(1);
 
         // Wake the persister once we reach the threshold.
-        if state.permits_available <= state.persist_threshold {
+        if state.permits_available <= state.persist_permits_threshold {
             self.persist_ready.notify_one();
         }
         Ok(())
@@ -369,7 +376,7 @@ impl<H> PersistChannel<H> {
                     return Err(PersistError::Shutdown);
                 }
                 // Unblock to persist when permits available <= threshold
-                if state.permits_available <= state.persist_threshold
+                if state.permits_available <= state.persist_permits_threshold
                     && state.latest_committed.is_some()
                 {
                     break (
@@ -439,7 +446,7 @@ struct PersistChannelState<H> {
     /// Maximum number of unpersisted commits allowed.
     max_permits: NonZeroU64,
     /// Persist when remaining permits are at or below this threshold.
-    persist_threshold: u64,
+    persist_permits_threshold: u64,
     /// Set to `true` when the channel has been closed.
     shutdown: bool,
     /// Nodestores awaiting reaping by the background thread.


### PR DESCRIPTION
## Why this should be merged

`deferred_persistence_commit_count` suggests a fixed persistence interval. The setting actually bounds how many committed revisions callers must go back from the latest committed state to reach a persisted state. Renaming it to `max_persistence_gap` makes that contract clearer.

## How this works

Renames the configuration across Rust, C, and Go, including validation errors, internal variables, tests, and benchmarks:

```diff
- deferred_persistence_commit_count
+ max_persistence_gap

- WithDeferredPersistenceCommitCount
+ WithMaxPersistenceGap
```

This PR also updates the documentation to distinguish committing from persisting and explain the existing guarantees:

- The last persisted state is at most `max_persistence_gap` committed revisions behind the latest committed state.
- Commits may wait for persistence to maintain this bound, but a successful commit does not guarantee that its revision has been persisted.
- Setting the gap to 1 ensures every committed revision is persisted before the next state-changing commit completes. Larger values allow intermediate revisions to be skipped.
- Only commits that change the current root count toward the bound; uncommitted proposals do not.
- A successful explicit close persists the latest committed state.

The default remains 1, and the value must remain positive and less than the number of retained revisions. Persistence behavior and the database format are unchanged.

## How this was tested

CI.

## Breaking Changes

- [x] firewood
- [ ] firewood-storage
- [x] firewood-ffi (C api)
- [x] firewood-go (Go api)
- [ ] fwdctl

Rust and C callers must replace `deferred_persistence_commit_count` with `max_persistence_gap`. Go callers must replace `WithDeferredPersistenceCommitCount` with `WithMaxPersistenceGap`.

Rust error matches must replace `ZeroCommitCount` with `ZeroMaxPersistenceGap` and the `InsufficientRevisions::commit_count` field with `max_persistence_gap`.

Existing configuration values remain valid. The C field retains its type and position, and database files require no migration.
