### PR TITLE
feat(labels): introduce versioned label taxonomy

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,173 @@
+# Source of truth for ava-labs/firewood GitHub labels.
+# Synced by .github/workflows/sync-labels.yaml via EndBug/label-sync.
+# `aliases` rename an existing label IN PLACE (associations preserved).
+# Colors are 6 hex digits, no leading '#'. See LABELS.md for the taxonomy.
+
+# --- area/* (magenta) -------------------------------------------------------
+- name: area/storage
+  color: de158e
+  description: "Nodestore, free-lists, on-disk format, FDL"
+  aliases:
+    - storage
+- name: area/revisions
+  color: de158e
+  description: "Revision manager, proposals, commit pipeline"
+  aliases: []
+- name: area/hashing
+  color: de158e
+  description: "SHA-256, ethhash, triehash"
+  aliases: []
+- name: area/proofs
+  color: de158e
+  description: "Range/change proofs, eth_getProof"
+  aliases: []
+- name: area/ffi
+  color: de158e
+  description: "C API and Go wrapper"
+  aliases: []
+- name: area/cli
+  color: de158e
+  description: "fwdctl command-line tool"
+  aliases: []
+- name: area/c-chain
+  color: de158e
+  description: "C-Chain reexecution, libevm integration"
+  aliases:
+    - c-chain
+- name: area/benchmark
+  color: de158e
+  description: "Benchmark suite and perf harness"
+  aliases: []
+- name: area/ci
+  color: de158e
+  description: "Workflows, devcontainer, release tooling, build infra"
+  aliases:
+    - devops
+    - dev infra
+    - github-actions
+- name: area/docs
+  color: de158e
+  description: "Documentation"
+  aliases:
+    - documentation
+
+# --- kind/* (blue) ----------------------------------------------------------
+- name: kind/correctness
+  color: 1d76db
+  description: "Logic or data correctness bugs and fixes"
+  aliases: []
+- name: kind/performance
+  color: 1d76db
+  description: "Throughput, latency, allocation, memory"
+  aliases:
+    - performance
+- name: kind/security
+  color: 1d76db
+  description: "Vulnerabilities and security audits"
+  aliases:
+    - security
+    - audit
+- name: kind/tech-debt
+  color: 1d76db
+  description: "Refactors, cleanup, debt paydown"
+  aliases:
+    - techdebt
+    - cleanup
+- name: kind/observability
+  color: 1d76db
+  description: "Logging, tracing, metrics"
+  aliases:
+    - observability
+- name: kind/testing
+  color: 1d76db
+  description: "Tests, flaky tests, test infrastructure"
+  aliases:
+    - testing
+    - Flaky Test
+- name: kind/dependencies
+  color: 1d76db
+  description: "Dependency updates"
+  aliases:
+    - dependencies
+- name: kind/research
+  color: 1d76db
+  description: "Needs investigation or design before work begins"
+  aliases:
+    - Research Project
+    - design doc
+
+# --- priority/* (severity gradient) -----------------------------------------
+- name: priority/P0
+  color: b60205
+  description: "Critical: data loss/corruption or broken main. Drop everything."
+  aliases: []
+- name: priority/P1
+  color: d93f0b
+  description: "High: needed for next release or blocks users."
+  aliases: []
+- name: priority/P2
+  color: fbca04
+  description: "Medium: should do, not urgent."
+  aliases: []
+- name: priority/P3
+  color: 0e8a16
+  description: "Low: nice to have / someday."
+  aliases:
+    - low priority
+
+# --- status/* ---------------------------------------------------------------
+- name: status/needs-triage
+  color: ededed
+  description: "New; not yet prioritized."
+  aliases: []
+- name: status/needs-info
+  color: fef2c0
+  description: "Blocked on reporter/author for more information."
+  aliases:
+    - needs more info
+    - question
+- name: status/blocked
+  color: e99695
+  description: "Blocked on an external dependency or another item."
+  aliases: []
+- name: status/ready
+  color: 0e8a16
+  description: "Triaged and ready to be picked up."
+  aliases: []
+- name: status/wontfix
+  color: ffffff
+  description: "Will not be worked on."
+  aliases:
+    - wontfix
+- name: status/do-not-merge
+  color: e11d21
+  description: "PR must not be merged in its current state."
+  aliases:
+    - DO NOT MERGE
+
+# --- special flags (un-namespaced) ------------------------------------------
+- name: good first issue
+  color: 7057ff
+  description: "Good for newcomers."
+  aliases: []
+- name: help wanted
+  color: "008672"
+  description: "Extra attention is needed."
+  aliases: []
+- name: no-changelog
+  color: 3af8eb
+  description: "Omit this PR from the changelog."
+  aliases: []
+- name: breaking-change
+  color: f9d0c4
+  description: "Contains a breaking change (affected crate noted in the PR body)."
+  aliases:
+    - breaking-change/firewood
+    - breaking-change/firewood-storage
+    - breaking-change/firewood-ffi
+    - breaking-change/firewood-go
+    - breaking-change/fwdctl
+- name: 3rd party contributor
+  color: fc9c45
+  description: "PR from a fork; flags extra review attention."
+  aliases: []

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - .github/labels.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/labels.yml
   workflow_dispatch:
     inputs:
       dry_run:
