### PR TITLE
chore(release): prepare for v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2026-06-09
+
+### 🚀 Features
+
+- *(proofs)* Emit canonical Ethereum MPT-RLP from ProofNode ([#2004](https://github.com/ava-labs/firewood/pull/2004))
+- *(storage)* Add NodeHashAlgorithm::is_ethereum predicate ([#2014](https://github.com/ava-labs/firewood/pull/2014))
+- *(ffi)* Code-hash iterator for change proofs ([#2033](https://github.com/ava-labs/firewood/pull/2033))
+- Add update convenience API ([#2029](https://github.com/ava-labs/firewood/pull/2029))
+- *(proofs)* 4/7 add AccountFields decoder and rlp byte-string parse helpers ([#2051](https://github.com/ava-labs/firewood/pull/2051))
+- *(metrics)* Add firewood_proof_keys histogram for proof sizes ([#2069](https://github.com/ava-labs/firewood/pull/2069))
+- *(launch)* Add validator scenario bootstrapping from S3 state snapshot ([#2071](https://github.com/ava-labs/firewood/pull/2071))
+
+### 🐛 Bug Fixes
+
+- *(storage)* 2/2 persist computed storageRoot in account node values ([#1938](https://github.com/ava-labs/firewood/pull/1938))
+- *(proofs)* Annotate edge-proof hash mismatches with Left/Right edge ([#2028](https://github.com/ava-labs/firewood/pull/2028))
+- Set background in Firewood architecture diagram ([#2065](https://github.com/ava-labs/firewood/pull/2065))
+- *(proofs)* Hash single storage child as storage-trie root ([#2058](https://github.com/ava-labs/firewood/pull/2058))
+- *(launch)* Repair grafana/prometheus metrics pipeline on launched instances ([#2070](https://github.com/ava-labs/firewood/pull/2070))
+
+### 💼 Other
+
+- *(ffi)* Run the ffi tests in debug mode ([#1562](https://github.com/ava-labs/firewood/pull/1562))
+- *(ffi)* Vendor golangci-lint as go tool, drop third-party action ([#2026](https://github.com/ava-labs/firewood/pull/2026))
+
+### 🚜 Refactor
+
+- Take &[u8] in key_value_iter_from_key ([#2041](https://github.com/ava-labs/firewood/pull/2041))
+
+### 📚 Documentation
+
+- *(changelog)* Detect breaking-change PR labels in CHANGELOG automatically ([#2016](https://github.com/ava-labs/firewood/pull/2016))
+- *(release)* Document undocumented steps, add versioning policy ([#2017](https://github.com/ava-labs/firewood/pull/2017))
+
+### ⚡ Performance
+
+- *(storage)* Fill predictive read buffer for unaligned reads ([#1964](https://github.com/ava-labs/firewood/pull/1964))
+
+### 🧪 Testing
+
+- *(fwdctl)* Refactor CLI test setup ([#2037](https://github.com/ava-labs/firewood/pull/2037))
+
+### ⚙️ Miscellaneous Tasks
+
+- Gate canonical-repo workflows on github.repository ([#2011](https://github.com/ava-labs/firewood/pull/2011))
+- Fix nightly clippy warnings ([#2019](https://github.com/ava-labs/firewood/pull/2019))
+- Bump go to 1.25.10 ([#2036](https://github.com/ava-labs/firewood/pull/2036))
+- Add 33m-33.5m benchmark ([#2038](https://github.com/ava-labs/firewood/pull/2038))
+- Add TODO checker ([#2044](https://github.com/ava-labs/firewood/pull/2044))
+
 ## [0.5.0] - 2026-05-19
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "firewood"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aquamarine",
  "bytemuck",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-benchmark"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -1806,7 +1806,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-ffi"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "cbindgen",
  "env_logger",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-fwdctl"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "askama",
  "assert_cmd",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "firewood-metrics",
  "proc-macro2",
@@ -1869,14 +1869,14 @@ dependencies = [
 
 [[package]]
 name = "firewood-metrics"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "metrics",
 ]
 
 [[package]]
 name = "firewood-replay"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "firewood",
  "firewood-metrics",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "firewood-storage"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aquamarine",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,12 @@ metrics-exporter-prometheus = { git = "https://github.com/demosdemon/metrics.git
 
 [workspace.dependencies]
 # workspace local packages
-firewood = { path = "firewood", version = "0.5.0" }
-firewood-macros = { path = "firewood-macros", version = "0.4.0" }
-firewood-storage = { path = "storage", version = "0.5.0" }
-firewood-ffi = { path = "ffi", version = "0.5.0" }
-firewood-metrics = { path = "metrics", version = "0.5.0" }
-firewood-replay = { path = "replay", version = "0.5.0" }
+firewood = { path = "firewood", version = "0.6.0" }
+firewood-macros = { path = "firewood-macros", version = "0.5.0" }
+firewood-storage = { path = "storage", version = "0.6.0" }
+firewood-ffi = { path = "ffi", version = "0.6.0" }
+firewood-metrics = { path = "metrics", version = "0.6.0" }
+firewood-replay = { path = "replay", version = "0.6.0" }
 
 # no longer bumping with workspace
 firewood-triehash = { path = "triehash", version = "0.0.16" }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-benchmark"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors = [
      "Aaron Buchwald <aaron.buchwald56@gmail.com>",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-ffi"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors = [
      "Aaron Buchwald <aaron.buchwald56@gmail.com>",

--- a/firewood-macros/Cargo.toml
+++ b/firewood-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-macros"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors = [
      "Ron Kuris <ron.kuris@avalabs.org>",

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors = [
      "Angel Leon <gubatron@gmail.com>",

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-fwdctl"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors = [
      "Dan Laine <daniel.laine@avalabs.org>",

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-metrics"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 license-file.workspace = true
 homepage.workspace = true

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-replay"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 license-file.workspace = true
 homepage.workspace = true

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firewood-storage"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 authors = [
      "Aaron Buchwald <aaron.buchwald56@gmail.com>",


### PR DESCRIPTION
## Why this should be merged

Bumps from v0.5.0 to v0.6.0.

## How this works

Followed instructions in `RELEASE.md`.

*Note*: any attempt to bump the Rust dependencies in this version failed as any bump would move `generic-array` from `0.14.7` to `0.14.9`, triggering a API deprecated error that would be caught by CI commands such as `cargo clippy --locked --features ethhash,logger --workspace --all-targets -- -D warnings`:

```
error: use of deprecated struct `sha3::digest::generic_array::GenericArray`: please upgrade to generic-array 1.x
   --> storage/src/hashtype/trie_hash.rs:6:34
    |
  6 | use sha2::digest::generic_array::GenericArray;
    |                                  ^^^^^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(deprecated)]`

  error: use of deprecated struct `sha3::digest::generic_array::GenericArray`: please upgrade to generic-array 1.x
    --> storage/src/hashtype/trie_hash.rs:92:11
     |
  92 | impl From<GenericArray<u8, typenum::U32>> for TrieHash {
     |           ^^^^^^^^^^^^

  error: use of deprecated struct `sha3::digest::generic_array::GenericArray`: please upgrade to generic-array 1.x
    --> storage/src/hashtype/trie_hash.rs:93:20
     |
  93 |     fn from(value: GenericArray<u8, typenum::U32>) -> Self {
     |                    ^^^^^^^^^^^^

  error: use of deprecated method `sha3::digest::generic_array::GenericArray::<T, N>::as_slice`: please upgrade to generic-array 1.x
     --> storage/src/hashers/ethhash.rs:162:79
      |
  162 |                     .and_then(|bytes| replace_list_field(bytes, 2, empty_root.as_slice()).ok())
      |                                                                               ^^^^^^^^

  error: use of deprecated method `sha3::digest::generic_array::GenericArray::<T, N>::as_slice`: please upgrade to generic-array 1.x
     --> storage/src/hashers/ethhash.rs:263:53
      |
  263 |                         RlpItem::Bytes(hashed_bytes.as_slice()),
      |                                                     ^^^^^^^^

  error: use of deprecated method `sha3::digest::generic_array::GenericArray::<T, N>::as_slice`: please upgrade to generic-array 1.x
    --> storage/src/hashtype/ethhash.rs:64:64
     |
  64 |             HashOrRlp::Rlp(r) => Keccak256::digest(r.as_ref()).as_slice() == other.as_ref(),
     |                                                                ^^^^^^^^

  error: use of deprecated method `sha3::digest::generic_array::GenericArray::<T, N>::as_slice`: please upgrade to generic-array 1.x
    --> storage/src/hashtype/ethhash.rs:73:64
     |
  73 |             HashOrRlp::Rlp(r) => Keccak256::digest(r.as_ref()).as_slice() == self.as_ref(),
     |                                                                ^^^^^^^^

  error: use of deprecated method `sha3::digest::generic_array::GenericArray::<T, N>::as_slice`: please upgrade to generic-array 1.x
    --> storage/src/hashtype/ethhash.rs:88:38
     |
  88 |                 Keccak256::digest(r).as_slice() == h.as_ref()
     |                                      ^^^^^^^^

  error: could not compile `firewood-storage` (lib) due to 8 previous errors
  warning: build failed, waiting for other jobs to finish...
  error: could not compile `firewood-storage` (lib test) due to 8 previous errors
```

Given that we shouldn't manually fix any dependencies bumps when releasing a new version, I went ahead and just bumped the versioning for each crate. 

## How this was tested

CI

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
