### PR TITLE
fix(launch): repair grafana/prometheus metrics pipeline on launched instances

### DIFF
--- a/benchmark/Grafana-dashboard.json
+++ b/benchmark/Grafana-dashboard.json
@@ -127,7 +127,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(firewood_cache_node{type=\"miss\", mode!=\"open\"}[$__rate_interval])",
+          "expr": "rate(firewood_node_cache_accesses_total{type=\"miss\", mode!=\"open\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "instant": false,
@@ -234,7 +234,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "100 * sum(increase(firewood_cache_node{type=\"hit\"}[$__rate_interval])) by (name) / sum(increase(firewood_cache_node[$__rate_interval])) by (name)",
+          "expr": "100 * sum(increase(firewood_node_cache_accesses_total{type=\"hit\"}[$__rate_interval])) by (name) / sum(increase(firewood_node_cache_accesses_total[$__rate_interval])) by (name)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -249,7 +249,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "100 * sum(increase(firewood_cache_freelist{type=\"hit\"}[$__rate_interval])) by (name) / sum(increase(firewood_cache_freelist[$__rate_interval])) by (name)",
+          "expr": "100 * sum(increase(firewood_freelist_cache_accesses_total{type=\"hit\"}[$__rate_interval])) by (name) / sum(increase(firewood_freelist_cache_accesses_total[$__rate_interval])) by (name)",
           "hide": false,
           "instant": false,
           "legendFormat": "freelist",
@@ -357,7 +357,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "firewood_proposals",
+          "expr": "firewood_proposals_total",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A",
@@ -463,7 +463,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(firewood_remove[$__rate_interval])",
+          "expr": "irate(firewood_node_removes_total[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "Remove {prefix=\"{{prefix}}\"}",
@@ -476,7 +476,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(firewood_insert{merkle!=\"update\"}[$__rate_interval]))",
+          "expr": "sum(irate(firewood_node_inserts_total{operation!=\"update\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Insert",
@@ -489,7 +489,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "irate(firewood_insert{merkle=\"update\"}[$__rate_interval])",
+          "expr": "irate(firewood_node_inserts_total{operation=\"update\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "Update",
@@ -602,7 +602,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(firewood_cache_node) / sum(firewood_insert)",
+          "expr": "sum(firewood_node_cache_accesses_total) / sum(firewood_node_inserts_total)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -802,8 +802,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "irate(firewood_insert[$__rate_interval])",
-          "legendFormat": "merkle=\"{{merkle}}\"",
+          "expr": "irate(firewood_node_inserts_total[$__rate_interval])",
+          "legendFormat": "operation=\"{{operation}}\"",
           "range": true,
           "refId": "A",
           "datasource": {
@@ -812,7 +812,7 @@
           }
         }
       ],
-      "title": "Insert Merkle Ops by Type",
+      "title": "Insert Ops by Operation Type",
       "type": "timeseries"
     }
   ],

--- a/benchmark/setup-scripts/install-grafana.sh
+++ b/benchmark/setup-scripts/install-grafana.sh
@@ -57,7 +57,7 @@ sed -i -E "s|^;?\s*admin_password\s*=.*|admin_password = firewood_is_fast|" /etc
 cat > /etc/grafana/provisioning/datasources/prometheus.yml <<EOF
 apiVersion: 1
 datasources:
- - name: Prometheus
+  - name: Prometheus
     type: prometheus
     access: proxy
     orgId: 1
@@ -86,15 +86,25 @@ mkdir -p /var/lib/grafana/dashboards
 wget -O /var/lib/grafana/dashboards/firewood.json https://github.com/ava-labs/firewood/raw/refs/heads/main/benchmark/Grafana-dashboard.json
 wget -O /var/lib/grafana/dashboards/node_exporter_full.json https://grafana.com/api/dashboards/1860/revisions/latest/download
 
-# configure prometheus to scrape firewood
-if ! grep -q '^  - job_name: firewood$' /etc/prometheus/prometheus.yml; then
-  cat >> /etc/prometheus/prometheus.yml <<!
-  - job_name: firewood
+# Configure prometheus to scrape avalanchego. A full node (e.g. the `validator`
+# scenario) exposes all metrics -- including the C-chain/coreth and the firewood
+# metrics merged in under avalanche_evm_firewood_* -- at /ext/metrics on 9650.
+# The firewood library no longer runs its own :3000 exporter, so that job is
+# gone. The coreth :6060 job is kept for the standalone reexecution benchmark.
+if ! grep -q '^  - job_name: avalanchego$' /etc/prometheus/prometheus.yml; then
+  cat >> /etc/prometheus/prometheus.yml <<'!'
+  - job_name: avalanchego
+    metrics_path: /ext/metrics
     static_configs:
-      - targets: ['localhost:3000']
+      - targets: ['localhost:9650']
     metric_relabel_configs:
+      # coreth registers firewood's gatherer under avalanche_evm_firewood_, and
+      # firewood's own metrics already carry a firewood_ prefix, producing
+      # avalanche_evm_firewood_firewood_*. Strip the coreth-added prefix so the
+      # metrics keep their native registry names (firewood_*), matching the
+      # firewood dashboard.
       - source_labels: [__name__]
-        regex: '(.*)'
+        regex: 'avalanche_evm_firewood_firewood_(.+)'
         target_label: __name__
         replacement: 'firewood_$1'
   - job_name: coreth


### PR DESCRIPTION
## Why this should be merged

Monitoring was broken end-to-end on launched instances:

1. **grafana-server crash-looped** on a malformed datasource provisioning file
   (`yaml: line 4: mapping values are not allowed in this context`).
2. **prometheus scraped dead ports** — `:3000` (firewood) and `:6060` (coreth),
   both connection-refused. firewood no longer runs its own `:3000` exporter,
   and a full node (the `validator` scenario) exposes everything at
   avalanchego's `/ext/metrics` on `9650`, which was not scraped at all.
3. **the firewood dashboard queried metric names that no longer exist**
   (`firewood_insert`, `firewood_remove`, `firewood_cache_node`,
   `firewood_proposals`, `firewood_cache_freelist`).

## How this works

- **`install-grafana.sh` (datasource):** fix the list-item indentation so the
  mapping keys align under `name`.
- **`install-grafana.sh` (prometheus):** replace the dead firewood `:3000` job
  with an `avalanchego` job scraping `/ext/metrics` on `9650`. coreth registers
  firewood's gatherer under `avalanche_evm_firewood_` and firewood metrics
  already carry a `firewood_` prefix, so a `metric_relabel` strips the
  coreth-added prefix back to the native `firewood_*` registry names. The coreth
  `:6060` job is kept for the standalone reexecution benchmark.
- **`Grafana-dashboard.json`:** update all panel queries to the current registry
  names (`firewood_node_inserts_total`, `firewood_node_removes_total`,
  `firewood_node_cache_accesses_total`, `firewood_freelist_cache_accesses_total`,
  `firewood_proposals_total`). The insert `merkle` label was renamed to
  `operation` upstream; queries and legends follow.

## How this was tested

- Confirmed the grafana provisioning YAML and the rendered prometheus scrape
  config parse cleanly.
- Verified against a live validator node that `/ext/metrics` exposes the
  firewood metrics and that `:3000`/`:6060` are refused.
- `bash -n` on `install-grafana.sh`; `Grafana-dashboard.json` validates as JSON
  with no remaining stale metric references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)