### PR TITLE
fix(proofs): change-proof verification rejects honest partial-storage…

### DIFF
--- a/firewood/src/merkle/reconcile.rs
+++ b/firewood/src/merkle/reconcile.rs
@@ -3,6 +3,9 @@
 
 use firewood_storage::{Mutable, NodeStore, Propose, ReadableStorage, ValueDigest};
 
+#[cfg(feature = "ethhash")]
+use firewood_storage::RlpList;
+
 use crate::{ProofError, ProofNode, Value, merkle::Merkle};
 
 impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
@@ -69,7 +72,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             _ => None,
         };
 
-        if proof_value == branch.value.as_deref() {
+        if values_match_for_reconcile(&key_nibbles, proof_value, branch.value.as_deref()) {
             return Ok(());
         }
 
@@ -77,4 +80,59 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
         branch.value = on_conflict(proof_node)?;
         Ok(())
     }
+}
+
+fn values_match_for_reconcile(
+    key_nibbles: &[u8],
+    proof_value: Option<&[u8]>,
+    branch_value: Option<&[u8]>,
+) -> bool {
+    if proof_value == branch_value {
+        return true;
+    }
+
+    #[cfg(feature = "ethhash")]
+    {
+        let (Some(proof_value), Some(branch_value)) = (proof_value, branch_value) else {
+            return false;
+        };
+        account_values_match_except_storage_root(key_nibbles, proof_value, branch_value)
+    }
+
+    #[cfg(not(feature = "ethhash"))]
+    {
+        let _ = key_nibbles;
+        false
+    }
+}
+
+#[cfg(feature = "ethhash")]
+fn account_values_match_except_storage_root(
+    key_nibbles: &[u8],
+    proof_value: &[u8],
+    branch_value: &[u8],
+) -> bool {
+    const ACCOUNT_DEPTH_NIBBLES: usize = 64;
+    const STORAGE_ROOT_FIELD: usize = 2;
+
+    if key_nibbles.len() != ACCOUNT_DEPTH_NIBBLES {
+        return false;
+    }
+
+    let Ok(proof_fields) = RlpList::parse(proof_value).and_then(|list| list.fields()) else {
+        return false;
+    };
+    let Ok(branch_fields) = RlpList::parse(branch_value).and_then(|list| list.fields()) else {
+        return false;
+    };
+
+    proof_fields.len() > STORAGE_ROOT_FIELD
+        && proof_fields.len() == branch_fields.len()
+        && proof_fields
+            .iter()
+            .zip(branch_fields.iter())
+            .enumerate()
+            .all(|(index, (proof_field, branch_field))| {
+                index == STORAGE_ROOT_FIELD || proof_field == branch_field
+            })
 }

--- a/firewood/src/merkle/tests/change/empty.rs
+++ b/firewood/src/merkle/tests/change/empty.rs
@@ -9,6 +9,39 @@
 
 use super::*;
 
