### PR TITLE
docs: author the mdBook content and design-doc subsystem

### DIFF
--- a/.devcontainer/features/firewood-tools/install.sh
+++ b/.devcontainer/features/firewood-tools/install.sh
@@ -38,8 +38,10 @@ rustup toolchain install nightly --profile minimal
 rustup component add clippy rustfmt rust-src rust-docs llvm-tools --toolchain nightly
 
 # 3. cargo-binstall (prebuilt) so the remaining tools install without compiling.
+#    Pin the installer to a release commit (v1.21.0) instead of the floating `main`
+#    branch, matching the repo convention of pinning third-party sources by commit SHA.
 curl -L --proto '=https' --tlsv1.2 -sSf \
-  https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+  https://raw.githubusercontent.com/cargo-bins/cargo-binstall/ead08b90bd7b2e6d81963fb9cf0b7239f66d5db4/install-from-binstall-release.sh | bash
 
 # 4. sccache, then wire it in as the global rustc wrapper.
 cargo binstall --no-confirm --locked sccache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,29 @@ The `fwdctl` tool provides command-line operations on databases. See `fwdctl/REA
 
 For more information on coding conventions and constraints, please refer to [CONTRIBUTING.md](./CONTRIBUTING.md)
 
+## Design Documents
+
+Firewood records designs as living documentation in a single flat directory,
+`docs/src/designs/` (rendered in the mdBook site). Every design is `NNNN-<slug>.md`;
+its lifecycle state lives in the `status` frontmatter field, not in its location.
+Follow this workflow when writing a design document:
+
+- **Propose:** run `just new-design <slug>` to scaffold
+  `docs/src/designs/NNNN-<slug>.md` (with `status: proposed`) from the RFC-style
+  template, fill it in, and open a pull request for review.
+- **Promote:** once the design is implemented, promote it in place — a status flip,
+  not a file move, so its `NNNN-<slug>.md` path stays stable. Following the checklist
+  in `docs/src/designs/README.md`: flip the frontmatter `status` to `active`, drop the
+  proposal-only sections, rewrite future-tense prose into the present tense, add
+  cross-links to the implementing PR(s), and update the index in
+  `docs/src/designs/README.md` and `docs/src/SUMMARY.md`.
+- `active` designs describe what the code does today; keep them up to date as the
+  design changes.
+
+When the `superpowers:brainstorming` skill produces a Firewood design spec, save it to
+`docs/src/designs/NNNN-<slug>.md` (via `just new-design`) — override the skill's
+default `docs/superpowers/specs/` location.
+
 ## Commit and PR Title Convention
 
 Commit messages and PR titles **must** follow the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,35 +10,49 @@ guidelines for contributing to firewood.
 * [Testing](#testing)
 * [How to submit changes](#how-to-submit-changes)
 * [Signing your commits](#signing-your-commits)
-* [Code Review Process](#code-review-process)
+* [Code review process](#code-review-process)
+* [How to report a bug](#how-to-report-a-bug)
+* [First time fixes for contributors](#first-time-fixes-for-contributors)
+* [How to request an enhancement](#how-to-request-an-enhancement)
 * [Labels](#labels)
+* [Style Guide / Coding Conventions](#style-guide--coding-conventions)
 * [Where can I ask for help?](#where-can-i-ask-for-help)
+* [Thank you](#thank-you)
 
 ## Quick Links
 
-* [Setting up docker](README.docker.md)
+* [Development container](.devcontainer/README.md)
 * [Auto-generated documentation](https://ava-labs.github.io/firewood/rustdoc/firewood/)
 * [Issue tracker](https://github.com/ava-labs/firewood/issues)
 
 ## Testing
 
-After submitting a PR, we'll run all the tests and verify your code meets our submission guidelines. To ensure it's more likely to pass these checks, you should run the following commands locally:
+CI runs all tests and verifies your code meets the submission guidelines. Run the following commands locally before opening a PR:
 
-    cargo fmt
-    cargo nextest run
-    cargo clippy
-    cargo doc --no-deps
+```sh
+cargo fmt
+cargo nextest run --workspace --features ethhash,logger --all-targets
+cargo +nightly-2026-07-05 clippy --workspace --features ethhash,logger --all-targets
+cargo +nightly-2026-07-05 clippy --profile maxperf --workspace --features ethhash,logger --all-targets
+cargo doc --no-deps
+```
 
 Resolve any warnings or errors before making your PR.
 
-Also, if you update any versions of packages, notably the MSRV (Minimum Supported Rust Version), you ought to update the nix ffi flake lock file to pin compatible versions of nix packages as well:
+Clippy runs on the pinned nightly toolchain (`nightly-2026-07-05`) that CI's
+required lint job uses, and the second invocation checks the `maxperf` profile
+(debug assertions off). Running clippy on stable can pass locally yet still fail
+the required CI check, which enforces lints stable does not.
 
-    ./scripts/run-just.sh update-ffi-flake
+Also, if you update any versions of packages, notably the MSRV (Minimum Supported Rust Version), update the nix ffi flake lock file to pin compatible versions of nix packages as well:
+
+```sh
+./scripts/run-just.sh update-ffi-flake
+```
 
 ## How to submit changes
 
-To create a PR, fork firewood, and use GitHub to create the PR. We typically prioritize reviews in the middle of the next work day,
-so you should expect a response during the week within 24 hours.
+To create a PR, fork firewood, and use GitHub to create the PR. Expect a response within one business day.
 
 ## Signing your commits
 
@@ -47,9 +61,11 @@ before you open one — GitHub should then show every commit as **Verified**.
 
 The quickest setup is signing with the SSH key you already push with:
 
-    git config --global gpg.format ssh
-    git config --global user.signingkey ~/.ssh/id_ed25519.pub
-    git config --global commit.gpgsign true
+```sh
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
 
 Then add that key to GitHub as a **Signing Key** under *Settings → SSH and GPG
 keys*. See GitHub's [signing commits][gh-signing] guide for full details,
@@ -57,38 +73,36 @@ including GPG keys and Windows/macOS setup.
 
 [gh-signing]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
 
-## Code Review Process
-
-Code review is a critical part of our development process. It ensures that our codebase remains maintainable, performant, and secure. This document outlines how we approach code reviews at Ava Labs, with responsibilities and expectations for both reviewers and authors.
+## Code review process
 
 ### For Reviewers
 
-Reviews should be completed or commented within one business day. We have a daily reminder for reviews that have not been reviewed that is posted in slack's #firewood channel.
+Reviews should be completed or commented within one business day.
 
 When reviewing code, your goal is to help the author improve the quality of the change and confirm that it meets our architectural and operational standards. GitHub provides three primary review options:
 
-#### ✅ Accept (Approve)
+#### Accept (Approve)
 
 Use this when the code is an improvement over the current state of the codebase.
 
 * It's okay to request minor changes in comments and still approve the pull request.
 * Perfection is not the goal — progress is. If the submitted code is better than what's in production, it's acceptable to approve even if small improvements remain. Consider adding a new issue or request adding a code TODO for larger changes.
 
-#### 💬 Comment (Comment Only)
+#### Comment (Comment Only)
 
 Use this when your review is incomplete, or you're not ready to approve or reject yet. You should use this if the code is too large to review in a limited amount of time (typically 30-60 minutes). You can also suggest how to break up this diff into a smaller diff.
 
 * This can be helpful for asking clarifying questions, suggesting optional improvements, or flagging issues you're unsure about.
 * This state signals that your review is in progress or advisory, not final.
 
-#### ❌ Reject (Request Changes)
+#### Reject (Request Changes)
 
 Use this when there are significant concerns with the code's correctness, architecture, design, or maintainability.
 
 * A "Reject" signals that the pull request must not be merged until the raised issues are addressed.
 * The author is expected to make substantial revisions and return the code for a second round of review by the same reviewer.
 
-#### Best Practices
+#### Best practices
 
 * Be respectful and constructive. Your comments should guide and empower the author, not discourage them.
 * Justify your feedback with principles, not preferences.
@@ -141,9 +155,9 @@ the GitHub UI.
 
 ## Style Guide / Coding Conventions
 
-We generally follow the same rules that `cargo fmt` and `cargo clippy` will report as warnings, with a few notable exceptions as documented in the associated Cargo.toml file.
+We generally follow the same rules that `cargo fmt` and `cargo clippy` will report as warnings, with a few notable exceptions as documented in the workspace `Cargo.toml` under `[workspace.lints.clippy]`.
 
-By default, we prohibit bare `unwrap` calls and index dereferencing, as there are usually better ways to write this code. In the case where you can't, please use `expect` with a message explaining why it would be a bug, which we currently allow. For more information on our motivation, please read this great article on unwrap: [Using unwrap() in Rust is Okay](https://blog.burntsushi.net/unwrap) by [Andrew Gallant](https://blog.burntsushi.net).
+By default, we prohibit bare `unwrap` calls and index dereferencing, as there are usually better ways to write this code. In the case where you can't, please use `expect` with a message explaining why it would be a bug, which we currently allow. For more information on our motivation, see [Using unwrap() in Rust is Okay](https://burntsushi.net/unwrap/) by [Andrew Gallant](https://burntsushi.net).
 
 ### Documenting wrappers, shims, and FFI adapters
 
@@ -171,16 +185,18 @@ Instead:
 In Rust, `rustdoc` renders `[Type::method]` as a clickable link, so referencing
 the canonical documentation is both DRY and convenient — prefer it:
 
-    /// Produce an `eth_getProof`-compatible proof against a reconstructed view
-    /// rather than a committed revision.
-    ///
-    /// See [`fwd_eth_get_proof`] for the proof format, arguments, return values,
-    /// and key-encoding requirements.
-    ///
-    /// # Safety
-    ///
-    /// As [`fwd_eth_get_proof`], except `reconstructed` must be a valid pointer to
-    /// a [`ReconstructedHandle`].
+```rust
+/// Produce an `eth_getProof`-compatible proof against a reconstructed view
+/// rather than a committed revision.
+///
+/// See [`fwd_eth_get_proof`] for the proof format, arguments, return values,
+/// and key-encoding requirements.
+///
+/// # Safety
+///
+/// As [`fwd_eth_get_proof`], except `reconstructed` must be a valid pointer to
+/// a [`ReconstructedHandle`].
+```
 
 In Go, doc links such as `[Revision.EthGetProof]` (available since Go 1.19) are
 clickable on pkg.go.dev and navigable via `gopls`, just as in Rust, so the same
@@ -192,8 +208,10 @@ principle and does not treat DRY as overriding, and the
 [Uber Go Style Guide][uber-go-style] is likewise a catalog of conventions that
 favor clarity and consistency:
 
-    // EthGetProof is [Revision.EthGetProof] evaluated against this reconstructed
-    // view. It returns [ErrDroppedReconstructed] if the view has been released.
+```go
+// EthGetProof is [Revision.EthGetProof] evaluated against this reconstructed
+// view. It returns [ErrDroppedReconstructed] if the view has been released.
+```
 
 [google-go-style]: https://google.github.io/styleguide/go/guide
 [uber-go-style]: https://github.com/uber-go/guide/blob/master/style.md
