### PR TITLE
perf: skip using FDL when running in archival mode

### DIFF
--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -8,7 +8,7 @@ use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use firewood::Merkle;
 use firewood::api::{Db as _, Proposal as _};
 use firewood::db::{BatchOp, DbConfig};
-use firewood_storage::{MemStore, NodeHashAlgorithm, NodeStore};
+use firewood_storage::{DeletedNodeTracking, MemStore, NodeHashAlgorithm, NodeStore};
 use pprof::ProfilerGuard;
 use rand::{RngExt, distr::Alphanumeric};
 use std::fs::File;
@@ -70,7 +70,8 @@ fn bench_merkle<const NKEYS: usize, const KEYSIZE: usize>(criterion: &mut Criter
             b.iter_batched(
                 || {
                     let store = Arc::new(MemStore::default());
-                    let nodestore = NodeStore::new_empty_proposal(store, true);
+                    let nodestore =
+                        NodeStore::new_empty_proposal(store, DeletedNodeTracking::Enabled);
                     let merkle = Merkle::from(nodestore);
 
                     let keys: Vec<Vec<u8>> =

--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -70,7 +70,7 @@ fn bench_merkle<const NKEYS: usize, const KEYSIZE: usize>(criterion: &mut Criter
             b.iter_batched(
                 || {
                     let store = Arc::new(MemStore::default());
-                    let nodestore = NodeStore::new_empty_proposal(store);
+                    let nodestore = NodeStore::new_empty_proposal(store, true);
                     let merkle = Merkle::from(nodestore);
 
                     let keys: Vec<Vec<u8>> =

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -1757,6 +1757,57 @@ mod test {
         assert_eq!(value, retrieved_value.as_ref());
     }
 
+    /// Verifies that proposals skip building the future-delete log when
+    /// archival mode is enabled, since it is never consumed.
+    #[test]
+    fn test_no_fdl_when_root_store_enabled() {
+        let db = TestDb::new_with_config(DbConfig::builder().root_store(true).build());
+
+        let key = b"key";
+        let batch = vec![BatchOp::Put {
+            key,
+            value: b"value",
+        }];
+        db.propose(batch).unwrap().commit().unwrap();
+
+        // Overwriting the key puts the existing node on the future-delete log.
+        let batch = vec![BatchOp::Put {
+            key,
+            value: b"new_value",
+        }];
+        db.propose(batch).unwrap().commit().unwrap();
+
+        assert_eq!(
+            db.manager.current_revision().deleted_len(),
+            0,
+            "future-delete log should not be built in archival mode"
+        );
+    }
+
+    /// Verifies that proposals build the future-delete log if archival mode is disabled.
+    #[test]
+    fn test_fdl_tracked_when_root_store_disabled() {
+        let db = TestDb::new_with_config(DbConfig::builder().root_store(false).build());
+
+        let key = b"key";
+        let batch = vec![BatchOp::Put {
+            key,
+            value: b"value",
+        }];
+        db.propose(batch).unwrap().commit().unwrap();
+
+        let batch = vec![BatchOp::Put {
+            key,
+            value: b"new_value",
+        }];
+        db.propose(batch).unwrap().commit().unwrap();
+
+        assert!(
+            db.manager.current_revision().deleted_len() > 0,
+            "future-delete log should record replaced nodes when archival mode is disabled"
+        );
+    }
+
     #[test]
     fn test_rootstore_empty_db_reopen() {
         let db = TestDb::new_with_config(DbConfig::builder().root_store(true).build());

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -654,7 +654,9 @@ impl<I: Iterator<Item = T>, T: KeyValuePair, K: KeyType> Iterator for FilteredKe
 mod tests {
     use super::*;
     use crate::merkle::Merkle;
-    use firewood_storage::{ImmutableProposal, MemStore, Mutable, NodeStore, Propose};
+    use firewood_storage::{
+        DeletedNodeTracking, ImmutableProposal, MemStore, Mutable, NodeStore, Propose,
+    };
     use std::sync::Arc;
     use test_case::test_case;
 
@@ -671,7 +673,7 @@ mod tests {
     pub(super) fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
         let memstore = MemStore::default();
         let memstore = Arc::new(memstore);
-        let nodestore = NodeStore::new_empty_proposal(memstore, true);
+        let nodestore = NodeStore::new_empty_proposal(memstore, DeletedNodeTracking::Enabled);
         Merkle::from(nodestore)
     }
 

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -671,7 +671,7 @@ mod tests {
     pub(super) fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
         let memstore = MemStore::default();
         let memstore = Arc::new(memstore);
-        let nodestore = NodeStore::new_empty_proposal(memstore);
+        let nodestore = NodeStore::new_empty_proposal(memstore, true);
         Merkle::from(nodestore)
     }
 

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -27,9 +27,9 @@ use firewood_metrics::{GaugeExt, firewood_counter, firewood_gauge, firewood_hist
 pub use firewood_storage::CacheReadStrategy;
 use firewood_storage::RootStore;
 use firewood_storage::{
-    BranchNode, Committed, CommittedId, FileBacked, FileIoError, HashedNodeReader,
-    ImmutableProposal, Mutable, MutableKind, NodeHashAlgorithm, NodeStore, NodeStoreHeader,
-    Propose, Recon, TrieHash,
+    BranchNode, Committed, CommittedId, DeletedNodeTracking, FileBacked, FileIoError,
+    HashedNodeReader, ImmutableProposal, Mutable, MutableKind, NodeHashAlgorithm, NodeStore,
+    NodeStoreHeader, Propose, Recon, TrieHash,
 };
 
 pub(crate) const DB_FILE_NAME: &str = "firewood.db";
@@ -196,12 +196,17 @@ impl RevisionManager {
             Err(err) => return Err(err.into()),
         };
         // `root_store` enables archival mode: old nodes are preserved on disk
-        // for historical queries, so disable delete tracking and skip the
-        // future-delete log (#2015).
+        // for historical queries, so disable delete node tracking and skip the
+        // future-delete log.
+        let deleted_node_tracking = if config.root_store {
+            DeletedNodeTracking::Disabled
+        } else {
+            DeletedNodeTracking::Enabled
+        };
         let nodestore = Arc::new(NodeStore::open(
             &header,
             storage.clone(),
-            !config.root_store,
+            deleted_node_tracking,
         )?);
         let root_store = config
             .root_store
@@ -546,9 +551,14 @@ impl RevisionManager {
         //    against the file backing carried by the latest committed revision.
         if HashKey::default_root_hash().as_ref() == Some(&root_hash) {
             let storage = self.current_revision().storage().clone();
+            let deleted_node_tracking = if self.root_store.is_some() {
+                DeletedNodeTracking::Disabled
+            } else {
+                DeletedNodeTracking::Enabled
+            };
             return Ok(Arc::new(NodeStore::new_empty_committed(
                 storage,
-                self.root_store.is_none(),
+                deleted_node_tracking,
             )));
         }
 

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -195,9 +195,7 @@ impl RevisionManager {
             }
             Err(err) => return Err(err.into()),
         };
-        // `root_store` enables archival mode: old nodes are preserved on disk
-        // for historical queries, so disable delete node tracking and skip the
-        // future-delete log.
+
         let deleted_node_tracking = if config.root_store {
             DeletedNodeTracking::Disabled
         } else {

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -195,7 +195,14 @@ impl RevisionManager {
             }
             Err(err) => return Err(err.into()),
         };
-        let nodestore = Arc::new(NodeStore::open(&header, storage.clone())?);
+        // `root_store` enables archival mode: old nodes are preserved on disk
+        // for historical queries, so disable delete tracking and skip the
+        // future-delete log (#2015).
+        let nodestore = Arc::new(NodeStore::open(
+            &header,
+            storage.clone(),
+            !config.root_store,
+        )?);
         let root_store = config
             .root_store
             .then(|| {
@@ -539,7 +546,10 @@ impl RevisionManager {
         //    against the file backing carried by the latest committed revision.
         if HashKey::default_root_hash().as_ref() == Some(&root_hash) {
             let storage = self.current_revision().storage().clone();
-            return Ok(Arc::new(NodeStore::new_empty_committed(storage)));
+            return Ok(Arc::new(NodeStore::new_empty_committed(
+                storage,
+                self.root_store.is_none(),
+            )));
         }
 
         // 3. Check `RootStore` (if it exists).

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -624,7 +624,7 @@ mod tests {
 
     fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_proposal(Arc::new(memstore));
+        let nodestore = NodeStore::new_empty_proposal(Arc::new(memstore), true);
         Merkle::from(nodestore)
     }
 

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -577,8 +577,9 @@ mod tests {
     };
 
     use firewood_storage::{
-        Committed, FileBacked, FileIoError, HashedNodeReader, ImmutableProposal, MemStore, Mutable,
-        NodeStore, Propose, SeededRng, TestRecorder, TrieReader,
+        Committed, DeletedNodeTracking, FileBacked, FileIoError, HashedNodeReader,
+        ImmutableProposal, MemStore, Mutable, NodeStore, Propose, SeededRng, TestRecorder,
+        TrieReader,
     };
     use lender::Lender;
     use std::{collections::HashSet, ops::Deref, path::PathBuf, sync::Arc};
@@ -624,7 +625,8 @@ mod tests {
 
     fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_proposal(Arc::new(memstore), true);
+        let nodestore =
+            NodeStore::new_empty_proposal(Arc::new(memstore), DeletedNodeTracking::Enabled);
         Merkle::from(nodestore)
     }
 

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -408,13 +408,14 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use firewood_storage::MemStore;
+    use firewood_storage::{DeletedNodeTracking, MemStore};
 
     use super::*;
 
     fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_proposal(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_proposal(memstore.into(), DeletedNodeTracking::Enabled);
         Merkle { nodestore }
     }
 

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -414,7 +414,7 @@ mod tests {
 
     fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_proposal(memstore.into());
+        let nodestore = NodeStore::new_empty_proposal(memstore.into(), true);
         Merkle { nodestore }
     }
 

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -989,7 +989,7 @@ fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
 ) -> Result<(), api::Error> {
     // Build in-memory merkle from key-value pairs
     let memstore = MemStore::default();
-    let nodestore = NodeStore::new_empty_proposal(memstore.into());
+    let nodestore = NodeStore::new_empty_proposal(memstore.into(), true);
     let mut proving_merkle: Merkle<NodeStore<Mutable<Propose>, MemStore>> = Merkle::from(nodestore);
 
     for (key, value) in key_values {

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -27,10 +27,10 @@ use crate::{
 use firewood_metrics::{HistogramExt, firewood_counter, firewood_histogram};
 use firewood_storage::MemStore;
 use firewood_storage::{
-    BranchNode, Child, Children, FileIoError, HashType, HashableShunt, HashedNodeReader,
-    ImmutableProposal, IntoHashType, LeafNode, MaybePersistedNode, Mutable, MutableKind,
-    NibblesIterator, Node, NodeStore, Path, PathBuf, PathComponent, Propose, ReadableStorage,
-    SharedNode, TrieHash, TrieReader, U4, ValueDigest,
+    BranchNode, Child, Children, DeletedNodeTracking, FileIoError, HashType, HashableShunt,
+    HashedNodeReader, ImmutableProposal, IntoHashType, LeafNode, MaybePersistedNode, Mutable,
+    MutableKind, NibblesIterator, Node, NodeStore, Path, PathBuf, PathComponent, Propose,
+    ReadableStorage, SharedNode, TrieHash, TrieReader, U4, ValueDigest,
 };
 use firewood_storage::{
     hash_node_as_storage_trie_root_for_node, hash_node_as_storage_trie_root_parts,
@@ -989,7 +989,7 @@ fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
 ) -> Result<(), api::Error> {
     // Build in-memory merkle from key-value pairs
     let memstore = MemStore::default();
-    let nodestore = NodeStore::new_empty_proposal(memstore.into(), true);
+    let nodestore = NodeStore::new_empty_proposal(memstore.into(), DeletedNodeTracking::Enabled);
     let mut proving_merkle: Merkle<NodeStore<Mutable<Propose>, MemStore>> = Merkle::from(nodestore);
 
     for (key, value) in key_values {

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -3,7 +3,7 @@
 
 use crate::api::OptionalHashKeyExt;
 use crate::merkle::Merkle;
-use firewood_storage::{Committed, MemStore, NodeStore};
+use firewood_storage::{Committed, DeletedNodeTracking, MemStore, NodeStore};
 
 use super::*;
 use ethereum_types::H256;
@@ -695,7 +695,8 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
     let header = NodeStoreHeader::read_from_storage(&*storage).unwrap();
 
     // Re-open from the clobbered MemStore so all reads come from disk.
-    let merkle = Merkle::from(NodeStore::open(&header, storage, true).unwrap());
+    let merkle =
+        Merkle::from(NodeStore::open(&header, storage, DeletedNodeTracking::Enabled).unwrap());
 
     // Sanity check: the stored values now contain dummy zeros.
     for (k, _) in &*accounts {

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -695,7 +695,7 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
     let header = NodeStoreHeader::read_from_storage(&*storage).unwrap();
 
     // Re-open from the clobbered MemStore so all reads come from disk.
-    let merkle = Merkle::from(NodeStore::open(&header, storage).unwrap());
+    let merkle = Merkle::from(NodeStore::open(&header, storage, true).unwrap());
 
     // Sanity check: the stored values now contain dummy zeros.
     for (k, _) in &*accounts {

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -72,7 +72,7 @@ where
         NodeHashAlgorithm::compile_option(),
     ));
     let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-    let base = Merkle::from(NodeStore::new_empty_committed(memstore.clone()));
+    let base = Merkle::from(NodeStore::new_empty_committed(memstore.clone(), true));
     let mut merkle = base.fork().unwrap();
 
     for (k, v) in iter.clone() {
@@ -200,7 +200,7 @@ fn insert_one() {
 fn create_in_memory_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
     let memstore = MemStore::default();
 
-    let nodestore = NodeStore::new_empty_proposal(memstore.into());
+    let nodestore = NodeStore::new_empty_proposal(memstore.into(), true);
 
     Merkle { nodestore }
 }

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -20,8 +20,8 @@ use std::fmt::Write;
 use super::*;
 use crate::{ProofError, ProofNode};
 use firewood_storage::{
-    Children, Committed, MemStore, Mutable, NodeHashAlgorithm, NodeStore, NodeStoreHeader,
-    PathComponent, Propose, RootReader, TrieHash, ValueDigest,
+    Children, Committed, DeletedNodeTracking, MemStore, Mutable, NodeHashAlgorithm, NodeStore,
+    NodeStoreHeader, PathComponent, Propose, RootReader, TrieHash, ValueDigest,
 };
 
 // Returns n random key-value pairs.
@@ -72,7 +72,10 @@ where
         NodeHashAlgorithm::compile_option(),
     ));
     let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-    let base = Merkle::from(NodeStore::new_empty_committed(memstore.clone(), true));
+    let base = Merkle::from(NodeStore::new_empty_committed(
+        memstore.clone(),
+        DeletedNodeTracking::Enabled,
+    ));
     let mut merkle = base.fork().unwrap();
 
     for (k, v) in iter.clone() {
@@ -200,7 +203,7 @@ fn insert_one() {
 fn create_in_memory_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
     let memstore = MemStore::default();
 
-    let nodestore = NodeStore::new_empty_proposal(memstore.into(), true);
+    let nodestore = NodeStore::new_empty_proposal(memstore.into(), DeletedNodeTracking::Enabled);
 
     Merkle { nodestore }
 }

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -72,7 +72,9 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     };
 
     let mut header = NodeStoreHeader::read_from_storage(storage.as_ref())?;
-    let nodestore = NodeStore::open(&header, storage)?;
+    // Open with delete tracking enabled: the checker repairs free lists, which
+    // requires it regardless of how the database is normally run.
+    let nodestore = NodeStore::open(&header, storage, true)?;
     let check_report = nodestore.check(&header, check_ops);
 
     println!("Errors ({}): ", check_report.errors.len());

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -73,9 +73,14 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     };
 
     let mut header = NodeStoreHeader::read_from_storage(storage.as_ref())?;
-    // Open with delete tracking enabled: the checker repairs free lists, which
-    // requires it regardless of how the database is normally run.
-    let nodestore = NodeStore::open(&header, storage, DeletedNodeTracking::Enabled)?;
+    // The checker never builds proposals, so this value is currently unused.
+    // Match how the database is normally run by checking if the RootStore directory exists.
+    let deleted_node_tracking = if opts.database.dbpath.join("root_store").is_dir() {
+        DeletedNodeTracking::Disabled
+    } else {
+        DeletedNodeTracking::Enabled
+    };
+    let nodestore = NodeStore::open(&header, storage, deleted_node_tracking)?;
     let check_report = nodestore.check(&header, check_ops);
 
     println!("Errors ({}): ", check_report.errors.len());

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -9,7 +9,8 @@ use askama::Template;
 use clap::Args;
 use firewood::api;
 use firewood_storage::{
-    CacheReadStrategy, CheckOpt, DBStats, FileBacked, NodeStore, NodeStoreHeader,
+    CacheReadStrategy, CheckOpt, DBStats, DeletedNodeTracking, FileBacked, NodeStore,
+    NodeStoreHeader,
 };
 use indicatif::{ProgressBar, ProgressFinish, ProgressStyle};
 use nonzero_ext::nonzero;
@@ -74,7 +75,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let mut header = NodeStoreHeader::read_from_storage(storage.as_ref())?;
     // Open with delete tracking enabled: the checker repairs free lists, which
     // requires it regardless of how the database is normally run.
-    let nodestore = NodeStore::open(&header, storage, true)?;
+    let nodestore = NodeStore::open(&header, storage, DeletedNodeTracking::Enabled)?;
     let check_report = nodestore.check(&header, check_ops);
 
     println!("Errors ({}): ", check_report.errors.len());

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -746,6 +746,7 @@ mod test {
     use nonzero_ext::nonzero;
 
     use super::*;
+    use crate::DeletedNodeTracking;
     use crate::linear::memory::MemStore;
     use crate::nodestore::NodeStoreHeader;
     use crate::nodestore::alloc::FreeLists;
@@ -992,7 +993,8 @@ mod test {
     // We use primitive calls here to do a low-level check.
     fn checker_traverse_correct_trie() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let test_trie = gen_test_trie(&nodestore);
         // let (_, high_watermark, (root_addr, root_hash)) = gen_test_trie(&mut nodestore);
@@ -1016,7 +1018,8 @@ mod test {
     // This test permutes the simple trie with a wrong hash and checks that the checker detects it.
     fn checker_traverse_trie_with_wrong_hash() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let mut test_trie = gen_test_trie(&nodestore);
         let root_addr = test_trie.root_address;
@@ -1090,7 +1093,8 @@ mod test {
         let rng = crate::SeededRng::from_env_or_random();
 
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         // write free areas
         let mut high_watermark = NodeStoreHeader::SIZE;
@@ -1136,7 +1140,8 @@ mod test {
     #[test]
     fn traverse_freelist_should_skip_offspring_of_incorrect_areas() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
         let TestFreelist {
             high_watermark,
             free_ranges,
@@ -1157,7 +1162,8 @@ mod test {
     #[test]
     fn fix_freelist_with_overlap() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
         let TestFreelist {
             high_watermark,
             free_ranges: _,
@@ -1200,7 +1206,8 @@ mod test {
         let mut rng = crate::SeededRng::from_env_or_random();
 
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let num_areas = 10;
 
@@ -1257,7 +1264,8 @@ mod test {
     #[expect(clippy::arithmetic_side_effects)]
     fn split_range_of_zeros_into_leaked_areas() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let expected_leaked_area_indices = vec![
             area_index!(8),
@@ -1308,7 +1316,8 @@ mod test {
     #[expect(clippy::arithmetic_side_effects)]
     fn split_range_into_leaked_areas_test() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         // write two free areas
         let mut high_watermark = NodeStoreHeader::SIZE;

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -992,7 +992,7 @@ mod test {
     // We use primitive calls here to do a low-level check.
     fn checker_traverse_correct_trie() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
 
         let test_trie = gen_test_trie(&nodestore);
         // let (_, high_watermark, (root_addr, root_hash)) = gen_test_trie(&mut nodestore);
@@ -1016,7 +1016,7 @@ mod test {
     // This test permutes the simple trie with a wrong hash and checks that the checker detects it.
     fn checker_traverse_trie_with_wrong_hash() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
 
         let mut test_trie = gen_test_trie(&nodestore);
         let root_addr = test_trie.root_address;
@@ -1090,7 +1090,7 @@ mod test {
         let rng = crate::SeededRng::from_env_or_random();
 
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
 
         // write free areas
         let mut high_watermark = NodeStoreHeader::SIZE;
@@ -1136,7 +1136,7 @@ mod test {
     #[test]
     fn traverse_freelist_should_skip_offspring_of_incorrect_areas() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
         let TestFreelist {
             high_watermark,
             free_ranges,
@@ -1157,7 +1157,7 @@ mod test {
     #[test]
     fn fix_freelist_with_overlap() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
         let TestFreelist {
             high_watermark,
             free_ranges: _,
@@ -1200,7 +1200,7 @@ mod test {
         let mut rng = crate::SeededRng::from_env_or_random();
 
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
 
         let num_areas = 10;
 
@@ -1257,7 +1257,7 @@ mod test {
     #[expect(clippy::arithmetic_side_effects)]
     fn split_range_of_zeros_into_leaked_areas() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
 
         let expected_leaked_area_indices = vec![
             area_index!(8),
@@ -1308,7 +1308,7 @@ mod test {
     #[expect(clippy::arithmetic_side_effects)]
     fn split_range_into_leaked_areas_test() {
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
 
         // write two free areas
         let mut high_watermark = NodeStoreHeader::SIZE;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -64,11 +64,12 @@ pub use linear::{FileIoError, ReadableStorage, WritableStorage};
 pub use node::path::{NibblesIterator, Path};
 pub use node::{BranchNode, Child, Children, ChildrenSlots, LeafNode, Node, PathIterItem};
 pub use nodestore::{
-    AreaIndex, Committed, CommittedId, CommittedParentHash, HashedNodeReader, ImmutableProposal,
-    LinearAddress, Mutable, MutableKind, NodeHashAlgorithm, NodeHashAlgorithmTryFromIntError,
-    NodeReader, NodeStore, NodeStoreHeader, Parentable, Propose, Recon, Reconstructed,
-    ReconstructionSource, RootReader, TrieReader, fix_account_storage_root_value,
-    hash_node_as_storage_trie_root_for_node, hash_node_as_storage_trie_root_parts,
+    AreaIndex, Committed, CommittedId, CommittedParentHash, DeletedNodeTracking, HashedNodeReader,
+    ImmutableProposal, LinearAddress, Mutable, MutableKind, NodeHashAlgorithm,
+    NodeHashAlgorithmTryFromIntError, NodeReader, NodeStore, NodeStoreHeader, Parentable, Propose,
+    Recon, Reconstructed, ReconstructionSource, RootReader, TrieReader,
+    fix_account_storage_root_value, hash_node_as_storage_trie_root_for_node,
+    hash_node_as_storage_trie_root_parts,
 };
 pub use path::{
     ComponentIter, IntoSplitPath, JoinedPath, PackedBytes, PackedPathComponents, PackedPathRef,

--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -251,14 +251,14 @@ enum MaybePersisted {
 mod test {
     use nonzero_ext::nonzero;
 
-    use crate::{LeafNode, MemStore, Node, NodeStore, Path};
+    use crate::{DeletedNodeTracking, LeafNode, MemStore, Node, NodeStore, Path};
 
     use super::*;
 
     #[test]
     fn test_maybe_persisted_node() -> Result<(), FileIoError> {
         let mem_store = MemStore::default().into();
-        let store = NodeStore::new_empty_committed(mem_store, true);
+        let store = NodeStore::new_empty_committed(mem_store, DeletedNodeTracking::Enabled);
         let node = SharedNode::new(Node::Leaf(LeafNode {
             partial_path: Path::new(),
             value: vec![0].into(),
@@ -289,7 +289,7 @@ mod test {
     #[test]
     fn test_clone_shares_underlying_shared_node() -> Result<(), FileIoError> {
         let mem_store = MemStore::default().into();
-        let store = NodeStore::new_empty_committed(mem_store, true);
+        let store = NodeStore::new_empty_committed(mem_store, DeletedNodeTracking::Enabled);
         let node = SharedNode::new(Node::Leaf(LeafNode {
             partial_path: Path::new(),
             value: vec![42].into(),

--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -258,7 +258,7 @@ mod test {
     #[test]
     fn test_maybe_persisted_node() -> Result<(), FileIoError> {
         let mem_store = MemStore::default().into();
-        let store = NodeStore::new_empty_committed(mem_store);
+        let store = NodeStore::new_empty_committed(mem_store, true);
         let node = SharedNode::new(Node::Leaf(LeafNode {
             partial_path: Path::new(),
             value: vec![0].into(),
@@ -289,7 +289,7 @@ mod test {
     #[test]
     fn test_clone_shares_underlying_shared_node() -> Result<(), FileIoError> {
         let mem_store = MemStore::default().into();
-        let store = NodeStore::new_empty_committed(mem_store);
+        let store = NodeStore::new_empty_committed(mem_store, true);
         let node = SharedNode::new(Node::Leaf(LeafNode {
             partial_path: Path::new(),
             value: vec![42].into(),

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -656,6 +656,7 @@ pub mod test_utils {
 #[expect(clippy::unwrap_used, clippy::indexing_slicing)]
 mod tests {
     use super::*;
+    use crate::DeletedNodeTracking;
     use crate::area_index;
     use crate::linear::memory::MemStore;
     use rand::seq::IteratorRandom;
@@ -684,7 +685,8 @@ mod tests {
     fn free_list_iterator() {
         let mut rng = crate::SeededRng::from_env_or_random();
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let area_index = rng.random_range(0..AreaIndex::NUM_AREA_SIZES as u8);
         let area_index_type = AreaIndex::try_from(area_index).unwrap();
@@ -737,7 +739,8 @@ mod tests {
     fn free_list_iter_with_metadata() {
         let rng = crate::SeededRng::from_env_or_random();
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let mut free_lists = FreeLists::default();
         let mut offset = NodeStoreHeader::SIZE;
@@ -863,7 +866,8 @@ mod tests {
         const AREA_INDEX2_PLUS_1: AreaIndex = area_index!(6);
 
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
+        let nodestore =
+            NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let mut free_lists = FreeLists::default();
         let mut offset = NodeStoreHeader::SIZE;

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -684,7 +684,7 @@ mod tests {
     fn free_list_iterator() {
         let mut rng = crate::SeededRng::from_env_or_random();
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
 
         let area_index = rng.random_range(0..AreaIndex::NUM_AREA_SIZES as u8);
         let area_index_type = AreaIndex::try_from(area_index).unwrap();
@@ -737,7 +737,7 @@ mod tests {
     fn free_list_iter_with_metadata() {
         let rng = crate::SeededRng::from_env_or_random();
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
 
         let mut free_lists = FreeLists::default();
         let mut offset = NodeStoreHeader::SIZE;
@@ -863,7 +863,7 @@ mod tests {
         const AREA_INDEX2_PLUS_1: AreaIndex = area_index!(6);
 
         let memstore = MemStore::default();
-        let nodestore = NodeStore::new_empty_committed(memstore.into());
+        let nodestore = NodeStore::new_empty_committed(memstore.into(), true);
 
         let mut free_lists = FreeLists::default();
         let mut offset = NodeStoreHeader::SIZE;

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -130,10 +130,20 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
     /// The header should be read using [`NodeStoreHeader::read_from_storage`] before calling this.
     /// This separation allows callers to manage the header lifecycle independently.
     ///
+    /// `track_deleted` controls whether proposals record removed and replaced
+    /// nodes in the future-delete log so their space can later be reclaimed.
+    /// Pass `false` when the log will never be consumed (e.g. archival mode,
+    /// where old nodes are preserved on disk for historical queries). It is
+    /// propagated to every nodestore derived from this one.
+    ///
     /// # Errors
     ///
     /// Returns a [`FileIoError`] if the root node cannot be read from storage.
-    pub fn open(header: &NodeStoreHeader, storage: Arc<S>) -> Result<Self, FileIoError> {
+    pub fn open(
+        header: &NodeStoreHeader,
+        storage: Arc<S>,
+        track_deleted: bool,
+    ) -> Result<Self, FileIoError> {
         let mut nodestore = Self {
             kind: Committed {
                 deleted: Box::default(),
@@ -142,6 +152,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
             },
             storage,
             must_recompute_storage_hash: header.must_recompute_storage_hash(),
+            track_deleted,
         };
 
         if let Some(root_address) = header.root_address() {
@@ -161,8 +172,11 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
     }
 
     /// Create a new, empty, Committed [`NodeStore`].
+    ///
+    /// `track_deleted` controls whether proposals build the future-delete log;
+    /// see [`NodeStore::open`].
     #[must_use]
-    pub fn new_empty_committed(storage: Arc<S>) -> Self {
+    pub fn new_empty_committed(storage: Arc<S>, track_deleted: bool) -> Self {
         Self {
             storage,
             kind: Committed {
@@ -174,6 +188,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
             // persists correct storageRoots at hash time, so proofs do not
             // need to recompute them.
             must_recompute_storage_hash: header::Version::new().must_recompute_storage_hash(),
+            track_deleted,
         }
     }
 
@@ -192,6 +207,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
         root_hash: HashType,
         root_address: LinearAddress,
         storage: Arc<S>,
+        track_deleted: bool,
     ) -> Result<Self, FileIoError> {
         // Read the on-disk version so account-storage-root recomputation at
         // proof time happens iff the persisted data predates the hfix.
@@ -205,6 +221,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
             },
             storage,
             must_recompute_storage_hash: header.must_recompute_storage_hash(),
+            track_deleted,
         };
 
         let node = nodestore.read_node(root_address)?;
@@ -318,7 +335,11 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
     pub fn new<F: Parentable>(parent: &NodeStore<F, S>) -> Result<Self, FileIoError> {
         let mut deleted = Vec::default();
         let root = if let Some(ref root) = parent.kind.root() {
-            deleted.push(root.clone());
+            // Record the replaced root in the future-delete log, unless delete
+            // tracking is off because the log will never be consumed.
+            if parent.track_deleted {
+                deleted.push(root.clone());
+            }
             let root = triomphe::Arc::unwrap_or_clone(root.as_shared_node(parent)?);
             Some(root)
         } else {
@@ -335,13 +356,19 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
             kind,
             storage: parent.storage.clone(),
             must_recompute_storage_hash: parent.must_recompute_storage_hash,
+            track_deleted: parent.track_deleted,
         })
     }
 
     /// Marks the node at `addr` as deleted in this proposal.
+    ///
+    /// No-op when delete tracking is disabled, since the future-delete log
+    /// would never be consumed.
     pub fn delete_node(&mut self, node: MaybePersistedNode) {
-        trace!("Pending delete at {node:?}");
-        self.kind.inner.deleted.push(node);
+        if self.track_deleted {
+            trace!("Pending delete at {node:?}");
+            self.kind.inner.deleted.push(node);
+        }
     }
 
     /// Take the nodes that have been marked as deleted in this proposal.
@@ -350,8 +377,13 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
     }
 
     /// Adds to the nodes deleted in this proposal.
+    ///
+    /// No-op when delete tracking is disabled, since the future-delete log
+    /// would never be consumed.
     pub fn delete_nodes(&mut self, nodes: &[MaybePersistedNode]) {
-        self.kind.inner.deleted.extend_from_slice(nodes);
+        if self.track_deleted {
+            self.kind.inner.deleted.extend_from_slice(nodes);
+        }
     }
 
     /// Creates a new [`NodeStore`] from a root node, inheriting the parent from another proposal.
@@ -367,6 +399,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
             },
             storage: parent.storage.clone(),
             must_recompute_storage_hash: parent.must_recompute_storage_hash,
+            track_deleted: parent.track_deleted,
         }
     }
 }
@@ -384,7 +417,12 @@ impl<K: MutableKind, S: ReadableStorage> NodeStore<Mutable<K>, S> {
     #[inline]
     pub fn read_for_update(&mut self, node: MaybePersistedNode) -> Result<Node, FileIoError> {
         let arc_wrapped_node = node.as_shared_node(self)?;
-        self.kind.inner.track_deleted(node);
+        // Skip building the future-delete log when delete tracking is off
+        // (it would never be consumed). This branch is on an immutable flag
+        // and is perfectly predicted.
+        if self.track_deleted {
+            self.kind.inner.track_deleted(node);
+        }
         Ok(triomphe::Arc::unwrap_or_clone(arc_wrapped_node))
     }
 }
@@ -424,6 +462,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Recon<S>>, S> {
             },
             storage: parent.storage.clone(),
             must_recompute_storage_hash: parent.must_recompute_storage_hash,
+            track_deleted: parent.track_deleted,
         })
     }
 }
@@ -461,7 +500,10 @@ impl<T, S> NodeStore<Mutable<T>, S> {
 impl<S: WritableStorage> NodeStore<Mutable<Propose>, S> {
     /// Creates a new, empty, [`NodeStore`].
     /// This is used during testing and during the creation of an in-memory merkle for proofs.
-    pub fn new_empty_proposal(storage: Arc<S>) -> Self {
+    ///
+    /// `track_deleted` controls whether proposals build the future-delete log;
+    /// see [`NodeStore::open`].
+    pub fn new_empty_proposal(storage: Arc<S>, track_deleted: bool) -> Self {
         NodeStore {
             kind: Mutable {
                 root: None,
@@ -481,6 +523,7 @@ impl<S: WritableStorage> NodeStore<Mutable<Propose>, S> {
             // Fresh proposal: writes go through current code, which persists
             // correct storageRoots at hash time.
             must_recompute_storage_hash: header::Version::new().must_recompute_storage_hash(),
+            track_deleted,
         }
     }
 }
@@ -492,7 +535,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Recon<S>>, S> {
     /// [`NodeStore::reconstruction_child`] with a real `Committed` source.
     #[cfg(any(test, feature = "test_utils"))]
     pub fn new_empty_recon(storage: Arc<S>) -> Self {
-        let parent_anchor = Arc::new(NodeStore::new_empty_committed(Arc::clone(&storage)));
+        let parent_anchor = Arc::new(NodeStore::new_empty_committed(Arc::clone(&storage), true));
         NodeStore {
             kind: Mutable {
                 root: None,
@@ -501,6 +544,9 @@ impl<S: ReadableStorage> NodeStore<Mutable<Recon<S>>, S> {
             storage,
             // Fresh reconstruction store: writes go through current code.
             must_recompute_storage_hash: header::Version::new().must_recompute_storage_hash(),
+            // Reconstruction views never participate in the future-delete
+            // log, so this value is irrelevant here.
+            track_deleted: true,
         }
     }
 }
@@ -814,6 +860,12 @@ pub struct NodeStore<T, S> {
     /// Whether account storage-root hashes must be recomputed at
     /// proof-generation time. Set from the database header version.
     must_recompute_storage_hash: bool,
+    /// Whether removed and replaced nodes are recorded in the future-delete
+    /// log so their space can later be reclaimed. Set at the root constructors
+    /// and propagated to every derived nodestore. Disabled when the log would
+    /// never be consumed (e.g. archival mode, where old nodes are preserved on
+    /// disk for historical queries), so proposals skip building it entirely.
+    track_deleted: bool,
 }
 
 /// Contains state for a reconstructed revision of the trie.
@@ -937,6 +989,7 @@ impl<S: ReadableStorage> From<NodeStore<Reconstructed<S>, S>> for NodeStore<Muta
             },
             storage: val.storage,
             must_recompute_storage_hash: val.must_recompute_storage_hash,
+            track_deleted: val.track_deleted,
         }
     }
 }
@@ -954,6 +1007,7 @@ impl<S: ReadableStorage> From<NodeStore<Mutable<Recon<S>>, S>> for NodeStore<Rec
             },
             storage: val.storage,
             must_recompute_storage_hash: val.must_recompute_storage_hash,
+            track_deleted: val.track_deleted,
         }
     }
 }
@@ -988,6 +1042,7 @@ impl<S> Clone for NodeStore<Reconstructed<S>, S> {
             kind: self.kind.clone(),
             storage: self.storage.clone(),
             must_recompute_storage_hash: self.must_recompute_storage_hash,
+            track_deleted: self.track_deleted,
         }
     }
 }
@@ -1024,7 +1079,7 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
     /// revision once `max_revisions` is exceeded.
     #[must_use]
     pub fn empty_committed_sibling(&self) -> NodeStore<Committed, S> {
-        NodeStore::new_empty_committed(self.storage.clone())
+        NodeStore::new_empty_committed(self.storage.clone(), self.track_deleted)
     }
 }
 
@@ -1041,6 +1096,7 @@ impl<S: WritableStorage> NodeStore<Arc<ImmutableProposal>, S> {
             },
             storage: self.storage.clone(),
             must_recompute_storage_hash: self.must_recompute_storage_hash,
+            track_deleted: self.track_deleted,
         }
     }
 }
@@ -1055,6 +1111,7 @@ impl<S: ReadableStorage> TryFrom<NodeStore<Mutable<Propose>, S>>
             kind,
             storage,
             must_recompute_storage_hash,
+            track_deleted,
         } = val;
         let Mutable {
             root,
@@ -1069,6 +1126,7 @@ impl<S: ReadableStorage> TryFrom<NodeStore<Mutable<Propose>, S>>
             }),
             storage,
             must_recompute_storage_hash,
+            track_deleted,
         };
 
         let Some(root) = root else {
@@ -1477,7 +1535,7 @@ mod tests {
     fn test_reparent() {
         // create an empty base revision
         let memstore = MemStore::default();
-        let base = NodeStore::new_empty_committed(memstore.into());
+        let base = NodeStore::new_empty_committed(memstore.into(), true);
 
         // create an empty r1, check that it's parent is the empty committed version
         let r1 = NodeStore::new(&base).unwrap();
@@ -1515,7 +1573,7 @@ mod tests {
     fn test_slow_giant_node() {
         let memstore = Arc::new(MemStore::default());
         let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-        let empty_root = NodeStore::new_empty_committed(Arc::clone(&memstore));
+        let empty_root = NodeStore::new_empty_committed(Arc::clone(&memstore), true);
 
         let mut node_store = NodeStore::new(&empty_root).unwrap();
 
@@ -1580,7 +1638,7 @@ mod tests {
             NodeHashAlgorithm::compile_option(),
         )?);
         let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-        let nodestore = NodeStore::open(&header, storage)?;
+        let nodestore = NodeStore::open(&header, storage, true)?;
 
         let mut proposal = NodeStore::new(&nodestore)?;
 
@@ -1659,7 +1717,7 @@ mod tests {
             NodeHashAlgorithm::compile_option(),
         )?);
         let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-        let base = NodeStore::open(&header, Arc::clone(&storage))?;
+        let base = NodeStore::open(&header, Arc::clone(&storage), true)?;
 
         // Create a proposal with a leaf node and persist it
         let mut proposal = NodeStore::new(&base)?;
@@ -1676,7 +1734,7 @@ mod tests {
         let root_hash = header.root_hash().unwrap().into_hash_type();
 
         // Reconstruct using with_root
-        let restored = NodeStore::with_root(root_hash.clone(), root_address, storage)?;
+        let restored = NodeStore::with_root(root_hash.clone(), root_address, storage, true)?;
         assert_eq!(restored.root_hash(), Some(root_hash.into_triehash()));
         assert_eq!(restored.root_address(), Some(root_address));
 
@@ -1698,7 +1756,7 @@ mod tests {
             NodeHashAlgorithm::compile_option(),
         )?);
         let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-        let base = NodeStore::open(&header, Arc::clone(&storage))?;
+        let base = NodeStore::open(&header, Arc::clone(&storage), true)?;
 
         // Create a proposal with a leaf node and persist it
         let mut proposal = NodeStore::new(&base)?;
@@ -1714,7 +1772,7 @@ mod tests {
 
         // Use a bogus hash
         let bad_hash = HashType::from([0xAB; 32]);
-        let result = NodeStore::with_root(bad_hash, root_address, storage);
+        let result = NodeStore::with_root(bad_hash, root_address, storage, true);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -1850,7 +1908,7 @@ mod tests {
         // the RevisionManager cannot reap the revision (and free its on-disk
         // nodes) while a derived view is still alive.
         let storage = Arc::new(MemStore::default());
-        let committed = Arc::new(NodeStore::new_empty_committed(Arc::clone(&storage)));
+        let committed = Arc::new(NodeStore::new_empty_committed(Arc::clone(&storage), true));
         assert_eq!(Arc::strong_count(&committed), 1);
 
         let recon = NodeStore::<Mutable<Recon<_>>, _>::new_for_reconstruction(

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -130,10 +130,8 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
     /// The header should be read using [`NodeStoreHeader::read_from_storage`] before calling this.
     /// This separation allows callers to manage the header lifecycle independently.
     ///
-    /// `track_deleted` controls whether proposals record removed and replaced
-    /// nodes in the future-delete log so their space can later be reclaimed.
-    /// Pass `false` when the log will never be consumed (e.g. archival mode,
-    /// where old nodes are preserved on disk for historical queries). It is
+    /// `deleted_node_tracking` controls whether proposals record removed and
+    /// replaced nodes in the future-delete log; see [`DeletedNodeTracking`]. It is
     /// propagated to every nodestore derived from this one.
     ///
     /// # Errors
@@ -142,7 +140,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
     pub fn open(
         header: &NodeStoreHeader,
         storage: Arc<S>,
-        track_deleted: bool,
+        deleted_node_tracking: DeletedNodeTracking,
     ) -> Result<Self, FileIoError> {
         let mut nodestore = Self {
             kind: Committed {
@@ -152,7 +150,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
             },
             storage,
             must_recompute_storage_hash: header.must_recompute_storage_hash(),
-            track_deleted,
+            deleted_node_tracking,
         };
 
         if let Some(root_address) = header.root_address() {
@@ -173,10 +171,13 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
 
     /// Create a new, empty, Committed [`NodeStore`].
     ///
-    /// `track_deleted` controls whether proposals build the future-delete log;
-    /// see [`NodeStore::open`].
+    /// `deleted_node_tracking` controls whether proposals build the future-delete
+    /// log; see [`DeletedNodeTracking`].
     #[must_use]
-    pub fn new_empty_committed(storage: Arc<S>, track_deleted: bool) -> Self {
+    pub fn new_empty_committed(
+        storage: Arc<S>,
+        deleted_node_tracking: DeletedNodeTracking,
+    ) -> Self {
         Self {
             storage,
             kind: Committed {
@@ -188,7 +189,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
             // persists correct storageRoots at hash time, so proofs do not
             // need to recompute them.
             must_recompute_storage_hash: header::Version::new().must_recompute_storage_hash(),
-            track_deleted,
+            deleted_node_tracking,
         }
     }
 
@@ -207,7 +208,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
         root_hash: HashType,
         root_address: LinearAddress,
         storage: Arc<S>,
-        track_deleted: bool,
+        deleted_node_tracking: DeletedNodeTracking,
     ) -> Result<Self, FileIoError> {
         // Read the on-disk version so account-storage-root recomputation at
         // proof time happens iff the persisted data predates the hfix.
@@ -221,7 +222,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
             },
             storage,
             must_recompute_storage_hash: header.must_recompute_storage_hash(),
-            track_deleted,
+            deleted_node_tracking,
         };
 
         let node = nodestore.read_node(root_address)?;
@@ -337,7 +338,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
         let root = if let Some(ref root) = parent.kind.root() {
             // Record the replaced root in the future-delete log, unless delete
             // tracking is off because the log will never be consumed.
-            if parent.track_deleted {
+            if parent.deleted_node_tracking.is_enabled() {
                 deleted.push(root.clone());
             }
             let root = triomphe::Arc::unwrap_or_clone(root.as_shared_node(parent)?);
@@ -356,7 +357,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
             kind,
             storage: parent.storage.clone(),
             must_recompute_storage_hash: parent.must_recompute_storage_hash,
-            track_deleted: parent.track_deleted,
+            deleted_node_tracking: parent.deleted_node_tracking,
         })
     }
 
@@ -365,7 +366,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
     /// No-op when delete tracking is disabled, since the future-delete log
     /// would never be consumed.
     pub fn delete_node(&mut self, node: MaybePersistedNode) {
-        if self.track_deleted {
+        if self.deleted_node_tracking.is_enabled() {
             trace!("Pending delete at {node:?}");
             self.kind.inner.deleted.push(node);
         }
@@ -381,7 +382,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
     /// No-op when delete tracking is disabled, since the future-delete log
     /// would never be consumed.
     pub fn delete_nodes(&mut self, nodes: &[MaybePersistedNode]) {
-        if self.track_deleted {
+        if self.deleted_node_tracking.is_enabled() {
             self.kind.inner.deleted.extend_from_slice(nodes);
         }
     }
@@ -399,7 +400,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Propose>, S> {
             },
             storage: parent.storage.clone(),
             must_recompute_storage_hash: parent.must_recompute_storage_hash,
-            track_deleted: parent.track_deleted,
+            deleted_node_tracking: parent.deleted_node_tracking,
         }
     }
 }
@@ -420,7 +421,7 @@ impl<K: MutableKind, S: ReadableStorage> NodeStore<Mutable<K>, S> {
         // Skip building the future-delete log when delete tracking is off
         // (it would never be consumed). This branch is on an immutable flag
         // and is perfectly predicted.
-        if self.track_deleted {
+        if self.deleted_node_tracking.is_enabled() {
             self.kind.inner.track_deleted(node);
         }
         Ok(triomphe::Arc::unwrap_or_clone(arc_wrapped_node))
@@ -462,7 +463,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Recon<S>>, S> {
             },
             storage: parent.storage.clone(),
             must_recompute_storage_hash: parent.must_recompute_storage_hash,
-            track_deleted: parent.track_deleted,
+            deleted_node_tracking: parent.deleted_node_tracking,
         })
     }
 }
@@ -501,9 +502,9 @@ impl<S: WritableStorage> NodeStore<Mutable<Propose>, S> {
     /// Creates a new, empty, [`NodeStore`].
     /// This is used during testing and during the creation of an in-memory merkle for proofs.
     ///
-    /// `track_deleted` controls whether proposals build the future-delete log;
-    /// see [`NodeStore::open`].
-    pub fn new_empty_proposal(storage: Arc<S>, track_deleted: bool) -> Self {
+    /// `deleted_node_tracking` controls whether proposals build the future-delete
+    /// log; see [`DeletedNodeTracking`].
+    pub fn new_empty_proposal(storage: Arc<S>, deleted_node_tracking: DeletedNodeTracking) -> Self {
         NodeStore {
             kind: Mutable {
                 root: None,
@@ -523,7 +524,7 @@ impl<S: WritableStorage> NodeStore<Mutable<Propose>, S> {
             // Fresh proposal: writes go through current code, which persists
             // correct storageRoots at hash time.
             must_recompute_storage_hash: header::Version::new().must_recompute_storage_hash(),
-            track_deleted,
+            deleted_node_tracking,
         }
     }
 }
@@ -535,7 +536,10 @@ impl<S: ReadableStorage> NodeStore<Mutable<Recon<S>>, S> {
     /// [`NodeStore::reconstruction_child`] with a real `Committed` source.
     #[cfg(any(test, feature = "test_utils"))]
     pub fn new_empty_recon(storage: Arc<S>) -> Self {
-        let parent_anchor = Arc::new(NodeStore::new_empty_committed(Arc::clone(&storage), true));
+        let parent_anchor = Arc::new(NodeStore::new_empty_committed(
+            Arc::clone(&storage),
+            DeletedNodeTracking::Enabled,
+        ));
         NodeStore {
             kind: Mutable {
                 root: None,
@@ -546,7 +550,7 @@ impl<S: ReadableStorage> NodeStore<Mutable<Recon<S>>, S> {
             must_recompute_storage_hash: header::Version::new().must_recompute_storage_hash(),
             // Reconstruction views never participate in the future-delete
             // log, so this value is irrelevant here.
-            track_deleted: true,
+            deleted_node_tracking: DeletedNodeTracking::Enabled,
         }
     }
 }
@@ -865,7 +869,30 @@ pub struct NodeStore<T, S> {
     /// and propagated to every derived nodestore. Disabled when the log would
     /// never be consumed (e.g. archival mode, where old nodes are preserved on
     /// disk for historical queries), so proposals skip building it entirely.
-    track_deleted: bool,
+    deleted_node_tracking: DeletedNodeTracking,
+}
+
+/// Whether removed and replaced nodes are recorded in the future-delete log
+/// so their space can later be reclaimed.
+///
+/// Set at the [`NodeStore`] root constructors and propagated to every derived
+/// nodestore. Pass [`DeletedNodeTracking::Disabled`] when the log would never be
+/// consumed (e.g. archival mode, where old nodes are preserved on disk for
+/// historical queries), so proposals skip building it entirely.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeletedNodeTracking {
+    /// Record removed and replaced nodes in the future-delete log.
+    Enabled,
+    /// Skip building the future-delete log.
+    Disabled,
+}
+
+impl DeletedNodeTracking {
+    /// Returns true if deleted nodes should be recorded in the future-delete log.
+    #[must_use]
+    pub const fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled)
+    }
 }
 
 /// Contains state for a reconstructed revision of the trie.
@@ -989,7 +1016,7 @@ impl<S: ReadableStorage> From<NodeStore<Reconstructed<S>, S>> for NodeStore<Muta
             },
             storage: val.storage,
             must_recompute_storage_hash: val.must_recompute_storage_hash,
-            track_deleted: val.track_deleted,
+            deleted_node_tracking: val.deleted_node_tracking,
         }
     }
 }
@@ -1007,7 +1034,7 @@ impl<S: ReadableStorage> From<NodeStore<Mutable<Recon<S>>, S>> for NodeStore<Rec
             },
             storage: val.storage,
             must_recompute_storage_hash: val.must_recompute_storage_hash,
-            track_deleted: val.track_deleted,
+            deleted_node_tracking: val.deleted_node_tracking,
         }
     }
 }
@@ -1042,7 +1069,7 @@ impl<S> Clone for NodeStore<Reconstructed<S>, S> {
             kind: self.kind.clone(),
             storage: self.storage.clone(),
             must_recompute_storage_hash: self.must_recompute_storage_hash,
-            track_deleted: self.track_deleted,
+            deleted_node_tracking: self.deleted_node_tracking,
         }
     }
 }
@@ -1079,7 +1106,7 @@ impl<S: ReadableStorage> NodeStore<Arc<ImmutableProposal>, S> {
     /// revision once `max_revisions` is exceeded.
     #[must_use]
     pub fn empty_committed_sibling(&self) -> NodeStore<Committed, S> {
-        NodeStore::new_empty_committed(self.storage.clone(), self.track_deleted)
+        NodeStore::new_empty_committed(self.storage.clone(), self.deleted_node_tracking)
     }
 }
 
@@ -1096,7 +1123,7 @@ impl<S: WritableStorage> NodeStore<Arc<ImmutableProposal>, S> {
             },
             storage: self.storage.clone(),
             must_recompute_storage_hash: self.must_recompute_storage_hash,
-            track_deleted: self.track_deleted,
+            deleted_node_tracking: self.deleted_node_tracking,
         }
     }
 }
@@ -1111,7 +1138,7 @@ impl<S: ReadableStorage> TryFrom<NodeStore<Mutable<Propose>, S>>
             kind,
             storage,
             must_recompute_storage_hash,
-            track_deleted,
+            deleted_node_tracking,
         } = val;
         let Mutable {
             root,
@@ -1126,7 +1153,7 @@ impl<S: ReadableStorage> TryFrom<NodeStore<Mutable<Propose>, S>>
             }),
             storage,
             must_recompute_storage_hash,
-            track_deleted,
+            deleted_node_tracking,
         };
 
         let Some(root) = root else {
@@ -1535,7 +1562,7 @@ mod tests {
     fn test_reparent() {
         // create an empty base revision
         let memstore = MemStore::default();
-        let base = NodeStore::new_empty_committed(memstore.into(), true);
+        let base = NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         // create an empty r1, check that it's parent is the empty committed version
         let r1 = NodeStore::new(&base).unwrap();
@@ -1573,7 +1600,8 @@ mod tests {
     fn test_slow_giant_node() {
         let memstore = Arc::new(MemStore::default());
         let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-        let empty_root = NodeStore::new_empty_committed(Arc::clone(&memstore), true);
+        let empty_root =
+            NodeStore::new_empty_committed(Arc::clone(&memstore), DeletedNodeTracking::Enabled);
 
         let mut node_store = NodeStore::new(&empty_root).unwrap();
 
@@ -1638,7 +1666,7 @@ mod tests {
             NodeHashAlgorithm::compile_option(),
         )?);
         let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-        let nodestore = NodeStore::open(&header, storage, true)?;
+        let nodestore = NodeStore::open(&header, storage, DeletedNodeTracking::Enabled)?;
 
         let mut proposal = NodeStore::new(&nodestore)?;
 
@@ -1717,7 +1745,7 @@ mod tests {
             NodeHashAlgorithm::compile_option(),
         )?);
         let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-        let base = NodeStore::open(&header, Arc::clone(&storage), true)?;
+        let base = NodeStore::open(&header, Arc::clone(&storage), DeletedNodeTracking::Enabled)?;
 
         // Create a proposal with a leaf node and persist it
         let mut proposal = NodeStore::new(&base)?;
@@ -1734,7 +1762,12 @@ mod tests {
         let root_hash = header.root_hash().unwrap().into_hash_type();
 
         // Reconstruct using with_root
-        let restored = NodeStore::with_root(root_hash.clone(), root_address, storage, true)?;
+        let restored = NodeStore::with_root(
+            root_hash.clone(),
+            root_address,
+            storage,
+            DeletedNodeTracking::Enabled,
+        )?;
         assert_eq!(restored.root_hash(), Some(root_hash.into_triehash()));
         assert_eq!(restored.root_address(), Some(root_address));
 
@@ -1756,7 +1789,7 @@ mod tests {
             NodeHashAlgorithm::compile_option(),
         )?);
         let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-        let base = NodeStore::open(&header, Arc::clone(&storage), true)?;
+        let base = NodeStore::open(&header, Arc::clone(&storage), DeletedNodeTracking::Enabled)?;
 
         // Create a proposal with a leaf node and persist it
         let mut proposal = NodeStore::new(&base)?;
@@ -1772,7 +1805,12 @@ mod tests {
 
         // Use a bogus hash
         let bad_hash = HashType::from([0xAB; 32]);
-        let result = NodeStore::with_root(bad_hash, root_address, storage, true);
+        let result = NodeStore::with_root(
+            bad_hash,
+            root_address,
+            storage,
+            DeletedNodeTracking::Enabled,
+        );
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -1908,7 +1946,10 @@ mod tests {
         // the RevisionManager cannot reap the revision (and free its on-disk
         // nodes) while a derived view is still alive.
         let storage = Arc::new(MemStore::default());
-        let committed = Arc::new(NodeStore::new_empty_committed(Arc::clone(&storage), true));
+        let committed = Arc::new(NodeStore::new_empty_committed(
+            Arc::clone(&storage),
+            DeletedNodeTracking::Enabled,
+        ));
         assert_eq!(Arc::strong_count(&committed), 1);
 
         let recon = NodeStore::<Mutable<Recon<_>>, _>::new_for_reconstruction(

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -327,7 +327,7 @@ mod tests {
     /// Helper to create a test node store with a specific root
     fn create_test_store_with_root(root: Node) -> NodeStore<Mutable<Propose>, MemStore> {
         let mem_store = MemStore::default().into();
-        let mut store = NodeStore::new_empty_proposal(mem_store);
+        let mut store = NodeStore::new_empty_proposal(mem_store, true);
         store.root_mut().replace(root);
         store
     }
@@ -365,7 +365,7 @@ mod tests {
     #[test]
     fn test_empty_nodestore() {
         let mem_store = MemStore::default().into();
-        let store = NodeStore::new_empty_proposal(mem_store);
+        let store = NodeStore::new_empty_proposal(mem_store, true);
         let mut iter = UnPersistedNodeIterator::new(&store);
 
         assert!(iter.next().is_none());
@@ -529,7 +529,7 @@ mod tests {
         // Create a base committed store with MemStore
         let mem_store = MemStore::default();
         let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-        let base_committed = NodeStore::new_empty_committed(mem_store.into());
+        let base_committed = NodeStore::new_empty_committed(mem_store.into(), true);
 
         // Create a mutable proposal from the base
         let mut mutable_store = NodeStore::new(&base_committed).unwrap();

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -307,8 +307,8 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
 mod tests {
     use super::*;
     use crate::{
-        Child, Children, HashType, ImmutableProposal, LinearAddress, NodeHashAlgorithm, NodeStore,
-        NodeStoreHeader, Path, PathComponent, SharedNode,
+        Child, Children, DeletedNodeTracking, HashType, ImmutableProposal, LinearAddress,
+        NodeHashAlgorithm, NodeStore, NodeStoreHeader, Path, PathComponent, SharedNode,
         linear::memory::MemStore,
         node::{BranchNode, LeafNode, Node},
         nodestore::{Mutable, Propose},
@@ -327,7 +327,7 @@ mod tests {
     /// Helper to create a test node store with a specific root
     fn create_test_store_with_root(root: Node) -> NodeStore<Mutable<Propose>, MemStore> {
         let mem_store = MemStore::default().into();
-        let mut store = NodeStore::new_empty_proposal(mem_store, true);
+        let mut store = NodeStore::new_empty_proposal(mem_store, DeletedNodeTracking::Enabled);
         store.root_mut().replace(root);
         store
     }
@@ -365,7 +365,7 @@ mod tests {
     #[test]
     fn test_empty_nodestore() {
         let mem_store = MemStore::default().into();
-        let store = NodeStore::new_empty_proposal(mem_store, true);
+        let store = NodeStore::new_empty_proposal(mem_store, DeletedNodeTracking::Enabled);
         let mut iter = UnPersistedNodeIterator::new(&store);
 
         assert!(iter.next().is_none());
@@ -529,7 +529,8 @@ mod tests {
         // Create a base committed store with MemStore
         let mem_store = MemStore::default();
         let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
-        let base_committed = NodeStore::new_empty_committed(mem_store.into(), true);
+        let base_committed =
+            NodeStore::new_empty_committed(mem_store.into(), DeletedNodeTracking::Enabled);
 
         // Create a mutable proposal from the base
         let mut mutable_store = NodeStore::new(&base_committed).unwrap();

--- a/storage/src/root_store.rs
+++ b/storage/src/root_store.rs
@@ -18,7 +18,7 @@ use weak_table::WeakValueHashMap;
 use derive_where::derive_where;
 
 use crate::linear::filebacked::FileBacked;
-use crate::nodestore::{Committed, LinearAddress, NodeStore};
+use crate::nodestore::{Committed, DeletedNodeTracking, LinearAddress, NodeStore};
 use crate::{IntoHashType, TrieHash};
 
 /// Type alias for a committed revision stored in the root store.
@@ -163,7 +163,7 @@ impl RootStore {
             self.storage.clone(),
             // `RootStore` only exists when the database was opened in
             // archival mode, where deleted nodes are never tracked.
-            false,
+            DeletedNodeTracking::Disabled,
         )?);
 
         // 5. Cache for future lookups.
@@ -208,7 +208,10 @@ mod tests {
 
         // Create a revision to cache. `RootStore` implies archival mode,
         // where deleted nodes are never tracked.
-        let revision = Arc::new(NodeStore::new_empty_committed(file_backed.clone(), false));
+        let revision = Arc::new(NodeStore::new_empty_committed(
+            file_backed.clone(),
+            DeletedNodeTracking::Disabled,
+        ));
 
         let hash = TrieHash::from_bytes([1; 32]);
         root_store

--- a/storage/src/root_store.rs
+++ b/storage/src/root_store.rs
@@ -161,6 +161,9 @@ impl RootStore {
             hash.clone().into_hash_type(),
             addr,
             self.storage.clone(),
+            // `RootStore` only exists when the database was opened in
+            // archival mode, where deleted nodes are never tracked.
+            false,
         )?);
 
         // 5. Cache for future lookups.
@@ -203,8 +206,9 @@ mod tests {
         let root_store_dir = tmpdir.as_ref().join("root_store");
         let root_store = RootStore::new(root_store_dir, file_backed.clone(), false).unwrap();
 
-        // Create a revision to cache.
-        let revision = Arc::new(NodeStore::new_empty_committed(file_backed.clone()));
+        // Create a revision to cache. `RootStore` implies archival mode,
+        // where deleted nodes are never tracked.
+        let revision = Arc::new(NodeStore::new_empty_committed(file_backed.clone(), false));
 
         let hash = TrieHash::from_bytes([1; 32]);
         root_store


### PR DESCRIPTION
## Why this should be merged

When archival mode is enabled, the future-delete log is built on every proposal, cloned into each committed revision, and retained for max_revisions but is never consumed: `PersistWorker::reap` short-circuits when `RootStore` is present, since old nodes must be preserved on disk for historical queries. This is wasted work (an allocation/push per replaced node on the hot proposal path) and wasted memory (the deleted lists pinned by every retained revision).

## How this works

`NodeStore<T, S>` gains a `deleted_node_tracking: DeletedNodeTracking` field, a two-variant enum (`Enabled` = build the future-delete log, `Disabled` = skip it). It is set at the root constructors and propagated by every derived constructor, so the whole nodestore lineage of a database shares one value. The manager passes `DeletedNodeTracking::Disabled` when opening the database with `root_store` enabled, and `Enabled` otherwise.

When tracking is `Disabled`, all four FDL population sites become no-ops: 
- `read_for_update`
- `delete_node`
- `delete_nodes` 
- `NodeStore::new`

Each guard branches on an immutable flag, so it is perfectly predicted and effectively free next to the adjacent node-cache lookup.

## How this was tested

Added two UTs to test if the future-delete log is built in archival and non-archival mode, respectively:
- `test_no_fdl_when_root_store_enabled()`
- `test_fdl_tracked_when_root_store_disabled()`

## Breaking Changes

- [ ] firewood
- [X] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