+#[cfg(feature = "ethhash")]
+fn rlp_encode_account(
+    nonce: u64,
+    balance: u64,
+    storage_root: &[u8; 32],
+    code_hash: &[u8; 32],
+) -> Box<[u8]> {
+    use rlp::RlpStream;
+
+    let mut rlp = RlpStream::new_list(4);
+    rlp.append(&nonce);
+    rlp.append(&balance);
+    rlp.append(&storage_root.as_slice());
+    rlp.append(&code_hash.as_slice());
+    rlp.out().to_vec().into_boxed_slice()
+}
+
+#[cfg(feature = "ethhash")]
+fn rlp_encode_storage(value: &[u8; 32]) -> Box<[u8]> {
+    use rlp::RlpStream;
+
+    let mut rlp = RlpStream::new();
+    rlp.append(&value.as_slice());
+    rlp.out().to_vec().into_boxed_slice()
+}
+
+#[cfg(feature = "ethhash")]
+fn empty_code_hash() -> [u8; 32] {
+    use sha3::{Digest, Keccak256};
+
+    Keccak256::digest([]).into()
+}
+
 /// Empty start trie, single key inserted. Complete proof (no bounds).
 #[test]
 fn test_empty_start_trie_single_key_no_bounds() {
@@ -24,6 +57,62 @@ fn test_empty_start_trie_single_key_no_bounds() {
     let empty_root_target = target.root_hash().unwrap();
 
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
+}
+
+#[test]
+fn test_change_proof_partial_storage_children_against_empty() {
+    let account_key: Box<[u8]> = [0x10u8; 32].into();
+    let storage_key_a: Box<[u8]> = [account_key.as_ref(), &[0x10u8; 32]].concat().into();
+    let storage_key_b: Box<[u8]> = [account_key.as_ref(), &[0x20u8; 32]].concat().into();
+    let end_between_storage_children: Box<[u8]> =
+        [account_key.as_ref(), &[0x18u8; 32]].concat().into();
+
+    let dummy_storage_root = [0u8; 32];
+    let account_value = rlp_encode_account(1, 100, &dummy_storage_root, &empty_code_hash());
+    let storage_value_a = rlp_encode_storage(&[0xaa; 32]);
+    let storage_value_b = rlp_encode_storage(&[0xbb; 32]);
+
+    let (source, _source_dir) = setup_db![];
+    let empty_root = source.root_hash().unwrap();
+    source
+        .propose(vec![
+            BatchOp::Put {
+                key: account_key.as_ref(),
+                value: account_value.as_ref(),
+            },
+            BatchOp::Put {
+                key: storage_key_a.as_ref(),
+                value: storage_value_a.as_ref(),
+            },
+            BatchOp::Put {
+                key: storage_key_b.as_ref(),
+                value: storage_value_b.as_ref(),
+            },
+        ])
+        .unwrap()
+        .commit()
+        .unwrap();
+    let root2 = source.root_hash().unwrap();
+
+    let cases = [
+        (None, Some(end_between_storage_children.as_ref())),
+        (
+            Some(account_key.as_ref()),
+            Some(end_between_storage_children.as_ref()),
+        ),
+    ];
+
+    for (start_key, end_key) in cases {
+        let proof = source
+            .change_proof(empty_root.clone(), root2.clone(), start_key, end_key, None)
+            .unwrap();
+        let ctx =
+            verify_change_proof_structure(&proof, root2.clone(), start_key, end_key, None).unwrap();
+
+        let (target, _target_dir) = setup_db![];
+        let empty_root_target = target.root_hash().unwrap();
+        verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
+    }
 }
 
 /// Empty start trie, multiple keys inserted, bounded range with inclusion

--- a/firewood/src/merkle/tests/reconcile.rs
+++ b/firewood/src/merkle/tests/reconcile.rs
@@ -80,3 +80,79 @@ fn test_reconcile_branch_proof_node_rejects_conflict_via_callback() {
     let branch = node.as_branch().expect("expected branch node");
     assert_eq!(branch.value.as_deref(), Some([1u8].as_slice()));
 }
+
+#[cfg(feature = "ethhash")]
+#[test]
+fn test_reconcile_branch_proof_node_accepts_account_storage_root_mismatch() {
+    use firewood_storage::{RlpItem, encode_list};
+
+    let account_key = [0x11u8; 32];
+    let account_nibbles: Vec<_> = NibblesIterator::new(&account_key).collect();
+
+    let proof_value = encode_list(&[
+        RlpItem::Bytes(&[0x01]),
+        RlpItem::Bytes(&[0x02]),
+        RlpItem::Bytes(&[0xaa; 32]),
+        RlpItem::Bytes(&[0xbb; 32]),
+    ]);
+    let branch_value = encode_list(&[
+        RlpItem::Bytes(&[0x01]),
+        RlpItem::Bytes(&[0x02]),
+        RlpItem::Bytes(&[0xcc; 32]),
+        RlpItem::Bytes(&[0xbb; 32]),
+    ]);
+
+    let mut merkle = create_in_memory_merkle();
+    merkle.insert(&account_key, branch_value.clone()).unwrap();
+
+    let proof_node = test_branch_proof_node(
+        &account_nibbles,
+        Some(ValueDigest::Value(proof_value.clone())),
+    );
+
+    merkle
+        .reconcile_branch_proof_node(&proof_node, |_| {
+            panic!("storageRoot-only mismatch should not be treated as a conflict")
+        })
+        .unwrap();
+
+    let node = merkle
+        .get_node_from_nibbles(&account_nibbles)
+        .unwrap()
+        .unwrap();
+    let branch = node.as_branch().expect("expected branch node");
+    assert_eq!(branch.value.as_deref(), Some(branch_value.as_ref()));
+}
+
+#[cfg(feature = "ethhash")]
+#[test]
+fn test_reconcile_branch_proof_node_rejects_account_non_storage_root_mismatch() {
+    use firewood_storage::{RlpItem, encode_list};
+
+    let account_key = [0x22u8; 32];
+    let account_nibbles: Vec<_> = NibblesIterator::new(&account_key).collect();
+
+    let proof_value = encode_list(&[
+        RlpItem::Bytes(&[0x01]),
+        RlpItem::Bytes(&[0x02]),
+        RlpItem::Bytes(&[0xaa; 32]),
+        RlpItem::Bytes(&[0xbb; 32]),
+    ]);
+    let branch_value = encode_list(&[
+        RlpItem::Bytes(&[0x09]),
+        RlpItem::Bytes(&[0x02]),
+        RlpItem::Bytes(&[0xaa; 32]),
+        RlpItem::Bytes(&[0xbb; 32]),
+    ]);
+
+    let mut merkle = create_in_memory_merkle();
+    merkle.insert(&account_key, branch_value).unwrap();
+
+    let proof_node =
+        test_branch_proof_node(&account_nibbles, Some(ValueDigest::Value(proof_value)));
+
+    let err = merkle
+        .reconcile_branch_proof_node(&proof_node, |_| Err(ProofError::UnexpectedValue))
+        .unwrap_err();
+    assert!(matches!(err, ProofError::UnexpectedValue));
+}


### PR DESCRIPTION
… proofs (ethhash)

## Why this should be merged
In ethhash mode, bounded change-proof verification rejected honest proofs through an account at depth 64 whenever the proof's boundary cut through that account's storage trie, leaving only a subset of its storage children in range.

## How this works
Relaxes the branch proof node value comparison at depth 64 (account level) to ignore the storageRoot field. This is sound because storageRoot is recomputed from the storage children at hash time, and the final root-hash comparison remains the primary integrity check.

## How this was tested
Added test cases in empty.rs and reconcile.rs verifying that change proof verification succeeds when storage children are partially in range.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
