### PR TITLE
fix(launch): correct restored C-chain config for the validator scenario

### DIFF
--- a/benchmark/launch/launch-stages.yaml
+++ b/benchmark/launch/launch-stages.yaml
@@ -201,20 +201,18 @@ stages:
     variables:
       state_bucket: "firewood-fuji-state-sync"
       data_dir: "{{ variables.nvme_base }}/ubuntu/data"
-      pruning_enabled: "true"
       state_history: "32768"
-      commit_interval: "64"
+      log_level: "info"
     commands:
       - "sudo -u ubuntu mkdir -p {{ variables.data_dir }}/db {{ variables.data_dir }}/chainData {{ variables.data_dir }}/configs"
       - "s5cmd cp 's3://{{ variables.state_bucket }}/db/*' {{ variables.data_dir }}/db/"
       - "s5cmd cp 's3://{{ variables.state_bucket }}/chainData/*' {{ variables.data_dir }}/chainData/"
       - "s5cmd cp 's3://{{ variables.state_bucket }}/configs/*' {{ variables.data_dir }}/configs/"
-      # The snapshot was produced by an archive node (pruning-enabled: false),
-      # which makes coreth open firewood in archival mode and maintain a
-      # root_store/ index. Force pruning mode and drop the restored archival
-      # index so it is not reopened.
-      - "jq '.[\"pruning-enabled\"] = {{ variables.pruning_enabled }} | .[\"state-history\"] = {{ variables.state_history }} | .[\"commit-interval\"] = {{ variables.commit_interval }}' {{ variables.data_dir }}/configs/chains/C/config.json > /tmp/c-config.json && mv /tmp/c-config.json {{ variables.data_dir }}/configs/chains/C/config.json"
-      - "rm -rf {{ variables.data_dir }}/chainData/*/firewood/root_store"
+      # The snapshot's metadata requires archive mode: avalanchego refuses to
+      # start unless pruning-enabled stays false, so leave it (and the restored
+      # root_store/ index) as downloaded. Bump state-history and drop the
+      # snapshot's debug log-level (very chatty) to info.
+      - "jq '.[\"state-history\"] = {{ variables.state_history }} | .[\"log-level\"] = \"{{ variables.log_level }}\"' {{ variables.data_dir }}/configs/chains/C/config.json > /tmp/c-config.json && mv /tmp/c-config.json {{ variables.data_dir }}/configs/chains/C/config.json"
       - "chown -R ubuntu:users {{ variables.data_dir }}"
       - "chmod -R g=u {{ variables.data_dir }}"
   # Start avalanchego as a Fuji node against the restored data directory. Runs


### PR DESCRIPTION
## Why this should be merged

The `validator` scenario (#2071) rewrote the restored C-chain config to pruning
mode (`pruning-enabled: true`) and removed the restored `root_store/` index. But
the Fuji snapshot's metadata **requires archive mode** — avalanchego refuses to
start unless `pruning-enabled` stays `false`. This reverts that, and also quiets
the snapshot's `debug` log level which floods the logs.

## How this works

The `download-node-state` stage now leaves `pruning-enabled` (false/archive),
`commit-interval`, and the restored `root_store/` index exactly as downloaded,
and adjusts only two values (both overridable via `--variable`):

| key | value | note |
| --- | --- | --- |
| `pruning-enabled` | `false` | left as snapshot (archive required) |
| `commit-interval` | `1` | left as snapshot |
| `state-history` | `32768` | bumped from snapshot's 16384 (`state_history`) |
| `log-level` | `info` | snapshot ships `debug`, very chatty (`log_level`) |

`root_store/` is no longer removed (archive mode uses it).

## How this was tested

- Ran the config-rewrite jq filter against the real C-chain `config.json`: it
  sets `state-history=32768` and `log-level=info` while preserving
  `pruning-enabled=false`, `commit-interval=1`, and `state-scheme=firewood`.
- `stage_config` unit tests pass.