### PR TITLE
feat(metrics): add firewood_proof_keys histogram for proof sizes

### DIFF
--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -23,7 +23,7 @@ use crate::proofs::change::ChangeProof;
 use crate::{
     ChangeProofVerificationContext, Proof, ProofCollection, ProofError, ProofNode, RangeProof,
 };
-use firewood_metrics::firewood_counter;
+use firewood_metrics::{firewood_counter, firewood_histogram};
 use firewood_storage::MemStore;
 use firewood_storage::{
     BranchNode, Child, Children, FileIoError, HashType, HashableShunt, HashedNodeReader,
@@ -1289,6 +1289,8 @@ impl<T: TrieReader> Merkle<T> {
         .transpose()?
         .unwrap_or_default();
 
+        firewood_histogram!(PROOF_KEYS, "kind" => "range").record(key_values.len() as f64);
+
         Ok(RangeProof::new(start_proof, end_proof, key_values))
     }
 
@@ -1488,6 +1490,8 @@ impl<T: HashedNodeReader> Merkle<T> {
             .map(|key| self.prove(key))
             .transpose()?
             .unwrap_or_default();
+
+        firewood_histogram!(PROOF_KEYS, "kind" => "change").record(batch_ops.len() as f64);
 
         Ok(ChangeProof::new(start_proof, end_proof, batch_ops))
     }

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -24,7 +24,7 @@ use crate::proofs::eth::ACCOUNT_DEPTH_NIBBLES;
 use crate::{
     ChangeProofVerificationContext, Proof, ProofCollection, ProofError, ProofNode, RangeProof,
 };
-use firewood_metrics::{firewood_counter, firewood_histogram};
+use firewood_metrics::{HistogramExt, firewood_counter, firewood_histogram};
 use firewood_storage::MemStore;
 use firewood_storage::{
     BranchNode, Child, Children, FileIoError, HashType, HashableShunt, HashedNodeReader,
@@ -1419,7 +1419,7 @@ impl<T: TrieReader> Merkle<T> {
         .transpose()?
         .unwrap_or_default();
 
-        firewood_histogram!(PROOF_KEYS, "kind" => "range").record(key_values.len() as f64);
+        firewood_histogram!(PROOF_KEYS, "kind" => "range").record_integer(key_values.len());
 
         Ok(RangeProof::new(start_proof, end_proof, key_values))
     }
@@ -1621,7 +1621,7 @@ impl<T: HashedNodeReader> Merkle<T> {
             .transpose()?
             .unwrap_or_default();
 
-        firewood_histogram!(PROOF_KEYS, "kind" => "change").record(batch_ops.len() as f64);
+        firewood_histogram!(PROOF_KEYS, "kind" => "change").record_integer(batch_ops.len());
 
         Ok(ChangeProof::new(start_proof, end_proof, batch_ops))
     }

--- a/firewood/src/registry.rs
+++ b/firewood/src/registry.rs
@@ -59,5 +59,7 @@ firewood_metrics::define_metrics! {
         BY_HASH_LOCK_WAIT_SECONDS = "firewood_by_hash_lock_wait_seconds" native(2.0, 160, 1e-9),
         /// Duration of submitting a revision to the persist worker channel
         PERSIST_SUBMIT_DURATION_SECONDS = "firewood_persist_submit_duration_seconds" native(2.0, 160, 1e-9),
+        /// Number of key/value pairs contained in a generated proof, by proof kind
+        PROOF_KEYS = "firewood_proof_keys" buckets([0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0, 65536.0, 131072.0]),
     },
 }

--- a/firewood/src/registry.rs
+++ b/firewood/src/registry.rs
@@ -60,6 +60,6 @@ firewood_metrics::define_metrics! {
         /// Duration of submitting a revision to the persist worker channel
         PERSIST_SUBMIT_DURATION_SECONDS = "firewood_persist_submit_duration_seconds" native(2.0, 160, 1e-9),
         /// Number of key/value pairs contained in a generated proof, by proof kind
-        PROOF_KEYS = "firewood_proof_keys" buckets([0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16384.0, 32768.0, 65536.0, 131072.0]),
+        PROOF_KEYS = "firewood_proof_keys" buckets([0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0, 16_384.0, 32_768.0, 65_536.0, 131_072.0]),
     },
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -99,6 +99,27 @@ impl CounterExt for metrics::Counter {
     }
 }
 
+/// Extension methods for [`metrics::Histogram`] that accept integer metric values.
+///
+/// [`metrics::Histogram::record`] requires `f64`. Casting integers to `f64`
+/// triggers `cast_precision_loss` at every call site. `record_integer`
+/// centralises the cast — any precision loss for values above 2^52 is
+/// intentional and acceptable for instrumentation.
+///
+/// Implemented for `u64` and `usize`; the conversion trait is sealed so external
+/// crates cannot add further implementations.
+pub trait HistogramExt {
+    /// Records the histogram observation from any supported integer type,
+    /// converting to `f64` internally.
+    fn record_integer<T: gauge_value::GaugeValue>(&self, value: T);
+}
+
+impl HistogramExt for metrics::Histogram {
+    fn record_integer<T: gauge_value::GaugeValue>(&self, value: T) {
+        self.record(value.as_f64());
+    }
+}
+
 /// How a histogram metric is bucketed in the Prometheus exporter.
 ///
 /// Defined in `firewood-metrics` (which has no dependency on `metrics-exporter-prometheus`)


### PR DESCRIPTION
## Why this should be merged

We want visibility into how large the proofs Firewood generates actually are. There was no metric tracking the number of keys returned in range or change proofs, so proof-size distributions (and outliers near the limit) were invisible to operators.

## How this works

Adds a new `firewood_proof_keys` histogram (in `firewood/src/registry.rs`), labelled by `kind`:

- `kind="range"` — recorded in `Merkle::range_proof`, counting the key/value pairs returned.
- `kind="change"` — recorded in `Merkle::change_proof`, counting the `BatchOp`s in the change set.

Buckets are `0` plus powers of two up to 128k (131072), so both tiny proofs and limit-capped large proofs land in meaningful bins.

Recording uses the default `firewood_histogram!` form, so it is gated behind the expensive-metrics flag, consistent with the existing per-operation duration histograms.

## How this was tested

`cargo build -p firewood --features ethhash,logger` builds clean. No behavioral change beyond metric emission.

## Breaking Changes

None.