### PR TITLE
refactor(storage): make Path use PathComponent for nibble safety

### DIFF
--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -143,7 +143,8 @@ impl<T: TrieReader> Iterator for MerkleNodeIter<'_, T> {
                                     }
                                 };
 
-                                let child_partial_path = child.partial_path().iter().copied();
+                                let child_partial_path =
+                                    child.partial_path().iter().map(|c| c.as_u8());
 
                                 // The child's key is its parent's key, followed by the child's index,
                                 // followed by the child's partial path (if any).
@@ -201,10 +202,10 @@ fn get_iterator_intial_state<T: TrieReader>(
         let partial_path = node.partial_path();
 
         let (comparison, new_unmatched_key_nibbles) =
-            compare_partial_path(partial_path.iter(), unmatched_key_nibbles);
+            compare_partial_path(partial_path.iter().copied(), unmatched_key_nibbles);
         unmatched_key_nibbles = new_unmatched_key_nibbles;
 
-        matched_key_nibbles.extend(partial_path.iter());
+        matched_key_nibbles.extend(partial_path.iter().map(|c| c.as_u8()));
 
         match comparison {
             Ordering::Less => {
@@ -435,9 +436,9 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
                 };
 
                 let (comparison, unmatched_key) =
-                    compare_partial_path(partial_path.iter(), unmatched_key);
+                    compare_partial_path(partial_path.iter().copied(), unmatched_key);
 
-                matched_key.extend(partial_path.iter());
+                matched_key.extend(partial_path.iter().map(|c| c.as_u8()));
                 let node_key =
                     PathBuf::path_from_unpacked_bytes(matched_key).expect("valid components");
 
@@ -550,7 +551,7 @@ fn compare_partial_path<'a, I1, I2>(
     mut unmatched_key_nibbles_iter: I2,
 ) -> (Ordering, I2)
 where
-    I1: Iterator<Item = &'a u8>,
+    I1: Iterator<Item = PathComponent>,
     I2: Iterator<Item = u8>,
 {
     for next_partial_path_nibble in partial_path_iter {
@@ -558,7 +559,7 @@ where
             return (Ordering::Greater, unmatched_key_nibbles_iter);
         };
 
-        match next_partial_path_nibble.cmp(&next_key_nibble) {
+        match next_partial_path_nibble.as_u8().cmp(&next_key_nibble) {
             Ordering::Less => return (Ordering::Less, unmatched_key_nibbles_iter),
             Ordering::Greater => return (Ordering::Greater, unmatched_key_nibbles_iter),
             Ordering::Equal => {}

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -546,7 +546,7 @@ impl<T: TrieReader> Iterator for PathIterator<'_, '_, T> {
 ///
 /// The second returned element is the unmatched portion of the key after the
 /// partial path has been matched.
-fn compare_partial_path<'a, I1, I2>(
+fn compare_partial_path<I1, I2>(
     partial_path_iter: I1,
     mut unmatched_key_nibbles_iter: I2,
 ) -> (Ordering, I2)

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -220,7 +220,7 @@ impl<'a, Left: HashedNodeReader, Right: HashedNodeReader> DiffMerkleNodeStream<'
     /// node from the left trie has a value.
     fn deleted_values(left_value: Option<&[u8]>, left_path: &Path) -> Option<BatchOp<Key, Value>> {
         left_value.map(|_val| BatchOp::Delete {
-            key: key_from_nibble_iter(left_path.iter().copied()),
+            key: key_from_nibble_iter(left_path.iter().map(|c| c.as_u8())),
         })
     }
 
@@ -228,7 +228,7 @@ impl<'a, Left: HashedNodeReader, Right: HashedNodeReader> DiffMerkleNodeStream<'
     /// node from the right trie has a value.
     fn added_values(right_value: Option<&[u8]>, right_path: &Path) -> Option<BatchOp<Key, Value>> {
         right_value.map(|val| BatchOp::Put {
-            key: key_from_nibble_iter(right_path.iter().copied()),
+            key: key_from_nibble_iter(right_path.iter().map(|c| c.as_u8())),
             value: val.into(),
         })
     }
@@ -435,13 +435,8 @@ impl<'a, T: HashedNodeReader> PreOrderIterator<'a, T> {
             // children in reverse order.
             for (path_comp, child) in branch.children.iter_present().rev() {
                 // Generate the pre-path for this child, and push it onto the traversal stack.
-                let child_pre_path = Path::from_nibbles_iterator(
-                    prev_node_info
-                        .path
-                        .iter()
-                        .copied()
-                        .chain(once(path_comp.as_u8())),
-                );
+                let mut child_pre_path = prev_node_info.path.clone();
+                child_pre_path.extend(once(path_comp));
                 self.traversal_stack.push(ComparableNodeInfo::new(
                     child_pre_path,
                     child,
@@ -492,16 +487,9 @@ impl<'a, T: HashedNodeReader> PreOrderIterator<'a, T> {
                         .iter_present()
                         .rev()
                         .map(|(path_comp, child)| {
-                            (
-                                child,
-                                Path::from_nibbles_iterator(
-                                    prev_node_info
-                                        .path
-                                        .iter()
-                                        .copied()
-                                        .chain(once(path_comp.as_u8())),
-                                ),
-                            )
+                            let mut child_pre_path = prev_node_info.path.clone();
+                            child_pre_path.extend(once(path_comp));
+                            (child, child_pre_path)
                         });
 
                 for (child, child_pre_path) in reversed_children_with_pre_path.by_ref() {
@@ -827,7 +815,7 @@ mod tests {
             let node_info = node_info.unwrap();
             assert!(node_info.hash.is_some());
             if let Some(val) = node_info.node.value() {
-                let key = key_from_nibble_iter(node_info.path.iter().copied());
+                let key = key_from_nibble_iter(node_info.path.iter().map(|c| c.as_u8()));
                 let batch_sorted_item = batch_sorted_it.next().unwrap();
                 assert!(
                     *key == **batch_sorted_item.key()
@@ -845,7 +833,7 @@ mod tests {
         while let Some(node_info) = preorder_it.next() {
             let node_info = node_info.unwrap();
             if let Some(val) = node_info.node.value() {
-                let key = key_from_nibble_iter(node_info.path.iter().copied());
+                let key = key_from_nibble_iter(node_info.path.iter().map(|c| c.as_u8()));
                 let batch_sorted_item = batch_sorted.get(index).unwrap();
                 assert!(
                     *key == **batch_sorted_item.key()

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -2,10 +2,9 @@
 // See the file LICENSE.md for licensing terms.
 
 use std::cmp::Ordering;
+use std::iter::once;
 
-use firewood_storage::{
-    Child, Mutable, Node, NodeStore, Path, PathComponent, Propose, ReadableStorage,
-};
+use firewood_storage::{Child, Mutable, Node, NodeStore, PathComponent, Propose, ReadableStorage};
 
 use crate::{ProofError, api, merkle::Merkle};
 
@@ -75,7 +74,7 @@ fn nibble_in_range(
 /// Builds the accumulated nibble prefix for a child node by extending
 /// `prefix` with the descent nibble and the child's `partial_path`.
 fn build_child_prefix(prefix: &[u8], nibble: u8, node: &Node) -> Box<[u8]> {
-    let pp = &node.partial_path().0;
+    let pp = node.partial_path().as_nibbles();
     // slice lengths are bounded by isize::MAX. Sum cannot overflow.
     #[allow(clippy::arithmetic_side_effects)]
     let capacity = prefix.len() + 1 + pp.len();
@@ -97,7 +96,7 @@ fn consume_partial_path<'a>(
     let (consumed, rest) = remaining
         .split_at_checked(pp.len())
         .ok_or(api::Error::ProofError(ProofError::ProofNodeUnreachable))?;
-    if !consumed.iter().zip(pp.iter()).all(|(a, b)| a.as_u8() == *b) {
+    if !consumed.iter().zip(pp.iter()).all(|(a, b)| a == b) {
         return Err(api::Error::ProofError(ProofError::ProofNodeUnreachable));
     }
     Ok(rest)
@@ -141,12 +140,12 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             && !remaining.is_empty()
             && prefix
                 .iter()
-                .zip(root_node.partial_path().0.iter())
-                .all(|(t, p)| t.as_u8() == *p)
+                .zip(root_node.partial_path().iter())
+                .all(|(t, p)| t == p)
         {
             // On error the root is left empty, but the caller discards
             // the proving trie on any verification failure.
-            let root_prefix: Box<[u8]> = root_node.partial_path().0.iter().copied().collect();
+            let root_prefix: Box<[u8]> = root_node.partial_path().as_nibbles().into();
             root_node = self.collapse_strip(root_node, remaining, &root_prefix, range)?;
         }
 
@@ -205,14 +204,14 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
         range: Option<(&[u8], &[u8])>,
     ) -> Result<Node, api::Error> {
         // get a reference to the partial path for ease of reading
-        let pp = &node.partial_path().0;
+        let pp = node.partial_path();
 
         // find the point where the key differs from the partial path
         // unwrap_or handles the case where they are subsets of each other
         let diverge = key
             .iter()
             .zip(pp.iter())
-            .position(|(pc, nibble)| pc.as_u8() != *nibble)
+            .position(|(pc, nibble)| pc != nibble)
             .unwrap_or(key.len().min(pp.len()));
 
         if diverge != pp.len() {
@@ -392,14 +391,9 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             return Ok(node);
         };
         let mut merged = self.read_for_update(only_child)?;
-        let merged_path = Path::from_nibbles_iterator(
-            branch
-                .partial_path
-                .iter()
-                .chain(std::iter::once(&child_idx.as_u8()))
-                .chain(merged.partial_path().iter())
-                .copied(),
-        );
+        let mut merged_path = branch.partial_path.clone();
+        merged_path.extend(once(child_idx));
+        merged_path.extend(merged.partial_path().iter().copied());
         merged.update_partial_path(merged_path);
         Ok(merged)
     }

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -53,7 +53,7 @@ use childmask::ChildMask;
 
 macro_rules! write_attributes {
     ($writer:ident, $node:expr, $value:expr) => {
-        if !$node.partial_path.0.is_empty() {
+        if !$node.partial_path.is_empty() {
             write!($writer, " pp={:x}", $node.partial_path)
                 .map_err(|e| FileIoError::from_generic_no_file(e, "write attributes"))?;
         }
@@ -68,7 +68,7 @@ macro_rules! write_attributes {
 fn get_helper<T: TrieReader>(
     nodestore: &T,
     node: &Node,
-    key: &[u8],
+    key: &[PathComponent],
 ) -> Result<Option<SharedNode>, FileIoError> {
     // 4 possibilities for the position of the `key` relative to `node`:
     // 1. The node is at `key`
@@ -89,7 +89,6 @@ fn get_helper<T: TrieReader>(
         }
         (None, None) => Ok(Some(node.clone().into())), // 1. The node is at `key`
         (Some((child_index, remaining_key)), None) => {
-            let child_index = PathComponent::try_new(child_index).expect("index is in bounds");
             // 3. The key is below the node (i.e. its descendant)
             match node {
                 Node::Leaf(_) => Ok(None),
@@ -1725,7 +1724,7 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
     fn insert_helper(
         &mut self,
         mut node: Node,
-        key: &[u8],
+        key: &[PathComponent],
         value: Value,
     ) -> Result<Node, FileIoError> {
         // 4 possibilities for the position of the `key` relative to `node`:
@@ -1733,7 +1732,7 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
         // 2. The key is above the node (i.e. its ancestor)
         // 3. The key is below the node (i.e. its descendant)
         // 4. Neither is an ancestor of the other
-        let path_overlap = PrefixOverlap::from(key, node.partial_path().as_ref());
+        let path_overlap = PrefixOverlap::from(key, node.partial_path());
 
         let unique_key = path_overlap.unique_a;
         let unique_node = path_overlap.unique_b;
@@ -1753,7 +1752,6 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
                 Ok(node)
             }
             (None, Some((child_index, partial_path))) => {
-                let child_index = PathComponent::try_new(child_index).expect("valid component");
                 // 2. The key is above the node (i.e. its ancestor)
                 // Make a new branch node and insert the current node as a child.
                 //    ...                ...
@@ -1775,7 +1773,6 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
                 Ok(Node::Branch(Box::new(branch)))
             }
             (Some((child_index, partial_path)), None) => {
-                let child_index = PathComponent::try_new(child_index).expect("valid component");
                 // 3. The key is below the node (i.e. its descendant)
                 //    ...                         ...
                 //     |                           |
@@ -1821,8 +1818,6 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
                 }
             }
             (Some((key_index, key_partial_path)), Some((node_index, node_partial_path))) => {
-                let key_index = PathComponent::try_new(key_index).expect("valid component");
-                let node_index = PathComponent::try_new(node_index).expect("valid component");
                 // 4. Neither is an ancestor of the other
                 //    ...                         ...
                 //     |                           |
@@ -1853,8 +1848,12 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
 
     /// Ensures a branch exists at `key` in the subtrie rooted at `node`.
     /// Each element of `key` is 1 nibble.
-    fn insert_branch_helper(&mut self, mut node: Node, key: &[u8]) -> Result<Node, FileIoError> {
-        let path_overlap = PrefixOverlap::from(key, node.partial_path().as_ref());
+    fn insert_branch_helper(
+        &mut self,
+        mut node: Node,
+        key: &[PathComponent],
+    ) -> Result<Node, FileIoError> {
+        let path_overlap = PrefixOverlap::from(key, node.partial_path());
 
         let unique_key = path_overlap.unique_a;
         let unique_node = path_overlap.unique_b;
@@ -1879,8 +1878,6 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
                 }
             },
             (None, Some((child_index, partial_path))) => {
-                let child_index = PathComponent::try_new(child_index).expect("valid component");
-
                 let mut branch = BranchNode {
                     partial_path: path_overlap.shared.into(),
                     value: None,
@@ -1892,48 +1889,41 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
 
                 Ok(Node::Branch(Box::new(branch)))
             }
-            (Some((child_index, partial_path)), None) => {
-                let child_index = PathComponent::try_new(child_index).expect("valid component");
-
-                match node {
-                    Node::Branch(ref mut branch) => {
-                        let Some(child) = branch.children.take(child_index) else {
-                            let new_branch = Node::Branch(Box::new(BranchNode {
-                                partial_path,
-                                value: None,
-                                children: Children::new(),
-                            }));
-                            branch.children[child_index] = Some(Child::Node(new_branch));
-                            return Ok(node);
-                        };
-
-                        let child = self.read_for_update(child)?;
-                        let child = self.insert_branch_helper(child, partial_path.as_ref())?;
-                        branch.children[child_index] = Some(Child::Node(child));
-                        Ok(node)
-                    }
-                    Node::Leaf(leaf) => {
-                        let mut branch = BranchNode {
-                            partial_path: leaf.partial_path,
-                            value: Some(leaf.value),
-                            children: Children::new(),
-                        };
-
+            (Some((child_index, partial_path)), None) => match node {
+                Node::Branch(ref mut branch) => {
+                    let Some(child) = branch.children.take(child_index) else {
                         let new_branch = Node::Branch(Box::new(BranchNode {
                             partial_path,
                             value: None,
                             children: Children::new(),
                         }));
                         branch.children[child_index] = Some(Child::Node(new_branch));
+                        return Ok(node);
+                    };
 
-                        Ok(Node::Branch(Box::new(branch)))
-                    }
+                    let child = self.read_for_update(child)?;
+                    let child = self.insert_branch_helper(child, partial_path.as_ref())?;
+                    branch.children[child_index] = Some(Child::Node(child));
+                    Ok(node)
                 }
-            }
-            (Some((key_index, key_partial_path)), Some((node_index, node_partial_path))) => {
-                let key_index = PathComponent::try_new(key_index).expect("valid component");
-                let node_index = PathComponent::try_new(node_index).expect("valid component");
+                Node::Leaf(leaf) => {
+                    let mut branch = BranchNode {
+                        partial_path: leaf.partial_path,
+                        value: Some(leaf.value),
+                        children: Children::new(),
+                    };
 
+                    let new_branch = Node::Branch(Box::new(BranchNode {
+                        partial_path,
+                        value: None,
+                        children: Children::new(),
+                    }));
+                    branch.children[child_index] = Some(Child::Node(new_branch));
+
+                    Ok(Node::Branch(Box::new(branch)))
+                }
+            },
+            (Some((key_index, key_partial_path)), Some((node_index, node_partial_path))) => {
                 let mut branch = BranchNode {
                     partial_path: path_overlap.shared.into(),
                     value: None,
@@ -1980,7 +1970,7 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
         let shared_len = key
             .iter()
             .zip(pp.iter())
-            .take_while(|(a, b)| a.as_u8() == **b)
+            .take_while(|(a, b)| a == b)
             .count();
         if shared_len != pp.len() {
             return None;
@@ -2037,14 +2027,14 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
     fn remove_helper(
         &mut self,
         node: Node,
-        key: &[u8],
+        key: &[PathComponent],
     ) -> Result<(Option<Node>, Option<Value>), FileIoError> {
         // 4 possibilities for the position of the `key` relative to `node`:
         // 1. The node is at `key`
         // 2. The key is above the node (i.e. its ancestor)
         // 3. The key is below the node (i.e. its descendant)
         // 4. Neither is an ancestor of the other
-        let path_overlap = PrefixOverlap::from(key, node.partial_path().as_ref());
+        let path_overlap = PrefixOverlap::from(key, node.partial_path());
 
         let unique_key = path_overlap.unique_a;
         let unique_node = path_overlap.unique_b;
@@ -2074,7 +2064,6 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
                 }
             }
             (Some((child_index, child_partial_path)), None) => {
-                let child_index = PathComponent::try_new(child_index).expect("valid component");
                 // 3. The key is below the node (i.e. its descendant)
                 match node {
                     // we found a non-matching leaf node, so the value does not exist
@@ -2129,7 +2118,7 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
     fn remove_prefix_helper(
         &mut self,
         node: Node,
-        key: &[u8],
+        key: &[PathComponent],
         deleted: &mut usize,
     ) -> Result<Option<Node>, FileIoError> {
         // 4 possibilities for the position of the `key` relative to `node`:
@@ -2137,7 +2126,7 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
         // 2. The key is above the node (i.e. its ancestor), so the parent needs to be restructured (TODO(rkuris)).
         // 3. The key is below the node (i.e. its descendant), so continue traversing the trie.
         // 4. Neither is an ancestor of the other, in which case there's no work to do.
-        let path_overlap = PrefixOverlap::from(key, node.partial_path().as_ref());
+        let path_overlap = PrefixOverlap::from(key, node.partial_path());
 
         let unique_key = path_overlap.unique_a;
         let unique_node = path_overlap.unique_b;
@@ -2171,7 +2160,6 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
                 Ok(Some(node))
             }
             (Some((child_index, child_partial_path)), None) => {
-                let child_index = PathComponent::try_new(child_index).expect("valid component");
                 // 3. The key is below the node (i.e. its descendant)
                 match node {
                     Node::Leaf(_) => Ok(Some(node)),
@@ -2270,14 +2258,9 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
 
         // The child's partial path is the concatenation of its (now removed) parent,
         // its (former) child index, and its partial path.
-        let child_partial_path = Path::from_nibbles_iterator(
-            branch_node
-                .partial_path
-                .iter()
-                .chain(once(&child_index.as_u8()))
-                .chain(child.partial_path().iter())
-                .copied(),
-        );
+        let mut child_partial_path = branch_node.partial_path.clone();
+        child_partial_path.extend(once(child_index));
+        child_partial_path.extend(child.partial_path().iter().copied());
         child.update_partial_path(child_partial_path);
 
         Ok(Some(child))
@@ -2296,7 +2279,8 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             return Ok(None);
         };
 
-        get_helper(&self.nodestore, &root, key_nibbles)
+        let key = Path::from(key_nibbles);
+        get_helper(&self.nodestore, &root, &key)
     }
 
     /// Ensures a branch exists at `key_nibbles` where each key element is a
@@ -2308,10 +2292,11 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
         &mut self,
         key_nibbles: &[u8],
     ) -> Result<(), FileIoError> {
+        let key_path = Path::from(key_nibbles);
         let root = self.nodestore.root_mut();
         let Some(root_node) = std::mem::take(root) else {
             let branch = BranchNode {
-                partial_path: key_nibbles.into(),
+                partial_path: key_path,
                 value: None,
                 children: Children::new(),
             };
@@ -2319,7 +2304,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             return Ok(());
         };
 
-        let root_node = self.insert_branch_helper(root_node, key_nibbles)?;
+        let root_node = self.insert_branch_helper(root_node, &key_path)?;
         *self.nodestore.root_mut() = root_node.into();
         Ok(())
     }

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -714,8 +714,7 @@ fn right_edge<'a>(
     // odd-length but carries a value before reaching here — see
     // [`reject_odd_nibble_value_digests`] — so we don't re-check parity.)
     if terminal.value_digest.is_some() {
-        let nibs: Vec<u8> = terminal.key.iter().map(|c| c.as_u8()).collect();
-        let terminal_full_key: Vec<u8> = Path::from(nibs.as_slice()).bytes_iter().collect();
+        let terminal_full_key: Vec<u8> = Path::from(terminal.key.as_slice()).bytes_iter().collect();
         match terminal_full_key.as_slice().cmp(last_kv_k) {
             std::cmp::Ordering::Greater => {
                 return RightBoundary::OutOfRange(Cow::Owned(terminal_full_key));
@@ -945,12 +944,7 @@ fn verify_proof_node_values(
             continue;
         };
         let proof_value = proof_value_bytes.as_ref();
-        let key_nibbles: Vec<u8> = proof_node
-            .key
-            .iter()
-            .map(|component| component.as_u8())
-            .collect();
-        let node_key_bytes: Vec<u8> = Path::from(key_nibbles.as_slice()).bytes_iter().collect();
+        let node_key_bytes: Vec<u8> = Path::from(proof_node.key.as_slice()).bytes_iter().collect();
         let within_right = match right_boundary {
             RightBoundary::InRange(None) => true,
             RightBoundary::InRange(Some(end)) => node_key_bytes.as_slice() <= *end,
@@ -1990,7 +1984,6 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
     /// Removes the value associated with the given `key`.
     /// Returns the value that was removed, if any.
     /// Otherwise returns `None`.
-    /// Each element of `key` is 2 nibbles.
     pub(crate) fn remove(&mut self, key: &[u8]) -> Result<Option<Value>, FileIoError> {
         self.remove_from_iter(NibblesIterator::new(key))
     }
@@ -1998,7 +1991,7 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
     /// Removes the value associated with the given `key` where `key` is a `NibblesIterator`
     /// Returns the value that was removed, if any.
     /// Otherwise returns `None`.
-    /// Each element of `key` is 2 nibbles.
+    /// Each yielded item is a single nibble.
     pub(crate) fn remove_from_iter(
         &mut self,
         key: NibblesIterator<'_>,
@@ -2268,31 +2261,29 @@ impl<K: MutableKind, S: ReadableStorage> Merkle<NodeStore<Mutable<K>, S>> {
 }
 
 impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
-    /// Returns the node mapped to by `key_nibbles` where each key element is a
-    /// single nibble.
+    /// Returns the node mapped to by `key` where each element is a single nibble.
     #[cfg(test)]
     pub(crate) fn get_node_from_nibbles(
         &self,
-        key_nibbles: &[u8],
+        key: &[PathComponent],
     ) -> Result<Option<SharedNode>, FileIoError> {
         let Some(root) = self.root() else {
             return Ok(None);
         };
 
-        let key = Path::from(key_nibbles);
+        let key = Path::from(key);
         get_helper(&self.nodestore, &root, &key)
     }
 
-    /// Ensures a branch exists at `key_nibbles` where each key element is a
-    /// single nibble.
+    /// Ensures a branch exists at `key` where each element is a single nibble.
     ///
     /// This creates missing branch structure without inserting a value at the
     /// target key. Existing values and descendants are preserved.
     pub(crate) fn insert_branch_from_nibbles(
         &mut self,
-        key_nibbles: &[u8],
+        key: &[PathComponent],
     ) -> Result<(), FileIoError> {
-        let key_path = Path::from(key_nibbles);
+        let key_path = Path::from(key);
         let root = self.nodestore.root_mut();
         let Some(root_node) = std::mem::take(root) else {
             let branch = BranchNode {

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -93,11 +93,7 @@ impl ParallelMerkle {
                 }
                 .into())
             },
-            |node| {
-                // Returns an error if it cannot convert a child index into a path component.
-                node.force_branch_for_insert()
-                    .map_err(|_| CreateProposalError::InvalidConversionToPathComponent)
-            },
+            |node| Ok(node.force_branch_for_insert()),
         )
     }
 

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -153,9 +153,12 @@ impl ParallelMerkle {
                 // should always be empty because of our prepare step, its (former) child index, and
                 // its partial path. Because the parent's partial path should always be empty, we
                 // can omit it and start with the `child_index`.
-                let partial_path = Path::from_nibbles_iterator(
-                    once(child_index.as_u8()).chain(child.partial_path().iter().copied()),
-                );
+                let partial_path = {
+                    let mut path = Path::new();
+                    path.extend(once(child_index));
+                    path.extend(child.partial_path().iter().copied());
+                    path
+                };
                 child.update_partial_path(partial_path);
                 Ok(Some(child))
             }
@@ -208,7 +211,7 @@ impl ParallelMerkle {
             .take()
             .map(|root| {
                 let (root_node, root_hash) =
-                    nodestore.hash_helper(root, Path::from(&[first_path_component.as_u8()]))?;
+                    nodestore.hash_helper(root, Path::from([first_path_component.as_u8()]))?;
                 Ok(Child::MaybePersisted(root_node, root_hash))
             })
             .transpose()

--- a/firewood/src/merkle/parallel.rs
+++ b/firewood/src/merkle/parallel.rs
@@ -206,8 +206,10 @@ impl ParallelMerkle {
             .root_mut()
             .take()
             .map(|root| {
-                let (root_node, root_hash) =
-                    nodestore.hash_helper(root, Path::from([first_path_component.as_u8()]))?;
+                let (root_node, root_hash) = nodestore.hash_helper(
+                    root,
+                    Path::from(core::slice::from_ref(&first_path_component)),
+                )?;
                 Ok(Child::MaybePersisted(root_node, root_hash))
             })
             .transpose()

--- a/firewood/src/merkle/reconcile.rs
+++ b/firewood/src/merkle/reconcile.rs
@@ -38,11 +38,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
         proof_node: &ProofNode,
         on_conflict: impl FnOnce(&ProofNode, Option<&[u8]>) -> Result<Option<Value>, ProofError>,
     ) -> Result<(), ProofError> {
-        let key_nibbles: Box<[u8]> = proof_node
-            .key
-            .iter()
-            .map(|component| component.as_u8())
-            .collect();
+        let key_nibbles = &proof_node.key;
 
         if !key_nibbles.len().is_multiple_of(2)
             && matches!(proof_node.value_digest, Some(ValueDigest::Value(_)))
@@ -50,7 +46,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             return Err(ProofError::ValueAtOddNibbleLength);
         }
 
-        self.insert_branch_from_nibbles(&key_nibbles)?;
+        self.insert_branch_from_nibbles(key_nibbles)?;
 
         // insert_branch_from_nibbles guarantees a branch exists at this path
         // and that all nodes along it are in-memory, so this cannot fail.

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -208,6 +208,13 @@ fn create_in_memory_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
     Merkle { nodestore }
 }
 
+fn nibbles(n: &[u8]) -> Vec<PathComponent> {
+    n.iter()
+        .copied()
+        .map(|nibble| PathComponent::try_new(nibble).expect("test nibble"))
+        .collect()
+}
+
 fn test_branch_proof_node(
     key_nibbles: &[u8],
     value_digest: Option<ValueDigest<Value>>,
@@ -232,7 +239,9 @@ fn test_get_node_from_nibbles_matches_byte_lookup() {
     merkle.insert(&[0xab, 0xcd], Box::from([1u8])).unwrap();
 
     let from_bytes = merkle.get_node(&[0xab, 0xcd]).unwrap();
-    let from_nibbles = merkle.get_node_from_nibbles(&[0xa, 0xb, 0xc, 0xd]).unwrap();
+    let from_nibbles = merkle
+        .get_node_from_nibbles(nibbles(&[0xa, 0xb, 0xc, 0xd]).as_slice())
+        .unwrap();
 
     assert_eq!(from_bytes, from_nibbles);
 }
@@ -241,10 +250,12 @@ fn test_get_node_from_nibbles_matches_byte_lookup() {
 fn test_insert_branch_from_nibbles_into_empty_trie() {
     let mut merkle = create_in_memory_merkle();
 
-    merkle.insert_branch_from_nibbles(&[0xa, 0xb, 0xc]).unwrap();
+    merkle
+        .insert_branch_from_nibbles(nibbles(&[0xa, 0xb, 0xc]).as_slice())
+        .unwrap();
 
     let node = merkle
-        .get_node_from_nibbles(&[0xa, 0xb, 0xc])
+        .get_node_from_nibbles(nibbles(&[0xa, 0xb, 0xc]).as_slice())
         .unwrap()
         .unwrap();
     let branch = node.as_branch().expect("expected branch node");
@@ -256,9 +267,14 @@ fn test_insert_branch_from_nibbles_converts_leaf_to_branch() {
     let mut merkle = create_in_memory_merkle();
     merkle.insert(&[0xab], Box::from([9u8])).unwrap();
 
-    merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
+    merkle
+        .insert_branch_from_nibbles(nibbles(&[0xa, 0xb]).as_slice())
+        .unwrap();
 
-    let node = merkle.get_node_from_nibbles(&[0xa, 0xb]).unwrap().unwrap();
+    let node = merkle
+        .get_node_from_nibbles(nibbles(&[0xa, 0xb]).as_slice())
+        .unwrap()
+        .unwrap();
     let branch = node.as_branch().expect("expected branch node");
     assert_eq!(branch.value.as_deref(), Some([9u8].as_slice()));
     assert_eq!(
@@ -272,9 +288,14 @@ fn test_insert_branch_from_nibbles_inserts_missing_ancestor() {
     let mut merkle = create_in_memory_merkle();
     merkle.insert(&[0xab, 0xcd], Box::from([7u8])).unwrap();
 
-    merkle.insert_branch_from_nibbles(&[0xa]).unwrap();
+    merkle
+        .insert_branch_from_nibbles(nibbles(&[0xa]).as_slice())
+        .unwrap();
 
-    let ancestor = merkle.get_node_from_nibbles(&[0xa]).unwrap().unwrap();
+    let ancestor = merkle
+        .get_node_from_nibbles(nibbles(&[0xa]).as_slice())
+        .unwrap()
+        .unwrap();
     let ancestor_branch = ancestor.as_branch().expect("expected ancestor branch");
     assert!(ancestor_branch.value.is_none());
     assert_eq!(
@@ -288,10 +309,12 @@ fn test_insert_branch_from_nibbles_inserts_missing_descendant() {
     let mut merkle = create_in_memory_merkle();
     merkle.insert(&[0xab], Box::from([5u8])).unwrap();
 
-    merkle.insert_branch_from_nibbles(&[0xa, 0xb, 0xc]).unwrap();
+    merkle
+        .insert_branch_from_nibbles(nibbles(&[0xa, 0xb, 0xc]).as_slice())
+        .unwrap();
 
     let descendant = merkle
-        .get_node_from_nibbles(&[0xa, 0xb, 0xc])
+        .get_node_from_nibbles(nibbles(&[0xa, 0xb, 0xc]).as_slice())
         .unwrap()
         .unwrap();
     let descendant_branch = descendant.as_branch().expect("expected descendant branch");
@@ -310,9 +333,14 @@ fn test_insert_branch_from_nibbles_splits_divergent_paths() {
 
     // Branch at [0xa, 0xc] shares prefix [a] then diverges: key goes 'c', node goes 'b'
     // This exercises the (Some, Some) arm of insert_branch_helper
-    merkle.insert_branch_from_nibbles(&[0xa, 0xc]).unwrap();
+    merkle
+        .insert_branch_from_nibbles(nibbles(&[0xa, 0xc]).as_slice())
+        .unwrap();
 
-    let branch = merkle.get_node_from_nibbles(&[0xa, 0xc]).unwrap().unwrap();
+    let branch = merkle
+        .get_node_from_nibbles(nibbles(&[0xa, 0xc]).as_slice())
+        .unwrap()
+        .unwrap();
     let branch_node = branch.as_branch().expect("expected branch node");
     assert!(branch_node.value.is_none());
     assert_eq!(

--- a/firewood/src/merkle/tests/reconcile.rs
+++ b/firewood/src/merkle/tests/reconcile.rs
@@ -16,7 +16,7 @@ fn test_reconcile_branch_proof_node_creates_missing_branch_without_value() {
         .unwrap();
 
     let node = merkle
-        .get_node_from_nibbles(&[0xa, 0xb, 0xc])
+        .get_node_from_nibbles(nibbles(&[0xa, 0xb, 0xc]).as_slice())
         .unwrap()
         .unwrap();
     let branch = node.as_branch().expect("expected branch node");
@@ -26,7 +26,9 @@ fn test_reconcile_branch_proof_node_creates_missing_branch_without_value() {
 #[test]
 fn test_reconcile_branch_proof_node_sets_missing_value_via_callback() {
     let mut merkle = create_in_memory_merkle();
-    merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
+    merkle
+        .insert_branch_from_nibbles(nibbles(&[0xa, 0xb]).as_slice())
+        .unwrap();
 
     let proof_node =
         test_branch_proof_node(&[0xa, 0xb], Some(ValueDigest::Value(Box::from([7u8]))));
@@ -39,7 +41,10 @@ fn test_reconcile_branch_proof_node_sets_missing_value_via_callback() {
         })
         .unwrap();
 
-    let node = merkle.get_node_from_nibbles(&[0xa, 0xb]).unwrap().unwrap();
+    let node = merkle
+        .get_node_from_nibbles(nibbles(&[0xa, 0xb]).as_slice())
+        .unwrap()
+        .unwrap();
     let branch = node.as_branch().expect("expected branch node");
     assert_eq!(branch.value.as_deref(), Some([7u8].as_slice()));
 }
@@ -48,7 +53,9 @@ fn test_reconcile_branch_proof_node_sets_missing_value_via_callback() {
 fn test_reconcile_branch_proof_node_clears_value_via_callback() {
     let mut merkle = create_in_memory_merkle();
     merkle.insert(&[0xab], Box::from([3u8])).unwrap();
-    merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
+    merkle
+        .insert_branch_from_nibbles(nibbles(&[0xa, 0xb]).as_slice())
+        .unwrap();
 
     let proof_node = test_branch_proof_node(&[0xa, 0xb], None);
 
@@ -57,7 +64,10 @@ fn test_reconcile_branch_proof_node_clears_value_via_callback() {
         .reconcile_branch_proof_node(&proof_node, |_, _| Ok(None))
         .unwrap();
 
-    let node = merkle.get_node_from_nibbles(&[0xa, 0xb]).unwrap().unwrap();
+    let node = merkle
+        .get_node_from_nibbles(nibbles(&[0xa, 0xb]).as_slice())
+        .unwrap()
+        .unwrap();
     let branch = node.as_branch().expect("expected branch node");
     assert!(branch.value.is_none());
 }
@@ -66,7 +76,9 @@ fn test_reconcile_branch_proof_node_clears_value_via_callback() {
 fn test_reconcile_branch_proof_node_rejects_conflict_via_callback() {
     let mut merkle = create_in_memory_merkle();
     merkle.insert(&[0xab], Box::from([1u8])).unwrap();
-    merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
+    merkle
+        .insert_branch_from_nibbles(nibbles(&[0xa, 0xb]).as_slice())
+        .unwrap();
 
     let proof_node =
         test_branch_proof_node(&[0xa, 0xb], Some(ValueDigest::Value(Box::from([2u8]))));
@@ -78,7 +90,10 @@ fn test_reconcile_branch_proof_node_rejects_conflict_via_callback() {
     assert!(matches!(err, ProofError::UnexpectedValue));
 
     // Value is unchanged.
-    let node = merkle.get_node_from_nibbles(&[0xa, 0xb]).unwrap().unwrap();
+    let node = merkle
+        .get_node_from_nibbles(nibbles(&[0xa, 0xb]).as_slice())
+        .unwrap()
+        .unwrap();
     let branch = node.as_branch().expect("expected branch node");
     assert_eq!(branch.value.as_deref(), Some([1u8].as_slice()));
 }
@@ -101,7 +116,7 @@ fn test_reconcile_branch_proof_node_account_storage_root_relaxation(
 
     // 32-byte account key == 64 nibbles == ACCOUNT_DEPTH_NIBBLES.
     let account_key = [0x11u8; 32];
-    let account_nibbles = [0x1u8; 64];
+    let account_nibbles = nibbles(&[0x1u8; 64]);
 
     // The branch holds the full on-disk value. The proof value always carries a
     // different storageRoot; in the conflicting case it also differs in balance.
@@ -110,10 +125,11 @@ fn test_reconcile_branch_proof_node_account_storage_root_relaxation(
 
     let mut merkle = create_in_memory_merkle();
     merkle.insert(&account_key, branch_value.clone()).unwrap();
-    merkle.insert_branch_from_nibbles(&account_nibbles).unwrap();
+    merkle
+        .insert_branch_from_nibbles(account_nibbles.as_slice())
+        .unwrap();
 
-    let proof_node =
-        test_branch_proof_node(&account_nibbles, Some(ValueDigest::Value(proof_value)));
+    let proof_node = test_branch_proof_node(&[0x1u8; 64], Some(ValueDigest::Value(proof_value)));
 
     // on_conflict always rejects, so the outcome reveals whether the relaxation
     // fired: a storageRoot-only diff returns early with Ok and never consults
@@ -131,7 +147,7 @@ fn test_reconcile_branch_proof_node_account_storage_root_relaxation(
     // relaxation returns before assignment, and on_conflict's Err propagates
     // before it.
     let node = merkle
-        .get_node_from_nibbles(&account_nibbles)
+        .get_node_from_nibbles(account_nibbles.as_slice())
         .unwrap()
         .unwrap();
     let branch = node.as_branch().expect("expected branch node");

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -516,7 +516,7 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
         key: K,
         root_hash: &TrieHash,
     ) -> Result<Option<ValueDigest<&[u8]>>, ProofError> {
-        let key = Path(NibblesIterator::new(key.as_ref()).collect());
+        let key = Path::from_nibbles_iterator(NibblesIterator::new(key.as_ref()));
 
         let Some(last_node) = self.0.as_ref().last() else {
             return Err(ProofError::Empty);

--- a/storage/benches/serializer.rs
+++ b/storage/benches/serializer.rs
@@ -17,7 +17,6 @@ use criterion::profiler::Profiler;
 use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use firewood_storage::{Children, LeafNode, Node, Path, PathComponent};
 use pprof::ProfilerGuard;
-use smallvec::SmallVec;
 
 use std::path::Path as FsPath;
 
@@ -82,7 +81,7 @@ fn to_bytes(input: &Node) -> Vec<u8> {
 fn leaf(c: &mut Criterion) {
     let mut group = c.benchmark_group("leaf");
     let input = Node::Leaf(LeafNode {
-        partial_path: Path(SmallVec::from_slice(&[0, 1])),
+        partial_path: Path::from([0, 1]),
         value: Box::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
     });
 
@@ -94,7 +93,7 @@ fn leaf(c: &mut Criterion) {
 fn branch(c: &mut Criterion) {
     let mut group = c.benchmark_group("has_value");
     let mut input = Node::Branch(Box::new(firewood_storage::BranchNode {
-        partial_path: Path(SmallVec::from_slice(&[0, 1])),
+        partial_path: Path::from([0, 1]),
         value: Some(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_boxed_slice()),
         children: Children::from_fn(|i| {
             if i.as_u8() == 0 {

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -41,12 +41,12 @@ fn extra_read_pages(addr: LinearAddress, bytes: u64) -> Option<u64> {
 #[cfg(feature = "ethhash")]
 fn is_valid_key(key: &Path) -> bool {
     const VALID_ETH_KEY_SIZES: [usize; 2] = [64, 128]; // in number of nibbles - two nibbles make a byte
-    VALID_ETH_KEY_SIZES.contains(&key.0.len())
+    VALID_ETH_KEY_SIZES.contains(&key.len())
 }
 
 #[cfg(not(feature = "ethhash"))]
 fn is_valid_key(key: &Path) -> bool {
-    key.0.len().is_multiple_of(2)
+    key.len().is_multiple_of(2)
 }
 
 #[expect(clippy::result_large_err)]
@@ -324,7 +324,9 @@ where
 
         // if the node has a value, check that the key is valid
         let mut current_path_prefix = path_prefix.clone();
-        current_path_prefix.0.extend_from_slice(node.partial_path());
+        current_path_prefix
+            .0
+            .extend(node.partial_path().iter().copied());
         if node.value().is_some() && !is_valid_key(&current_path_prefix) {
             return Err(vec![CheckerError::InvalidKey {
                 key: current_path_prefix,
@@ -366,7 +368,7 @@ where
                 // collect kv count
                 trie_stats.kv_count = trie_stats.kv_count.saturating_add(1);
                 // collect kv pair bytes - this is the minimum number of bytes needed to store the data
-                let key_bytes = current_path_prefix.0.len().div_ceil(2);
+                let key_bytes = current_path_prefix.len().div_ceil(2);
                 let value_bytes = value.len();
                 trie_stats.kv_bytes = trie_stats
                     .kv_bytes
@@ -428,7 +430,7 @@ where
                 {
                     let parent = TrieNodeParent::Parent(subtrie_root_address, nibble);
                     let mut child_path_prefix = current_path_prefix.clone();
-                    child_path_prefix.0.push(nibble.as_u8());
+                    child_path_prefix.0.push(nibble);
                     let child_subtrie = SubTrieMetadata {
                         root_address: address,
                         root_hash: hash.clone(),
@@ -1027,7 +1029,7 @@ mod test {
         let (branch_node, branch_addr) = test_trie
             .nodes
             .iter_mut()
-            .find(|(node, _)| matches!(node, Node::Branch(b) if *b.partial_path.0 == [3]))
+            .find(|(node, _)| matches!(node, Node::Branch(b) if b.partial_path.as_components() == [PathComponent::ALL[3]]))
             .unwrap();
 
         let branch = branch_node.as_branch_mut().unwrap();
@@ -1057,7 +1059,7 @@ mod test {
         let (root_node, _) = test_trie
             .nodes
             .iter()
-            .find(|(node, _)| matches!(node, Node::Branch(b) if *b.partial_path.0 == [2]))
+            .find(|(node, _)| matches!(node, Node::Branch(b) if b.partial_path.as_components() == [PathComponent::ALL[2]]))
             .unwrap();
         let root_branch = root_node.as_branch().unwrap();
         let (_, parent_stored_hash) = root_branch.children[PathComponent::ALL[0]]

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -16,7 +16,9 @@
 
 use crate::node::branch::ReadSerializable;
 use crate::nodestore::AreaIndex;
-use crate::{HashType, LinearAddress, Path, PathBuf, PathComponent, SharedNode};
+use crate::{
+    HashType, LinearAddress, Path, PathBuf, PathComponent, SharedNode, TriePathFromUnpackedBytes,
+};
 use bitfield::bitfield;
 use branch::Serializable as _;
 pub use branch::{BranchNode, Child};
@@ -436,11 +438,8 @@ impl Node {
     ///     branch.
     /// 2.  If the existing node does not have a partial path, then there is nothing we need
     ///     to do if it is a branch. If it is a leaf, then convert it into a branch.
-    ///
-    /// # Errors
-    ///
-    /// Returns an `Error` if it cannot create a `PathComponent` from a u8 index.
-    pub fn force_branch_for_insert(mut self) -> Result<Box<BranchNode>, Error> {
+    #[must_use]
+    pub fn force_branch_for_insert(mut self) -> Box<BranchNode> {
         // If the `partial_path` is non-empty, then create a branch that will be the new
         // root with the previous root as the child at the index returned from split_first.
         if let Some((child_index, child_path)) = self
@@ -454,11 +453,10 @@ impl Node {
                 children: Children::default(),
             };
             self.update_partial_path(child_path);
-            let child_path_component = child_index;
-            *branch.children.get_mut(child_path_component) = Some(Child::Node(self));
-            Ok(branch.into())
+            *branch.children.get_mut(child_index) = Some(Child::Node(self));
+            branch.into()
         } else {
-            Ok(match self {
+            match self {
                 Node::Leaf(leaf) => {
                     // Root is a leaf with an empty partial path. Replace it with a branch.
                     BranchNode {
@@ -469,7 +467,7 @@ impl Node {
                     .into()
                 }
                 Node::Branch(branch) => branch,
-            })
+            }
         }
     }
 }
@@ -517,7 +515,9 @@ fn read_path_with_prefix_length(reader: &mut impl Read) -> std::io::Result<Path>
 
 #[inline]
 fn read_path_with_provided_length(reader: &mut impl Read, len: usize) -> std::io::Result<Path> {
-    reader.read_fixed_len(len).map(Path::from)
+    let bytes = reader.read_fixed_len(len)?;
+    Path::path_from_unpacked_bytes(&bytes)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
 }
 
 struct DisplayTruncatedHex<'a>(&'a [u8]);

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -516,8 +516,12 @@ fn read_path_with_prefix_length(reader: &mut impl Read) -> std::io::Result<Path>
 #[inline]
 fn read_path_with_provided_length(reader: &mut impl Read, len: usize) -> std::io::Result<Path> {
     let bytes = reader.read_fixed_len(len)?;
-    Path::path_from_unpacked_bytes(&bytes)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    Path::path_from_unpacked_bytes(&bytes).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid path nibbles 0x{}: {e}", hex::encode(bytes)),
+        )
+    })
 }
 
 struct DisplayTruncatedHex<'a>(&'a [u8]);
@@ -657,5 +661,25 @@ than 126 bytes as the length would be encoded in multiple bytes.
             area_index,
             "Area index should be calculated from node size only"
         );
+    }
+
+    #[test]
+    fn from_reader_rejects_invalid_path_nibble() {
+        use std::io::Cursor;
+
+        let node = Node::Leaf(LeafNode {
+            partial_path: Path::from([0, 1, 2, 3]),
+            value: vec![4, 5, 6, 7].into(),
+        });
+        let mut serialized = Vec::new();
+        node.as_bytes(&mut serialized).unwrap();
+        // Area index at 0; leaf first byte at 1; path nibbles at 2..6.
+        *serialized.get_mut(2).expect("path nibble byte") = 0x10;
+
+        let mut cursor = Cursor::new(&serialized);
+        cursor.set_position(1);
+        let err = Node::from_reader(&mut cursor).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("invalid path nibbles"));
     }
 }

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -269,7 +269,7 @@ impl Node {
                 if pp_len == BRANCH_PARTIAL_PATH_LEN_OVERFLOW {
                     encoded.extend_var_int(b.partial_path.len());
                 }
-                encoded.extend_from_slice(&b.partial_path);
+                encoded.extend_from_slice(b.partial_path.as_nibbles());
 
                 // encode the value. For tries that have the same length keys, this is always empty
                 if let Some(v) = &b.value {
@@ -313,7 +313,7 @@ impl Node {
                 if pp_len == LEAF_PARTIAL_PATH_LEN_OVERFLOW {
                     encoded.extend_var_int(l.partial_path.len());
                 }
-                encoded.extend_from_slice(&l.partial_path);
+                encoded.extend_from_slice(l.partial_path.as_nibbles());
 
                 // encode the value
                 encoded.extend_var_int(l.value.len());
@@ -454,8 +454,7 @@ impl Node {
                 children: Children::default(),
             };
             self.update_partial_path(child_path);
-            let child_path_component = PathComponent::try_new(child_index)
-                .ok_or_else(|| Error::other("invalid child index"))?;
+            let child_path_component = child_index;
             *branch.children.get_mut(child_path_component) = Some(Child::Node(self));
             Ok(branch.into())
         } else {

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -87,6 +87,7 @@ impl<const N: usize> From<[u8; N]> for Path {
     }
 }
 
+#[cfg(test)]
 impl From<SmallVec<[u8; 64]>> for Path {
     fn from(value: SmallVec<[u8; 64]>) -> Self {
         Self::from(value.as_slice())
@@ -101,6 +102,12 @@ impl From<&[PathComponent]> for Path {
 
 const FLAG_ODD_LEN: u8 = 0b0001;
 
+/// # Panics
+///
+/// The [`From`] implementations for byte slices (`&[u8]`, `[u8; N]`, [`Vec<u8>`])
+/// panic if any byte is outside `0x00..=0x0F`. Prefer
+/// [`TriePathFromUnpackedBytes::path_from_unpacked_bytes`] at untrusted
+/// boundaries.
 impl Path {
     /// Return an iterator over the encoded bytes
     pub fn iter_encoded(&self) -> impl Iterator<Item = u8> {
@@ -121,8 +128,13 @@ impl Path {
             .chain(self.as_nibbles().iter().copied())
     }
 
-    /// Creates a Path from a [Iterator] or other iterator that returns
-    /// nibbles
+    /// Creates a Path from an iterator that yields nibbles.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the iterator yields any value outside `0x00..=0x0F`. Callers
+    /// with validated [`PathComponent`] iterators should build a [`Path`] via
+    /// [`From<&[PathComponent]>`] or [`Self::extend`] instead.
     pub fn from_nibbles_iterator<T: Iterator<Item = u8>>(nibbles_iter: T) -> Self {
         Self(
             nibbles_iter
@@ -140,10 +152,12 @@ impl Path {
         Path(SmallVec::new())
     }
 
-    /// Read from an iterator that returns nibbles with a prefix
-    /// The prefix is one optional byte -- if not present, the Path is empty
-    /// If there is one byte, and the byte contains a [`Flags::ODD_LEN`] (0x1)
-    /// then there is another discarded byte after that.
+    /// Read from an iterator that returns encoded path bytes with a prefix.
+    ///
+    /// The prefix is one optional byte — if not present, the path is empty.
+    /// If [`FLAG_ODD_LEN`] is set in the prefix byte, the path has an odd
+    /// number of nibbles and no padding byte follows. Otherwise a padding
+    /// byte is read and discarded before the nibble bytes.
     #[cfg(test)]
     pub fn from_encoded_iter<Iter: Iterator<Item = u8>>(mut iter: Iter) -> Self {
         let flags = iter.next().unwrap_or_default();
@@ -410,5 +424,31 @@ mod test {
     fn test_fmt_lower_hex(path: Path, expected: &str, expected_with_prefix: &str) {
         assert_eq!(format!("{path:x}"), expected);
         assert_eq!(format!("{path:#x}"), expected_with_prefix);
+    }
+
+    #[test]
+    fn path_trait_round_trip() {
+        use crate::{PartialPath, TriePath};
+
+        let path = Path::from([0x1, 0x2, 0xa, 0xf]);
+        let components: Vec<_> = path.components().collect();
+        assert_eq!(components, path.as_components());
+        assert_eq!(path.as_nibbles(), &[0x1, 0x2, 0xa, 0xf]);
+        match path.as_component_slice() {
+            PartialPath::Borrowed(slice) => assert_eq!(slice, components.as_slice()),
+            PartialPath::Owned(_) => panic!("expected borrowed partial path"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "path must contain only nibbles")]
+    fn from_bytes_panics_on_invalid_nibble() {
+        let _ = Path::from([0x10u8].as_slice());
+    }
+
+    #[test]
+    #[should_panic(expected = "nibbles iterator must yield values in 0..=0x0F")]
+    fn from_nibbles_iterator_panics_on_invalid_nibble() {
+        let _ = Path::from_nibbles_iterator([0x10u8].into_iter());
     }
 }

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -6,10 +6,6 @@
     reason = "Found 8 occurrences after enabling the lint."
 )]
 #![expect(
-    clippy::from_iter_instead_of_collect,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::inline_always,
     reason = "Found 1 occurrences after enabling the lint."
 )]
@@ -128,10 +124,13 @@ impl Path {
     /// Creates a Path from a [Iterator] or other iterator that returns
     /// nibbles
     pub fn from_nibbles_iterator<T: Iterator<Item = u8>>(nibbles_iter: T) -> Self {
-        let nibbles: SmallVec<[u8; 64]> = SmallVec::from_iter(nibbles_iter);
         Self(
-            SmallVec::path_from_unpacked_bytes(&nibbles)
-                .expect("nibbles iterator must yield values in 0..=0x0F"),
+            nibbles_iter
+                .map(|b| {
+                    PathComponent::try_new(b)
+                        .expect("nibbles iterator must yield values in 0..=0x0F")
+                })
+                .collect(),
         )
     }
 

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -19,14 +19,14 @@ use std::fmt::{self, Debug, LowerHex};
 use std::iter::{FusedIterator, once};
 use std::ops::Add;
 
-use crate::{PathComponent, TriePathFromUnpackedBytes};
-
-static NIBBLES: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+use crate::{
+    ComponentIter, PathComponent, PathComponentSliceExt, TriePath, TriePathFromUnpackedBytes,
+};
 
 /// Path is part or all of a node's path in the trie.
-/// Each element is a nibble.
+/// Each element is a nibble stored as a [`PathComponent`].
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Default)]
-pub struct Path(pub SmallVec<[u8; 64]>);
+pub struct Path(pub SmallVec<[PathComponent; 64]>);
 
 impl lru_mem::HeapSize for Path {
     fn heap_size(&self) -> usize {
@@ -41,12 +41,8 @@ impl lru_mem::HeapSize for Path {
 
 impl Debug for Path {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        for nib in &self.0 {
-            if *nib > 0xf {
-                write!(f, "[invalid {:02x}] ", *nib)?;
-            } else {
-                write!(f, "{:x} ", *nib)?;
-            }
+        for component in &self.0 {
+            write!(f, "{component:x} ")?;
         }
         Ok(())
     }
@@ -61,8 +57,8 @@ impl LowerHex for Path {
             if f.alternate() {
                 write!(f, "0x")?;
             }
-            for nib in &self.0 {
-                write!(f, "{:x}", *nib)?;
+            for component in &self.0 {
+                write!(f, "{component:x}")?;
             }
             Ok(())
         }
@@ -70,15 +66,40 @@ impl LowerHex for Path {
 }
 
 impl std::ops::Deref for Path {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
+    type Target = [PathComponent];
+
+    fn deref(&self) -> &[PathComponent] {
         &self.0
     }
 }
 
-impl<T: AsRef<[u8]>> From<T> for Path {
-    fn from(value: T) -> Self {
-        Self(SmallVec::from_slice(value.as_ref()))
+impl From<&[u8]> for Path {
+    fn from(value: &[u8]) -> Self {
+        Self(SmallVec::path_from_unpacked_bytes(value).expect("path must contain only nibbles"))
+    }
+}
+
+impl From<Vec<u8>> for Path {
+    fn from(value: Vec<u8>) -> Self {
+        Self::from(value.as_slice())
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for Path {
+    fn from(value: [u8; N]) -> Self {
+        Self::from(value.as_slice())
+    }
+}
+
+impl From<SmallVec<[u8; 64]>> for Path {
+    fn from(value: SmallVec<[u8; 64]>) -> Self {
+        Self::from(value.as_slice())
+    }
+}
+
+impl From<&[PathComponent]> for Path {
+    fn from(value: &[PathComponent]) -> Self {
+        Self(value.into())
     }
 }
 
@@ -99,13 +120,19 @@ impl Path {
             Some(0)
         };
 
-        once(flags).chain(extra_byte).chain(self.0.iter().copied())
+        once(flags)
+            .chain(extra_byte)
+            .chain(self.as_nibbles().iter().copied())
     }
 
     /// Creates a Path from a [Iterator] or other iterator that returns
     /// nibbles
     pub fn from_nibbles_iterator<T: Iterator<Item = u8>>(nibbles_iter: T) -> Self {
-        Path(SmallVec::from_iter(nibbles_iter))
+        let nibbles: SmallVec<[u8; 64]> = SmallVec::from_iter(nibbles_iter);
+        Self(
+            SmallVec::path_from_unpacked_bytes(&nibbles)
+                .expect("nibbles iterator must yield values in 0..=0x0F"),
+        )
     }
 
     /// Creates an empty Path
@@ -126,11 +153,11 @@ impl Path {
             let _ = iter.next();
         }
 
-        Self(iter.collect())
+        Self::from(iter.collect::<SmallVec<[u8; 64]>>())
     }
 
-    /// Add nibbles to the end of a path
-    pub fn extend<T: IntoIterator<Item = u8>>(&mut self, iter: T) {
+    /// Add path components to the end of a path
+    pub fn extend<T: IntoIterator<Item = PathComponent>>(&mut self, iter: T) {
         self.0.extend(iter);
     }
 
@@ -139,15 +166,47 @@ impl Path {
     #[must_use]
     pub fn bytes_iter(&self) -> BytesIterator<'_> {
         BytesIterator {
-            nibbles_iter: self.iter(),
+            nibbles_iter: self.as_nibbles().iter(),
         }
     }
 
-    /// Casts the path to a slice of its components.
+    /// Returns this path as a slice of its components.
     #[must_use]
     pub fn as_components(&self) -> &[PathComponent] {
-        TriePathFromUnpackedBytes::path_from_unpacked_bytes(&self.0)
-            .expect("path should contain only nibbles")
+        &self.0
+    }
+
+    /// Returns this path as a slice of raw nibble bytes.
+    #[must_use]
+    pub fn as_nibbles(&self) -> &[u8] {
+        self.as_components().as_byte_slice()
+    }
+}
+
+impl TriePath for Path {
+    type Components<'a>
+        = ComponentIter<'a>
+    where
+        Self: 'a;
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn components(&self) -> Self::Components<'_> {
+        self.0.iter().copied()
+    }
+
+    fn as_component_slice(&self) -> crate::PartialPath<'_> {
+        crate::PartialPath::Borrowed(&self.0)
+    }
+}
+
+impl TriePathFromUnpackedBytes<'_> for Path {
+    type Error = crate::u4::TryFromIntError;
+
+    fn path_from_unpacked_bytes(bytes: &[u8]) -> Result<Self, Self::Error> {
+        SmallVec::path_from_unpacked_bytes(bytes).map(Self)
     }
 }
 
@@ -186,6 +245,8 @@ impl Iterator for BytesIterator<'_> {
         )
     }
 }
+
+static NIBBLES: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
 
 /// Iterates over the nibbles in `data`.
 /// That is, each byte in `data` is converted to two nibbles.
@@ -340,16 +401,13 @@ mod test {
     #[test_case([1, 2, 3, 4], [2, 3, 4])]
     fn encode_decode<T: AsRef<[u8]> + PartialEq + Debug, U: AsRef<[u8]>>(encode: T, expected: U) {
         let from_encoded = Path::from_encoded_iter(encode.as_ref().iter().copied());
-        assert_eq!(
-            from_encoded.0,
-            SmallVec::<[u8; 32]>::from_slice(expected.as_ref())
-        );
+        assert_eq!(from_encoded.as_nibbles(), expected.as_ref());
         let to_encoded = from_encoded.iter_encoded().collect::<SmallVec<[u8; 32]>>();
         assert_eq!(encode.as_ref(), to_encoded.as_ref());
     }
 
     #[test_case(Path::new(), "[]", "[]")]
-    #[test_case(Path::from([0x12, 0x34, 0x56, 0x78]), "12345678", "0x12345678")]
+    #[test_case(Path::from([0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8]), "12345678", "0x12345678")]
     fn test_fmt_lower_hex(path: Path, expected: &str, expected_with_prefix: &str) {
         assert_eq!(format!("{path:x}"), expected);
         assert_eq!(format!("{path:#x}"), expected_with_prefix);

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -144,7 +144,7 @@ where
             // Both lengths are usize counts of nibbles in a trie path, so their
             // sum cannot overflow on any platform firewood targets.
             #[cfg(feature = "ethhash")]
-            let make_fake_root = if path_prefix.0.len().wrapping_add(b.partial_path.0.len()) == 64 {
+            let make_fake_root = if path_prefix.0.len().wrapping_add(b.partial_path.len()) == 64 {
                 // looks like we're at an account branch
                 // tally up how many hashes we need to deal with
                 let ClassifiedChildren {
@@ -157,7 +157,7 @@ where
                     let shared = child_node.as_shared_node(&self)?;
                     let hash = {
                         let mut path_guard = PathGuard::new(&mut path_prefix);
-                        path_guard.0.extend(b.partial_path.0.iter().copied());
+                        path_guard.0.extend(b.partial_path.iter().copied());
                         if unhashed.is_empty() {
                             hash_node_as_storage_trie_root_for_node(
                                 path_guard.as_components(),
@@ -165,7 +165,7 @@ where
                                 &shared,
                             )
                         } else {
-                            path_guard.0.push(child_idx.as_u8());
+                            path_guard.0.push(*child_idx);
                             hash_node(&shared, &path_guard)
                         }
                     };
@@ -205,15 +205,15 @@ where
                 let (child_node, child_hash) = {
                     // we extend and truncate path_prefix to reduce memory allocations]
                     let mut child_path_prefix = PathGuard::new(&mut path_prefix);
-                    child_path_prefix.0.extend(b.partial_path.0.iter().copied());
+                    child_path_prefix.0.extend(b.partial_path.iter().copied());
                     #[cfg(feature = "ethhash")]
                     if make_fake_root.is_none() {
                         // we don't push the nibble there is only one unhashed child and
                         // we're on an account
-                        child_path_prefix.0.push(nibble.as_u8());
+                        child_path_prefix.0.push(nibble);
                     }
                     #[cfg(not(feature = "ethhash"))]
-                    child_path_prefix.0.push(nibble.as_u8());
+                    child_path_prefix.0.push(nibble);
                     #[cfg(feature = "ethhash")]
                     let (child_node, child_hash) =
                         self.hash_helper_inner(child_node, child_path_prefix, make_fake_root)?;
@@ -375,10 +375,7 @@ pub fn hash_node_as_storage_trie_root_parts<Prefix: SplitPath, Partial: SplitPat
 fn update_account_storage_root(node: &mut Node, path_prefix: &Path) {
     // Both lengths are usize counts of nibbles in a trie path, so their
     // sum cannot overflow on any platform firewood targets.
-    let total_depth = path_prefix
-        .0
-        .len()
-        .wrapping_add(node.partial_path().0.len());
+    let total_depth = path_prefix.0.len().wrapping_add(node.partial_path().len());
     if total_depth != 64 {
         return;
     }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -54,7 +54,6 @@ use crate::linear::{OffsetReader, ReadableNodeMode};
 use crate::logger::{debug, trace};
 use crate::node::branch::ReadSerializable as _;
 use firewood_metrics::{firewood_counter, firewood_histogram};
-use smallvec::SmallVec;
 use std::fmt::Debug;
 use std::io::{Error, ErrorKind};
 use std::num::NonZeroU64;
@@ -160,7 +159,7 @@ impl<S: ReadableStorage> NodeStore<Committed, S> {
                 debug!("No root hash in header; computing from disk");
                 nodestore
                     .read_node_from_disk(root_address, ReadableNodeMode::Open)
-                    .map(|n| hash_node(&n, &Path(SmallVec::default())))?
+                    .map(|n| hash_node(&n, &Path::new()))?
             };
 
             nodestore.kind.root = Some(Child::AddressWithHash(root_address, root_hash));

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -562,7 +562,7 @@ mod tests {
         let root_node = root_maybe_persisted
             .as_shared_node(&committed_store)
             .unwrap();
-        assert_eq!(*root_node.partial_path(), Path::from(&[0]));
+        assert_eq!(*root_node.partial_path(), Path::from([0]));
         assert_eq!(root_node.value(), Some(&b"branch_value"[..]));
         assert!(root_node.is_branch());
         let root_branch = root_node.as_branch().unwrap();
@@ -575,7 +575,7 @@ mod tests {
         let child1_node = child1_maybe_persisted
             .as_shared_node(&committed_store)
             .unwrap();
-        assert_eq!(*child1_node.partial_path(), Path::from(&[1, 2, 3]));
+        assert_eq!(*child1_node.partial_path(), Path::from([1, 2, 3]));
         assert_eq!(child1_node.value(), Some(&b"value1"[..]));
 
         let child2 = root_branch.children[PathComponent::ALL[2]]
@@ -585,7 +585,7 @@ mod tests {
         let child2_node = child2_maybe_persisted
             .as_shared_node(&committed_store)
             .unwrap();
-        assert_eq!(*child2_node.partial_path(), Path::from(&[4, 5, 6]));
+        assert_eq!(*child2_node.partial_path(), Path::from([4, 5, 6]));
         assert_eq!(child2_node.value(), Some(&b"value2"[..]));
     }
 }

--- a/storage/src/path/component.rs
+++ b/storage/src/path/component.rs
@@ -6,6 +6,7 @@ use smallvec::SmallVec;
 use super::{PartialPath, TriePath, TriePathFromUnpackedBytes};
 
 /// A path component in a hexary trie; which is only 4 bits (aka a nibble).
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PathComponent(pub crate::u4::U4);
 
@@ -371,14 +372,9 @@ impl<T: std::ops::Deref<Target = [PathComponent]>> PathComponentSliceExt for T {
 const unsafe fn byte_slice_as_path_components_unchecked(bytes: &[u8]) -> &[PathComponent] {
     #![expect(unsafe_code)]
 
-    // SAFETY: The caller must ensure that all bytes are valid for `PathComponent`,
-    // which is trivially true for 256-ary tries. For hexary tries, the caller must
-    // ensure that each byte is in the range 0x00 to 0x0F inclusive.
-    //
-    // We also rely on the fact that `PathComponent` is a single element type
-    // over `u8` (or `u4` which looks like a `u8` for this purpose).
-    //
-    // borrow rules ensure that the pointer for `bytes` is not null and
+    // SAFETY: `PathComponent` is `#[repr(transparent)]` over `U4`, which is
+    // `#[repr(transparent)]` over `Repr` (`#[repr(u8)]` with discriminants
+    // 0x0..=0xF). Each path-component byte therefore matches its nibble value.
     // `bytes.len()` is always valid. The returned reference will have the same
     // lifetime as `bytes` so it cannot outlive the original slice.
     unsafe {
@@ -390,8 +386,7 @@ const unsafe fn byte_slice_as_path_components_unchecked(bytes: &[u8]) -> &[PathC
 const fn path_components_as_byte_slice(components: &[PathComponent]) -> &[u8] {
     #![expect(unsafe_code)]
 
-    // SAFETY: We rely on the fact that `PathComponent` is a single element type
-    // over `u8` (or `u4` which looks like a `u8` for this purpose).
+    // SAFETY: `PathComponent` and `U4` have the same layout as `u8` (see above).
     //
     // borrow rules ensure that the pointer for `components` is not null and
     // `components.len()` is always valid. The returned reference will have the same

--- a/storage/src/u4.rs
+++ b/storage/src/u4.rs
@@ -19,6 +19,7 @@ pub struct TryFromIntError;
 /// memory efficiency when used in data structures like [`Option`] as well as
 /// allowing for faster indexing into [`Children`](crate::node::Children) arrays
 /// by enabling the compiler to optimize away bounds checks.
+#[repr(transparent)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct U4(Repr);
 
@@ -144,24 +145,25 @@ impl TryFrom<u8> for U4 {
 /// like the [`Children`](crate::Children) array in the hexary trie, the compiler can
 /// optimize away bounds checks and remove possible panic points. This is because the
 /// compiler knows that the value of [`U4`] can only be one of the 16 valid indices.
+#[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum Repr {
-    Ox0,
-    Ox1,
-    Ox2,
-    Ox3,
-    Ox4,
-    Ox5,
-    Ox6,
-    Ox7,
-    Ox8,
-    Ox9,
-    OxA,
-    OxB,
-    OxC,
-    OxD,
-    OxE,
-    OxF,
+    Ox0 = 0x0,
+    Ox1 = 0x1,
+    Ox2 = 0x2,
+    Ox3 = 0x3,
+    Ox4 = 0x4,
+    Ox5 = 0x5,
+    Ox6 = 0x6,
+    Ox7 = 0x7,
+    Ox8 = 0x8,
+    Ox9 = 0x9,
+    OxA = 0xA,
+    OxB = 0xB,
+    OxC = 0xC,
+    OxD = 0xD,
+    OxE = 0xE,
+    OxF = 0xF,
 }
 
 impl Repr {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this should be merged

Fixes #1876. `firewood_storage::node::path::Path` was created before `PathComponent`/`U4` existed and stored raw `u8` values even though paths are documented to contain only nibbles. This change enforces that invariant at the type level.

## How this works

- Change `Path` internal storage from `SmallVec<[u8; 64]>` to `SmallVec<[PathComponent; 64]>`.
- Implement `TriePath` and `TriePathFromUnpackedBytes` for `Path`.
- Add `as_nibbles()` for on-disk serialization and byte-oriented helpers that still need raw nibble bytes.
- Update merkle/checker/nodestore call sites to use `PathComponent` slices and component-aware path construction instead of raw `u8` access via `.0`.

## How this was tested

CI

## Breaking Changes

- [ ] firewood
- [x] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl

`Path` no longer derefs to `[u8]`; callers should use `as_nibbles()`, `as_components()`, or `TriePath` methods. Constructing a `Path` from invalid nibble bytes (>0x0F) now fails instead of silently storing invalid data.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd4d6ed0-9baa-41c2-bbc9-6c03e618c9d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd4d6ed0-9baa-41c2-bbc9-6c03e618c9d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