@@ -25,5 +29,5 @@ jobs:
         with:
           config-file: .github/labels.yml
           delete-other-labels: true
-          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || github.event_name == 'pull_request' || false }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -1,0 +1,29 @@
+name: Sync labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview changes without applying them"
+        type: boolean
+        default: true
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sync labels from manifest
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: true
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ guidelines for contributing to firewood.
 * [Testing](#testing)
 * [How to submit changes](#how-to-submit-changes)
 * [Code Review Process](#code-review-process)
+* [Labels](#labels)
 * [Where can I ask for help?](#where-can-i-ask-for-help)
 
 ## Quick Links
@@ -112,6 +113,13 @@ please reach out. We hope you work on an easy task before tackling a harder one.
 ## How to request an enhancement
 
 Just like bugs, please use the [issue tracker](https://github.com/ava-labs/firewood/issues) for requesting enhancements. Please tag the issue with the "enhancement" tag.
+
+## Labels
+
+Issues and pull requests are organized with a namespaced label taxonomy
+(`area/*`, `kind/*`, `priority/*`, `status/*`). See [`LABELS.md`](./LABELS.md).
+Labels are managed as code in `.github/labels.yml` — edit the manifest, never
+the GitHub UI.
 
 ## Style Guide / Coding Conventions
 

--- a/LABELS.md
+++ b/LABELS.md
@@ -1,0 +1,45 @@
+# Firewood Label Taxonomy
+
+Labels are managed as code in [`.github/labels.yml`](.github/labels.yml) and
+synced by the [`Sync labels`](.github/workflows/sync-labels.yaml) workflow. Do
+**not** create or rename labels in the GitHub UI — edit the manifest instead.
+
+GitHub **issue types** (Bug, Feature, Task) answer *"what is this?"*. Labels are
+orthogonal and grouped into four namespaces plus a few flags.
+
+## `area/*` — where in the system
+
+`storage`, `revisions`, `hashing`, `proofs`, `ffi`, `cli`, `c-chain`,
+`benchmark`, `ci`, `docs`. Multiple allowed.
+
+## `kind/*` — the concern
+
+`correctness`, `performance`, `security`, `tech-debt`, `observability`,
+`testing`, `dependencies`, `research`. Multiple allowed.
+
+## `priority/*` — how urgent (one per item; absence = untriaged)
+
+| Label | Meaning |
+| :--- | :--- |
+| `priority/P0` | Critical — data loss/corruption, broken `main`. Drop everything. |
+| `priority/P1` | High — needed for next release / blocks users. |
+| `priority/P2` | Medium — should do, not urgent. |
+| `priority/P3` | Low — nice to have / someday. |
+
+## `status/*` — triage/workflow state
+
+`needs-triage` (auto at intake), `needs-info`, `blocked`, `ready`, `wontfix`,
+`do-not-merge` (PR gate; may coexist with another status).
+
+## Flags
+
+`good first issue`, `help wanted`, `no-changelog`, `breaking-change`,
+`3rd party contributor`.
+
+## How labels get applied
+
+- **Issues**: the intake form sets the issue type and `status/needs-triage`.
+  A maintainer adds `priority/*` (which auto-swaps to `status/ready`), plus
+  `area/*`/`kind/*` as useful.
+- **PRs**: `area/*` is auto-applied from changed paths; `kind/*` is derived from
+  the conventional-commit title. `area/c-chain` is applied manually at review.


### PR DESCRIPTION
## Why this should be merged

Firewood's labels accreted organically into ~39 inconsistent labels that mix
several unrelated concerns under no naming or color convention (e.g. `techdebt`
vs `cleanup`, `devops` vs `dev infra` vs `github-actions`), and some duplicate
the org-level **issue types** (`bug`, `enhancement`). This PR introduces a
small, namespaced taxonomy **managed as code**, optimized for the two jobs the
team actually needs: triage/prioritization and discoverability/filtering.

This is **phase 1 of a phased rollout** — it lands only the label definitions,
the sync automation, and documentation. Intake forms, PR/issue labeling
workflows, and the backfill of existing items follow in later PRs.

## How this works

GitHub **issue types** (Bug/Feature/Task) answer *"what is this?"*; labels are
orthogonal and grouped into four namespaces plus a few flags:

- **`area/*`** (10) — where in the system: storage, revisions, hashing, proofs, ffi, cli, c-chain, benchmark, ci, docs
- **`kind/*`** (8) — the concern: correctness, performance, security, tech-debt, observability, testing, dependencies, research
- **`priority/*`** (4) — P0–P3 (absence = untriaged)
- **`status/*`** (6) — needs-triage, needs-info, blocked, ready, wontfix, do-not-merge
- **flags** (5) — good first issue, help wanted, no-changelog, breaking-change, 3rd party contributor

`.github/labels.yml` is the single source of truth (33 labels). The
`Sync labels` workflow runs [`EndBug/label-sync`](https://github.com/EndBug/label-sync)
on pushes to `main` that touch the manifest, plus manual dispatch (defaulting to
**dry-run**). Its `aliases` mechanism renames existing labels **in place**, which
preserves every existing issue/PR association, and `delete-other-labels` removes
the labels intentionally dropped or retired. `LABELS.md` documents the taxonomy
for humans and is linked from `CONTRIBUTING.md`.

The migration of the 39 current labels is encoded entirely as `aliases` in the
manifest:
- **Renames** (associations preserved): `storage`→`area/storage`,
  `low priority`→`priority/P3`, `techdebt`+`cleanup`→`kind/tech-debt`,
  `devops`+`dev infra`+`github-actions`→`area/ci`,
  `breaking-change/{crate}`(×5)→`breaking-change`, etc.
- **Dropped** (redundant with issue types / language noise): `bug`, `enhancement`, `rust`, `go`.
- **Retired** (cohort/process): `intern project`, `vibecoded`, `STACKED`, `TODO`.

## How this was tested

- The manifest was validated for exactly 33 labels, 6-hex-digit colors,
  descriptions present, and that every renamed old label is covered by an alias
  (no orphaned associations) with no alias colliding with a kept label name.
- All touched YAML parses.
- The sync itself has **not** been run against the repo yet. The dry-run CI run 
  on the pull request confirms every aliased label is reported as a **rename** 
  (not delete+create) and only the four dropped + four retired labels appear 
  under deletions. <https://github.com/ava-labs/firewood/actions/runs/27649528699/job/81769839720>

## Follow-ups (not in this PR)

- Later PRs: typed issue forms, path-based `area/*` labeler, `kind/*`-from-title, `needs-triage`→`ready` promotion, dependabot label rename.
- Backfill existing in-scope issues/PRs.

## Breaking Changes

None to any published artifact (`firewood`, `firewood-storage`, `firewood-ffi`,
`firewood-go`, `fwdctl`). This PR only affects repository metadata.
