### PR TITLE
refactor(storage): remove bitflags dependency from path.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,6 @@ dependencies = [
  "aquamarine",
  "arc-swap",
  "bitfield",
- "bitflags 2.13.0",
  "bumpalo",
  "bytemuck",
  "bytemuck_derive",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -34,7 +34,6 @@ smallvec.workspace = true
 thiserror.workspace = true
 # Regular dependencies
 bitfield = "0.19.4"
-bitflags = "2.13.0"
 fjall = "=2.11.2" # 3.0.0 has breaking changes
 derive-where = "1.6.1"
 enum-as-inner = "0.7.0"

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -99,9 +99,7 @@ impl Path {
             Some(0)
         };
 
-        once(flags)
-            .chain(extra_byte)
-            .chain(self.0.iter().copied())
+        once(flags).chain(extra_byte).chain(self.0.iter().copied())
     }
 
     /// Creates a Path from a [Iterator] or other iterator that returns

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -14,8 +14,6 @@
     reason = "Found 1 occurrences after enabling the lint."
 )]
 
-// TODO(rkuris): remove bitflags, we only use one bit
-use bitflags::bitflags;
 use smallvec::SmallVec;
 use std::fmt::{self, Debug, LowerHex};
 use std::iter::{FusedIterator, once};
@@ -84,29 +82,24 @@ impl<T: AsRef<[u8]>> From<T> for Path {
     }
 }
 
-bitflags! {
-    // should only ever be the size of a nibble
-    struct Flags: u8 {
-        const ODD_LEN  = 0b0001;
-    }
-}
+const FLAG_ODD_LEN: u8 = 0b0001;
 
 impl Path {
     /// Return an iterator over the encoded bytes
     pub fn iter_encoded(&self) -> impl Iterator<Item = u8> {
-        let mut flags = Flags::empty();
+        let mut flags = 0u8;
 
         let has_odd_len = self.0.len() & 1 == 1;
 
         let extra_byte = if has_odd_len {
-            flags.insert(Flags::ODD_LEN);
+            flags |= FLAG_ODD_LEN;
 
             None
         } else {
             Some(0)
         };
 
-        once(flags.bits())
+        once(flags)
             .chain(extra_byte)
             .chain(self.0.iter().copied())
     }
@@ -129,9 +122,9 @@ impl Path {
     /// then there is another discarded byte after that.
     #[cfg(test)]
     pub fn from_encoded_iter<Iter: Iterator<Item = u8>>(mut iter: Iter) -> Self {
-        let flags = Flags::from_bits_retain(iter.next().unwrap_or_default());
+        let flags = iter.next().unwrap_or_default();
 
-        if !flags.contains(Flags::ODD_LEN) {
+        if (flags & FLAG_ODD_LEN) == 0 {
             let _ = iter.next();
         }
 


### PR DESCRIPTION
## Why this should be merged
This PR resolves an outstanding codebase TODO left by @rkuris to remove the bitflags crate from the firewood-storage module. Previously, the entire bitflags dependency and its complex macro system were being pulled in to track a single boolean state (ODD_LEN). Removing it eliminates an unnecessary external dependency, reduces the dependency tree, and simplifies the codebase.

## How this works
Removed the bitflags crate from storage/Cargo.toml.
Replaced the bitflags! { struct Flags } macro in storage/src/node/path.rs with a zero-cost const FLAG_ODD_LEN: u8 = 0b0001;.
Updated the boolean checks in iter_encoded() and from_encoded_iter() to use standard, lightweight bitwise | and & operators.

## How this was tested
Ran the full storage test suite and linter to guarantee zero regressions:

cargo test -p firewood-storage --all-targets (309 tests passed)
cargo clippy -p firewood-storage --all-targets (0 warnings)

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
