### PR TITLE
feat(proofs): 4/7 add AccountFields decoder and rlp byte-string parse helpers

### DIFF
--- a/firewood/src/proofs/eth.rs
+++ b/firewood/src/proofs/eth.rs
@@ -28,8 +28,8 @@
 
 use firewood_storage::eth_encoding::nibbles_to_eth_compact;
 use firewood_storage::{
-    BranchNode, Children, HashType, PathComponent, RlpItem, ValueDigest, encode_list,
-    fix_account_storage_root_value,
+    BranchNode, Children, HashType, PathComponent, RlpError, RlpItem, RlpList, ValueDigest,
+    encode_list, fix_account_storage_root_value, parse_be_uint, parse_fixed,
 };
 use sha3::{Digest, Keccak256};
 use smallvec::{SmallVec, smallvec};
@@ -201,6 +201,77 @@ pub fn synth_storage_leaf_rlp(storage_child: &ProofNode) -> Option<Box<[u8]>> {
     ]))
 }
 
+/// Structured errors raised while decoding an account RLP value. Wrapped
+/// into [`crate::api::Error::InternalError`] at the public boundary so the
+/// firewood API surface keeps a single error type.
+#[derive(Debug, thiserror::Error)]
+enum AccountDecodeError {
+    #[error("malformed account RLP: {0}")]
+    Rlp(#[from] RlpError),
+    #[error("account RLP has {0} fields, expected at least 4")]
+    FieldCount(usize),
+    #[error("account field {0}: {1}")]
+    Field(&'static str, RlpError),
+}
+
+impl From<AccountDecodeError> for crate::api::Error {
+    fn from(e: AccountDecodeError) -> Self {
+        crate::api::Error::InternalError(Box::new(e))
+    }
+}
+
+/// Decoded fields of an ethereum account RLP value.
+///
+/// `balance` is zero-padded big-endian to fit the JSON-RPC `quantity` shape
+/// without an extra allocation. `storage_root` is the storage trie root as
+/// encoded in the account leaf; callers that need the ethereum-canonical
+/// storage hash for an account with exactly one storage slot must override
+/// this with `Keccak256(synth_storage_leaf_rlp(...))`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AccountFields {
+    /// Transaction count for this account.
+    pub nonce: u64,
+    /// Account balance, zero-padded big-endian.
+    pub balance: [u8; 32],
+    /// Storage trie root recorded in the account leaf.
+    pub storage_root: [u8; 32],
+    /// Keccak-256 of the account's contract code (or empty-code hash).
+    pub code_hash: [u8; 32],
+}
+
+impl AccountFields {
+    /// Parse an ethereum account RLP value (`[nonce, balance, storageRoot, codeHash]`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::api::Error::InternalError`] if the RLP is malformed,
+    /// the field count is wrong, `nonce` is more than 8 bytes, `balance` is
+    /// more than 32 bytes, or either hash field is not exactly 32 bytes.
+    pub fn from_rlp(rlp_bytes: &[u8]) -> Result<Self, crate::api::Error> {
+        Self::from_rlp_inner(rlp_bytes).map_err(Into::into)
+    }
+
+    fn from_rlp_inner(rlp_bytes: &[u8]) -> Result<Self, AccountDecodeError> {
+        let list = RlpList::parse(rlp_bytes)?;
+        let fields = list.fields()?;
+        // Coreth emits 5-item account RLP with a trailing empty byte
+        // (see firewood/src/merkle/tests/ethhash.rs:267-270); accept any
+        // list with at least the four standard fields and ignore extras.
+        let &[nonce_bytes, balance_bytes, storage_bytes, code_bytes] = fields
+            .first_chunk::<4>()
+            .ok_or(AccountDecodeError::FieldCount(fields.len()))?;
+
+        let field = |name: &'static str| move |e| AccountDecodeError::Field(name, e);
+
+        Ok(Self {
+            nonce: u64::from_be_bytes(parse_be_uint::<8>(nonce_bytes).map_err(field("nonce"))?),
+            balance: parse_be_uint::<32>(balance_bytes).map_err(field("balance"))?,
+            storage_root: parse_fixed::<32>(storage_bytes).map_err(field("storageRoot"))?,
+            code_hash: parse_fixed::<32>(code_bytes).map_err(field("codeHash"))?,
+        })
+    }
+}
+
 /// Encode one child slot of a branch as an [`RlpItem`] for proof emission.
 ///
 /// Distinct from `firewood_storage::nodestore::hash::child_to_rlp_item`,
@@ -370,6 +441,120 @@ mod tests {
         // The hash referenced in the outer must equal keccak(inner).
         let inner_hash = Keccak256::digest(&bytes[1]);
         assert_eq!(outer_fields[1], inner_hash.as_slice());
+    }
+
+    fn build_account_rlp(
+        nonce: &[u8],
+        balance: &[u8],
+        storage_root: &[u8; 32],
+        code_hash: &[u8; 32],
+    ) -> Box<[u8]> {
+        firewood_storage::encode_list(&[
+            RlpItem::Bytes(nonce),
+            RlpItem::Bytes(balance),
+            RlpItem::Bytes(storage_root),
+            RlpItem::Bytes(code_hash),
+        ])
+    }
+
+    #[test]
+    fn decode_account_round_trip() {
+        let storage = [0x11u8; 32];
+        let code = [0x22u8; 32];
+        let bytes = build_account_rlp(&[0x42], &[0x05, 0x00], &storage, &code);
+        let fields = AccountFields::from_rlp(&bytes).unwrap();
+        assert_eq!(fields.nonce, 0x42);
+        assert_eq!(fields.balance[30..], [0x05, 0x00]);
+        assert!(fields.balance[..30].iter().all(|&b| b == 0));
+        assert_eq!(fields.storage_root, storage);
+        assert_eq!(fields.code_hash, code);
+    }
+
+    #[test]
+    fn decode_account_zero_nonce_zero_balance() {
+        let storage = [0u8; 32];
+        let code = [0u8; 32];
+        // Per RLP minimal encoding, 0 is the empty byte string.
+        let bytes = build_account_rlp(&[], &[], &storage, &code);
+        let fields = AccountFields::from_rlp(&bytes).unwrap();
+        assert_eq!(fields.nonce, 0);
+        assert_eq!(fields.balance, [0u8; 32]);
+    }
+
+    #[test]
+    fn decode_account_rejects_too_few_fields() {
+        let bytes = firewood_storage::encode_list(&[
+            RlpItem::Bytes(&[0x01]),
+            RlpItem::Bytes(&[0x02]),
+            RlpItem::Bytes(&[0x03]),
+        ]);
+        match AccountFields::from_rlp_inner(&bytes) {
+            Err(AccountDecodeError::FieldCount(3)) => {}
+            other => panic!("expected FieldCount(3), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_account_accepts_coreth_five_item_shape() {
+        // Coreth emits a 5-item account RLP: [nonce, balance, storageRoot,
+        // codeHash, trailing-empty]. Extras past field 3 must be ignored.
+        let storage = [0x11u8; 32];
+        let code = [0x22u8; 32];
+        let bytes = firewood_storage::encode_list(&[
+            RlpItem::Bytes(&[0x42]),
+            RlpItem::Bytes(&[0x05]),
+            RlpItem::Bytes(&storage),
+            RlpItem::Bytes(&code),
+            RlpItem::Empty,
+        ]);
+        let fields = AccountFields::from_rlp(&bytes).unwrap();
+        assert_eq!(fields.nonce, 0x42);
+        assert_eq!(fields.storage_root, storage);
+        assert_eq!(fields.code_hash, code);
+    }
+
+    #[test]
+    fn decode_account_rejects_oversized_nonce() {
+        let storage = [0u8; 32];
+        let code = [0u8; 32];
+        let bytes = build_account_rlp(&[1u8; 9], &[], &storage, &code);
+        match AccountFields::from_rlp_inner(&bytes) {
+            Err(AccountDecodeError::Field("nonce", RlpError::TooLong { actual: 9, max: 8 })) => {}
+            other => panic!("expected nonce TooLong, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_account_rejects_short_storage_root() {
+        let code = [0u8; 32];
+        let bytes = firewood_storage::encode_list(&[
+            RlpItem::Bytes(&[]),
+            RlpItem::Bytes(&[]),
+            RlpItem::Bytes(&[0u8; 31]),
+            RlpItem::Bytes(&code),
+        ]);
+        match AccountFields::from_rlp_inner(&bytes) {
+            Err(AccountDecodeError::Field(
+                "storageRoot",
+                RlpError::WrongLength {
+                    actual: 31,
+                    expected: 32,
+                },
+            )) => {}
+            other => panic!("expected storageRoot WrongLength, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_account_public_wraps_internal_error() {
+        // The public API surface returns api::Error, wrapping AccountDecodeError.
+        let bytes = firewood_storage::encode_list(&[
+            RlpItem::Bytes(&[0x01]),
+            RlpItem::Bytes(&[0x02]),
+            RlpItem::Bytes(&[0x03]),
+        ]);
+        let err = AccountFields::from_rlp(&bytes).expect_err("3 fields should fail");
+        assert!(matches!(err, crate::api::Error::InternalError(_)));
     }
 
     #[test]

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -84,7 +84,10 @@ pub use u4::{TryFromIntError, U4};
 pub use linear::filebacked::FileBacked;
 pub use linear::memory::MemStore;
 pub use node::persist::MaybePersistedNode;
-pub use rlp::{NULL_RLP, RlpError, RlpItem, RlpList, encode_list, replace_list_field};
+pub use rlp::{
+    NULL_RLP, RlpError, RlpItem, RlpList, encode_list, parse_be_uint, parse_fixed,
+    replace_list_field,
+};
 pub use root_store::RootStore;
 #[cfg(any(test, feature = "test_utils"))]
 pub use test_utils::SeededRng;

--- a/storage/src/rlp.rs
+++ b/storage/src/rlp.rs
@@ -38,6 +38,23 @@ pub enum RlpError {
     /// Length prefix or single-byte form was not used in its minimal encoding.
     #[error("non-minimal RLP length encoding")]
     NonMinimalLength,
+    /// Byte-string longer than the caller's bound when parsing a variable-
+    /// length unsigned integer.
+    #[error("RLP byte string is {actual} bytes, max {max}")]
+    TooLong {
+        /// Length of the input byte string.
+        actual: usize,
+        /// Maximum length the caller accepts.
+        max: usize,
+    },
+    /// Byte-string length did not match the caller's fixed-size expectation.
+    #[error("RLP byte string is {actual} bytes, expected {expected}")]
+    WrongLength {
+        /// Length of the input byte string.
+        actual: usize,
+        /// Expected exact length.
+        expected: usize,
+    },
 }
 
 /// One child of a list passed to [`encode_list`].
@@ -233,6 +250,45 @@ pub fn replace_list_field(
     out.extend_from_slice(suffix);
     debug_assert_eq!(out.len(), new_total);
     Ok(out.into_boxed_slice())
+}
+
+/// Right-align an RLP byte string into an `N`-byte big-endian buffer, padding
+/// the high bytes with zero.
+///
+/// Matches the shape of RLP-encoded unsigned integers: leading zeros are
+/// stripped on the wire, so a `u64` of value 1 arrives as the single byte
+/// `0x01` — this helper widens it back to the fixed-size form the caller
+/// wants.
+///
+/// # Errors
+///
+/// Returns [`RlpError::TooLong`] if `bytes.len() > N`.
+#[inline]
+pub fn parse_be_uint<const N: usize>(bytes: &[u8]) -> Result<[u8; N], RlpError> {
+    if bytes.len() > N {
+        return Err(RlpError::TooLong {
+            actual: bytes.len(),
+            max: N,
+        });
+    }
+    let mut out = [0u8; N];
+    for (slot, &b) in out.iter_mut().rev().zip(bytes.iter().rev()) {
+        *slot = b;
+    }
+    Ok(out)
+}
+
+/// Convert an RLP byte string of exactly `N` bytes into `[u8; N]`.
+///
+/// # Errors
+///
+/// Returns [`RlpError::WrongLength`] if `bytes.len() != N`.
+#[inline]
+pub fn parse_fixed<const N: usize>(bytes: &[u8]) -> Result<[u8; N], RlpError> {
+    bytes.try_into().map_err(|_| RlpError::WrongLength {
+        actual: bytes.len(),
+        expected: N,
+    })
 }
 
 // ---------- internals ----------
@@ -624,6 +680,47 @@ mod tests {
         expected: RlpError,
     ) {
         assert_eq!(replace_list_field(input, index, replacement), Err(expected));
+    }
+
+    // ---------- parse_be_uint / parse_fixed ----------
+
+    #[test_case(&[], [0u8; 8] ; "empty pads to all zeros")]
+    #[test_case(&[0xaa, 0xbb, 0xcc], [0, 0, 0, 0, 0, 0xaa, 0xbb, 0xcc] ; "short right-aligns")]
+    #[test_case(&[0, 1, 2, 3, 4, 5, 6, 7], [0, 1, 2, 3, 4, 5, 6, 7] ; "exact length is identity")]
+    fn parse_be_uint_pads(input: &[u8], expected: [u8; 8]) {
+        assert_eq!(parse_be_uint::<8>(input).unwrap(), expected);
+    }
+
+    #[test_case(9 ; "one over")]
+    #[test_case(16 ; "double")]
+    fn parse_be_uint_rejects_overlong(len: usize) {
+        let bytes = vec![0u8; len];
+        assert_eq!(
+            parse_be_uint::<8>(&bytes),
+            Err(RlpError::TooLong {
+                actual: len,
+                max: 8
+            })
+        );
+    }
+
+    #[test]
+    fn parse_fixed_exact() {
+        let bytes = [0xabu8; 32];
+        assert_eq!(parse_fixed::<32>(&bytes).unwrap(), bytes);
+    }
+
+    #[test_case(31; "too short")]
+    #[test_case(33; "too long")]
+    fn parse_fixed_rejects_wrong_length(len: usize) {
+        let bytes = vec![0u8; len];
+        assert_eq!(
+            parse_fixed::<32>(&bytes),
+            Err(RlpError::WrongLength {
+                actual: len,
+                expected: 32,
+            })
+        );
     }
 
     // ---------- parity with the upstream `rlp` crate ----------


### PR DESCRIPTION
## Why this should be merged

To answer Ethereum's `eth_getProof` against a firewood revision we must decode
the four standard account scalars (nonce / balance / storageRoot / codeHash)
out of an account node's RLP value. This adds that decoder plus the small RLP
byte-string parsing primitives it needs — the bottom of the eth_getProof stack
the higher layers build on.

## How this works

- `storage::rlp` gains `parse_be_uint` and `parse_fixed` for the common
  RLP-byte-string → fixed-array conversions, with new `RlpError::TooLong` and
  `RlpError::WrongLength` variants. `parse_be_uint` right-aligns a
  variable-length big-endian byte string into `[u8; N]`; `parse_fixed`
  enforces exact length.
- `firewood::proofs::eth` adds `AccountFields` with a `from_rlp` constructor
  that decodes ethereum account RLP into nonce / balance / storageRoot /
  codeHash. It uses `slice::first_chunk::<4>()` to grab the four standard
  fields, ignoring any trailing entries — tolerating coreth's 5-item shape
  (trailing empty byte).
- Decoder errors surface as `api::Error::InternalError`; the inner
  `AccountDecodeError` stays private behind the trait-object boundary.
- All new code is always-compiled (no `#[cfg(feature = "ethhash")]` walls) to
  ease the later migration to a runtime ethhash flag.

## How this was tested

`cargo nextest run` + `cargo clippy` + `cargo doc --no-deps` on the workspace
with `--features ethhash,logger`.

## Breaking Changes

None. Promotes some `storage::rlp` items to `pub`; no existing signatures change.
