### PR TITLE
chore: add TODO checker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,9 @@ jobs:
           strict: true
       - name: Format
         run: cargo fmt -- --check
+      # Fails on TODO/FIXME markers lacking an owner or issue (see issue #1603).
+      - name: Check TODO/FIXME annotations
+        run: ./scripts/check-todos.sh
 
   rust-lint-pr-comments:
     # caveat emptor: actions-rs/clippy-check can only write comments on pull requests

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -1739,7 +1739,7 @@ func TestProposeOnProposalRehash(t *testing.T) {
 }
 
 func parseKVFromDumpFormat(dumpstr string) ([][]byte, [][]byte, error) {
-	// TODO: make this same as dump format outputted by firewood (slightly different, this is a debug one from my replay stuff)
+	// TODO(AminR443): make this same as dump format outputted by firewood (slightly different, this is a debug one from my replay stuff)
 	keys := make([][]byte, 0)
 	values := make([][]byte, 0)
 	lines := strings.SplitSeq(dumpstr, "\n")

--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -205,7 +205,7 @@ func (db *Database) VerifyRangeProof(
 	}
 
 	// keep the database alive while the proof owns the embedded proposal
-	// TODO: use runtime.AddCleanup and shared handle[T] infrastructure
+	// TODO(bernard-avalabs): use runtime.AddCleanup and shared handle[T] infrastructure
 	// instead of SetFinalizer, for consistency with Proposal and Revision.
 	proof.keepAliveHandle.init(&db.outstandingHandles)
 	runtime.SetFinalizer(proof, (*RangeProof).Free)

--- a/ffi/src/replay.rs
+++ b/ffi/src/replay.rs
@@ -298,7 +298,7 @@ pub(crate) fn flush_to_disk() -> io::Result<()> {
     // we don't use recorder() here because flushing should not init
     // the recorder. TestMain opens and closes a db, that causes
     // some tests to fail.
-    // TODO[AMIN]: this should change when we make record db-specific.
+    // TODO(AminR443): this should change when we make record db-specific.
     if let Some(Some(rec)) = RECORDER.get() {
         rec.lock().flush_to_disk()
     } else {

--- a/ffi/src/value/results.rs
+++ b/ffi/src/value/results.rs
@@ -733,7 +733,7 @@ enum Panic {
     SendSyncErr(Box<dyn std::error::Error + Send + Sync>),
     SendErr(Box<dyn std::error::Error + Send>),
     Unknown(#[expect(unused)] Box<dyn std::any::Any + Send>),
-    // TODO: add variant to capture backtrace with panic hook
+    // TODO(demosdemon): add variant to capture backtrace with panic hook
     // https://doc.rust-lang.org/stable/std/panic/fn.set_hook.html
 }
 

--- a/ffi/tests/firewood/merkle_compatibility_test.go
+++ b/ffi/tests/firewood/merkle_compatibility_test.go
@@ -378,7 +378,7 @@ func fuzzTree(t *testing.T, randSource int64, byteSteps []byte) {
 
 	tr := newTestTree(t, rand)
 
-	// TODO: replace randomly generated values with bytes from the fuzzer
+	// TODO(#2045): replace randomly generated values with bytes from the fuzzer
 	for _, step := range byteSteps {
 		step = step % maxStep
 		// Make this two lines so debugger displays the stepStr value

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -118,7 +118,7 @@ pub struct DbConfig {
     pub manager: RevisionManagerConfig,
     // Whether to perform parallel proposal creation. If set to BatchSize, then firewood
     // performs parallel proposal creation if the batch is >= to the BatchSize value.
-    // TODO: Experimentally determine the right value for BatchSize.
+    // TODO(bernard-avalabs): Experimentally determine the right value for BatchSize.
     #[builder(default = UseParallel::BatchSize(8))]
     pub use_parallel: UseParallel,
     /// Whether to enable `RootStore`.

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -262,7 +262,7 @@ fn get_iterator_intial_state<T: TrieReader>(
                     node = match child {
                         None => return Ok(NodeIterState::Iterating { iter_stack }),
                         Some(Child::AddressWithHash(addr, _)) => merkle.read_node(*addr)?,
-                        Some(Child::Node(node)) => (*node).clone().into(), // TODO can we avoid cloning this?
+                        Some(Child::Node(node)) => (*node).clone().into(), // TODO(rkuris) can we avoid cloning this?
                         Some(Child::MaybePersisted(maybe_persisted, _)) => {
                             // For MaybePersisted, we need to get the node
                             maybe_persisted.as_shared_node(merkle)?

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -354,7 +354,7 @@ impl RevisionManager {
         // Revision reaping: when we exceed max_revisions, remove the oldest revision from memory
         // and send it to the `PersistWorker`.
         // If you crash after freeing some of these, then the free list will point to nodes that are not actually free.
-        // TODO: Handle the case where we get something off the free list that is not free
+        // TODO(rkuris): Handle the case where we get something off the free list that is not free
         while revisions.len() >= self.max_revisions {
             let oldest = revisions.pop_front().expect("must be present");
             let oldest_hash = oldest.root_hash().or_default_root_hash();

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -1986,7 +1986,7 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
     ) -> Result<Option<Node>, FileIoError> {
         // 4 possibilities for the position of the `key` relative to `node`:
         // 1. The node is at `key`, in which case we need to delete this node and all its children.
-        // 2. The key is above the node (i.e. its ancestor), so the parent needs to be restructured (TODO).
+        // 2. The key is above the node (i.e. its ancestor), so the parent needs to be restructured (TODO(rkuris)).
         // 3. The key is below the node (i.e. its descendant), so continue traversing the trie.
         // 4. Neither is an ancestor of the other, in which case there's no work to do.
         let path_overlap = PrefixOverlap::from(key, node.partial_path().as_ref());

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -467,7 +467,7 @@ impl ParallelMerkle {
             )?;
 
             // Send the current operation to the worker.
-            // TODO: Currently the key from the BatchOp is copied to a Box<[u8]> before it is sent
+            // TODO(bernard-avalabs): Currently the key from the BatchOp is copied to a Box<[u8]> before it is sent
             //       to the worker. It may be possible to send a nibble iterator instead of a
             //       Box<[u8]> to the worker if we use rayon scoped threads. This change would
             //       eliminate a memory copy but may require some code refactoring.

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -7,7 +7,7 @@ mod change;
 mod collapse;
 #[cfg(feature = "ethhash")]
 mod ethhash;
-// TODO: get the hashes from merkledb and verify compatibility with branch factor 256
+// TODO(rkuris): get the hashes from merkledb and verify compatibility with branch factor 256
 mod proof;
 mod range;
 mod reconcile;
@@ -634,7 +634,7 @@ fn test_insert_leaf_prefix() {
 #[test]
 fn test_insert_sibling_leaf() {
     // The node at key is a branch node with children key_2 and key_3.
-    // TODO assert in this test that key is the parent of key_2 and key_3.
+    // TODO(rkuris) assert in this test that key is the parent of key_2 and key_3.
     // i.e. the node types are branch, leaf, leaf respectively.
     let key = vec![0xff];
     let val = [1];

--- a/firewood/src/merkle/tests/proof.rs
+++ b/firewood/src/merkle/tests/proof.rs
@@ -193,7 +193,7 @@ fn test_bad_proof() {
         let mut new_proof = proof.into_mutable();
         new_proof.pop();
 
-        // TODO: verify error result matches expected error
+        // TODO(demosdemon): verify error result matches expected error
         assert!(new_proof.verify(key, Some(value), &root_hash).is_err());
     }
 }

--- a/firewood/src/proofs/de.rs
+++ b/firewood/src/proofs/de.rs
@@ -70,7 +70,7 @@ impl<T: Version0> Version0 for Box<[T]> {
             .read_item::<usize>()
             .map_err(|err| err.set_item("array length"))?;
 
-        // FIXME: we must somehow validate `num_items` matches what is expected
+        // FIXME(demosdemon): we must somehow validate `num_items` matches what is expected
         // An incorrect, or unexpectedly large value could lead to DoS via OOM
         // or panicing
         (0..num_items).map(|_| reader.read_v0_item()).collect()

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -17,7 +17,7 @@ use num_format::{Locale, ToFormattedString};
 
 use crate::DatabasePath;
 
-// TODO: (optionally) add a fix option
+// TODO(#2046): (optionally) add a fix option
 #[derive(Args, Debug)]
 pub struct Options {
     #[command(flatten)]

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -382,7 +382,7 @@ fn test_slow_fwdctl_check_db_with_data() {
 
         create_db(db_path);
 
-        // TODO: bulk loading data instead of inserting one by one
+        // TODO(#2047): bulk loading data instead of inserting one by one
         for _ in 0..4 {
             let key = sample_iter.by_ref().take(64).collect::<String>();
             let value = sample_iter.by_ref().take(10).collect::<String>();

--- a/scripts/check-todos.sh
+++ b/scripts/check-todos.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Enforces that every TODO/FIXME has an attached owner or issue.
+#
+# Motivation (https://github.com/ava-labs/firewood/issues/1603): bare TODOs lose
+# their context over time and have no backlog/grooming pressure behind them.
+# Requiring each one to name an owner or link an issue keeps that context alive.
+#
+# Rule: a TODO or FIXME marker in a .rs or .go file must be annotated with an
+# owner or GitHub issue inside parentheses immediately after the marker:
+#
+#   TODO(owner or GH issue) - e.g. TODO(#1603), TODO(@foo), FIXME(rust-lang/rust#143874)
+#
+# The Rust todo!() macro is held to the same rule: it must carry a non-empty
+# message naming an owner or issue, e.g. todo!("#1603: implement this"). A bare
+# todo!() is a violation.
+#
+# Any marker without a non-empty parenthesized annotation is a violation, e.g.:
+#   TODO:  /  TODO foo:  /  TODO[foo]:  /  //TODO  /  todo!()
+#
+# The contents of the parentheses are not validated beyond being non-empty; the
+# syntax can be tightened later. Comment markers are matched as whole, uppercase
+# words anywhere on a line; the todo!() macro is matched in lowercase.
+#
+# Exit status: 0 when clean, 1 when any violation is found.
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/check-todos.sh [-h|--help]
+
+Scans tracked .rs and .go files for TODO/FIXME markers and the Rust todo!()
+macro, and reports any that are not annotated with an owner or GitHub issue.
+
+A marker is valid when it is immediately followed by a non-empty parenthesized
+annotation:
+
+  TODO(owner or GH issue)   e.g. TODO(#1603), TODO(@foo), FIXME(rust-lang/rust#143874)
+  todo!("...")              e.g. todo!("#1603: implement this")
+
+Exit status: 0 when no violations, 1 otherwise.
+EOF
+}
+
+case "${1:-}" in
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    "") ;;
+    *)
+        echo "error: unexpected argument '$1'" >&2
+        usage >&2
+        exit 2
+        ;;
+esac
+
+# Run from the repository root so paths are repo-relative and the whole tree is
+# covered regardless of the caller's working directory.
+cd "$(git rev-parse --show-toplevel)"
+
+# A whole-word TODO/FIXME marker (not preceded/followed by an identifier char).
+marker_re='(^|[^A-Za-z0-9_])(TODO|FIXME)([^A-Za-z0-9_]|$)'
+
+# A validly-annotated marker: TODO/FIXME immediately followed by a non-empty
+# parenthesized annotation (an owner or GitHub issue). The contents are not
+# validated further for now — the syntax can be tightened later.
+valid_re='(^|[^A-Za-z0-9_])(TODO|FIXME)\([^)]*[^)[:space:]][^)]*\)'
+
+# The Rust todo!() macro, held to the same rule. The marker is a lowercase
+# todo! invocation; it is valid only when followed by a non-empty parenthesized
+# message (which should name an owner or issue). A bare todo!() is a violation.
+macro_marker_re='(^|[^A-Za-z0-9_])todo!'
+macro_valid_re='(^|[^A-Za-z0-9_])todo![[:space:]]*\([^)]*[^)[:space:]][^)]*\)'
+
+# git grep skips target/, untracked, and gitignored files for us. It exits 1
+# when there are no matches, which is not an error for us.
+candidates=$(git grep -nE 'TODO|FIXME|todo!' -- '*.rs' '*.go' || true)
+
+violations=0
+while IFS= read -r match; do
+    [ -n "$match" ] || continue
+
+    file=${match%%:*}
+    rest=${match#*:}
+    lineno=${rest%%:*}
+    content=${rest#*:}
+
+    # A line is flagged if it carries an unannotated comment marker or an
+    # unannotated todo!() macro. Substring-only hits (e.g. MYTODO) match neither.
+    flagged=0
+    if [[ $content =~ $marker_re ]] && ! [[ $content =~ $valid_re ]]; then
+        flagged=1
+    fi
+    if [[ $content =~ $macro_marker_re ]] && ! [[ $content =~ $macro_valid_re ]]; then
+        flagged=1
+    fi
+    [ "$flagged" -eq 1 ] || continue
+
+    trimmed=${content#"${content%%[![:space:]]*}"}
+    echo "${file}:${lineno}: ${trimmed}"
+    violations=$((violations + 1))
+done <<< "$candidates"
+
+if [ "$violations" -eq 0 ]; then
+    echo "No TODO/FIXME violations found."
+    exit 0
+fi
+
+echo ""
+echo "Found ${violations} TODO/FIXME violation(s)."
+echo "Each TODO/FIXME must be annotated as TODO(owner or GH issue), e.g. TODO(#1603) or TODO(@foo)."
+exit 1

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -618,7 +618,7 @@ impl<S: WritableStorage> NodeStore<Mutable<Propose>, S> {
                     if let CheckerError::AreaLeaks(ranges) = &error {
                         {
                             let _leaked_areas = self.split_all_leaked_ranges(ranges, None);
-                            // TODO: add _leaked_areas to the free list
+                            // TODO(#2048): add _leaked_areas to the free list
                         }
                         unfixable.push((error, None));
                     } else {

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -12,7 +12,7 @@ impl<'a, P: SplitPath> HashableShunt<'a, P, &'a [PathComponent]> {
         match node {
             Node::Branch(node) => {
                 // All child hashes should be filled in.
-                // TODO danlaine: Enforce this with the type system.
+                // TODO(#2052): Enforce this with the type system.
                 debug_assert!(
                     node.children
                         .iter()

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -203,7 +203,7 @@ impl<T: Hashable> Preimage for T {
                 // need to get the value again
                 if let Some(ValueDigest::Value(rlp_encoded_bytes)) = self.value_digest() {
                     // rlp_encoded_bytes needs to be decoded
-                    // TODO: Handle corruption
+                    // TODO(rkuris): Handle corruption
                     // needs to be the hash of the RLP encoding of the root node that
                     // would have existed here (instead of this account node)
                     // the "root node" is actually this branch node iff there is

--- a/storage/src/hashtype/ethhash.rs
+++ b/storage/src/hashtype/ethhash.rs
@@ -17,7 +17,7 @@ use crate::{
 #[derive(Clone)]
 pub enum HashOrRlp {
     Hash(TrieHash),
-    // TODO: this slice is never larger than 32 bytes so smallvec is probably not our best container
+    // TODO(rkuris): this slice is never larger than 32 bytes so smallvec is probably not our best container
     // the length is stored in a `usize` but it could be in a `u8` and it will never overflow
     Rlp(SmallVec<[u8; 32]>),
 }

--- a/storage/src/node/branch.rs
+++ b/storage/src/node/branch.rs
@@ -214,7 +214,7 @@ impl Debug for BranchNode {
         for (i, c) in &self.children {
             match c {
                 None => {}
-                Some(Child::Node(_)) => {} //TODO
+                Some(Child::Node(_)) => {} //TODO(rkuris)
                 Some(Child::AddressWithHash(addr, hash)) => {
                     write!(f, "({i:?}: address={addr:?} hash={hash})")?;
                 }

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -34,7 +34,7 @@ pub mod path;
 pub mod persist;
 /// A node, either a Branch or Leaf
 
-// TODO: explain why Branch is boxed but Leaf is not
+// TODO(rkuris): explain why Branch is boxed but Leaf is not
 #[derive(PartialEq, Eq, Clone, Debug, EnumAsInner)]
 #[repr(C)]
 pub enum Node {
@@ -104,7 +104,7 @@ impl Default for LeafFirstByte {
     }
 }
 
-// TODO: Unstable extend_reserve re-implemented here
+// TODO(rkuris): Unstable extend_reserve re-implemented here
 // Extend<A>::extend_reserve is unstable so we implement it here
 // see https://github.com/rust-lang/rust/issues/72631
 pub trait ExtendableBytes: Write {
@@ -229,7 +229,7 @@ impl Node {
     /// The first byte of the encoding is the area size index, which is calculated from the total
     /// size of the encoded node. This method returns the `AreaIndex` for the encoded node.
     ///
-    /// TODO: We could pack two bytes of the partial path into one and handle the odd byte length
+    /// TODO(rkuris): We could pack two bytes of the partial path into one and handle the odd byte length
     ///
     /// # Errors
     ///
@@ -379,7 +379,7 @@ impl Node {
                 if childcount == 0 {
                     // branch is full of all children
                     for (_, child) in &mut children {
-                        // TODO: we can read them all at once
+                        // TODO(rkuris): we can read them all at once
                         let mut address_buf = [0u8; 8];
                         serialized.read_exact(&mut address_buf)?;
                         let address = u64::from_ne_bytes(address_buf);

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -14,7 +14,7 @@
     reason = "Found 1 occurrences after enabling the lint."
 )]
 
-// TODO: remove bitflags, we only use one bit
+// TODO(rkuris): remove bitflags, we only use one bit
 use bitflags::bitflags;
 use smallvec::SmallVec;
 use std::fmt::{self, Debug, LowerHex};
@@ -55,7 +55,7 @@ impl Debug for Path {
 }
 
 impl LowerHex for Path {
-    // TODO: handle fill / alignment / etc
+    // TODO(#2049): handle fill / alignment / etc
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         if self.0.is_empty() {
             write!(f, "[]")

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -239,7 +239,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
 /// This means that the nodestore can have children.
 /// Only [`ImmutableProposal`] and [Committed] implement this trait.
 /// [`Mutable<Propose>`] and [`Mutable<Recon>`] do not implement this trait because they are not valid parents.
-/// TODO: Maybe this can be renamed to `ImmutableNodestore`
+/// TODO(rkuris): Maybe this can be renamed to `ImmutableNodestore`
 pub trait Parentable {
     /// Returns the parent of this nodestore.
     fn as_nodestore_parent(&self) -> NodeStoreParent;
@@ -1135,7 +1135,7 @@ impl<T, S: ReadableStorage> RootReader for NodeStore<Mutable<T>, S> {
 
 impl<S: ReadableStorage> RootReader for NodeStore<Committed, S> {
     fn root_node(&self) -> Option<SharedNode> {
-        // TODO: If the read_node fails, we just say there is no root; this is incorrect
+        // TODO(rkuris): If the read_node fails, we just say there is no root; this is incorrect
         self.kind
             .root
             .as_ref()
@@ -1242,7 +1242,7 @@ impl<T: HashedNodeReader> HashedNodeReader for &T {
     }
 }
 
-// TODO: return only the index since we can easily get the size from the index
+// TODO(rkuris): return only the index since we can easily get the size from the index
 fn area_index_and_size<S: ReadableStorage>(
     storage: &S,
     addr: LinearAddress,
@@ -1403,7 +1403,7 @@ where
     NodeStore<T, S>: NodeReader,
 {
     // Find the area index and size of the stored area at the given address if the area is valid.
-    // TODO: there should be a way to read stored area directly instead of try reading as a free area then as a node
+    // TODO(#2050): there should be a way to read stored area directly instead of try reading as a free area then as a node
     pub(crate) fn read_leaked_area(
         &self,
         address: LinearAddress,
@@ -1444,7 +1444,7 @@ mod tests {
 
     #[test]
     fn test_area_size_to_index() {
-        // TODO: rustify using: for size in AREA_SIZES
+        // TODO(rkuris): rustify using: for size in AREA_SIZES
         for (i, area_size) in area_size_iter() {
             // area size is at top of range
             assert_eq!(AreaIndex::from_size(area_size).unwrap(), i);

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -79,7 +79,7 @@ impl<'a, N: NodeReader + RootReader> UnPersistedNodeIterator<'a, N> {
 
         // we must have an unpersisted root node to use this iterator
         // It's hard to tell at compile time if this is the case, so we assert it here
-        // TODO: can we use another trait or generic to enforce this?
+        // TODO(rkuris): can we use another trait or generic to enforce this?
         debug_assert!(root.as_ref().is_none_or(|r| r.unpersisted().is_some()));
         let (child_iter_stack, stack) = if let Some(root) = root {
             if let Some(branch) = root

--- a/storage/src/nodestore/primitives.rs
+++ b/storage/src/nodestore/primitives.rs
@@ -22,7 +22,7 @@ use std::num::NonZeroU64;
 include!(concat!(env!("OUT_DIR"), "/area_sizes.rs"));
 
 /// Returns an iterator over all valid area sizes.
-// TODO: return a named iterator
+// TODO(rkuris): return a named iterator
 pub(crate) fn area_size_iter() -> impl DoubleEndedIterator<Item = (AreaIndex, u64)> {
     AREA_SIZES
         .iter()


### PR DESCRIPTION
## Why this should be merged

Closes #1603 by adding a TODO/FIXME checker to CI.

## How this works

This PR consists of two commits:

- [d200ead](https://github.com/ava-labs/firewood/pull/2044/commits/d200eadbbf9b7da3c837286c038cb82707e93c3a): adds the TODO/FIXME checker. Running `./scripts/check-todos.sh --help` provides a good summary of what this tool does:
```
Usage: scripts/check-todos.sh [-h|--help]

Scans tracked .rs and .go files for TODO/FIXME markers and the Rust todo!()
macro, and reports any that are not annotated with an owner or GitHub issue.

A marker is valid when it is immediately followed by a non-empty parenthesized
annotation:

  TODO(owner or GH issue)   e.g. TODO(#1603), TODO(@foo), FIXME(rust-lang/rust#143874)
  todo!("...")              e.g. todo!("#1603: implement this")

Exit status: 0 when no violations, 1 otherwise.
```

- [eaed37d](https://github.com/ava-labs/firewood/pull/2044/commits/eaed37de51398ecd43bdb644d4caf3415ffe7e3d): satisfies the linter by adding issues/owners to all TODOs/FIXMEs. The owner of an issue was determined via `git log` with the intent being to attach the owner who introduced the issue in-code. For owners not on the Firewood team, I deferred to creating issues for these issues.

In the future, we can add stricter rules to this check (e.g. all TODOs/FIXMEs must have a GH issue attached to them); however, this is a good start to making sure all TODOs/FIXMEs in the Firewood repository have sufficient context (either via an issue or an owner).

## How this was tested

Case where there are TODO violations: https://github.com/ava-labs/firewood/actions/runs/26830137698/job/79108776074?pr=2044

Case where there are no violations: https://github.com/ava-labs/firewood/actions/runs/26837932459/job/79136793249?pr=2044

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
