### PR TITLE
feat(launch): add validator scenario bootstrapping from S3 state snapshot

### DIFF
--- a/benchmark/launch/launch-stages.yaml
+++ b/benchmark/launch/launch-stages.yaml
@@ -192,6 +192,42 @@ stages:
     name: "Copy file(s) from {{ variables.src }} to s3://{{ variables.s3_bucket }}/{{ variables.dst }}"
     commands:
       - "s5cmd cp '{{ variables.src }}' 's3://{{ variables.s3_bucket }}/{{ variables.dst }}'"
+  # Download a full avalanchego data directory snapshot from S3. The snapshot
+  # layout (db/, chainData/, configs/chains/) maps directly onto avalanchego's
+  # --data-dir sub-defaults. The bucket's staking/ identity is intentionally
+  # skipped so the node generates a fresh NodeID on first boot.
+  download-node-state:
+    name: "Downloading node state from s3://{{ variables.state_bucket }}"
+    variables:
+      state_bucket: "firewood-fuji-state-sync"
+      data_dir: "{{ variables.nvme_base }}/ubuntu/data"
+      pruning_enabled: "true"
+      state_history: "32768"
+      commit_interval: "64"
+    commands:
+      - "sudo -u ubuntu mkdir -p {{ variables.data_dir }}/db {{ variables.data_dir }}/chainData {{ variables.data_dir }}/configs"
+      - "s5cmd cp 's3://{{ variables.state_bucket }}/db/*' {{ variables.data_dir }}/db/"
+      - "s5cmd cp 's3://{{ variables.state_bucket }}/chainData/*' {{ variables.data_dir }}/chainData/"
+      - "s5cmd cp 's3://{{ variables.state_bucket }}/configs/*' {{ variables.data_dir }}/configs/"
+      # The snapshot was produced by an archive node (pruning-enabled: false),
+      # which makes coreth open firewood in archival mode and maintain a
+      # root_store/ index. Force pruning mode and drop the restored archival
+      # index so it is not reopened.
+      - "jq '.[\"pruning-enabled\"] = {{ variables.pruning_enabled }} | .[\"state-history\"] = {{ variables.state_history }} | .[\"commit-interval\"] = {{ variables.commit_interval }}' {{ variables.data_dir }}/configs/chains/C/config.json > /tmp/c-config.json && mv /tmp/c-config.json {{ variables.data_dir }}/configs/chains/C/config.json"
+      - "rm -rf {{ variables.data_dir }}/chainData/*/firewood/root_store"
+      - "chown -R ubuntu:users {{ variables.data_dir }}"
+      - "chmod -R g=u {{ variables.data_dir }}"
+  # Start avalanchego as a Fuji node against the restored data directory. Runs
+  # in the foreground (backgrounded with `&`) logging to /var/log/bootstrap.log
+  # so `--follow follow-with-progress` can stream startup. A fresh staking key
+  # is generated under {{ variables.data_dir }}/staking on first boot.
+  run-validator:
+    name: "Starting Fuji validator from restored state"
+    variables:
+      data_dir: "{{ variables.nvme_base }}/ubuntu/data"
+      public_ip_resolution: "opendns"
+    commands:
+      - "sudo -u ubuntu -D {{ variables.nvme_base }}/ubuntu/avalanchego --login ./build/avalanchego --network-id=fuji --data-dir={{ variables.data_dir }} --public-ip-resolution-service={{ variables.public_ip_resolution }} --http-host=0.0.0.0 > /var/log/bootstrap.log 2>&1 &"
 
 scenarios:
   reexecute:
@@ -237,6 +273,21 @@ scenarios:
         variables:
           src: "{{ variables.nvme_base }}/ubuntu/exec-data/current-state/replay_50k_log_db"
           dst: "amin-replay-logs/replay_50k_log_db"
+  validator:
+    description: "Restore a Fuji node data directory from S3 and start a validator"
+    stages:
+      - rust-install
+      - ssm-agent
+      - clone-firewood
+      - setup-environment
+      - install-go-grafana
+      - clone-repos
+      - configure-go-modules
+      - build-firewood-ffi
+      - build-avalanchego
+      - install-s5cmd
+      - download-node-state
+      - run-validator
   snapshotter:
     description: "Execute and snapshot state at 1m, 10m, 20m, and 30m blocks"
     stages:

--- a/fwdctl/README.launch.md
+++ b/fwdctl/README.launch.md
@@ -216,6 +216,15 @@ Current embedded scenarios:
 - `reexecute`
 - `replay-log-gen`
 - `snapshotter`
+- `validator`
+
+The `validator` scenario restores a full avalanchego data directory from an S3
+snapshot and starts a Fuji node. It downloads `db/`, `chainData/`, and
+`configs/` from `s3://firewood-fuji-state-sync` (override with
+`--variable state_bucket=<bucket>`) into the node data dir
+(`--variable data_dir=<path>`, default `/mnt/nvme/ubuntu/data`), then launches
+avalanchego against the restored state. The snapshot's staking identity is
+intentionally skipped so the node generates a fresh NodeID on first boot.
 
 ## Operational behavior
 


### PR DESCRIPTION
## Why this should be merged

Adds a way to stand up a Fuji avalanchego node from a pre-synced state snapshot
instead of bootstrapping from genesis, so a validator can come up quickly
against known state.

## How this works

Adds two shared stages to `benchmark/launch/launch-stages.yaml` and a new
`validator` scenario that chains them after the standard build stages. No Rust
changes are needed since `--scenario` is a free-form string.

- **`download-node-state`** — `s5cmd`-copies `db/`, `chainData/`, and `configs/`
  from `s3://firewood-fuji-state-sync` (overridable via
  `--variable state_bucket=<bucket>`) into the avalanchego data dir
  (`--variable data_dir`, default `/mnt/nvme/ubuntu/data`). The snapshot layout
  maps directly onto avalanchego's `--data-dir` sub-defaults. The bucket's
  `staking/` identity is intentionally skipped so the node generates a fresh
  NodeID on first boot.

  The snapshot was produced by an **archive** node (`pruning-enabled: false`),
  which makes coreth open firewood in archival mode and maintain a `root_store/`
  index. The stage rewrites the C-chain config to pruning mode + tuned params
  and removes the restored `root_store/` so it is not reopened:

  | key | value | variable |
  | --- | --- | --- |
  | `pruning-enabled` | `true` | `pruning_enabled` |
  | `state-history` | `32768` | `state_history` |
  | `commit-interval` | `64` | `commit_interval` |

  (all overridable via `--variable`; `state-scheme: firewood` is preserved).
- **`run-validator`** — starts avalanchego on `--network-id=fuji` against the
  restored data dir, foregrounded to `/var/log/bootstrap.log` so
  `--follow follow-with-progress` can stream startup.

Usage:

```sh
fwdctl launch deploy --scenario validator \
  --instance-type i4i.xlarge --region us-east-1 --sg <sg-id> \
  --follow follow-with-progress
```

## How this was tested

- Rendered the scenario end-to-end with `--dry-run plan-with-cloud-init`.
- Launched an `i4i.xlarge` in `us-east-1`, restored the ~328 GB snapshot, and
  confirmed the node starts and validates on Fuji.
- Verified the config-rewrite jq filter against the real C-chain `config.json`
  produces `pruning-enabled=true`, `state-history=32768`, `commit-interval=64`
  while preserving `state-scheme=firewood`.
- `stage_config` unit tests pass; `markdownlint-cli2` passes on the updated README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)