### PR TITLE
refactor(storage): add FreeLists newtype

### DIFF
--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -916,7 +916,7 @@ mod test {
         next_free_block1 = Some(free_list1_area1);
         high_watermark += area_size1;
 
-        free_lists[AREA_INDEX1.as_usize()] = next_free_block1;
+        free_lists[AREA_INDEX1] = next_free_block1;
 
         // second free list
         let area_size2 = AREA_INDEX2.size();
@@ -933,7 +933,7 @@ mod test {
         high_watermark += area_size2;
         let expected_high_watermark = high_watermark;
 
-        free_lists[AREA_INDEX2.as_usize()] = next_free_block2;
+        free_lists[AREA_INDEX2] = next_free_block2;
 
         // third free list
         high_watermark += 1; // + 1 to create gap
@@ -944,12 +944,12 @@ mod test {
         next_free_block3 = Some(free_list3_area1);
         high_watermark += area_size3;
 
-        free_lists[AREA_INDEX3.as_usize()] = next_free_block3;
+        free_lists[AREA_INDEX3] = next_free_block3;
 
         // write header
         let header = test_write_header(nodestore, high_watermark, None, free_lists);
 
-        let expected_start_addr = header.free_lists()[AREA_INDEX1.as_usize()].unwrap();
+        let expected_start_addr = header.free_lists()[AREA_INDEX1].unwrap();
         let expected_end_addr = LinearAddress::new(expected_high_watermark).unwrap();
         let expected_free_areas = vec![expected_start_addr..expected_end_addr];
         let expected_freelist_errors = vec![
@@ -1114,7 +1114,7 @@ mod test {
                 }
                 high_watermark += area_size;
             }
-            freelist[area_index.as_usize()] = next_free_block;
+            freelist[area_index] = next_free_block;
             if num_free_areas > 0 {
                 free_area_counts.insert(area_size, num_free_areas);
             }

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -741,7 +741,6 @@ fn update_progress_bar(progress_bar: Option<&ProgressBar>, range_set: &LinearAdd
 #[cfg(test)]
 mod test {
     #![expect(clippy::unwrap_used)]
-    #![expect(clippy::indexing_slicing)]
 
     use nonzero_ext::nonzero;
 

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -54,13 +54,13 @@ impl FreeLists {
         Self([const { None }; AreaIndex::NUM_AREA_SIZES])
     }
 
-    /// Returns a reference to the free list head for `index`.
+    /// Returns the free list head for `index`.
     ///
     /// This is infallible because [`AreaIndex`] is guaranteed to be in-bounds.
     #[must_use]
-    pub const fn get(&self, index: AreaIndex) -> &Option<LinearAddress> {
+    pub const fn get(&self, index: AreaIndex) -> Option<LinearAddress> {
         #![expect(clippy::indexing_slicing)]
-        &self.0[index.as_usize()]
+        self.0[index.as_usize()]
     }
 
     /// Returns a mutable reference to the free list head for `index`.
@@ -83,7 +83,8 @@ impl Index<AreaIndex> for FreeLists {
     type Output = Option<LinearAddress>;
 
     fn index(&self, index: AreaIndex) -> &Self::Output {
-        self.get(index)
+        #[expect(clippy::indexing_slicing)]
+        &self.0[index.as_usize()]
     }
 }
 
@@ -702,7 +703,7 @@ pub mod test_utils {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, clippy::indexing_slicing)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::DeletedNodeTracking;

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -43,6 +43,9 @@ const fn var_int_max_size<VI>() -> usize {
 }
 
 /// Heads of the free lists for each area size.
+///
+/// The derives and transparent representation preserve the original header
+/// layout and satisfy [`NodeStoreHeader`]'s persisted-field trait bounds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Zeroable, Pod)]
 #[repr(transparent)]
 pub struct FreeLists([Option<LinearAddress>; AreaIndex::NUM_AREA_SIZES]);
@@ -70,6 +73,11 @@ impl FreeLists {
     pub const fn get_mut(&mut self, index: AreaIndex) -> &mut Option<LinearAddress> {
         #![expect(clippy::indexing_slicing)]
         &mut self.0[index.as_usize()]
+    }
+
+    /// Returns an iterator over free list heads.
+    pub fn iter(&self) -> std::slice::Iter<'_, Option<LinearAddress>> {
+        self.0.iter()
     }
 }
 
@@ -470,8 +478,9 @@ pub(crate) struct FreeAreaWithMetadata {
 
 pub(crate) struct FreeListsIterator<'a, S: ReadableStorage> {
     storage: &'a S,
-    free_lists: &'a FreeLists,
-    next_free_list_id: Option<AreaIndex>,
+    free_lists_iter: std::iter::Skip<
+        std::iter::Enumerate<std::slice::Iter<'a, std::option::Option<LinearAddress>>>,
+    >,
     current_free_list: Option<(AreaIndex, FreeListIterator<'a, S>)>,
 }
 
@@ -481,36 +490,26 @@ impl<'a, S: ReadableStorage> FreeListsIterator<'a, S> {
         free_lists: &'a FreeLists,
         start_area_index: AreaIndex,
     ) -> Self {
-        let current_free_list = Some(Self::free_list_iterator(
-            storage,
-            free_lists,
-            start_area_index,
-        ));
+        let mut free_lists_iter = free_lists
+            .iter()
+            .enumerate()
+            .skip(start_area_index.as_usize());
+        let current_free_list = free_lists_iter.next().map(|(id, head)| {
+            let free_list_id =
+                AreaIndex::try_from(id).expect("id is less than AreaIndex::NUM_AREA_SIZES");
+            let free_list_iter = FreeListIterator::new(
+                storage,
+                free_list_id,
+                *head,
+                FreeListParent::FreeListHead(free_list_id),
+            );
+            (free_list_id, free_list_iter)
+        });
         Self {
             storage,
-            free_lists,
-            next_free_list_id: Self::next_area_index(start_area_index),
+            free_lists_iter,
             current_free_list,
         }
-    }
-
-    fn free_list_iterator(
-        storage: &'a S,
-        free_lists: &FreeLists,
-        free_list_id: AreaIndex,
-    ) -> (AreaIndex, FreeListIterator<'a, S>) {
-        let free_list_iter = FreeListIterator::new(
-            storage,
-            free_list_id,
-            free_lists[free_list_id],
-            FreeListParent::FreeListHead(free_list_id),
-        );
-        (free_list_id, free_list_iter)
-    }
-
-    fn next_area_index(index: AreaIndex) -> Option<AreaIndex> {
-        let next_index = index.get().checked_add(1)?;
-        AreaIndex::new(next_index)
     }
 
     pub(crate) fn next_with_metadata(
@@ -537,16 +536,19 @@ impl<'a, S: ReadableStorage> FreeListsIterator<'a, S> {
     }
 
     pub(crate) fn move_to_next_free_list(&mut self) {
-        let Some(next_free_list_id) = self.next_free_list_id else {
+        let Some((next_free_list_id, next_free_list_head)) = self.free_lists_iter.next() else {
             self.current_free_list = None;
             return;
         };
-        self.next_free_list_id = Self::next_area_index(next_free_list_id);
-        self.current_free_list = Some(Self::free_list_iterator(
+        let next_free_list_id = AreaIndex::try_from(next_free_list_id)
+            .expect("next_free_list_id is less than AreaIndex::NUM_AREA_SIZES");
+        let next_free_list_iter = FreeListIterator::new(
             self.storage,
-            self.free_lists,
             next_free_list_id,
-        ));
+            *next_free_list_head,
+            FreeListParent::FreeListHead(next_free_list_id),
+        );
+        self.current_free_list = Some((next_free_list_id, next_free_list_iter));
     }
 }
 

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -43,9 +43,6 @@ const fn var_int_max_size<VI>() -> usize {
 }
 
 /// Heads of the free lists for each area size.
-///
-/// The derives and transparent representation preserve the original header
-/// layout and satisfy [`NodeStoreHeader`]'s persisted-field trait bounds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Zeroable, Pod)]
 #[repr(transparent)]
 pub struct FreeLists([Option<LinearAddress>; AreaIndex::NUM_AREA_SIZES]);
@@ -73,11 +70,6 @@ impl FreeLists {
     pub const fn get_mut(&mut self, index: AreaIndex) -> &mut Option<LinearAddress> {
         #![expect(clippy::indexing_slicing)]
         &mut self.0[index.as_usize()]
-    }
-
-    /// Returns an iterator over free list heads.
-    pub fn iter(&self) -> std::slice::Iter<'_, Option<LinearAddress>> {
-        self.0.iter()
     }
 }
 
@@ -478,9 +470,8 @@ pub(crate) struct FreeAreaWithMetadata {
 
 pub(crate) struct FreeListsIterator<'a, S: ReadableStorage> {
     storage: &'a S,
-    free_lists_iter: std::iter::Skip<
-        std::iter::Enumerate<std::slice::Iter<'a, std::option::Option<LinearAddress>>>,
-    >,
+    free_lists: &'a FreeLists,
+    next_free_list_id: Option<AreaIndex>,
     current_free_list: Option<(AreaIndex, FreeListIterator<'a, S>)>,
 }
 
@@ -490,26 +481,36 @@ impl<'a, S: ReadableStorage> FreeListsIterator<'a, S> {
         free_lists: &'a FreeLists,
         start_area_index: AreaIndex,
     ) -> Self {
-        let mut free_lists_iter = free_lists
-            .iter()
-            .enumerate()
-            .skip(start_area_index.as_usize());
-        let current_free_list = free_lists_iter.next().map(|(id, head)| {
-            let free_list_id =
-                AreaIndex::try_from(id).expect("id is less than AreaIndex::NUM_AREA_SIZES");
-            let free_list_iter = FreeListIterator::new(
-                storage,
-                free_list_id,
-                *head,
-                FreeListParent::FreeListHead(free_list_id),
-            );
-            (free_list_id, free_list_iter)
-        });
+        let current_free_list = Some(Self::free_list_iterator(
+            storage,
+            free_lists,
+            start_area_index,
+        ));
         Self {
             storage,
-            free_lists_iter,
+            free_lists,
+            next_free_list_id: Self::next_area_index(start_area_index),
             current_free_list,
         }
+    }
+
+    fn free_list_iterator(
+        storage: &'a S,
+        free_lists: &FreeLists,
+        free_list_id: AreaIndex,
+    ) -> (AreaIndex, FreeListIterator<'a, S>) {
+        let free_list_iter = FreeListIterator::new(
+            storage,
+            free_list_id,
+            free_lists[free_list_id],
+            FreeListParent::FreeListHead(free_list_id),
+        );
+        (free_list_id, free_list_iter)
+    }
+
+    fn next_area_index(index: AreaIndex) -> Option<AreaIndex> {
+        let next_index = index.get().checked_add(1)?;
+        AreaIndex::new(next_index)
     }
 
     pub(crate) fn next_with_metadata(
@@ -536,19 +537,16 @@ impl<'a, S: ReadableStorage> FreeListsIterator<'a, S> {
     }
 
     pub(crate) fn move_to_next_free_list(&mut self) {
-        let Some((next_free_list_id, next_free_list_head)) = self.free_lists_iter.next() else {
+        let Some(next_free_list_id) = self.next_free_list_id else {
             self.current_free_list = None;
             return;
         };
-        let next_free_list_id = AreaIndex::try_from(next_free_list_id)
-            .expect("next_free_list_id is less than AreaIndex::NUM_AREA_SIZES");
-        let next_free_list_iter = FreeListIterator::new(
+        self.next_free_list_id = Self::next_area_index(next_free_list_id);
+        self.current_free_list = Some(Self::free_list_iterator(
             self.storage,
+            self.free_lists,
             next_free_list_id,
-            *next_free_list_head,
-            FreeListParent::FreeListHead(next_free_list_id),
-        );
-        self.current_free_list = Some((next_free_list_id, next_free_list_iter));
+        ));
     }
 }
 

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -83,6 +83,8 @@ impl Index<AreaIndex> for FreeLists {
     type Output = Option<LinearAddress>;
 
     fn index(&self, index: AreaIndex) -> &Self::Output {
+        // `AreaIndex` is bounds-checked by construction, so this cannot index
+        // outside the fixed free-list array.
         #[expect(clippy::indexing_slicing)]
         &self.0[index.as_usize()]
     }

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -29,9 +29,11 @@ use crate::nodestore::NodeStoreHeader;
 use firewood_metrics::{firewood_counter, firewood_gauge};
 use integer_encoding::VarIntReader;
 
+use bytemuck_derive::{Pod, Zeroable};
 use std::io::{Error, ErrorKind, Read};
 use std::iter::FusedIterator;
 use std::mem::size_of;
+use std::ops::{Index, IndexMut};
 
 use crate::{FreeListParent, MaybePersistedNode, ReadableStorage, WritableStorage};
 
@@ -40,8 +42,56 @@ const fn var_int_max_size<VI>() -> usize {
     const { (size_of::<VI>() * 8 + 7) / 7 }
 }
 
-/// `FreeLists` is an array of `Option<LinearAddress>` for each area size.
-pub type FreeLists = [Option<LinearAddress>; AreaIndex::NUM_AREA_SIZES];
+/// Heads of the free lists for each area size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Zeroable, Pod)]
+#[repr(transparent)]
+pub struct FreeLists([Option<LinearAddress>; AreaIndex::NUM_AREA_SIZES]);
+
+impl FreeLists {
+    /// Creates a new [`FreeLists`] with all heads set to `None`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self([const { None }; AreaIndex::NUM_AREA_SIZES])
+    }
+
+    /// Returns a reference to the free list head for `index`.
+    ///
+    /// This is infallible because [`AreaIndex`] is guaranteed to be in-bounds.
+    #[must_use]
+    pub const fn get(&self, index: AreaIndex) -> &Option<LinearAddress> {
+        #![expect(clippy::indexing_slicing)]
+        &self.0[index.as_usize()]
+    }
+
+    /// Returns a mutable reference to the free list head for `index`.
+    ///
+    /// This is infallible because [`AreaIndex`] is guaranteed to be in-bounds.
+    #[must_use]
+    pub const fn get_mut(&mut self, index: AreaIndex) -> &mut Option<LinearAddress> {
+        #![expect(clippy::indexing_slicing)]
+        &mut self.0[index.as_usize()]
+    }
+}
+
+impl Default for FreeLists {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Index<AreaIndex> for FreeLists {
+    type Output = Option<LinearAddress>;
+
+    fn index(&self, index: AreaIndex) -> &Self::Output {
+        self.get(index)
+    }
+}
+
+impl IndexMut<AreaIndex> for FreeLists {
+    fn index_mut(&mut self, index: AreaIndex) -> &mut Self::Output {
+        self.get_mut(index)
+    }
+}
 
 /// A [`FreeArea`] is stored at the start of the area that contained a node that
 /// has been freed.
@@ -231,11 +281,7 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
         &mut self,
         index: AreaIndex,
     ) -> Result<Option<LinearAddress>, FileIoError> {
-        let free_stored_area_addr = self
-            .header
-            .free_lists_mut()
-            .get_mut(index.as_usize())
-            .expect("index is less than AreaIndex::NUM_AREA_SIZES");
+        let free_stored_area_addr = self.header.free_lists_mut().get_mut(index);
         if let Some(address) = free_stored_area_addr {
             let address = *address;
             if let Some(free_head) = self.storage.free_list_cache(address) {
@@ -312,7 +358,6 @@ impl<S: WritableStorage> NodeAllocator<'_, S> {
     /// # Errors
     ///
     /// Returns a [`FileIoError`] if the area cannot be read or written.
-    #[expect(clippy::indexing_slicing)]
     pub(crate) fn delete_node(&mut self, node: MaybePersistedNode) -> Result<(), FileIoError> {
         let Some(addr) = node.as_linear_address() else {
             return Ok(());
@@ -328,16 +373,16 @@ impl<S: WritableStorage> NodeAllocator<'_, S> {
 
         // The area that contained the node is now free.
         let mut stored_area_bytes = Vec::new();
-        FreeArea::new(self.header.free_lists()[area_size_index.as_usize()])
+        FreeArea::new(self.header.free_lists()[area_size_index])
             .as_bytes(area_size_index, &mut stored_area_bytes);
 
         self.storage.write(addr.into(), &stored_area_bytes)?;
 
         self.storage
-            .add_to_free_list_cache(addr, self.header.free_lists()[area_size_index.as_usize()]);
+            .add_to_free_list_cache(addr, self.header.free_lists()[area_size_index]);
 
         // The newly freed block is now the head of the free list.
-        self.header.free_lists_mut()[area_size_index.as_usize()] = Some(addr);
+        self.header.free_lists_mut()[area_size_index] = Some(addr);
 
         Ok(())
     }
@@ -424,9 +469,8 @@ pub(crate) struct FreeAreaWithMetadata {
 
 pub(crate) struct FreeListsIterator<'a, S: ReadableStorage> {
     storage: &'a S,
-    free_lists_iter: std::iter::Skip<
-        std::iter::Enumerate<std::slice::Iter<'a, std::option::Option<LinearAddress>>>,
-    >,
+    free_lists: &'a FreeLists,
+    next_free_list_id: Option<AreaIndex>,
     current_free_list: Option<(AreaIndex, FreeListIterator<'a, S>)>,
 }
 
@@ -436,26 +480,36 @@ impl<'a, S: ReadableStorage> FreeListsIterator<'a, S> {
         free_lists: &'a FreeLists,
         start_area_index: AreaIndex,
     ) -> Self {
-        let mut free_lists_iter = free_lists
-            .iter()
-            .enumerate()
-            .skip(start_area_index.as_usize());
-        let current_free_list = free_lists_iter.next().map(|(id, head)| {
-            let free_list_id =
-                AreaIndex::try_from(id).expect("id is less than AreaIndex::NUM_AREA_SIZES");
-            let free_list_iter = FreeListIterator::new(
-                storage,
-                free_list_id,
-                *head,
-                FreeListParent::FreeListHead(free_list_id),
-            );
-            (free_list_id, free_list_iter)
-        });
+        let current_free_list = Some(Self::free_list_iterator(
+            storage,
+            free_lists,
+            start_area_index,
+        ));
         Self {
             storage,
-            free_lists_iter,
+            free_lists,
+            next_free_list_id: Self::next_area_index(start_area_index),
             current_free_list,
         }
+    }
+
+    fn free_list_iterator(
+        storage: &'a S,
+        free_lists: &FreeLists,
+        free_list_id: AreaIndex,
+    ) -> (AreaIndex, FreeListIterator<'a, S>) {
+        let free_list_iter = FreeListIterator::new(
+            storage,
+            free_list_id,
+            free_lists[free_list_id],
+            FreeListParent::FreeListHead(free_list_id),
+        );
+        (free_list_id, free_list_iter)
+    }
+
+    fn next_area_index(index: AreaIndex) -> Option<AreaIndex> {
+        let next_index = index.get().checked_add(1)?;
+        AreaIndex::new(next_index)
     }
 
     pub(crate) fn next_with_metadata(
@@ -482,19 +536,16 @@ impl<'a, S: ReadableStorage> FreeListsIterator<'a, S> {
     }
 
     pub(crate) fn move_to_next_free_list(&mut self) {
-        let Some((next_free_list_id, next_free_list_head)) = self.free_lists_iter.next() else {
+        let Some(next_free_list_id) = self.next_free_list_id else {
             self.current_free_list = None;
             return;
         };
-        let next_free_list_id = AreaIndex::try_from(next_free_list_id)
-            .expect("next_free_list_id is less than AreaIndex::NUM_AREA_SIZES");
-        let next_free_list_iter = FreeListIterator::new(
+        self.next_free_list_id = Self::next_area_index(next_free_list_id);
+        self.current_free_list = Some(Self::free_list_iterator(
             self.storage,
+            self.free_lists,
             next_free_list_id,
-            *next_free_list_head,
-            FreeListParent::FreeListHead(next_free_list_id),
-        );
-        self.current_free_list = Some((next_free_list_id, next_free_list_iter));
+        ));
     }
 }
 
@@ -534,9 +585,7 @@ impl<T, S: WritableStorage> NodeStore<T, S> {
     ) -> Result<(), FileIoError> {
         match free_list_parent {
             FreeListParent::FreeListHead(area_size_index) => {
-                *free_lists
-                    .get_mut(area_size_index.as_usize())
-                    .expect("area_size_index is less than AreaIndex::NUM_AREA_SIZES") = None;
+                free_lists[area_size_index] = None;
                 Ok(())
             }
             FreeListParent::PrevFreeArea {
@@ -761,7 +810,7 @@ mod tests {
         next_free_block1 = Some(free_list1_area1);
         offset += area_size1;
 
-        free_lists[area_index1.as_usize()] = next_free_block1;
+        free_lists[area_index1] = next_free_block1;
 
         // second free list
         let area_index2 = AreaIndex::new(
@@ -783,7 +832,7 @@ mod tests {
         next_free_block2 = Some(free_list2_area1);
         offset += area_size2;
 
-        free_lists[area_index2.as_usize()] = next_free_block2;
+        free_lists[area_index2] = next_free_block2;
 
         // write header
         test_write_header(&nodestore, offset, None, free_lists);
@@ -886,7 +935,7 @@ mod tests {
         next_free_block1 = Some(free_list1_area1);
         offset += area_size1;
 
-        free_lists[AREA_INDEX1.as_usize()] = next_free_block1;
+        free_lists[AREA_INDEX1] = next_free_block1;
 
         // second free list
         assert_ne!(AREA_INDEX1, AREA_INDEX2);
@@ -903,7 +952,7 @@ mod tests {
         next_free_block2 = Some(free_list2_area1);
         offset += area_size2;
 
-        free_lists[AREA_INDEX2.as_usize()] = next_free_block2;
+        free_lists[AREA_INDEX2] = next_free_block2;
 
         // write header
         test_write_header(&nodestore, offset, None, free_lists);

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -54,15 +54,6 @@ impl FreeLists {
         Self([const { None }; AreaIndex::NUM_AREA_SIZES])
     }
 
-    /// Returns the free list head for `index`.
-    ///
-    /// This is infallible because [`AreaIndex`] is guaranteed to be in-bounds.
-    #[must_use]
-    pub const fn get(&self, index: AreaIndex) -> Option<LinearAddress> {
-        #![expect(clippy::indexing_slicing)]
-        self.0[index.as_usize()]
-    }
-
     /// Returns a mutable reference to the free list head for `index`.
     ///
     /// This is infallible because [`AreaIndex`] is guaranteed to be in-bounds.

--- a/storage/src/nodestore/header.rs
+++ b/storage/src/nodestore/header.rs
@@ -358,7 +358,7 @@ impl NodeStoreHeader {
             endian_test: 1,
             root_address: None,
             version: Version::new(),
-            free_lists: Default::default(),
+            free_lists: FreeLists::default(),
             area_size_hash: AREA_SIZES_HASH,
             node_hash_algorithm: node_hash_algorithm as u64,
             root_hash: TrieHash::empty().into(),
@@ -584,7 +584,7 @@ mod tests {
 
         // Check the header is correctly initialized.
         assert_eq!(header.version, Version::new());
-        let empty_free_list: FreeLists = Default::default();
+        let empty_free_list = FreeLists::default();
         assert_eq!(*header.free_lists(), empty_free_list);
     }
 }


### PR DESCRIPTION
## Why this should be merged

Closes #1194 by replacing the raw free-list array alias with a dedicated `FreeLists` newtype that can be indexed by `AreaIndex`.

## How this works

- Adds a `#[repr(transparent)]` `FreeLists` wrapper around the persisted free-list head array.
- Derives the bytemuck and standard traits needed by `NodeStoreHeader` so the on-disk header layout remains unchanged.
- Implements `Index<AreaIndex>` and `IndexMut<AreaIndex>` and updates storage/checker call sites to use them directly.
- Updates `FreeListsIterator` to advance through `AreaIndex` values and index through the newtype instead of iterating the wrapped array directly.

## How this was tested

CI

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