@@ -204,4 +222,4 @@ If you have questions or need help, please post them as issues in the [issue tra
 
 ## Thank you
 
-We'd like to extend a pre-emptive "thank you" for reading through this and submitting your first contribution!
+We'd like to extend a preemptive "thank you" for reading through this and submitting your first contribution!

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Firewood: Compaction-Less Database Optimized for Efficiently Storing Recent Merkleized Blockchain State
+# Firewood: compaction-less database optimized for efficiently storing recent Merkleized blockchain state
 
 ![Github Actions](https://github.com/ava-labs/firewood/actions/workflows/ci.yaml/badge.svg?branch=main)
 [![Ecosystem license](https://img.shields.io/badge/License-Ecosystem-blue.svg)](./LICENSE.md)
 
-> :warning: Firewood is beta-level software.
-> The Firewood API may change with little to no warning.
+> [!WARNING]
+> Firewood is beta-level software. Its API may change with little to no warning.
 
 Firewood is an embedded key-value store, optimized to store recent Merkleized blockchain
 state with minimal overhead. Most blockchains, including Avalanche's C-Chain and Ethereum, store their state in Merkle tries to support efficient generation and verification of state proofs.
@@ -17,7 +17,7 @@ to feed into the underlying database that is unaware of the data being stored.
 The convenient byproduct of this approach is that iteration is still fast (for serving state sync queries)
 but compaction is not required to maintain the index.
 Firewood was first conceived to provide a very fast storage layer for the EVM,
-but could be used on any blockchain that requires an authenticated state.
+but can be used on any blockchain that requires an authenticated state.
 
 By default, Firewood only attempts to store recent revisions on-disk and will actively clean up unused data when revisions expire.
 It keeps some configurable number of previous states in memory and on disk to power state sync and APIs
@@ -30,7 +30,7 @@ Firewood also supports archival mode via `RootStore`, which retains all historic
 
 Hashes are not used to determine where a node is stored on disk in the database file.
 Instead space for nodes may be allocated from the end of the file,
-or from space freed from expired revision. Free space management algorithmically resembles that of traditional heap memory management, with free lists used to track different-size spaces that can be reused.
+or from space freed from expired revision. Free space management resembles that of traditional heap memory management, with free lists used to track different-size spaces that can be reused.
 The root address of a node is simply the disk offset within the database file,
 and each branch node points to the disk offset of that other node.
 
@@ -65,7 +65,7 @@ as well as carefully managing the free list during the creation and expiration o
 - `Change Proof` - A proof that consists of a set of all changes between two
   revisions.
 - `Put` - An operation for a `Key`/`Value` pair. A put means "create if it doesn't
-  exist, or update it if it does. A put operation is how you add a `Value` for a
+  exist, or update it if it does". A put operation is how you add a `Value` for a
   specific `Key`.
 - `Delete` - An operation indicating that a `Key` should be removed from the trie.
 - `Batch Operation` - An operation of either `Put` or `Delete`.
@@ -86,13 +86,14 @@ as well as carefully managing the free list during the creation and expiration o
 
 ## Metrics
 
-Firewood provides comprehensive metrics for monitoring database performance, resource utilization, and operational characteristics. For detailed information about all available metrics, how to enable them, and how to interpret them, see [METRICS.md](METRICS.md).
+Firewood exposes metrics for monitoring database performance and resource utilization.
+See [METRICS.md](METRICS.md) for details.
 
 ## Development Environment
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ava-labs/firewood)
 
-The quickest way to get started is with the included devcontainer, which
+The simplest way to get started is with the included devcontainer, which
 provides a fully configured environment with all required tools pre-installed.
 
 **GitHub Codespaces** — click the badge above or go to
@@ -115,9 +116,9 @@ See [`.devcontainer/`](.devcontainer/) for the full configuration.
 In order to build firewood, the following dependencies must be installed:
 
 - `cargo` See [installation instructions](https://doc.rust-lang.org/cargo/getting-started/installation.html).
-- `make` See [download instructions](https://www.gnu.org/software/make/#download) or run `sudo apt install build-essential` on Linux.
+- **[just](https://github.com/casey/just)** — task runner (`just --list` shows available recipes). Optional; all commands can also be run with `cargo` directly.
 
-More detailed build instructions, including some scripts,
+More detailed build instructions, including benchmark environment setup scripts,
 can be found in the [benchmark setup scripts](benchmark/setup-scripts).
 
 If you want to build and test the ffi layer for another platform,
@@ -136,28 +137,31 @@ understands that an "account" is actually just a node in the storage tree at a s
 and computes the hash of the account trie as if it were an actual root.
 
 It is worth noting that the hash stored as a value inside the account root RLP is not used.
-During hash calculations, we know the hash of the children,
-and use that directly to modify the value in-place
+During hash calculations, the hashes of the children are already known
+and are used directly to modify the value in-place
 when hashing the node.
-See [replace\_hash](firewood/storage/src/hashers/ethhash.rs) for more details.
+See [replace\_list\_field](storage/src/hashers/ethhash.rs) for more details.
 
 ## Run
 
 Example(s) are in the [examples](firewood/examples) directory, that simulate real world
-use-cases. Try running the insert example via the command-line, via `cargo run --release
---example insert`.
+use-cases. Try running the insert example:
+
+```sh
+cargo run --release --example insert
+```
 
 For performance benchmarking — C-Chain re-execution, Rust criterion, and synthetic workloads — see [benchmark/README.md](benchmark/README.md).
 
 For maximum runtime performance at the cost of compile time,
-use `cargo run --maxperf` instead,
+use `cargo run --profile maxperf` instead,
 which enables maximum link time compiler optimizations.
 
 ## Logging
 
 If you want logging, enable the `logging` feature flag, and then set RUST\_LOG accordingly.
 See the documentation for [env\_logger](https://docs.rs/env_logger/latest/env_logger/) for specifics.
-We currently have very few logging statements, but this is useful for print-style debugging.
+Firewood currently emits very few log statements, but this is useful for print-style debugging.
 
 ## Release
 
@@ -175,8 +179,10 @@ Firewood comes with a CLI tool called `fwdctl` that enables one to create and in
 ## Test
 
 ```sh
-cargo nextest --release
+cargo nextest run --workspace --features ethhash,logger --all-targets
 ```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md#testing) for the full set of pre-PR checks.
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,11 @@
-# Releasing firewood
+# Releasing Firewood
 
-Releasing firewood is straightforward and can mostly be done in CI. Updating the
-Cargo.toml file is currently manual.
+Most of the release process runs in CI. Updating `Cargo.toml` is a manual step.
 
 Firewood is made up of several sub-projects in a workspace. Each project is in
 its own crate and has an independent version.
 
-## Workspace Dependencies
+## Prerequisites
 
 Ensure the following tools are installed before beginning:
 
@@ -25,11 +24,9 @@ branch 'release/v0.1.1' set up to track 'origin/main'.
 Switched to a new branch 'release/v0.1.1'
 ```
 
-If already on a new branch, ensure `HEAD` is the same as the remote's `main`.
-As the upstream repo changes, rebase the branch onto `main` so that the changes
-from `git cliff` follow the repository history in the correct linear order.
-
-On rebase, quickly redo the generative steps with `just`:
+If the release branch falls behind `origin/main` while in review, rebase it
+(not merge — `git cliff` requires a linear commit history for correct changelog
+ordering) and regenerate the release artifacts:
 
 ```shell
 just release-step-update-rust-dependencies && just release-step-refresh-changelog v0.1.1
@@ -42,21 +39,21 @@ just release-step-update-rust-dependencies && just release-step-refresh-changelo
 Optionally, the minimum supported rust version can be bumped. See
 <https://blog.rust-lang.org/releases/latest> for the latest version. Best
 effort 2 releases behind the current latest stable [^1]. However, Rust evolves
-fairly quickly and we occasionally want to take advantage of a new improvement
-before the stable release matures.
+fairly quickly, and a new improvement is occasionally worth adopting before the
+stable release matures.
 
 Updating the Rust MSRV requires edits in two places:
 
 - [clippy.toml]
   - Update the root `msrv` setting to indicate the set MSRV. This configures
     clippy to include newer lints that would otherwise be incorrect with a lower
-    MSRV; such as recommending newly stablized features that were unstable in
+    MSRV; such as recommending newly stabilized features that were unstable in
     the older release.
 - [Cargo.toml]
   - Update `workspace.package.rust-version` which will propagate through the
     other cargo packages that have `package.rust-version.workspace = true` set.
 
-[^1]: e.g., with 1.91 stable, 1.89 is the best effort MSRV
+[^1]: e.g., with 1.96 stable, 1.94 is the best effort MSRV
 
 ### Cargo Dependencies
 
@@ -100,7 +97,7 @@ bump signals non-breaking changes.
 
 ### Crates with public API guarantees
 
-| Crate | Public interface |
+| Component | Public interface |
 | ----- | ---------------- |
 | `firewood` | Rust API |
 | `firewood-storage` | Rust API |
@@ -108,15 +105,19 @@ bump signals non-breaking changes.
 | `firewood-go` (via `firewood-go-ethhash`) | Go module API |
 | `fwdctl` | CLI flags and config file format |
 
-Tag pull requests with the appropriate `breaking-change/<crate>` label when the
-change breaks the public interface. `git cliff` reads these labels via the GitHub
-API and marks affected entries in the CHANGELOG automatically.
+Tag pull requests with the `breaking-change` label when the change breaks the
+public interface. `git cliff` reads this label via the GitHub API and marks
+affected entries in the CHANGELOG automatically.
 
 ### Crates without public API guarantees
 
-`firewood-macros`, `firewood-benchmark`, `firewood-replay`, and `firewood-triehash`
-have no stability guarantees. `firewood-triehash` is a test helper pinned at its
-current version; do not bump it during workspace releases.
+`firewood-macros`, `firewood-metrics`, `firewood-benchmark`, `firewood-replay`, and
+`firewood-triehash` have no stability guarantees. `firewood-triehash` is a test helper
+pinned at its current version; do not bump it during workspace releases.
+`firewood-metrics` provides shared metrics utilities and has no independent stability
+guarantee (the metrics schema consumers rely on is covered by `firewood-ffi`, above).
+While the workspace patches `metrics` to a git fork, crates.io publishing is currently
+blocked: crates.io rejects the resulting non-registry dependency (see Publish, below).
 
 ### Determining whether a change is breaking
 
@@ -144,7 +145,7 @@ For semver breaking changes, all downstream packages require upgrading to the ne
 therefore, the next step is to bump the dependency declarations to the new version.
 Packages within the workspace that are used as libraries are also defined within
 the [`[workspace.dependencies]`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table)
-table. E.g.,:
+table. For example:
 
 ```toml
 [workspace.dependencies]
@@ -154,8 +155,7 @@ firewood = { path = "firewood", version = "0.1.1" }
 
 This allows packages within the workspace to inherit the dependency,
 including path, version, and workspace-level features by adding `workspace = true`
-to the dependency table (note: using `cargo add -p firewood-fwdctl firewood-metrics`
-would automatically add the dependency with `workspace = true`).
+to the dependency table.
 
 ```toml
 [dependencies]
@@ -169,8 +169,9 @@ firewood-storage = { workspace = true, features = ["io-uring"] }
 firewood-storage.workspace = true
 ```
 
-Thefefore, after updating the `workspace.package.version` value, we must update
-the dependency versions to match.
+Therefore, after updating each package's version in `[workspace.dependencies]`
+(and in the crate's own `Cargo.toml` if it sets `package.version` directly),
+update the matching dependency declarations to the new version.
 
 Run `cargo update` after editing the `Cargo.toml` files to ensure the lockfile
 is correct and reflects the new package versions.
@@ -191,7 +192,7 @@ just release-step-refresh-changelog v0.1.1
 ```
 
 Breaking changes are detected automatically from both conventional commit
-syntax (`feat!:`, `BREAKING CHANGE:` footer) and PR labels (`breaking-change/*`).
+syntax (`feat!:`, `BREAKING CHANGE:` footer) and PR labels (`breaking-change`).
 No manual edits to `CHANGELOG.md` are needed or expected.
 
 ## Commit
@@ -202,16 +203,16 @@ Commit the version bump and change log updates. Using the summary prefix:
 
 will cause `git-cliff` to omit the commit from the changelog. This is why
 substantive changes when upgrading dependencies should be in their own commit.
-If you do not use the prefix, there will be an egg-and-chicken problem as the
-commit message generated by GitHub includes the pull request as a suffix.
-Manually resolve this in the CHANGELOG if needed; otherwise, the CHANGELOG will
-have irrelevant changes on future releases.
+Without this prefix, `git cliff` includes the version-bump commit in the next
+release's changelog, producing a stale pull-request reference (the PR number
+did not exist when the commit was written). Manually correct the CHANGELOG if
+the prefix was omitted.
 
-## Review
+## Open and merge the release PR
 
-> ❗ Be sure to update the versions of all sub-projects before creating a new
-> release. Open a PR with the updated versions and merge it before continuing to
-> the next step.
+> [!IMPORTANT]
+> Update the versions of all relevant packages before opening this PR. After
+> the PR merges, continue to the tagging and publishing steps.
 
 ## Publish
 
@@ -228,7 +229,8 @@ git push origin v0.1.1
 
 ### What CI does automatically
 
-Pushing the tag triggers three automated jobs:
+Pushing the tag triggers two automated jobs (the crates.io publish is a separate
+step that runs later, when the draft release is published — see below):
 
 1. **Draft GitHub release** ([`.github/workflows/release.yaml`](.github/workflows/release.yaml)):
    Creates a draft release with auto-generated notes. Do not act yet — publish
@@ -241,7 +243,8 @@ Pushing the tag triggers three automated jobs:
 
 ### Publish the draft release (manual step)
 
-The crates.io workflow does **not** run until the GitHub release is published.
+> [!IMPORTANT]
+> The crates.io workflow does **not** run until the GitHub release is published.
 
 1. Go to <https://github.com/ava-labs/firewood/releases>.
 2. Find the draft (labelled **Draft**).
@@ -261,8 +264,6 @@ dependency order, automatically skipping:
   (crates.io rejects non-registry dependencies).
 
 ## Milestone
-
-> NOTE: this should be automated as well.
 
 Close the GitHub milestone for the version that was released. Be sure to create
 a new milestone for the next version if one does not already exist. Carry over

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -32,3 +32,6 @@ command = "../scripts/mdbook-frontmatter-strip.sh"
 
 [output.linkcheck2]
 follow-web-links = false
+# Exclude deployed-site paths that resolve only on the production GitHub Pages site
+# (/firewood/rustdoc/, /firewood/ffi/, /firewood/bench/).
+exclude = ['^/firewood/(rustdoc|ffi|bench)/']

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,29 +4,36 @@
 
 # Guides
 
-- [Getting Started]()
-  - [Development Environment]()
+- [Getting Started](getting-started/README.md)
+  - [Development Environment](getting-started/dev-environment.md)
 
 # Concepts
 
-- [Concepts & Architecture]()
+- [Concepts & Architecture](concepts/README.md)
 
 # Design Documents
 
-- [Designs]()
+- [Designs](designs/README.md)
+  - [0001 — mdBook documentation site](designs/0001-mdbook-documentation-site.md)
+  - [0002 — v2 on-disk file format](designs/0002-v2-file-format.md)
+  - [0003 — on-disk format and addressing](designs/0003-on-disk-format-and-addressing.md)
+  - [0004 — development container](designs/0004-devcontainer.md)
+  - [Template](designs/template.md)
 
 # Integration
 
-- [AvalancheGo & EVM Integration]()
+- [AvalancheGo & EVM Integration](integration/README.md)
 
 # Operations
 
-- [Operations & Benchmarking]()
+- [Operations & Benchmarking](operations/README.md)
 
 # Reference
 
-- [Reference]()
+- [Reference](reference/README.md)
 
 # Meta
 
-- [About These Docs]()
+- [About These Docs](meta/README.md)
+  - [How these docs work](meta/documentation.md)
+  - [Release process](meta/release.md)

--- a/docs/src/concepts/README.md
+++ b/docs/src/concepts/README.md
@@ -1,0 +1,37 @@
+# Concepts & Architecture
+
+Firewood uses the Merkle trie directly as its on-disk index. New roots are created
+per revision; superseded nodes are tracked in a future-delete log and their space
+returns to free lists once no live revision references them.
+
+![Firewood architecture](../assets/architecture.svg)
+
+## Terminology
+
+- **Revision** — a historical, point-in-time state of the trie, including all
+  key/value pairs and nodes at that point.
+- **View** — a read-only interface into a `Revision`, `Proposal`, or reconstructed
+  state.
+- **Node** — a portion of the trie; nodes link to other nodes and/or hold key/value
+  pairs.
+- **Future-delete log (FDL)** — the per-revision record of nodes superseded by a
+  commit; their on-disk space is not freed until the revision that produced them
+  expires.
+- **Free list** — a set of size-classed lists tracking freed on-disk space so later
+  allocations can reuse it.
+- **Hash / Root Hash** — the Merkle hash of a node; the root hash is the hash of a
+  revision's root node.
+- **Key / Value** — the byte arrays a trie indexes; a zero-length value is valid.
+- **Proof types** — a *key proof* attests a key exists in a revision; a *range proof*
+  bounds a key range with two key proofs plus the pairs between them; a *change proof*
+  is the set of changes between two revisions.
+- **Batch / Batch Operation** — a `Put` or `Delete` is a batch operation; an ordered
+  set of them is a batch.
+- **Proposal** — a base root hash plus a batch, not yet committed. A proposal is
+  required to commit.
+- **Reconstructed** — a base historical state plus a batch applied in memory;
+  read-only and not committable.
+- **Commit** — applying one or more proposals to the most recent revision.
+
+For the on-disk representation that implements these concepts, see
+[On-disk format and addressing](../designs/0003-on-disk-format-and-addressing.md).

--- a/docs/src/designs/0001-mdbook-documentation-site.md
+++ b/docs/src/designs/0001-mdbook-documentation-site.md
@@ -108,7 +108,8 @@ output into a subdirectory.
    `designs/README.md`), not a file move — so a design keeps its stable `NNNN-slug.md`
    path and review-thread and cross-doc references never break.
 5. **Backfill scope:** One template + one fully-written seed (`on-disk format &
-   addressing`) + a TODO backfill index (in `designs/README.md`) for the rest.
+   addressing`) + a backfill index (a GitHub issue linked from `designs/README.md`)
+   for the rest.
 6. **Extra sections:** Concepts/Architecture, AvalancheGo/EVM Integration, Operations
    & Benchmarking, Reference (generated artifacts), and Meta (self-documenting docs +
    repository-process docs: release, contributing, code review). Sections with real
@@ -167,10 +168,10 @@ docs/
     ├── concepts/
     │   └── README.md          # authored landing: promoted README terminology + architecture prose
     ├── designs/                  # FLAT: every design is NNNN-slug.md; status lives in frontmatter
-    │   ├── README.md             # explains the model + how to propose + status-flip promotion checklist + design-age tooling + TODO backfill list
+    │   ├── README.md             # explains the model + how to propose + status-flip promotion checklist + design-age tooling + backfill issue link
     │   ├── template.md           # single RFC-style template carrying the frontmatter schema
     │   ├── 0001-mdbook-documentation-site.md      # this design (status: active)
-    │   └── NNNN-on-disk-format-and-addressing.md  # the one FULLY WRITTEN seed (status: active; NNNN assigned by new-design)
+    │   └── 0003-on-disk-format-and-addressing.md  # the one FULLY WRITTEN seed (status: active)
     ├── integration/
     │   └── README.md          # authored: Go API (Database/Proposal/Revision) + firewood-go-ethhash publish relationship
     ├── operations/
@@ -230,11 +231,13 @@ work — old external deep links 404, accepted in exchange for the cleaner root 
 
 `SUMMARY.md` supports raw-URL entries, which render as sidebar items. A
 `reference/` section and sidebar entries link to the deployed paths
-(`/firewood/rustdoc/`, `/firewood/ffi/`, `/firewood/bench/`). These resolve on the
-deployed site; under local `mdbook serve` they point at the live production site.
-The `reference/README.md` page notes this explicitly. `mdbook-linkcheck2` is
-configured with `follow-web-links = false` so these external link-outs do not break
-local/CI builds.
+(`/firewood/rustdoc/`, `/firewood/ffi/`, `/firewood/bench/`). These are scheme-less
+absolute paths that resolve only on the deployed site; under local `mdbook serve` (or
+a fork's Pages deployment) they 404. The `reference/README.md` page notes this
+explicitly. Because they are scheme-less (not `http(s)://`) links, `follow-web-links =
+false` does not exempt them from link checking; an explicit
+`exclude = ['^/firewood/(rustdoc|ffi|bench)/']` under `[output.linkcheck2]` is what
+keeps them from breaking local/CI builds.
 
 ## Design-doc subsystem
 
@@ -326,18 +329,23 @@ path is stable across a design's whole life:
 
 ### Seed design — on-disk format & addressing
 
-Filed flat as `NNNN-on-disk-format-and-addressing.md`, its sequence number assigned by
-`new-design` at authoring time. Fully written (`status: active`) from `README.md` prose
+Filed flat as `0003-on-disk-format-and-addressing.md`. Fully written (`status: active`)
+from `README.md` prose
 plus the `storage/` and `firewood/src/` sources. Covers: disk-offset addressing (root address = disk offset;
 branch nodes point to disk offsets), node allocation from end-of-file vs. free lists,
 free-list size-class management, the future-delete log (FDL), and recoverability
 guarantees (no references to new nodes before flush; careful free-list management
 across revision creation/expiration).
 
-### `designs/README.md` backfill TODO list
+### `designs/README.md` backfill list
 
-Revision management; free lists & FDL; hashing (SHA-256 vs. ethhash/Keccak-256);
-proposals & commits; archival mode (`RootStore`).
+The subsystems still to be documented — revision management; hashing (SHA-256 vs.
+ethhash/Keccak-256); proposals & commits; state sync & reconstruction (folding in
+archival mode / `RootStore`); and the Go FFI layer — are tracked in
+[ava-labs/firewood#2139](https://github.com/ava-labs/firewood/issues/2139), linked
+from `designs/README.md` rather than duplicated inline where the list would drift.
+Free lists & the FDL are already covered by `0003` and are deliberately not on the
+list.
 
 ## CI/CD changes (`gh-pages.yaml`)
 
@@ -454,11 +462,13 @@ end-to-end coverage; the build is not split into a book-only fast path.
 ### Link checking
 
 `mdbook-linkcheck2` runs as a backend during `mdbook build`, configured under
-`[output.linkcheck2]` with `follow-web-links = false`. It validates internal book
-links (broken `SUMMARY.md` entries, bad cross-references) without choking on the
-external `/rustdoc/` link-outs that exist only post-deploy. Broken internal links fail
-the PR build. Enabling this second renderer is what moves HTML output to
-`docs/book/html/` (see build step 4).
+`[output.linkcheck2]` with `follow-web-links = false` and an
+`exclude = ['^/firewood/(rustdoc|ffi|bench)/']`. It validates internal book links
+(broken `SUMMARY.md` entries, bad cross-references) while the `exclude` skips the
+site-absolute `/rustdoc/`, `/ffi/`, and `/bench/` link-outs that exist only
+post-deploy — `follow-web-links` alone would not skip them, since they are scheme-less
+(not web) links. Broken internal links fail the PR build. Enabling this second renderer
+is what moves HTML output to `docs/book/html/` (see build step 4).
 
 `mdbook-linkcheck2` is a maintained fork of the original `mdbook-linkcheck`. The
 original (last released 2022) rejects a `book.toml` whose `[rust]` table sets
@@ -508,7 +518,10 @@ relocation.
   not surface as a stray `<hr>` + heading. It is an in-repo jq script (needs `jq` on
   `PATH`; no binary to install). mdBook runs preprocessor commands from the book root,
   so the `command` path is relative to `docs/`, not the repo root.
-- `[output.linkcheck2]` with `follow-web-links = false`.
+- `[output.linkcheck2]` with `follow-web-links = false` and
+  `exclude = ['^/firewood/(rustdoc|ffi|bench)/']` (the `exclude`, not
+  `follow-web-links`, skips the site-absolute `/rustdoc/`, `/ffi/`, `/bench/`
+  link-outs — they are scheme-less paths, so `follow-web-links` never applies).
 
 ## Local tooling
 
@@ -628,10 +641,10 @@ in `avalanchego/go.mod` and in the `graft/evm`, `graft/coreth`, and `graft/subne
 `go.mod`s. That published module tracks the `firewood-ffi` crate version: when
 `firewood-ffi` is released, CI builds the static libraries, copies the in-repo `ffi/`
 directory into the `ava-labs/firewood-go-ethhash` repository, and tags it (see
-[`RELEASE.md`](../../../RELEASE.md) and
-[`.github/workflows/attach-static-libs.yaml`](../../../.github/workflows/attach-static-libs.yaml)).
+[`RELEASE.md`](https://github.com/ava-labs/firewood/blob/main/RELEASE.md) and
+[`.github/workflows/attach-static-libs.yaml`](https://github.com/ava-labs/firewood/blob/main/.github/workflows/attach-static-libs.yaml)).
 The section documents how the in-repo `ffi/` crate is built (the `cargo build` →
-`go tool cgo` flow described in [`ffi/README.md`](../../../ffi/README.md)), packaged,
+`go tool cgo` flow described in [`ffi/README.md`](https://github.com/ava-labs/firewood/blob/main/ffi/README.md)), packaged,
 and published, and how a downstream consumer pins and upgrades it. It links to `/ffi/`
 (godoc) for the generated API reference and to `meta/release.md` for the publish/version
 cadence. Without this, the integration story is incomplete: a reader following the
@@ -720,7 +733,7 @@ Distilled from the [`mdbooks.yaml` catalog](https://github.com/szabgab/mdbooks.c
       canonical repo. A `smoke` job (`needs: [build, deploy]`) runs after `deploy`
       (non-PR events) and `curl --fail`s `/`, `/rustdoc/`, `/rustdoc/firewood/`, and
       `/ffi/`, plus `/bench/` only when the build reports benchmark history.
-- [ ] Introduction and a fully-authored `getting-started/dev-environment.md`
+- [x] Introduction and a fully-authored `getting-started/dev-environment.md`
       (macOS, Docker, remote SSH) are written. *Structural completeness*
       (reviewer-checkable): every section contains the concrete install/build/verify
       commands from the outline.
@@ -728,12 +741,12 @@ Distilled from the [`mdbooks.yaml` catalog](https://github.com/szabgab/mdbooks.c
       run the macOS and devcontainer command sequences end-to-end on a clean
       environment before merge; the remote-SSH section reuses the same commands and is
       reviewed for accuracy.
-- [ ] `designs/` is a flat directory: every design is `NNNN-slug.md` with lifecycle
+- [x] `designs/` is a flat directory: every design is `NNNN-slug.md` with lifecycle
       state in a `status` frontmatter field (no `proposed/`/`active/` folders). It
       contains a single RFC-style `template.md`, a `README.md` documenting the model +
-      status-flip promotion checklist + backfill TODO, and the fully-written
-      `NNNN-on-disk-format-and-addressing.md` seed (number assigned at authoring time).
-- [ ] Design docs carry the YAML frontmatter schema (`title`, `status`, `category`,
+      status-flip promotion checklist + a link to the backfill tracking issue, and the
+      fully-written `0003-on-disk-format-and-addressing.md` seed.
+- [x] Design docs carry the YAML frontmatter schema (`title`, `status`, `category`,
       `authors`, optional `tracking-issue`) with **no date fields**; the in-repo
       `[preprocessor.frontmatter-strip]` jq script strips it so it does not render.
       `0001` itself uses
@@ -750,19 +763,19 @@ Distilled from the [`mdbooks.yaml` catalog](https://github.com/szabgab/mdbooks.c
       documents the Go wrapper types (`Database`/`Proposal`/`Revision`, mapping to the
       Rust `Db`/`Proposal`/`DbView`) and the `firewood-go-ethhash` publish relationship
       that AvalancheGo actually consumes.
-- [ ] A `meta/` section exists with an **authored** `documentation.md` (how the docs
+- [x] A `meta/` section exists with an **authored** `documentation.md` (how the docs
       work: tooling, layout, build/serve, authoring, design workflow) and thin
       repository-function pages (`release.md` plus link-out pointers to CONTRIBUTING /
       CODE_REVIEW); the process-doc link-outs are in `meta/`, not `reference/`.
 - [x] `justfile` gains `book-assets`, `book-serve`, and `book-build` (PR 1 — foundation).
-- [ ] `justfile` gains a `new-design` recipe scaffolding
+- [x] `justfile` gains a `new-design` recipe scaffolding
       `docs/src/designs/NNNN-slug.md` from `template.md` (PR 3 — content).
 - [x] Mermaid assets are installed at build time (not committed): CI and the
       `book-assets` recipe run `mdbook-mermaid install docs`, the generated asset paths
       are git-ignored, and a fresh checkout builds without a manual install step.
 - [x] `architecture.svg` is moved to `docs/src/assets/` and the root `README.md`
       reference is updated accordingly; the book renders the diagram.
-- [ ] `markdownlint-cli2 .` passes.
+- [x] `markdownlint-cli2 .` passes.
 
 ## Accepted trade-off
 

--- a/docs/src/designs/0001-mdbook-documentation-site.md
+++ b/docs/src/designs/0001-mdbook-documentation-site.md
@@ -21,8 +21,8 @@ peer-reviewable, RFC-style workflow for proposing designs and promoting them to
 living documentation — a `status` frontmatter flip, not a file move — once
 implemented. Additional sections (Concepts,
 AvalancheGo/EVM Integration, Operations & Benchmarking, Reference, Meta) each ship an
-authored landing page; not-yet-written sub-pages are listed as mdBook draft chapters
-(greyed-out sidebar entries) rather than empty stub files.
+authored landing page; not-yet-written sub-pages are omitted from the sidebar until
+their content lands, rather than shipped as empty stub files.
 
 > [!NOTE]
 > **Bootstrapping note.** This is the first design and is numbered accordingly:
@@ -54,7 +54,7 @@ authored landing page; not-yet-written sub-pages are listed as mdBook draft chap
 - Backfilling every existing design. This MVP writes exactly one fully-realized
   active design (on-disk format & addressing) and lists the rest as TODO.
 - Authoring full content for the scaffolded sections beyond an authored landing page;
-  their deeper sub-pages remain draft chapters until written.
+  their deeper sub-pages are omitted from `SUMMARY.md` until written.
 - Changing how benchmark data is collected or stored (`track-performance.yml` and
   the `benchmark-data` branch are unchanged).
 - Custom mdBook theming beyond the preprocessor-provided assets and standard
@@ -113,10 +113,12 @@ output into a subdirectory.
 6. **Extra sections:** Concepts/Architecture, AvalancheGo/EVM Integration, Operations
    & Benchmarking, Reference (generated artifacts), and Meta (self-documenting docs +
    repository-process docs: release, contributing, code review). Sections with real
-   seed content are authored at landing-page depth; sections (and sub-pages) without
-   content yet are listed as mdBook **draft chapters** (link-less `SUMMARY.md` entries,
-   which render as greyed-out/disabled sidebar items) rather than empty stub pages —
-   see "Scaffolding via draft chapters" below.
+   seed content are authored at landing-page depth. Every section ships an authored
+   landing page; not-yet-written *sub-pages* are omitted from `SUMMARY.md` until their
+   content lands, rather than shipped as empty stub pages. mdBook **draft chapters**
+   (link-less `SUMMARY.md` entries that render greyed-out) remain available if the
+   outline should later advertise a "coming soon" page — see "Scaffolding via draft
+   chapters" below.
 7. **Preprocessors and callouts:** Two preprocessors: `mdbook-mermaid` (diagrams) and
    an in-repo frontmatter stripper (`scripts/mdbook-frontmatter-strip.sh`, a small jq
    script that removes each chapter's YAML frontmatter so the schema metadata does not
@@ -175,7 +177,7 @@ docs/
     ├── integration/
     │   └── README.md          # authored: Go API (Database/Proposal/Revision) + firewood-go-ethhash publish relationship
     ├── operations/
-    │   └── README.md          # authored landing: fwdctl, benchmarks, dashboards; links benchmark/docs/* + /bench/ (sub-pages are draft chapters until written)
+    │   └── README.md          # authored landing: fwdctl, benchmarks, dashboards; links benchmark/docs/* + /bench/ (sub-pages omitted until written)
     ├── reference/
     │   └── README.md          # authored landing: link-out hub for GENERATED artifacts: rustdoc ↗, godoc ↗, benchmarks ↗
     └── meta/
@@ -189,8 +191,9 @@ docs/
 > seed content, linked in `SUMMARY.md`; **thin** = a short real page that mostly links
 > out; **draft chapter** = a `SUMMARY.md` entry written with empty link parentheses
 > (`- [Title]()`), which has **no file** and renders greyed-out (see "Scaffolding via
-> draft chapters"). Every section above ships an authored landing page at MVP; only
-> not-yet-written *sub-pages* are draft chapters.
+> draft chapters"). Every section above ships an authored landing page at MVP;
+> not-yet-written *sub-pages* are omitted from `SUMMARY.md` until written (the MVP
+> ships no draft chapters).
 
 ### Architecture diagram asset (relocation)
 
@@ -579,9 +582,9 @@ and links to upstream install docs (and may include concrete install commands).
 mdBook supports **draft chapters** — `SUMMARY.md` entries written with empty link
 parentheses (`- [Title]()`), which render as greyed-out/disabled items in the sidebar.
 Per the mdBook guide their purpose is "to signal future chapters still to be written."
-This is the idiomatic mdBook mechanism this design uses **instead of** creating empty
-stub `.md` files (hollow pages would be search-indexed and present as real-but-empty
-content). The rule:
+This is the idiomatic mdBook mechanism for signalling future chapters **instead of**
+creating empty stub `.md` files (hollow pages would be search-indexed and present as
+real-but-empty content). The rule:
 
 - A section or sub-page with real seed content gets an authored landing page and a
   *linked* `SUMMARY.md` entry.
@@ -589,8 +592,9 @@ content). The rule:
   it shows in the outline as "coming soon" without creating a hollow page, and is
   promoted to a linked entry when its first real content lands.
 
-Applying that rule to the extra sections (those with seed content are authored now;
-the rest are draft chapters):
+Applying that rule to the extra sections — all four ship an authored landing page, and
+no sub-page draft chapters ship in the MVP (unwritten sub-pages are omitted from
+`SUMMARY.md` until their content lands):
 
 - `concepts/` — authored: seeded by promoting the README terminology + architecture-
   diagram prose.
@@ -605,7 +609,7 @@ the rest are draft chapters):
   the new layout. Migrating their content into the book is a follow-up. The landing
   page links to `/bench/` for the live dashboards. **MVP scope:** exactly one file,
   `operations/README.md`; deeper sub-pages (e.g. `fwdctl.md`, `benchmarks.md`) are
-  draft-chapter entries in `SUMMARY.md` (no files) until their content is written.
+  omitted from `SUMMARY.md` until their content is written.
 - `reference/` — authored landing page (`reference/README.md`): a link-out hub for
   *generated* artifacts only (rustdoc ↗, godoc ↗, benchmarks ↗). It is authored (the
   three link-outs are its content), not a draft chapter. Repository-process docs
@@ -737,7 +741,7 @@ Distilled from the [`mdbooks.yaml` catalog](https://github.com/szabgab/mdbooks.c
       (macOS, Docker, remote SSH) are written. *Structural completeness*
       (reviewer-checkable): every section contains the concrete install/build/verify
       commands from the outline.
-- [ ] *Author sign-off* (recorded in the PR description, not a CI gate): the author has
+- [x] *Author sign-off* (recorded in the PR description, not a CI gate): the author has
       run the macOS and devcontainer command sequences end-to-end on a clean
       environment before merge; the remote-SSH section reuses the same commands and is
       reviewed for accuracy.
@@ -755,14 +759,15 @@ Distilled from the [`mdbooks.yaml` catalog](https://github.com/szabgab/mdbooks.c
       remaining docs land with the content PR.)*
 - [x] `scripts/design-doc-age.sh` (run via `just design-age`) lists each design by last
       git-commit date, oldest-first, from git history alone — never in-doc dates.
-- [ ] Sections with seed content (`concepts/`, `integration/`, `operations/`,
-      `reference/`) have authored landing pages and linked `SUMMARY.md` entries;
-      sections/sub-pages without content yet are mdBook draft chapters (link-less
-      `SUMMARY.md` entries that render greyed-out), not empty `.md` files. `reference/`
-      links only to generated artifacts (rustdoc/godoc/benchmarks). `integration/`
-      documents the Go wrapper types (`Database`/`Proposal`/`Revision`, mapping to the
-      Rust `Db`/`Proposal`/`DbView`) and the `firewood-go-ethhash` publish relationship
-      that AvalancheGo actually consumes.
+- [x] Sections with seed content (`concepts/`, `integration/`, `operations/`,
+      `reference/`) have authored landing pages and linked `SUMMARY.md` entries.
+      Not-yet-written sub-pages are omitted from `SUMMARY.md` (added when their content
+      lands) rather than shipped as empty `.md` files; no sub-page draft chapters ship
+      in the MVP. `reference/` links only to generated artifacts
+      (rustdoc/godoc/benchmarks). `integration/` documents the Go wrapper types
+      (`Database`/`Proposal`/`Revision`, mapping to the Rust `Db`/`Proposal`/`DbView`)
+      and the `firewood-go-ethhash` publish relationship that AvalancheGo actually
+      consumes.
 - [x] A `meta/` section exists with an **authored** `documentation.md` (how the docs
       work: tooling, layout, build/serve, authoring, design workflow) and thin
       repository-function pages (`release.md` plus link-out pointers to CONTRIBUTING /

--- a/docs/src/designs/0002-v2-file-format.md
+++ b/docs/src/designs/0002-v2-file-format.md
@@ -1,0 +1,674 @@
+---
+title: v2 On-Disk File Format
+status: proposed
+category: storage
+authors: [demosdemon]
+tracking-issue: ava-labs/firewood#804
+---
+
+# v2 On-Disk File Format
+
+## Summary
+
+A version 2 (v2) on-disk file format for Firewood, a clean break from v1 (no v1
+backward compatibility) designed for zero-deserialization reads on the traversal
+hot path — read directly with `pread` in v2.0 and zero-copy through `mmap` in
+v2.1 — while preserving Firewood's defining property: a compaction-less store in
+which a node's address is its direct byte offset on disk. The format is frozen for
+all of major version 2 and is built so that any v2.x reader reads any v2.y file in
+both directions, so the next migration on a multi-terabyte state file is deferred
+as far as possible.
+
+## Motivation
+
+The [v1 format](0003-on-disk-format-and-addressing.md) serializes each trie
+node with a variable-length encoding that must be parsed field-by-field on every
+read, and it bakes the area-size table into the binary (a mismatch is rejected at
+open). Two pressures motivate a new format:
+
+- **Read cost.** Path traversal is Firewood's dominant operation. A format whose
+  nodes can be reinterpreted directly from mapped bytes — with the data traversal
+  needs (child addresses) separated from the data it does not (hashes, values) —
+  removes per-node deserialization from the hot path.
+- **Migration cost.** A production state file is already in the 2 TiB range, and a
+  format migration on a file that size is extremely expensive. v2 must therefore
+  be future-proof enough to evolve *within* major version 2 without forcing
+  another migration, which v1's compiled-in assumptions and ad-hoc encoding cannot
+  support.
+
+The four tenets, in priority order:
+
+1. **Compaction-less, direct addressing.** A node's address is its byte offset
+   within the file. No compaction step; no hash-indexed indirection.
+2. **Zero-copy-ready layout.** Nodes are reinterpreted from their on-disk bytes
+   with no field-by-field deserialization.
+3. **Within-major compatibility, future-proofed.** Any v2.x reader reads any v2.y
+   file, in both directions.
+4. **Traversal-first structure.** The layout favors path/trie traversal above all
+   else.
+
+### Scope
+
+In scope: the header, the area/allocation model and alignment, node encodings,
+partial-path encoding, the free-list on-disk layout, the read path (direct in
+v2.0, `mmap` in v2.1), and the commit/recovery protocol.
+
+Out of scope (semantics retained from v1, only their serialization changes): the
+revision-retention policy, revision-history semantics, and the public Rust/FFI
+APIs. Durable revision history is deferred (see [Future possibilities](#future-possibilities)),
+though the format reserves the hooks to add it without a break.
+
+### Operating requirements
+
+These are stated requirements of v2, not open questions:
+
+- **Single writer.** At most one process writes a database at a time; the
+  recoverability protocol assumes it. Reads may run concurrently with the writer.
+- **High-throughput storage.** The database targets an NVMe-class block device or
+  better; the commit protocol and layout are tuned for low-latency random writes
+  and `fsync`. Performance on spinning or network-backed storage is out of scope.
+
+## Guide-level explanation
+
+A v2 file is a small double-buffered header followed by a sequence of 8-byte
+aligned **areas**. Each area holds one node, one overflow value, or a free-list
+entry. A node's address is simply its byte offset in the file.
+
+```text
+FILE = [ Header slot A ][ Header slot B ][ Area ][ Area ][ Area ] ...
+        \__ double-buffered, checksummed, seq-numbered __/   \__ 8-aligned, size-classed __/
+
+AREA = [ AreaHeader 8B: size_class, kind, flags ]   (kind: node | value-overflow | free)
+       [ payload ... ]
+
+NODE payload (kind = node):
+  HOT  (zero-copy; traversal touches only this):
+    NodeHeader 8B  : flags, child_bitmap:u16, path_len_nibbles:u32
+    child_addrs    : [u64; popcount(child_bitmap)]   (8-aligned)
+    partial_path   : packed nibbles (ceil(n/2) bytes)
+  COLD (faulted only for value reads / hashing / proofs):
+    [ethhash] child_hash_lens : [u8; popcount]
+    child_hashes              : [[u8;32]; popcount]
+    value                     : inline (len + bytes) OR overflow (u64 addr + u64 len)
+    [optional feature-gated cold TLV regions, skippable]
+
+ADDRESS = global u64 file offset, 8-byte aligned (low 3 bits reserved as tag bits).
+```
+
+The defining idea is the **hot/cold split**: traversal reads addresses, not
+hashes. Child addresses are hot and contiguous; child hashes and values are cold
+and faulted only when hashing, generating a proof, or reading a value at a
+destination. A single hop reads the 8-byte node header, one `u64` child address,
+and the packed partial path — all within the first cache line or two.
+
+The **read mechanism is versioned but the bytes are not.** A v2.0 reader fetches
+an area with one positioned read (`pread`) and reinterprets the buffer with
+`bytemuck` — no deserialization, one copy. A v2.1 reader maps the file and
+reinterprets node bytes in place (true zero-copy). Both read identical files, so
+`mmap` is a reader capability, not a format change.
+
+Like every Firewood design, a proposed document precedes the build; this proposal
+tracks [issue #804](https://github.com/ava-labs/firewood/issues/804) and is
+promoted to `active/` once implemented.
+
+## Detailed design
+
+### Areas, alignment, and addressing
+
+**Alignment.** All areas begin at an 8-byte-aligned offset; 8-byte alignment is
+frozen. It is chosen over 16-byte alignment because finer size-class granularity
+(multiples of 8 vs 16) reduces internal fragmentation for the most numerous nodes
+(tiny leaves), which dominates space at 2 TiB scale, and 8-byte alignment already
+yields 3 structurally-zero low address bits reserved as tag bits.
+
+**Area structure.**
+
+```text
+AREA (8-aligned):
+  AreaHeader (8 bytes, repr(C), little-endian):
+    off 0  size_class : u8     index into the file's size-class table
+    off 1  kind       : u8     0 = node, 1 = free, 2 = value-overflow, 3.. reserved
+    off 2  flags      : u8     reserved per-area bits
+    off 3  reserved   : u8
+    off 4  reserved   : u32    future (write 0)
+  payload @ +8:
+    kind = node            -> NodeHeader @ +8, child_addrs @ +16 (8-aligned)
+    kind = value-overflow  -> raw value bytes @ +8
+    kind = free            -> next_free : u64 @ +8 (intrusive free-list link)
+```
+
+Separating allocator metadata (`AreaHeader`) from trie content (`NodeHeader`)
+guarantees the 8-byte alignment the zero-copy casts need. The `reserved` bytes
+exist only to fill the 8 bytes alignment already demands, so they cost no extra
+space; a v2.x writer that assigns them meaning announces it with a feature bit, and
+a v2.0 reader treats nonzero values there as an unknown feature, not corruption.
+On the traversal path, an area whose `kind` is not 0, 1, or 2 MUST be treated as a
+corruption error — `kind` is not part of the skippable extension surface, so a new
+`kind` value would be a v3 event.
+
+**Addressing.** An address is a global `u64` byte offset, 8-byte aligned, with `0`
+reserved as null (the niche for `Option<Address>`):
+
+```text
+Address = u64
+  bits 63..3 : the offset
+  bits  2..0 : RESERVED TAG BITS. v2.0 writers MUST write 0; readers MUST mask
+               (addr & !0b111) before dereferencing. Future per-edge metadata is
+               assigned to these bits only under a header feature flag.
+  value 0    : null
+```
+
+The address *is* the disk offset; segmentation (below) never leaks into it. The
+masking rule applies to every stored `Address` — child addresses, the value
+`overflow_addr`, `root_address`, and `free_list_heads` entries.
+
+**Size classes (self-describing).** The size-class table is data in the header,
+not a compiled-in constant. A frozen maximum of 64 classes keeps the header
+fixed-size; the per-area `size_class` byte indexes the file's own table, so every
+reader and writer agrees on what a class means for that file. This eliminates the
+v1 trap where a compiled-in table mismatch rejects the file. v2.0 ships a sensible
+default table (geometric, ~16 B to 16 MiB); a future writer may choose different
+values for new files, and old readers honor whatever the file declares. All class
+sizes are multiples of 8.
+
+**Read path and segmented mapping.** v2.0 reads via `pread` + `bytemuck` cast.
+v2.1 maps the file in fixed-size **segments** (`segment_size`, frozen at 1 GiB but
+recorded in the header; it MUST be a multiple of `page_size`). The v2.1 reader
+decomposes an address as `seg = addr / segment_size`,
+`ptr = segment_base[seg] + addr % segment_size`, maps segments lazily, and never
+relocates a live mapping (new segments map additively), so growth is safe for
+concurrent readers and works identically on Linux and macOS.
+
+*No-straddle invariant:* an area never crosses a segment boundary, so any node
+lies within one contiguous mapping. A bump allocation that would straddle the next
+boundary pads the tail gap and registers it as free area(s). The gap is decomposed
+deterministically and independently of the (per-file) size-class table:
+
+```text
+remaining = gap_bytes
+while remaining >= area_sizes[0]:          # area_sizes[0] is the minimum class
+    c = max index where area_sizes[c] <= remaining
+    emit a `kind = free` area of class c on free_list_heads[c]
+    remaining -= area_sizes[c]
+# remaining (< area_sizes[0]) is unreclaimable slop
+```
+
+The gap at a boundary is at most one max-area (16 MiB per 1 GiB segment, ≈ 1.56%),
+but almost all of it re-enters the free lists; permanently unreclaimed waste per
+boundary is only the sub-minimum residual (< `area_sizes[0]` bytes).
+
+**Endianness.** All integers are little-endian by definition. On the little-endian
+targets Firewood supports this is native, giving true zero-copy. A big-endian host
+is unsupported and refused at open rather than byte-swapped; the header
+`endian_test` field also detects an accidentally big-endian-written file.
+
+### Node encodings
+
+```text
+NodeHeader (8 bytes, repr(C), little-endian):
+  off 0  flags            : u8
+           bit 0  kind            0 = branch, 1 = leaf
+           bit 1  has_value       node carries a value
+           bit 2  value_overflow  0 = inline value, 1 = overflow reference
+           bits 3..7  reserved    (write 0)
+  off 1  reserved0        : u8     reserved per-node growth surface (write 0)
+  off 2  child_bitmap     : u16    bit i set if a child exists at nibble i
+  off 4  path_len_nibbles : u32
+```
+
+The trie is 16-ary (one nibble per level), so `child_bitmap` is exactly 16 bits.
+`path_len_nibbles` is `u32` — a deliberate, frozen hard cap of ~4.29e9 nibbles
+(~2 GiB key), about seven orders of magnitude above any realistic key, chosen to
+eliminate an overflow branch on the hot path. The `child_addrs` array follows at
+`+16` (8-aligned); the `partial_path` follows it as packed nibbles (two per byte,
+high nibble first), `ceil(path_len_nibbles / 2)` bytes.
+
+**Branch node.**
+
+```text
+AREA (8-aligned)
+  AreaHeader(8)                size_class, kind = node
+  HOT:
+    NodeHeader(8)  @ +8        flags(branch), child_bitmap, path_len_nibbles
+    child_addrs    @ +16       [Address; pc]  (8-aligned; pc = popcount(child_bitmap))
+    partial_path   @ +16+8*pc  packed nibbles
+  COLD:
+    child hashes (size fixed given pc + file hash algorithm):
+      [ethhash only] child_hash_lens : [u8; pc]
+      child_hashes                   : [[u8;32]; pc]
+    value section (present iff flags.has_value):
+      inline   : value_len : u32, bytes[value_len]
+      overflow : overflow_addr : Address, value_len : u64
+  [optional feature-gated cold TLV regions: [tag:u16][len:u32][bytes], skippable]
+```
+
+Child lookup at nibble `n` (the hot path) is branch-free aside from one `POPCNT`:
+
+```text
+if (child_bitmap & (1 << n)) == 0  -> no child
+idx  = popcount(child_bitmap & ((1 << n) - 1))
+addr = child_addrs[idx] & !0b111                 // strip tag bits
+// child_hashes[idx] is consulted only when hashing or proving
+```
+
+A **leaf** is the same shape with `child_bitmap = 0` (no address array) and a
+value section in its cold tail; it stores no hash of its own (its hash lives in its
+parent's `child_hashes` slot, and the root's hash lives in the header).
+
+**Cold-region seek invariant (frozen).** Every cold sub-region's byte extent MUST
+be computable from the hot header (`pc`, `has_value`, `value_overflow`,
+`path_len_nibbles`) plus the file's `hash_algorithm` alone — never from the cold
+bytes. The `child_hashes` block is always `32 * pc` bytes: the physical stride is
+32 bytes per child regardless of `child_hash_lens`, which is interpretation-only.
+The value-section offset is therefore a closed form, computable without faulting
+the hash block. The only variable-length cold element is a trailing TLV region,
+which carries its own `[tag:u16][len:u32]` length. This invariant is what makes
+"skip an unknown cold region" actually hold.
+
+**Inline-value threshold is writer policy, not format.** A reader never consults a
+threshold — `flags.value_overflow` is self-describing per node, so nodes written
+under different thresholds coexist. The default is 256 B (so account RLP and
+storage slots stay inline) and is persisted as an advisory
+`default_inline_value_threshold` that readers ignore. The inline `value_len` is a
+`u32` by format; if it exceeds the area's remaining payload, the reader MUST return
+a corruption error, never truncate.
+
+### Header, versioning, and compatibility
+
+The file opens with two header slots. The fixed slot content is the first 8192
+bytes; the on-disk slot stride is `max(8192, page_size)` (zero padding fills the
+remainder under large pages). Each commit writes the **older** slot (lower
+`sequence`), checksums it, and `fsync`s it, so a torn header write never damages
+the last-good slot.
+
+```text
+DbHeaderSlot (repr(C), little-endian; fixed content = 8192 B):
+  // identity and version (FROZEN CORE)
+  off    0  magic                          : [u8;8]
+  off    8  major_version                  : u16      = 2; reader refuses if != its major
+  off   10  minor_version                  : u16
+  off   12  min_reader_version             : u16      read gate
+  off   14  header_content_size            : u16      = 8192 (on-disk stride is max(8192, page_size))
+  off   16  endian_test                    : u64      = 1
+  off   24  feature_bits                   : [u64;4]  256 optional-capability bits
+  off   56  required_writer_features       : [u64;4]  256 write-gate bits
+  off   88  sequence                       : u64      monotonic commit counter
+  // format parameters (self-describing)
+  off   96  segment_size                   : u64      mmap segment size (default 1 GiB)
+  off  104  hash_algorithm                 : u8       0 = SHA-256, 1 = Keccak-256; selects runtime hash mode
+  off  105  size_class_count               : u8       N <= 64
+  off  106  clean_shutdown                 : u8       1 if last close was clean
+  off  107  page_size_log2                 : u8       log2 of the page alignment the file guarantees (>= 12)
+  off  108  default_inline_value_threshold : u32      advisory
+  // root and allocation state (rewritten every commit)
+  off  112  root_address                   : u64      0 = empty tree
+  off  120  high_water_mark                : u64      next bump-allocation offset
+  off  128  root_hash                      : [u8;32]
+  off  160  fdl_head                       : u64      RESERVED, feature-gated, 0 in v2.0
+  off  168  fdl_tail                       : u64      RESERVED, feature-gated, 0 in v2.0
+  off  176  revision_index_anchor          : u64      RESERVED, feature-gated, 0 in v2.0
+  off  184  reserved_b                     : u64      RESERVED, feature-gated, 0 in v2.0
+  // tables
+  off  192  area_sizes                     : [u64;64] entries >= size_class_count are 0
+  off  704  free_list_heads                : [u64;64] per-class free-list head Address
+  // advisory
+  off 1216  writer_build                   : [u8;64]  build stamp, diagnostic only
+  off 1280  reserved                       : [u8;6904] frozen-core headroom
+  // integrity (last field)
+  off 8184  checksum                       : u64      XXH3-64 digest over bytes [0, 8184)
+```
+
+The `checksum` is a full 64-bit XXH3-64 digest over `[0, 8184)`; it occupies the
+entire `u64` with no spare bits, so a future writer cannot smuggle meaning into it.
+New fixed fields are carved from `reserved` (off 1280) low-end upward, each
+recorded next to the `feature_bits` bit that announces it.
+
+**Page alignment (frozen rule).** The file records `page_size_log2`
+(`page_size = 1 << page_size_log2`, a power of two, ≥ 4096). The slot stride is
+`max(8192, page_size)`, so the first area begins at `2 * max(8192, page_size)` —
+always a multiple of `page_size`, hence page-aligned, and always at least 16384.
+On open a reader refuses the file if `page_size < the system page size`: a file
+aligned to a smaller page cannot be mapped on a host with larger pages, while a
+file aligned to a larger page maps fine anywhere with pages ≤ it. `page_size_log2`
+is set once at creation and immutable thereafter (every commit rewrites it with the
+same value), so it locates slot B reliably even when slot A's checksum fails;
+because each slot spans at least one full page, a single torn page write damages at
+most one slot, preserving the double buffer's independent-failure property.
+
+**Three compatibility mechanisms (the heart of tenet 3).** Within-major
+bidirectional compatibility rests on two one-way gates plus a bidirectional
+extension channel, over a frozen hot core:
+
+| Concern | `feature_bits` | `min_reader_version` | `required_writer_features` |
+| --- | --- | --- | --- |
+| Meaning | file uses optional capability X | reader must understand minor >= V | writer must support X to write |
+| On unknown | reader ignores the bit, skips the cold region | reader refuses the file | writer opens read-only |
+| Compatibility | bidirectional (additions optional, skippable) | one-way read gate | one-way write gate |
+| Intended use | the default channel for all evolution | break-glass only | gate for any write-affecting feature |
+
+`feature_bits` is the routine channel: every ordinary addition ships as a feature
+bit plus self-delimiting cold data (a cold TLV record, an address tag-bit meaning,
+or an advisory `reserved` field). `min_reader_version` is reserved for a
+non-skippable read change — moving it is by definition a v3 signal.
+`required_writer_features` is the write gate: a writer that does not support a set
+bit opens read-only, which is the insurance that lets any write-affecting feature
+be added later without older writers silently corrupting it. To classify a change,
+ask in order: does a reader need new bytes to read the latest revision (raise
+`min_reader_version`)? does a writer need to maintain a new invariant (set
+`required_writer_features`)? otherwise set a `feature_bits` bit. Unknown
+`feature_bits`, unknown cold TLV tags (assigned from a central registry —
+`0x0000`–`0x00FF` core, `0x0100`–`0x01FF` ethhash), and set address tag bits are
+all skipped, never fatal.
+
+### Commit and recovery
+
+The whole recovery argument rests on a single invariant:
+
+> **Never mutate any area the live header transitively references, until a new
+> header is durably published.**
+
+The live header is the valid slot with the highest `sequence`; it transitively
+references the committed root tree and the free-list chains. Everything else (bump
+space beyond `high_water_mark`, areas in neither the tree nor a free chain) is safe
+to write. Because the header swap is atomic, a crash lands on the old or the new
+header, never a mix.
+
+**Commit** is two `fsync`s:
+
+```text
+Phase 1 - write node bytes (only to NON-live-referenced areas):
+   - new nodes -> bump space (beyond live high_water_mark), and/or
+   - areas from the reserved pool (popped and published by a PRIOR commit)
+   fsync                                   // node bytes durable
+Phase 2 - publish (atomic):
+   - write the scratch (older) header slot: root_address, root_hash,
+     high_water_mark, free_list_heads[], sequence + 1, checksum
+   fsync                                   // the commit point
+```
+
+The Phase-1 write of each new area includes its full `AreaHeader` (with
+`kind = node`), so a `kind = node` byte may be durable before Phase 2 publishes —
+this is safe because the area is off all live-header references. The two-`fsync`
+ordering is a hard requirement of any write backend; a writer using io-uring must
+chain a barrier `fsync` or fall back to a blocking one between phases.
+
+**Reuse and reaping are safe** because each touches only non-live-referenced areas:
+an area is *popped one commit ahead* of being filled (commit N−1 publishes a header
+excluding area X; commit N then overwrites X), and a node is *reaped* only after
+its retaining revision expires (so it is in no live tree and not yet on a free
+list). This is why `free_list_heads` lives inside the checksummed, double-buffered
+header: the head array publishes atomically, and the only mutable-in-place state —
+the intrusive `next_free` links — is always written to non-live-referenced areas.
+
+**Recovery on open:**
+
+```text
+1. Bootstrap and read both slots:
+     a. Read the fixed 8192-byte content at offset 0 (always present: stride >= 8192).
+     b. Read page_size_log2 (off 107); verify it is plausible (12..=30) else refuse.
+        It is immutable since creation, so it authoritatively locates slot B.
+     c. slot_stride = max(8192, 1 << page_size_log2); read slot B at slot_stride.
+     d. For each slot verify magic, major == 2, endian_test, checksum; a valid slot
+        whose own page_size_log2 disagrees with (b) is treated as invalid.
+     e. Refuse if neither slot is valid, or if page_size < the system page size.
+   Select the runtime hash mode from the adopted slot's hash_algorithm.
+2. Enforce gates (a precondition of handle acquisition, atomic with it):
+     refuse        if min_reader_version > mine;
+     read-only     if any required_writer_features bit is unsupported.
+3. Adopt the valid slot with the highest sequence; this IS the committed state.
+4. Trust its root tree and free_list_heads / chains (the invariant guarantees it).
+5. Treat anything beyond its high_water_mark as uncommitted debris and ignore it.
+```
+
+No redo/undo log is needed. A crash can strand reserved-pool areas (popped but
+never filled) and bump debris beyond `high_water_mark`; both are harmless,
+bounded, unreclaimed space, recovered by an optional free-space rebuild scan gated
+behind the `clean_shutdown` flag (set to 0 by every Phase-2 write, to 1 only by a
+cooperative close), so the scan runs only after an unclean open.
+
+The rebuild scan is a **total** classification over every area, keyed on
+`AreaHeader.kind`, reachability from the live root (`R_root`), and membership on a
+published free chain (`R_free`):
+
+| `kind` | `R_root` | `R_free` | Classification |
+| --- | --- | --- | --- |
+| `node` | yes | — | **live node** — retain |
+| `node` | no | — | **reclaim-to-free** — mid-fill debris whose header never published |
+| `free` | — | yes | **free** — already correct |
+| `free` | — | no | **reclaim-to-free** — popped-but-unfilled reserved-pool area |
+| other | — | — | **leak** — sub-minimum slop or unrecognized; counted toward the waste bound |
+
+Keying on `R_root` rather than on `kind` alone is what closes the "bounded per
+crash but unbounded across crashes" hazard: a `kind = node` area off the live root
+is positively classified as reclaimable, never mistaken for a live node.
+
+### Allocation and free lists
+
+To allocate, pick the smallest size class that fits `AreaHeader(8) + hot + cold`,
+then reuse (`pop free_list_heads[c]`, O(1)) or bump (`carve at high_water_mark`,
+honoring the no-straddle rule). A freed area's payload becomes its intrusive link:
+
+```text
+FREE AREA (8-aligned):
+  AreaHeader(8)        size_class = c, kind = free
+  next_free : u64 @ +8 Address of next free area in class c's list (0 = end)
+```
+
+The discriminator is the `AreaHeader.kind` field (not a magic byte), and the link
+is a fixed 8-aligned `u64` (not a varint), so a free area is a trivially zero-copy
+record and the free-list walk chases aligned `u64`s with no decode.
+
+Deferred free stays in memory, as in v1: a superseded node is recorded in an
+in-memory per-proposal list and returns to the free lists only when its owning
+revision expires; on restart, in-flight proposals are discarded. The only
+allocation state v2 persists is `free_list_heads` and `high_water_mark`. The
+`fdl_*` / `revision_index_anchor` header fields are reserved for a future durable
+variant.
+
+### Hashing integration
+
+The format stores hashes but is agnostic to hashing semantics, which stay in the
+hashing layer. `hash_algorithm` is a file-global, immutable header field (`0` =
+SHA-256/merkledb, `1` = Keccak-256/ethhash) that **selects the runtime hash mode at
+open**: both modes are built into one binary as two traits — there is no
+compile-time hash feature — so any binary opens any file in the mode its header
+declares, and an unrecognized value is refused. There is no cross-algorithm path to
+guard. A node's own hash lives in its parent's cold `child_hashes` slot; the root's
+hash lives in `root_hash`. Under ethhash, `child_hash_lens[i] == 32` is a full
+Keccak hash and `1..=31` is an embedded RLP node in the slot's first `len` bytes (a
+present child is never length 0; the writer zeroes bytes `len..32` and a reader uses
+only `0..len`, keeping stored bytes reproducible). merkledb files omit
+`child_hash_lens` entirely.
+
+**Correctness constraint.** v2 changes storage, not Merkle semantics: for any
+logical tree under a given algorithm, the v2 root hash MUST be byte-identical to
+v1's — blockchain consensus depends on exact state roots.
+
+### Frozen invariants
+
+Frozen for all of major version 2 (changing any is a v3 event): 8-byte alignment
+and 3 reserved address tag bits; the `AreaHeader` and `NodeHeader` layouts, the
+`+16` child-address-array position, and packed-nibble paths; the 8192-byte header
+content layout (field offsets and the `area_sizes`/`free_list_heads` tables, with
+`checksum` at 8184) and double-buffering, with on-disk slot stride
+`max(8192, page_size)` and first area at `2 * slot_stride`; little-endian integers;
+the XXH3-64 checksum with no spare bits; the page-alignment rule; the three
+compatibility mechanisms and the cold-TLV extension model; the recoverability
+invariant and atomic header-swap commit point; the kind-byte/fill invariant and the
+total rebuild predicate; the cold-region seek invariant; runtime hash-mode
+selection; the `required_writer_features` open-for-write precondition; the
+`clean_shutdown` protocol; and the address-masking rule.
+
+Accepted, owned limits (each a v3 event to raise): `path_len_nibbles` at the `u32`
+ceiling, the 64-class size-class cap, the 256-bit gate arrays, and the `u32` inline
+value length. Values that are header data and so may differ per file without
+breaking compatibility: the `area_sizes` table, `segment_size`, `page_size_log2`,
+`hash_algorithm`, and `default_inline_value_threshold`.
+
+## Drawbacks
+
+- **A frozen format is a long commitment.** Every byte layout decision is hard to
+  reverse at 2 TiB scale; the compatibility machinery (gates, reserved space,
+  cold-TLV) is overhead that exists solely to defer the next migration.
+- **The hot/cold split costs a second fault** when a caller does need a node's
+  hashes or an overflowed value (hashing, proofs), in exchange for a faster
+  traversal hot path.
+- **Two `fsync`s per commit** is a real write-path cost (its magnitude versus v1 is
+  unmeasured; see Unresolved questions).
+- **Crash recovery trades a bounded space leak** (reserved-pool and bump debris)
+  for never corrupting committed state, requiring an occasional rebuild scan after
+  an unclean shutdown.
+- **The `mmap` reader and an `mmap` writer are net-new** surfaces deferred to later
+  versions; v2.0 ships only the simpler `pread` reader.
+
+## Rationale and alternatives
+
+- **8-byte vs 16-byte alignment.** 16-byte alignment would add one tag bit and
+  16-aligned address arrays, but the SIMD benefit is weak (traversal does scalar
+  reads) and coarser size classes would waste tens of GB on small-node padding at
+  scale. 8-byte wins on space and already supplies enough tag bits.
+- **Self-describing size-class table vs compiled-in.** v1 hashes a compiled-in
+  table and rejects mismatches, which would break within-major compatibility.
+  Storing the table (and `segment_size`, `page_size_log2`, `hash_algorithm`,
+  threshold) in the header lets files evolve without rejection.
+- **Split address/hash vs interleaved or fully separate.** Interleaving hashes with
+  addresses pollutes the traversal cache line; a fully separate hash store doubles
+  free-list and recovery bookkeeping. The node-local cold tail keeps recovery
+  single-region while still keeping hashes off the hot path.
+- **`pread` now, `mmap` later vs `mmap` now.** Deferring `mmap` keeps the largest
+  novel-correctness surface (lazy mapping, growth-without-relocation,
+  `pwrite`-to-`mmap` coherence) out of the v2.0 critical path while the format stays
+  `mmap`-ready, so v2.1 drops in with no format change.
+- **Page size in the header vs a fixed platform envelope.** Recording
+  `page_size_log2` and scaling the slot stride lets one format serve 4/16/64 KiB
+  page hosts and keeps each header slot on its own page (so a torn page write can
+  damage only one slot), which a fixed 16384-byte prologue could not guarantee.
+- **Runtime hash mode vs a compile-time feature.** A header-selected mode removes
+  the cross-algorithm guard surface entirely and lets a single binary serve both
+  merkledb and ethhash files.
+
+## Prior art
+
+The [v1 on-disk format](0003-on-disk-format-and-addressing.md) establishes
+disk-offset addressing, end-of-file/free-list allocation, size-class free lists,
+the future-delete log, and recoverability via not referencing new nodes before
+flush — all of which v2 keeps in spirit while changing the encoding. The
+double-buffered, checksummed, sequence-numbered superblock is the standard
+crash-safe header pattern used across filesystems and embedded databases. The
+bitmap + popcount child array mirrors HAMT/CHAMP node encodings. The
+`feature_bits` / `min_reader_version` split mirrors read/write feature flags in
+formats such as SQLite and ext-family filesystems.
+
+## Unresolved questions
+
+These do not gate the format freeze but must be answered before or during
+implementation:
+
+1. **Two-`fsync` commit throughput is unmeasured.** Benchmark against v1 during
+   implementation; if it materially regresses the C-Chain commit path, advance the
+   `mmap`-writer follow-up (which can batch differently). The format does not change
+   either way.
+2. **Writer-exclusivity mechanism.** Single-writer access is a stated requirement;
+   the open question is only enforcement. v2 most likely keeps v1's advisory
+   `flock`, but the guarantee boundary on shared/network storage or container
+   runtimes (where advisory locks are unreliable) must be stated at implementation
+   time.
+3. **v2.1 `mmap` reader isolation model.** The default is snapshot-pinned-at-open: a
+   reader reads the header once, pins `root_address`, and traverses that revision;
+   because committed nodes are immutable, no re-validation and no extra header field
+   are needed. A "follow-latest" reader (re-read the header each traversal) is the
+   alternative; the double-buffered header supports both, so this is a reader-policy
+   choice, not a format change.
+
+## Future possibilities
+
+- **Durable revision history (DRH).** Make the last N revisions traversable after a
+  restart (in v2.0 they are in-memory only). DRH adds a revision index of retained
+  roots (anchored by `revision_index_anchor`) and an on-disk future-delete log
+  (chained `kind = fdl` areas anchored by `fdl_head`/`fdl_tail`), plus commit and
+  reclamation steps — all in reserved, feature-gated space, with node bytes
+  unchanged. It is additive precisely because the `required_writer_features` write
+  gate ships in v2.0: an older writer ignorant of DRH would corrupt retained
+  history, and the gate forces it read-only instead. DRH is therefore a clean v2.x
+  addition rather than a v3 migration.
+- **`mmap`-based writer.** Mutate mapped pages directly with `msync` range ordering,
+  landing with a test asserting zero format-byte change versus the `pread`/`pwrite`
+  writer's output.
+- **Cross-algorithm reads.** Not offered, and unnecessary under runtime hash-mode
+  selection; recorded only as a non-goal.
+
+## Verification and merge gates
+
+The pre-freeze and implementation gates below must pass on the schedule indicated;
+freeze gates block locking any byte layout, implementation gates block merging the
+implementation.
+
+### Freeze gates (must pass before any byte is frozen)
+
+- [ ] **Round-trip property tests:** every node shape — leaf/branch, all
+      `child_bitmap` populations, path lengths 0/1/2 + odd/even + 40..60 +
+      `u32`-large, inline/overflow values, merkledb + ethhash cold blocks — encode
+      then read back via the v2.0 `pread` path; structural equality + correct
+      nibble-indexed child lookup.
+- [ ] **Byte-layout lock-in:** `insta` snapshots of representative nodes, headers,
+      and free areas, landing with the format definition.
+- [ ] **Compatibility matrix:** hand-crafted future files (unknown `feature_bits`,
+      unknown cold-TLV tags, set address tag bits, raised `min_reader_version`, set
+      `required_writer_features`) assert skip/refuse/read-only behavior and
+      v2.x-reads-v2.0, including an unknown cold-TLV *preceding* a known one (proves
+      skip arithmetic, not just tail-skip).
+- [ ] **Crash consistency / fault injection:** a backend that can truncate,
+      torn-write, or fail at each `fsync` boundary; after any crash, `open()` yields
+      exactly the old or new committed state, never a mix. Cover both
+      reclaim-to-free rows of the rebuild predicate, and assert the leak bound holds
+      across repeated crash-reopen cycles with no monotonic accumulation.
+- [ ] **Allocator:** alloc/free/reuse, segment-straddle padding + reclaim, the
+      pop-ahead reserved pool, rebuild-scan idempotence.
+- [ ] **Differential vs v1 (consensus gate, non-negotiable):** identical workloads
+      produce byte-identical root hashes under each algorithm, with exhaustive
+      ethhash RLP-embedding coverage (every `child_hash_lens` value in `1..=32`,
+      every account-depth case).
+- [ ] **Hash-mode selection at open:** the open path dispatches to the trait for the
+      file's `hash_algorithm`; a merkledb file opens in merkledb mode and an ethhash
+      file in ethhash mode; an unrecognized value is refused.
+- [ ] **Zero-copy mechanism under `unsafe`-deny:** `AreaHeader`, `NodeHeader`, and
+      the address-array element derive `bytemuck` `Pod`/`Zeroable` and cast via
+      `bytemuck::from_bytes` with no new `unsafe` outside `ffi`
+      (`cargo build -p firewood-storage`; the only permitted `unsafe impl`s are the
+      established `PodInOption`/`ZeroableInOption`).
+- [ ] **Header checksum pinned + test vector:** the slot checksum is XXH3-64 over
+      `[0, 8184)`; lock one concrete crate (candidates: `xxhash-rust` with `xxh3`,
+      or `twox-hash`; pure-Rust preferred) before any byte-layout snapshot lands,
+      record a byte-for-byte test vector, and assert a reader rejects a mismatch.
+- [ ] **Inline `value_len` overflow rejects:** a value length exceeding the area's
+      remaining payload is corruption, never truncated.
+
+### Implementation gates (after the format is frozen)
+
+- [ ] **`mmap` growth + concurrency (v2.1):** file grows across 1 GiB boundaries;
+      segmented mapping returns correct bytes; a reader observes a consistent
+      snapshot while a writer appends + swaps the header. Exercise publish-ordering,
+      not just page-cache coherence. (Gates the v2.1 reader; v2.0 uses `pread`.)
+- [ ] **Reader fuzzing (`cargo-fuzz`):** arbitrary/corrupted bytes yield clean
+      errors only, never panic/UB. Deferrable past freeze only because the
+      cold-region seek invariant makes parsing unambiguous from the hot header.
+- [ ] **Scale + soak:** C-Chain reexecution on v2; disk footprint + traversal
+      latency vs v1; the `test_slow_` suite under the `ci` profile.
+- [ ] **io-uring Phase-1 barrier:** the io-uring write path provides the Phase-1
+      `fsync` barrier before the Phase-2 header write (chained barrier or blocking
+      fallback); no node bytes reorder after the header publish.
+- [ ] **Endianness + page-size guard:** `endian_test` flags a big-endian-written
+      file; a big-endian host is refused at open; a file whose recorded `page_size`
+      is smaller than the system page size is refused at open.
+- [ ] **`clean_shutdown` protocol wired correctly:** Phase-2 writes set it to 0;
+      cooperative close sets it to 1; open runs the rebuild scan unless the adopted
+      slot reads 1.
+
+### Implementation notes
+
+- Removing the compile-time `ethhash` Cargo feature (so hash mode is runtime) is a
+  separate, in-flight, cross-cutting refactor and an accepted breaking change to the
+  `firewood-storage` API; the format freeze does not depend on it landing, and the
+  `--features ethhash` recipes in repository tooling must drop the feature once it is
+  gone.
+- `markdownlint-cli2 .` passes on the added Markdown.

--- a/docs/src/designs/0003-on-disk-format-and-addressing.md
+++ b/docs/src/designs/0003-on-disk-format-and-addressing.md
@@ -1,0 +1,118 @@
+---
+title: On-Disk Format & Addressing
+status: active
+category: storage
+authors: [demosdemon]
+---
+
+# On-disk format and addressing
+
+**Source:** `storage/src/`, `firewood/src/`
+
+## Overview
+
+Firewood stores Merkle trie nodes directly on disk in a single database file and
+uses the trie structure itself as the on-disk index. There is no separate key-value
+store underneath and no background compaction. This document describes how nodes are
+addressed, allocated, and reclaimed, and the guarantees that make the format
+crash-recoverable.
+
+## Architecture
+
+A node's address is simply its byte offset within the database file. Branch nodes
+reference their children by storing those children's disk offsets, so traversing the
+trie on disk is a sequence of offset reads — no hash-to-location lookup table is
+required. Each revision has a root node, and the root's address is the entry point
+for reading that revision.
+
+The database file begins with a fixed-size header (`NodeStoreHeader`, occupying the
+first 2048 bytes) that stores the current file size, the root node location, and the
+heads of all free-list chains. The header also contains a `root_hash` field, but this
+field is only populated in `firewood-v1` format databases; older databases leave it
+uninitialized. After the header, the remainder of the file
+consists of contiguous stored areas, each prefixed by a one-byte area-index that
+identifies its size class.
+
+## Key data structures
+
+- **`NodeStore<T, S>`** (`storage/src/nodestore/mod.rs`) — the main nodestore
+  container. The type parameter `T` encodes the lifecycle state: `Committed`,
+  `Mutable<Propose>`, `Arc<ImmutableProposal>`, `Mutable<Recon>`, or
+  `Reconstructed`. The parameter `S` is the storage backend.
+- **`LinearAddress`** (`storage/src/nodestore/primitives.rs`) — a non-zero `u64`
+  byte offset into the database file. This is the node identity used by branch nodes
+  to reference their children.
+- **`AreaIndex`** (`storage/src/nodestore/primitives.rs`) — a one-byte index into
+  the table of 23 valid area sizes (16 bytes through 16 MiB). Every stored area is
+  prefixed with its `AreaIndex` so the allocator can determine the area's size when
+  freeing it.
+- **Free lists** (`storage/src/nodestore/alloc.rs`) — one singly-linked list per
+  size class. The head of each list is stored in the `NodeStoreHeader`; each free
+  area stores the address of the next free area of the same size class. Together they
+  form 23 independent linked lists of reclaimed space.
+- **Future-delete log (FDL)** — the `deleted` field in `Mutable<Propose>`,
+  `ImmutableProposal`, and `Committed` (`storage/src/nodestore/mod.rs`). Collects
+  `MaybePersistedNode` values replaced or deleted during proposal construction that
+  cannot be freed yet, because older in-memory or on-disk revisions may still
+  reference them.
+
+## Invariants and guarantees
+
+- **No forward references before flush.** A node is never referenced by an address
+  that has not yet been flushed to disk, so a crash cannot leave a live node pointing
+  at unwritten data.
+- **Careful free-list management across revisions.** Space is returned to the free
+  lists only once no surviving revision can reference it, so reuse never corrupts a
+  revision that is still readable.
+
+Together these invariants make the database recoverable after an unclean shutdown
+without a separate write-ahead log replay over user data.
+
+> [!NOTE]
+> This durability guarantee is narrower for space reclaimed from *reaped* revisions.
+> When an expired revision is reaped, its freed areas are written to disk, but the
+> free-list heads in the `NodeStoreHeader` are updated in memory and flushed only on
+> the next commit's `persist`. A crash in that window cannot corrupt a still-readable
+> revision (the reaped revision is already gone), but it can leave the reclaimed space
+> unreachable — leaked rather than merely delayed. This is a known limitation (see the
+> reap path in `firewood/src/manager.rs`); `Db::check` (`storage/src/checker`) detects
+> and recovers leaked areas.
+
+## On-disk and runtime behavior
+
+- **Allocation.** A new node is serialized into a byte buffer; the allocator finds
+  the smallest area size that fits (`AreaIndex::from_size`). It first tries to pop
+  the head of that size class's free list; if the list is empty, it extends the file
+  by advancing the stored size pointer (`allocate_from_end`).
+- **Area layout.** Each stored area on disk begins with one byte holding the
+  `AreaIndex`, followed by one byte that is `0xFF` for free areas or a node-type
+  discriminant for live nodes, followed by the serialized content.
+- **Free-list size classes.** There are 23 size classes: 16, 32, 64, 96, 128, 256,
+  512, 768, and 1024 bytes, then powers of two from 2 KiB through 16 MiB. The set is
+  defined in `storage/build.rs` and hashed into the `NodeStoreHeader` so a database
+  cannot be opened with a mismatched size table.
+- **Revision creation.** Committing a proposal writes new nodes, producing a new root
+  address and hash. Nodes replaced by the commit are recorded in the proposal's
+  delete list (the FDL) rather than freed immediately.
+- **Revision expiration.** The `RevisionManager` (`firewood/src/manager.rs`) keeps a
+  configurable number of committed revisions in memory (`max_revisions`, default 128). When the oldest
+  revision is reaped, the FDL entries it carries are freed via `NodeAllocator::delete_node`,
+  which writes a free-area record over the node and prepends it to the appropriate
+  size-class free list.
+- **Archival mode.** When `RootStore` is enabled, deleted-node tracking is disabled
+  (`DeletedNodeTracking::Disabled`) and the root address mapping for expired
+  revisions is retained, enabling reconstruction by root hash.
+
+## Trade-offs
+
+- Offset-based addressing keeps reads cheap (a child traversal is a single
+  `stream_from` call) but ties a node's identity to its physical location, so
+  relocation requires rewriting all referrers.
+- Retaining superseded nodes in the FDL trades temporary space overhead for the
+  ability to serve recent historical revisions and to recover cleanly after a crash.
+- The fixed 23-size-class table is compact and cache-friendly but accepts internal
+  fragmentation when a node's serialized size falls between two class boundaries.
+
+## Related designs
+
+- See [Design Documents](README.md) for other subsystems still to be documented.

--- a/docs/src/designs/0004-devcontainer.md
+++ b/docs/src/designs/0004-devcontainer.md
@@ -1,0 +1,153 @@
+---
+title: Development Container
+status: active
+category: tooling
+authors: [demosdemon]
+---
+
+# Development Container
+
+**Source:** `.devcontainer/`, `.github/workflows/devcontainer.yaml`
+
+## Overview
+
+Firewood's development container provides the Rust and Go toolchains, Nix, and the
+project's developer tooling. It is assembled declaratively from published
+[Dev Container features](https://containers.dev/features) plus one local feature —
+there is no `Dockerfile`. `devcontainer.json` layers features over the
+`mcr.microsoft.com/devcontainers/base:ubuntu26.04` base image (which provides the
+non-root `vscode` user, sudo, and common packages). Named Docker volumes persist
+developer authentication and shell history across container rebuilds.
+
+## Feature composition
+
+`devcontainer.json` composes these features, each pinned to its major version so
+patch and minor updates flow automatically while majors remain a deliberate bump:
+
+| Source | Provides |
+| --- | --- |
+| `mcr.microsoft.com/devcontainers/base:ubuntu26.04` (image) | base OS, non-root `vscode` user, sudo, common packages |
+| `github-cli:1` | `gh` |
+| `go:1` | Go toolchain (tracks `latest`) and `golangci-lint` |
+| `rust:1` (`profile: default`) | rustup + the stable toolchain with `clippy`, `rustfmt`, `rust-analyzer`, `rust-src` |
+| `nix:1` | Nix in daemon mode (`experimental-features = nix-command flakes`, `trusted-users = root vscode`) |
+| `node:1` | Node, required by the Claude Code feature |
+| `docker-in-docker:2` (`moby: false`) | Docker CE — Moby's `moby-cli` is not published for Ubuntu 26.04 |
+| `anthropics/devcontainer-features/claude-code:1` | the Claude Code CLI and its editor extension |
+| `./features/firewood-tools` (local) | build deps, sccache, cargo-nextest and other Cargo/Go tools, shell wiring (starship, sccache config, Claude Code symlink) — see [The local `firewood-tools` feature](#the-local-firewood-tools-feature) |
+
+Go tracks `latest` rather than a pinned version; `latest` always satisfies the Go
+floor in `ffi/go.mod`, which ends the manual version tracking that previously drifted.
+
+## The local `firewood-tools` feature
+
+`.devcontainer/features/firewood-tools/` is an in-repo feature that installs tooling
+with no maintained upstream equivalent. Its `devcontainer-feature.json` declares
+`installsAfter: [rust, go]` so it runs after those features during the image build.
+`install.sh` runs as root at build time and provides:
+
+- Build dependencies: `clang`, `cmake`, `libssl-dev`, `pkg-config`, `build-essential`,
+  `jq`, `shellcheck`.
+- Extra stable-toolchain components (`llvm-tools`, `rust-docs`) and a full `nightly`
+  toolchain.
+- `cargo-binstall`, then `sccache`, then sccache wiring written into
+  `/usr/local/cargo/config.toml`.
+- Cargo tools (via binstall): `ast-grep`, `cargo-edit`, `cargo-expand`,
+  `cargo-machete`, `cargo-msrv`, `cargo-nextest`, `git-cliff`, `just`, `ripgrep`,
+  `rustfilt`, `starship`.
+- Go tools (via `go install`): `dockerfmt`, `shfmt`.
+- Shell wiring: `starship` init, a persistent `HISTFILE`, and a symlink from
+  `~/.claude.json` to `~/.claude/user-claude.json` so Claude Code settings
+  land in the persistent volume.
+
+## Why there is no Dockerfile
+
+When `devcontainer.json` uses `build.dockerfile` together with `features`, the CLI
+builds the Dockerfile first and layers features on top — so anything that depends on
+`cargo`/`rustup` (cargo-binstall, sccache, the cargo tools, the nightly toolchain)
+cannot live in a Dockerfile, because it would run before the `rust` feature installs
+the toolchain. The local feature's `installsAfter: [rust, go]` orders that tooling
+after the toolchains within the feature layer, which is what makes the Dockerfile-less
+layout work. `installsAfter` only *orders* features that are already listed; it does
+not pull missing ones in, so `rust` and `go` stay explicitly listed in
+`devcontainer.json`.
+
+## Persistent state
+
+The named volumes below (suffixed `-${localEnv:USER}` for per-user isolation on
+shared hosts) start empty and fill on first use, so a one-time login survives rebuilds:
+
+| Volume target | Purpose |
+| --- | --- |
+| `/home/vscode/.cache/sccache` | sccache cache |
+| `/usr/local/cargo/registry`, `/usr/local/cargo/git` | cargo caches |
+| `/go/pkg` | Go module cache |
+| `/home/vscode/.config/gh` | `gh` authentication |
+| `/home/vscode/.claude` | Claude Code authentication, projects, and history |
+| `/home/vscode/.commandhistory` | shell history |
+
+Cargo and Go homes keep the features' defaults (`/usr/local/cargo`,
+`/usr/local/rustup`, `GOPATH=/go`); the cache volumes mount onto sub-paths so the
+features' PATH entries and tool proxies stay intact.
+
+## Build and runtime behavior
+
+- The container starts as the base image's `vscode` user.
+- Named volumes are created root-owned and mounted after the image build, so
+  `post-create.sh` (the `postCreateCommand`) `chown`s the volume targets to `vscode`
+  by username, then runs a verification smoke test (`rustup show`, `go version`,
+  `nix --version`, `sccache --show-stats`). The script is idempotent and safe to re-run on
+  rebuild.
+- `postStartCommand` runs `sccache --show-stats`.
+
+## Trade-offs and known interactions
+
+- **Rebuild required when upgrading** from the old Dockerfile-based container: an
+  editor reuses a container by its workspace-folder label, so the upgrade needs a
+  one-time "Rebuild Container" or the stale container fails with
+  `unable to find user vscode`.
+- The container user changes from the host `$USER` to `vscode`.
+- Go floats at `latest` rather than a pinned version.
+- Nix uses the upstream daemon-mode installer with `/nix` on a volume; the `ffi/`
+  flake is unchanged.
+- **IPv6 and `claude login`:** disabling IPv6 is not done by default (it is hard to
+  reverse). If `claude login` fails, `devcontainer.json` carries a commented
+  `--sysctl net.ipv6.conf.all.disable_ipv6=1` runArg to uncomment; see
+  [`.devcontainer/README.md`](https://github.com/ava-labs/firewood/blob/main/.devcontainer/README.md).
+
+## Security considerations
+
+This container is a developer convenience, not a hardened sandbox. Three properties
+are worth calling out:
+
+- **Privileged container.** The `docker-in-docker` feature runs the container
+  `--privileged`, which effectively grants root on the host's Docker. Do not use this
+  container to run untrusted code.
+- **Trusted Nix users.** The Nix install marks `root` and `vscode` as trusted users,
+  so anything running as `vscode` can reconfigure the Nix store and substituters. The
+  added risk is low, since `vscode` already has passwordless sudo in the base image.
+- **Tool installs are only partly pinned.** The `firewood-tools` feature bootstraps
+  `cargo-binstall` from a pinned installer commit, but the ~15 tools it then installs
+  via `cargo binstall`/`go install` float at their latest versions, so an upstream
+  compromise would land in the image. Pinning them is a possible follow-up.
+
+Per-user volume isolation is also incomplete. The volumes defined in
+`devcontainer.json` (the table above) are suffixed with `${localEnv:USER}`, but the
+volumes injected by the `nix` and `docker-in-docker` features — the Nix store and
+Docker's `/var/lib/docker` and `/var/lib/containerd` — are keyed by `${devcontainerId}`
+(derived from the workspace path, not the user). Two users who clone to the same path
+on a shared host still share those three volumes. This is accepted for now, not a
+guarantee.
+
+## Testing
+
+`.github/workflows/devcontainer.yaml` builds the container with the `devcontainers/ci`
+action on every `.devcontainer/**` change and smoke-tests the toolchains and
+feature-provided tools (`cargo +nightly`, `golangci-lint`, `shfmt`, `dockerfmt`,
+`starship`, `claude`, `shellcheck`, `jq`, and more). Because the action runs the full
+create lifecycle, `post-create.sh` is exercised in CI.
+
+## Related designs
+
+See [Design Documents](README.md) for the design workflow. For the broader local setup, see
+[Development Environment](../getting-started/dev-environment.md).

--- a/docs/src/designs/README.md
+++ b/docs/src/designs/README.md
@@ -1,0 +1,70 @@
+# Design Documents
+
+Firewood records its designs as living documentation in a single flat directory.
+Every design is `NNNN-slug.md` — a zero-padded sequence number (a permanent,
+never-reused identifier and a stable reference in review threads) followed by a short
+slug. A design's lifecycle state lives in its `status` frontmatter field, not in its
+location:
+
+- **`proposed`** — under review, not yet built. A proposal typically lands before
+  development so reviewers comment on the document through normal pull-request review.
+- **`active`** — reflects what the code does today; a living document, updated as the
+  code evolves.
+- **`draft`**, **`superseded`**, **`rejected`** — a work in progress, a design replaced
+  by a newer one, or a design considered and declined; each kept for the record.
+
+> [!NOTE]
+> This is a lightweight convention, not a mandatory gate. A `proposed` design is
+> encouraged for significant or non-obvious work, where writing it down sharpens the
+> discussion; small or low-risk changes do not need one, and nothing blocks a pull
+> request for lacking one. An `active` design may also be written after the fact to
+> document something already built. Optimize for "more designs discussed and
+> recorded," not "process followed."
+
+## Designs
+
+- [0001 — mdBook documentation site](0001-mdbook-documentation-site.md) — active
+- [0002 — v2 on-disk file format](0002-v2-file-format.md) — proposed
+- [0003 — on-disk format and addressing](0003-on-disk-format-and-addressing.md) — active
+- [0004 — development container](0004-devcontainer.md) — active
+
+## Designs still to be written
+
+Several core subsystems are documented only in code, not yet as designs. The
+backlog — revision management, hashing, proposals & commits, state sync &
+reconstruction, and the Go FFI layer — is tracked in
+[ava-labs/firewood#2139](https://github.com/ava-labs/firewood/issues/2139).
+
+## Frontmatter
+
+Every design begins with a YAML frontmatter block, stripped from the rendered site by
+the in-repo `frontmatter-strip` preprocessor:
+
+| Field | Required | Values |
+| --- | --- | --- |
+| `title` | yes | Human-readable design title. |
+| `status` | yes | `draft`, `proposed`, `active`, `superseded`, or `rejected`. |
+| `category` | yes | A Firewood subsystem: `storage`, `ffi`, `revision-management`, `hashing`, `proposals`, `docs`, or `tooling`. |
+| `authors` | yes | List of GitHub handles. |
+| `tracking-issue` | no | An `owner/repo#N` reference to the issue or PR tracking the work. |
+
+The schema has **no date fields** — git history is the single source of truth for a
+design's age. Run `just design-age` to list designs by last git-commit date, oldest
+first, to spot stale documents.
+
+## Propose a design
+
+Run `just new-design <slug>` to scaffold `NNNN-<slug>.md` from `template.md`, fill it
+in, and open a pull request.
+
+## Promote a design
+
+When a proposed design is implemented, promote it in place — a status flip, not a file
+move, so its `NNNN-slug.md` path stays stable:
+
+1. Flip the frontmatter `status: proposed` to `status: active`.
+2. Drop the proposal-only sections (Drawbacks, Unresolved questions), folding any
+   surviving content into the living structure.
+3. Rewrite any future-tense prose as present tense — the design now describes reality.
+4. Add cross-links to the implementing pull request(s) and commits.
+5. Update this index's status marker and `SUMMARY.md`.

--- a/docs/src/designs/template.md
+++ b/docs/src/designs/template.md
@@ -1,0 +1,48 @@
+---
+title:
+status: proposed
+category:
+authors: []
+tracking-issue:
+---
+
+# \<Title\>
+
+## Summary
+
+One paragraph describing the change.
+
+## Motivation
+
+Why this is worth doing; the problem it solves.
+
+## Guide-level explanation
+
+Explain the design as if teaching it to another contributor.
+
+## Detailed design
+
+The technical detail: data structures, algorithms, on-disk/runtime behavior,
+edge cases.
+
+## Drawbacks
+
+Reasons this design might not be worth doing. (Proposal-only; drop when promoting to
+`active`.)
+
+## Rationale and alternatives
+
+Why this design over others; what alternatives were considered.
+
+## Prior art
+
+Comparable designs in other systems, if any.
+
+## Unresolved questions
+
+Open questions to settle during review. (Proposal-only; drop when promoting to
+`active`.)
+
+## Future possibilities
+
+Natural extensions, explicitly out of scope here.

--- a/docs/src/getting-started/README.md
+++ b/docs/src/getting-started/README.md
@@ -1,0 +1,10 @@
+# Getting Started
+
+This section gets you from a clean machine to a working Firewood build.
+
+- [Development Environment](dev-environment.md) — set up a development environment on
+  macOS, in the dev container, or on a remote Linux host over SSH, and verify it.
+
+Once your environment is set up, [Concepts & Architecture](../concepts/README.md) explains how
+Firewood stores state, and [Design Documents](../designs/README.md) captures the
+designs behind it.

--- a/docs/src/getting-started/dev-environment.md
+++ b/docs/src/getting-started/dev-environment.md
@@ -1,0 +1,94 @@
+# Development Environment
+
+Firewood is a Rust workspace (edition 2024, minimum supported Rust 1.94.0) with a Go
+FFI layer. This guide covers three ways to set up a development environment and how to
+verify it.
+
+## Common prerequisites
+
+- **Rust** via [rustup](https://rustup.rs/), with the `rustfmt`, `clippy`,
+  `rust-analyzer`, and `rust-src` components, plus the pinned nightly toolchain
+  (`nightly-2026-07-05`) that the `clippy` checks use (see
+  [Verifying your setup](#verifying-your-setup)).
+- **[just](https://github.com/casey/just)** — the command runner used throughout this
+  repository (`just --list` shows available recipes).
+- **Go** (see `ffi/go.mod` for the version) — required
+  for the FFI layer.
+- **[Nix](https://nixos.org/)** — used by the FFI flake (`ffi/flake.nix`).
+- **[jq](https://jqlang.github.io/jq/)** — used by the in-repo mdBook frontmatter
+  preprocessor, so `just book-build` and `book-serve` work on a fresh machine.
+- **The mdBook toolchain** for building this site: `mdbook`, `mdbook-mermaid`,
+  `mdbook-linkcheck2`. Install with
+  `cargo binstall mdbook@0.5.3 mdbook-mermaid@0.17.0`. Install `mdbook-linkcheck2`
+  separately: `cargo binstall mdbook-linkcheck2@0.12.2` (it is not in the
+  `taiki-e/install-action` manifest, so CI installs it via `cargo binstall` directly).
+
+## macOS (local)
+
+1. Install rustup, the stable components, and the pinned nightly used for clippy:
+
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+   rustup component add rustfmt clippy rust-analyzer rust-src
+   rustup toolchain install nightly-2026-07-05 --component clippy
+   ```
+
+2. Install `just` and the mdBook toolchain (for example, via `brew install just` and the
+   `cargo binstall` line above).
+3. In VS Code, install the `rust-analyzer` extension and point it at the workspace.
+4. Build and test:
+
+   ```bash
+   cargo build
+   cargo nextest run --workspace --features ethhash,logger --all-targets
+   ```
+
+## Docker / dev container
+
+Requires a running Docker daemon (Docker Desktop on macOS, Docker Engine on Linux)
+and the VS Code **Dev Containers** extension. Use the checked-in `.devcontainer/` (see
+[`.devcontainer/README.md`](https://github.com/ava-labs/firewood/blob/main/.devcontainer/README.md)):
+
+1. Open the repository in VS Code with the **Dev Containers** extension and run
+   **"Reopen in Container"**.
+2. The container is assembled entirely from published Dev Container features plus a
+   local `firewood-tools` feature over an Ubuntu 26.04 base — no separate Dockerfile.
+   Rust, Go, Nix, `sccache`, and the project's developer tooling are all provided.
+3. `post-create.sh` (the `postCreateCommand`) fixes volume ownership and runs a
+   verification smoke test (`rustup show && go version && nix --version &&
+   sccache --show-stats`). `postStartCommand` also runs `sccache --show-stats` on
+   every container start to confirm the cache daemon is live.
+4. Developer authentication (`gh`, Claude Code) and shell history persist across
+   rebuilds via named volumes — log in once. Then run the build/test commands from the
+   macOS section inside the container.
+
+> [!IMPORTANT]
+> If you previously used the old Dockerfile-based container, upgrading requires a
+> one-time **rebuild**. "Reopen in Container" reuses the stale container and fails
+> with `unable to find user vscode`. Run **"Dev Containers: Rebuild Container"** instead.
+
+For the design behind this setup, see
+[Development Container](../designs/0004-devcontainer.md).
+
+## Remote Linux over SSH
+
+1. Connect with the VS Code **Remote-SSH** extension; `rust-analyzer` runs on the host.
+2. On the host, install rustup, Go, and Nix as in the common prerequisites.
+3. To preview this site, run `just book-serve` on the host and forward the mdBook port
+   (3000) to your machine (VS Code forwards it automatically, or use
+   `ssh -L 3000:localhost:3000 <host>`).
+
+## Verifying your setup
+
+Verify your environment by running the same checks CI runs (see `CONTRIBUTING.md`):
+
+```bash
+cargo fmt
+cargo nextest run --workspace --features ethhash,logger --all-targets
+cargo +nightly-2026-07-05 clippy --workspace --features ethhash,logger --all-targets
+cargo +nightly-2026-07-05 clippy --profile maxperf --workspace --features ethhash,logger --all-targets
+cargo doc --no-deps
+```
+
+All tests must pass with no clippy warnings. To build this documentation site
+locally, run `just book-build` (or `just book-serve` for live reload).

--- a/docs/src/integration/README.md
+++ b/docs/src/integration/README.md
@@ -1,0 +1,43 @@
+# AvalancheGo & EVM Integration
+
+Firewood exposes a Go API through its FFI layer, and downstream consumers (AvalancheGo
+and downstream projects) depend on a separately published Go module.
+
+## The Go API surface
+
+The in-repo `ffi/` directory ships a Go wrapper. Its public types map onto Firewood's
+Rust concepts — the Go names deliberately differ from the Rust ones:
+
+| Go type | Rust concept | Notes |
+| --- | --- | --- |
+| `Database` (`firewood.go`) | `Db` | the database handle; there is no Go type named `Db` |
+| `Proposal` (`proposal.go`) | `Proposal` | uncommitted batch atop a base root |
+| `Revision` (`revision.go`) | `DbView` | read-only view backed by a pinned revision (`DbView` is a Rust trait) |
+| `Reconstructed` (`reconstructed.go`) | reconstructed/archival view | state rebuilt from range proofs during state sync; freed by calling `Drop()` |
+| `Iterator` (`iterator.go`) | view iterator | streams key/value pairs; `Next` copies, `NextBorrowed` lends Rust memory |
+| `BatchOp` (`batch_op.go`) | `BatchOp` | a single `Put`/`Delete`/`PrefixDelete`; the unit of a write batch |
+| `RangeProof`, `ChangeProof`, `NextKeyRange` (`proofs.go`) | proof types | range/change proofs and key-range cursors for state sync |
+
+`New` constructs each type; the `With*` options tune it. The metrics and logging
+entry points (`Gatherer`, `LogConfig`, `StartMetrics`, `StartLogs`) wire up
+observability. The generated Go API reference is published as
+[Go API documentation (godoc) ↗](/firewood/ffi/) (resolves only on the deployed site).
+
+## How downstream consumers depend on Firewood
+
+AvalancheGo and downstream projects do **not** import the in-repo `ffi/` directory. They depend
+on the separately published Go module `github.com/ava-labs/firewood-go-ethhash/ffi`,
+pinned in their `go.mod` files. Firewood's crates are versioned independently, and that
+module tracks the `firewood-ffi` crate: the crate version is bumped by hand before a
+release (see the release process), and pushing the matching semver tag triggers CI to
+build the static libraries, copy the in-repo `ffi/` directory into the
+`ava-labs/firewood-go-ethhash` repository, and tag it there. See
+the build flow in [`ffi/README.md`](https://github.com/ava-labs/firewood/blob/main/ffi/README.md)
+(`cargo build` → `go tool cgo`) and the publish/version cadence in
+[the release process](../meta/release.md).
+
+> [!NOTE]
+> The Go module path in `firewood-go-ethhash` is rewritten by CI from the in-repo
+> path to `github.com/ava-labs/firewood-go-ethhash/ffi`. The tag format follows Go
+> module conventions: a `firewood-ffi` release `vX.Y.Z` is tagged as
+> `ffi/vX.Y.Z` in the `firewood-go-ethhash` repository.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -9,15 +9,16 @@ as its on-disk index rather than emulating a trie on top of a generic key-value
 store such as LevelDB or RocksDB. It is compaction-less: trie nodes are written
 directly to a single database file, addressed by their offset within that file.
 
-This site is the front door to Firewood's documentation:
+Firewood's documentation is organized into the following sections:
 
 - **Getting Started** walks through setting up a development environment.
-- **Concepts & Architecture** explains the trie storage model, revisions, and hashing.
-- **Design Documents** records the designs behind Firewood's on-disk format and
+- **Concepts & Architecture** explains the trie storage model and revisions.
+- **Design Documents** captures the designs behind Firewood's on-disk format and
   subsystems, and describes how new designs are proposed and reviewed.
 - **Integration** covers the Go FFI and how AvalancheGo consumes Firewood.
 - **Operations & Benchmarking** covers the `fwdctl` CLI and performance dashboards.
 - **Reference** links to the generated Rust and Go API documentation.
+- **Meta** documents the repository's processes and how these docs are built.
 
 > [!WARNING]
 > Firewood is beta-level software. Its API is still evolving and stability is not

--- a/docs/src/meta/README.md
+++ b/docs/src/meta/README.md
@@ -1,0 +1,7 @@
+# About These Docs
+
+This section documents the repository's processes and the documentation system
+itself.
+
+- [How these docs work](documentation.md)
+- [Release process](release.md)

--- a/docs/src/meta/documentation.md
+++ b/docs/src/meta/documentation.md
@@ -1,0 +1,38 @@
+# How These Docs Work
+
+This site is an [mdBook](https://rust-lang.github.io/mdBook/) rooted at `docs/`
+(`docs/book.toml`, `docs/src/`).
+
+## Toolchain
+
+- `mdbook` builds the book.
+- `mdbook-mermaid` renders Mermaid diagrams; its JS assets are generated at build time
+  by `just book-assets` and are git-ignored.
+- Callouts use mdBook's native alert syntax (`> [!NOTE]`, `> [!WARNING]`, …) — no
+  preprocessor required.
+- `mdbook-linkcheck2` runs as a backend during `mdbook build` and validates internal
+  links (`follow-web-links = false`).
+- The in-repo `frontmatter-strip` preprocessor removes each design doc's YAML
+  frontmatter before rendering (it needs `jq` on `PATH`; no binary to install).
+
+## Build and serve
+
+- `just book-serve` — serve locally with live reload.
+- `just book-build` — build and run the link checker. This mirrors the book-build and
+  link-check part of CI, not the full site assembly (rustdoc, Go docs, benchmark merge)
+  the Pages workflow also runs.
+
+Install the toolchain as described in
+[Development Environment](../getting-started/dev-environment.md).
+
+## Adding or editing a page
+
+1. Add or edit a Markdown file under `docs/src/`.
+2. Add it to `docs/src/SUMMARY.md` — a linked entry for real content, or a draft
+   chapter (`- [Title]()`) for a page not yet written.
+3. Run `just book-build` to validate, then open a pull request.
+
+## Designs
+
+The [Design Documents](../designs/README.md) section describes how to propose and
+promote designs, including the `just new-design` scaffolder.

--- a/docs/src/meta/release.md
+++ b/docs/src/meta/release.md
@@ -1,0 +1,15 @@
+# Release Process
+
+Firewood's release process is documented in
+[`RELEASE.md`](https://github.com/ava-labs/firewood/blob/main/RELEASE.md). It covers
+semver tagging, publishing the Rust workspace crates to crates.io, and triggering the
+CI pipeline that builds the static library, copies `ffi/` into the
+`ava-labs/firewood-go-ethhash` repository, and tags the resulting Go module.
+
+## Related repository processes
+
+- [Contributing](https://github.com/ava-labs/firewood/blob/main/CONTRIBUTING.md) —
+  testing requirements, PR workflow, and coding conventions
+- [Code review](https://github.com/ava-labs/firewood/blob/main/CODE_REVIEW.md) —
+  the Firewood-specific review checklist: Rust safety, lint suppression, and
+  FFI/unsafe code

--- a/docs/src/operations/README.md
+++ b/docs/src/operations/README.md
@@ -1,0 +1,20 @@
+# Operations & Benchmarking
+
+This section covers running and measuring Firewood.
+
+## `fwdctl`
+
+`fwdctl` is the command-line tool for operating on a Firewood database. See its
+[README](https://github.com/ava-labs/firewood/blob/main/fwdctl/README.md) for the
+available commands.
+
+## Benchmarking
+
+Firewood tracks performance with a C-Chain reexecution benchmark and synthetic
+workloads:
+
+- [C-Chain reexecution benchmark](https://github.com/ava-labs/firewood/blob/main/benchmark/docs/cchain-reexecution.md)
+- [Synthetic workloads](https://github.com/ava-labs/firewood/blob/main/benchmark/docs/synthetic-workloads.md)
+
+Live benchmark dashboards are published at [`/bench/` ↗](/firewood/bench/) (resolves
+only on the deployed site).

--- a/docs/src/reference/README.md
+++ b/docs/src/reference/README.md
@@ -1,0 +1,9 @@
+# Reference
+
+Generated API documentation and dashboards. These are site-absolute paths that
+resolve only on the deployed site; under local `mdbook serve` (or a fork's Pages
+deployment) they 404.
+
+- [Rust API documentation (rustdoc) ↗](/firewood/rustdoc/)
+- [Go API documentation (godoc) ↗](/firewood/ffi/)
+- [Benchmark dashboards ↗](/firewood/bench/)

--- a/justfile
+++ b/justfile
@@ -209,6 +209,21 @@ book-serve: book-assets
 book-build: book-assets
     mdbook build docs
 
+# Scaffold a new proposed design document from the template
+new-design slug:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    dir="docs/src/designs"
+    tmpl="docs/src/designs/template.md"
+    # Highest existing 4-digit prefix (base-10), else 0000; gaps are not backfilled.
+    max=$(ls "$dir"/[0-9][0-9][0-9][0-9]-*.md 2>/dev/null \
+        | sed -E 's#.*/([0-9]{4})-.*#\1#' | sort -n | tail -1)
+    max=${max:-0000}
+    next=$(printf '%04d' $((10#$max + 1)))
+    out="$dir/${next}-{{slug}}.md"
+    cp "$tmpl" "$out"
+    echo "Created $out"
+
 # List design docs by last git-commit date (oldest/stalest first).
 # Freshness comes from git history — design docs carry no in-doc dates.
 design-age:


### PR DESCRIPTION
### Why this should be merged

The site scaffolding and GitHub Pages CI already landed (the foundation and Pages
PRs in this stack); the mdBook is empty. This third and final PR fills it with
authored content and a design-doc subsystem, and aligns the repo's process docs with
it — so a new contributor can learn Firewood and its processes from the docs
themselves.

### How this works

- **Design-doc subsystem** (`docs/src/designs/`): a single flat directory where every
  design is `NNNN-slug.md` and lifecycle state lives in a `status` frontmatter field
  (`draft`/`proposed`/`active`/`superseded`/`rejected`). Promotion is a status flip,
  not a file move, so a design's path stays stable. Ships a `README` documenting the
  model and promotion checklist, an RFC-style `template.md`, a `just new-design`
  scaffolder, and a `just design-age` freshness report driven by git history (designs
  carry no in-doc dates). Four designs are included: `0001` (this documentation site),
  `0002` (v2 file format, proposed), `0003` (on-disk format & addressing), and `0004`
  (development container). The backlog of subsystems still to document is tracked in
  #2139.
- **Frontmatter stripping**: an in-repo jq preprocessor
  (`scripts/mdbook-frontmatter-strip.sh`) wired into `book.toml` strips each design's
  YAML frontmatter before rendering, avoiding a single-maintainer third-party crate.
- **Getting Started**: a fully authored `dev-environment.md` (macOS, dev container,
  remote SSH) whose prerequisites and verify commands match CI — including the pinned
  nightly clippy toolchain and the `jq` the frontmatter preprocessor needs.
- **Section landing pages**: Concepts (terminology + architecture diagram),
  Integration (the Go wrapper types and the `firewood-go-ethhash` publish relationship
  AvalancheGo actually consumes), Operations (`fwdctl` + benchmarks), Reference (a
  link-out hub for generated rustdoc/godoc/benchmarks), and Meta (how the docs work +
  release process). Every section ships an authored landing page; not-yet-written
  sub-pages are omitted from `SUMMARY.md` until written. Deploy-only `/firewood/...`
  link-outs are marked as resolving only on the deployed site.
- **Repo docs**: the README test command matches CI; the CONTRIBUTING table of
  contents is completed and its code blocks fenced; `RELEASE.md` is corrected (two
  tag-triggered jobs, `firewood-metrics` documented); `AGENTS.md` (surfaced as
  `CLAUDE.md`) has its design-doc workflow rewritten for the flat layout.
- **Tooling**: `justfile` gains `new-design` and `design-age`; the devcontainer's
  `cargo-binstall` installer is pinned to a release commit rather than the floating
  `main` branch.

### How this was tested

- `just book-build` builds cleanly (mermaid + linkcheck2); a broken internal link
  fails the build, and the linkcheck2 `exclude` skips the deploy-only link-outs.
- `markdownlint-cli2` reports no errors on the touched Markdown.
- Design-doc technical claims were verified against the sources: `0003` against
  `storage/src/nodestore/*` and `firewood/src/manager.rs`; the integration publish
  facts against `RELEASE.md` and `.github/workflows/attach-static-libs.yaml`; `0004`
  against the shipped `.devcontainer/` files.
- **Author sign-off**: the macOS and dev-container setup/build/verify sequences were
  run end-to-end on a clean environment; the remote-SSH section reuses the same
  commands.

### Breaking Changes

None. Documentation, `justfile` recipes, and a devcontainer install pin only.