### PR TITLE
refactor(storage): unconditional HashType enum + per-mode codecs [3/9]

### DIFF
--- a/firewood/src/merkle/reconcile.rs
+++ b/firewood/src/merkle/reconcile.rs
@@ -60,11 +60,12 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
 
         let proof_value = match proof_node.value_digest.as_ref() {
             Some(ValueDigest::Value(v)) => Some(v.as_ref()),
-            #[cfg(not(feature = "ethhash"))]
             Some(digest @ ValueDigest::Hash(_)) => {
                 // In merkledb mode, large values (>= 32 bytes) are stored as
                 // hashes in serialized proofs. If the branch's value hashes to
                 // the same value, the proof and trie agree — no conflict.
+                // (Dead but harmless under the Ethereum scheme, which never
+                // emits a `Hash` digest.)
                 if matches!(branch.value.as_deref(), Some(v) if digest.as_ref().verify(v)) {
                     return Ok(());
                 }

--- a/firewood/src/merkle/reconcile.rs
+++ b/firewood/src/merkle/reconcile.rs
@@ -51,6 +51,12 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
             return Err(ProofError::ValueAtOddNibbleLength);
         }
 
+        if DefaultHashMode::ALGORITHM.is_ethereum()
+            && matches!(proof_node.value_digest, Some(ValueDigest::Hash(_)))
+        {
+            return Err(ProofError::UnexpectedValueDigest);
+        }
+
         self.insert_branch_from_nibbles(&key_nibbles)?;
 
         // insert_branch_from_nibbles guarantees a branch exists at this path
@@ -60,7 +66,6 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
 
         let proof_value = match proof_node.value_digest.as_ref() {
             Some(ValueDigest::Value(v)) => Some(v.as_ref()),
-            #[cfg(not(feature = "ethhash"))]
             Some(digest @ ValueDigest::Hash(_)) => {
                 // In merkledb mode, large values (>= 32 bytes) are stored as
                 // hashes in serialized proofs. If the branch's value hashes to

--- a/firewood/src/merkle/tests/reconcile.rs
+++ b/firewood/src/merkle/tests/reconcile.rs
@@ -5,6 +5,28 @@ use super::*;
 #[cfg(feature = "ethhash")]
 use test_case::test_case;
 
+#[cfg(feature = "ethhash")]
+#[test]
+fn test_reconcile_branch_proof_node_rejects_hashed_value_digest() {
+    let mut merkle = create_in_memory_merkle();
+    let proof_node = test_branch_proof_node(
+        &[0xa, 0xb],
+        Some(ValueDigest::Hash(TrieHash::from([0xabu8; 32]).into())),
+    );
+
+    let err = merkle
+        .reconcile_branch_proof_node(&proof_node, |_, _| {
+            panic!("invalid digest must be rejected before conflict resolution")
+        })
+        .unwrap_err();
+
+    assert!(matches!(err, ProofError::UnexpectedValueDigest));
+    assert!(
+        merkle.get_node_from_nibbles(&[0xa, 0xb]).unwrap().is_none(),
+        "invalid digest must be rejected before mutating the trie"
+    );
+}
+
 #[test]
 fn test_reconcile_branch_proof_node_creates_missing_branch_without_value() {
     let mut merkle = create_in_memory_merkle();

--- a/firewood/src/proofs/de.rs
+++ b/firewood/src/proofs/de.rs
@@ -19,9 +19,10 @@ use crate::{
     merkle::{Key, Value},
     proofs::magic::{BATCH_DELETE, BATCH_DELETE_RANGE, BATCH_PUT},
 };
-#[cfg(feature = "ethhash")]
-use firewood_storage::HashType;
-use firewood_storage::{Children, PathBuf, TrieHash, TriePathFromUnpackedBytes, ValueDigest};
+use firewood_storage::{
+    Children, DefaultHashMode, HashMode, HashType, PathBuf, TrieHash, TriePathFromUnpackedBytes,
+    ValueDigest,
+};
 use integer_encoding::VarInt;
 use std::num::NonZeroUsize;
 
@@ -302,7 +303,6 @@ impl<'a> ReadItem<'a> for ValueDigest<&'a [u8]> {
             .map_err(|err| err.set_item("value digest discriminant"))?
         {
             0 => Ok(ValueDigest::Value(reader.read_item()?)),
-            #[cfg(not(feature = "ethhash"))]
             1 => Ok(ValueDigest::Hash(reader.read_item()?)),
             found => Err(reader.invalid_item(
                 "value digest discriminant",
@@ -317,7 +317,6 @@ impl<'a> ReadItem<'a> for ValueDigest<Box<[u8]>> {
     fn read_item(reader: &mut ProofReader<'a>) -> Result<Self, ReadError> {
         reader.read_item::<ValueDigest<&[u8]>>().map(|vd| match vd {
             ValueDigest::Value(v) => ValueDigest::Value(v.into()),
-            #[cfg(not(feature = "ethhash"))]
             ValueDigest::Hash(h) => ValueDigest::Hash(h),
         })
     }
@@ -343,18 +342,25 @@ impl<'a> ReadItem<'a> for ChildMask {
     }
 }
 
-#[cfg(feature = "ethhash")]
 impl<'a> ReadItem<'a> for HashType {
     fn read_item(reader: &mut ProofReader<'a>) -> Result<Self, ReadError> {
-        match reader
-            .read_item::<u8>()
-            .map_err(|err| err.set_item("hash type discriminant"))?
-        {
-            0 => Ok(HashType::Hash(reader.read_item()?)),
-            1 => Ok(HashType::Rlp(reader.read_item::<&[u8]>()?.into())),
-            found => {
-                Err(reader.invalid_item("hash type discriminant", "0 (hash) or 1 (rlp)", found))
+        // The two schemes use different proof wire layouts for a child hash;
+        // dispatch on the database's algorithm so each format is read back the
+        // way it was written.
+        if DefaultHashMode::ALGORITHM.is_ethereum() {
+            match reader
+                .read_item::<u8>()
+                .map_err(|err| err.set_item("hash type discriminant"))?
+            {
+                0 => Ok(HashType::Hash(reader.read_item()?)),
+                1 => Ok(HashType::Rlp(reader.read_item::<&[u8]>()?.into())),
+                found => {
+                    Err(reader.invalid_item("hash type discriminant", "0 (hash) or 1 (rlp)", found))
+                }
             }
+        } else {
+            // MerkleDB child hashes are a bare 32-byte hash, no discriminant.
+            Ok(HashType::from(reader.read_item::<TrieHash>()?))
         }
     }
 }

--- a/firewood/src/proofs/de.rs
+++ b/firewood/src/proofs/de.rs
@@ -19,7 +19,9 @@ use crate::{
     merkle::{Key, Value},
     proofs::magic::{BATCH_DELETE, BATCH_DELETE_RANGE, BATCH_PUT},
 };
-use firewood_storage::{HashType, PathBuf, TrieHash, TriePathFromUnpackedBytes, ValueDigest};
+use firewood_storage::{
+    DefaultHashMode, HashMode, HashType, PathBuf, TrieHash, TriePathFromUnpackedBytes, ValueDigest,
+};
 use integer_encoding::VarInt;
 use std::num::NonZeroUsize;
 
@@ -302,7 +304,6 @@ impl<'a> ReadItem<'a> for ValueDigest<&'a [u8]> {
             .map_err(|err| err.set_item("value digest discriminant"))?
         {
             0 => Ok(ValueDigest::Value(reader.read_item()?)),
-            #[cfg(not(feature = "ethhash"))]
             1 => Ok(ValueDigest::Hash(reader.read_item()?)),
             found => Err(reader.invalid_item(
                 "value digest discriminant",
@@ -317,7 +318,6 @@ impl<'a> ReadItem<'a> for ValueDigest<Box<[u8]>> {
     fn read_item(reader: &mut ProofReader<'a>) -> Result<Self, ReadError> {
         reader.read_item::<ValueDigest<&[u8]>>().map(|vd| match vd {
             ValueDigest::Value(v) => ValueDigest::Value(v.into()),
-            #[cfg(not(feature = "ethhash"))]
             ValueDigest::Hash(h) => ValueDigest::Hash(h),
         })
     }
@@ -343,18 +343,25 @@ impl<'a> ReadItem<'a> for ChildMask {
     }
 }
 
-#[cfg(feature = "ethhash")]
 impl<'a> ReadItem<'a> for HashType {
     fn read_item(reader: &mut ProofReader<'a>) -> Result<Self, ReadError> {
-        match reader
-            .read_item::<u8>()
-            .map_err(|err| err.set_item("hash type discriminant"))?
-        {
-            0 => Ok(HashType::Hash(reader.read_item()?)),
-            1 => Ok(HashType::Rlp(reader.read_item::<&[u8]>()?.into())),
-            found => {
-                Err(reader.invalid_item("hash type discriminant", "0 (hash) or 1 (rlp)", found))
+        // The two schemes use different proof wire layouts for a child hash;
+        // dispatch on the database's algorithm so each format is read back the
+        // way it was written.
+        if DefaultHashMode::ALGORITHM.is_ethereum() {
+            match reader
+                .read_item::<u8>()
+                .map_err(|err| err.set_item("hash type discriminant"))?
+            {
+                0 => Ok(HashType::Hash(reader.read_item()?)),
+                1 => Ok(HashType::Rlp(reader.read_item::<&[u8]>()?.into())),
+                found => {
+                    Err(reader.invalid_item("hash type discriminant", "0 (hash) or 1 (rlp)", found))
+                }
             }
+        } else {
+            // MerkleDB child hashes are a bare 32-byte hash, no discriminant.
+            Ok(HashType::from(reader.read_item::<TrieHash>()?))
         }
     }
 }

--- a/firewood/src/proofs/eth.rs
+++ b/firewood/src/proofs/eth.rs
@@ -275,21 +275,10 @@ impl AccountFields {
 /// `unreachable!()`. This emitter runs at any depth, so it must surface
 /// inline-RLP children as `RlpItem::Raw` (verbatim inlining) for a
 /// verifier to walk them.
-#[cfg(feature = "ethhash")]
 fn proof_child_rlp_item(child: Option<&HashType>) -> RlpItem<'_> {
     match child {
         Some(HashType::Hash(hash)) => RlpItem::Bytes(hash.as_slice()),
         Some(HashType::Rlp(rlp_bytes)) => RlpItem::Raw(rlp_bytes),
-        None => RlpItem::Empty,
-    }
-}
-
-#[cfg(not(feature = "ethhash"))]
-fn proof_child_rlp_item(child: Option<&HashType>) -> RlpItem<'_> {
-    // Without ethhash, HashType is just a 32-byte TrieHash and there is no
-    // inline-RLP form; every present child is referenced by hash.
-    match child {
-        Some(hash) => RlpItem::Bytes(hash.as_slice()),
         None => RlpItem::Empty,
     }
 }

--- a/firewood/src/proofs/eth.rs
+++ b/firewood/src/proofs/eth.rs
@@ -272,21 +272,10 @@ impl AccountFields {
 /// `unreachable!()`. This emitter runs at any depth, so it must surface
 /// inline-RLP children as `RlpItem::Raw` (verbatim inlining) for a
 /// verifier to walk them.
-#[cfg(feature = "ethhash")]
 fn proof_child_rlp_item(child: Option<&HashType>) -> RlpItem<'_> {
     match child {
         Some(HashType::Hash(hash)) => RlpItem::Bytes(hash.as_slice()),
         Some(HashType::Rlp(rlp_bytes)) => RlpItem::Raw(rlp_bytes),
-        None => RlpItem::Empty,
-    }
-}
-
-#[cfg(not(feature = "ethhash"))]
-fn proof_child_rlp_item(child: Option<&HashType>) -> RlpItem<'_> {
-    // Without ethhash, HashType is just a 32-byte TrieHash and there is no
-    // inline-RLP form; every present child is referenced by hash.
-    match child {
-        Some(hash) => RlpItem::Bytes(hash.as_slice()),
         None => RlpItem::Empty,
     }
 }

--- a/firewood/src/proofs/ser.rs
+++ b/firewood/src/proofs/ser.rs
@@ -7,7 +7,7 @@
 //! It provides efficient encoding of proof nodes, child bitmaps, and range proofs
 //! for transmission or persistent storage.
 
-use firewood_storage::{PathBuf, PathComponentSliceExt, ValueDigest};
+use firewood_storage::{DefaultHashMode, HashMode, PathBuf, PathComponentSliceExt, ValueDigest};
 use integer_encoding::VarInt;
 
 use super::{
@@ -199,7 +199,8 @@ impl<T: AsRef<[u8]>> WriteItem for ValueDigest<T> {
                 out.push(0);
                 v.write_item(out);
             }
-            #[cfg(not(feature = "ethhash"))]
+            // Only produced by the merkledb scheme (large values hashed); the
+            // Ethereum scheme never emits a `Hash` digest.
             ValueDigest::Hash(h) => {
                 out.push(1);
                 h.write_item(out);
@@ -220,17 +221,30 @@ impl WriteItem for firewood_storage::TrieHash {
     }
 }
 
-#[cfg(feature = "ethhash")]
 impl WriteItem for firewood_storage::HashType {
     fn write_item(&self, out: &mut Vec<u8>) {
-        match self {
-            firewood_storage::HashType::Hash(h) => {
-                out.push(0);
-                h.write_item(out);
+        // The two schemes use different proof wire layouts for a child hash;
+        // dispatch on the database's algorithm so each format is preserved
+        // byte-for-byte.
+        if DefaultHashMode::ALGORITHM.is_ethereum() {
+            match self {
+                firewood_storage::HashType::Hash(h) => {
+                    out.push(0);
+                    h.write_item(out);
+                }
+                firewood_storage::HashType::Rlp(h) => {
+                    out.push(1);
+                    h.write_item(out);
+                }
             }
-            firewood_storage::HashType::Rlp(h) => {
-                out.push(1);
-                h.write_item(out);
+        } else {
+            // MerkleDB child hashes are always a bare 32-byte hash, with no
+            // discriminant byte.
+            match self {
+                firewood_storage::HashType::Hash(h) => h.write_item(out),
+                firewood_storage::HashType::Rlp(_) => {
+                    unreachable!("merkledb child hash is never inline RLP")
+                }
             }
         }
     }

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -112,6 +112,11 @@ pub enum ProofError {
     #[error("unexpected value")]
     UnexpectedValue,
 
+    /// A proof contained a hashed value digest under a hashing mode that only
+    /// supports literal values.
+    #[error("hashed value digest is not supported by the active hash mode")]
+    UnexpectedValueDigest,
+
     /// Value mismatch
     #[error("value mismatch")]
     ValueMismatch,
@@ -509,6 +514,8 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
     ///   expected hash from its parent (or `root_hash` for the first node).
     /// - [`ProofError::ValueAtOddNibbleLength`] — a node whose key has an odd
     ///   number of nibbles carries a value digest, which is structurally invalid.
+    /// - [`ProofError::UnexpectedValueDigest`] — a node carries a hashed value
+    ///   digest under a scheme that only produces literal values.
     /// - [`ProofError::ShouldBePrefixOfProvenKey`] — an intermediate node's key
     ///   is not a prefix of `key`.
     /// - [`ProofError::ShouldBePrefixOfNextKey`] — a node's key is not a prefix
@@ -566,6 +573,14 @@ impl<T: ProofCollection + ?Sized> Proof<T> {
             // have a `value_digest`.
             if !node.full_path().len().is_multiple_of(2) && node.value_digest().is_some() {
                 return Err(ProofError::ValueAtOddNibbleLength);
+            }
+
+            // Reject a hashed value digest under the Ethereum scheme, which
+            // only ever emits literal values.
+            if DefaultHashMode::ALGORITHM.is_ethereum()
+                && matches!(node.value_digest(), Some(ValueDigest::Hash(_)))
+            {
+                return Err(ProofError::UnexpectedValueDigest);
             }
 
             if let Some(next_node) = iter.peek() {
@@ -933,6 +948,43 @@ mod tests {
         assert!(matches!(
             proof.value_digest([0x50u8], &root_hash),
             Err(ProofError::ShouldBePrefixOfNextKey),
+        ));
+    }
+
+    /// Under the Ethereum scheme a hashed value digest must be rejected
+    /// outright. It cannot be caught by the root-hash check: eth's preimage
+    /// encoding ignores a `Hash` digest, so a node carrying one hashes exactly
+    /// like the valueless node it was forged from. Without the guard, such a
+    /// proof would verify as asserting a value the trie does not hold.
+    #[cfg(feature = "ethhash")]
+    #[test]
+    fn eth_hashed_value_digest_is_rejected() {
+        use firewood_storage::U4;
+
+        // Honest trie: a root branch with two children and no value.
+        let leaf = make_node(&[3, 0], 1, Some(b"val_b"), DenseChildren::new());
+        let mut root_children = DenseChildren::new();
+        root_children.insert(U4::new_masked(3), leaf.to_hash());
+        root_children.insert(U4::new_masked(5), HashType::from([0xCCu8; 32]));
+        let honest_root = make_node(&[], 0, None, root_children.clone());
+        let root_hash: TrieHash = honest_root.to_hash().into_triehash();
+
+        // Forged root: same structure, plus a fabricated hashed digest for the
+        // empty key.
+        let mut forged_root = make_node(&[], 0, None, root_children);
+        forged_root.value_digest = Some(ValueDigest::Hash(HashType::from([0xABu8; 32])));
+
+        // The forgery is invisible to the hash check.
+        assert_eq!(
+            forged_root.to_hash(),
+            honest_root.to_hash(),
+            "eth preimage encoding must ignore a Hash digest for this test to be meaningful"
+        );
+
+        // So the guard has to reject it explicitly.
+        assert!(matches!(
+            Proof::new(vec![forged_root]).value_digest(b"", &root_hash),
+            Err(ProofError::UnexpectedValueDigest),
         ));
     }
 }

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -2,7 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 use crate::{
-    Children, HashType, HashableShunt, IntoSplitPath, Node, Path, PathComponent, SplitPath,
+    Children, DefaultHashMode, HashMode, HashType, HashableShunt, IntoSplitPath, Node, Path,
+    PathComponent, SplitPath, TrieHash,
 };
 use smallvec::SmallVec;
 
@@ -76,9 +77,10 @@ impl<A: smallvec::Array<Item = u8>> HasUpdate for SmallVec<A> {
 pub enum ValueDigest<T> {
     /// The node's value.
     Value(T),
-    #[cfg(not(feature = "ethhash"))]
     /// For MerkleDB hashing, the digest is the hash of the value if it is 32
-    /// bytes or longer.
+    /// bytes or longer. (Unused by the Ethereum scheme, which never stores a
+    /// value as a hash, but the variant exists unconditionally so both schemes
+    /// share one data type.)
     Hash(HashType),
 }
 
@@ -90,12 +92,12 @@ impl<T: AsRef<[u8]>> ValueDigest<T> {
                 // This proof proves that `key` maps to `got_value`.
                 got_value.as_ref() == expected.as_ref()
             }
-            #[cfg(not(feature = "ethhash"))]
             Self::Hash(got_hash) => {
                 use sha2::{Digest, Sha256};
                 // This proof proves that `key` maps to a value
-                // whose hash is `got_hash`.
-                *got_hash == HashType::from(Sha256::digest(expected.as_ref()))
+                // whose hash is `got_hash`. `HashType` implements
+                // `PartialEq<TrieHash>`, so compare without re-wrapping.
+                *got_hash == TrieHash::from(Sha256::digest(expected.as_ref()))
             }
         }
     }
@@ -104,39 +106,40 @@ impl<T: AsRef<[u8]>> ValueDigest<T> {
     pub fn as_ref(&self) -> ValueDigest<&[u8]> {
         match self {
             Self::Value(v) => ValueDigest::Value(v.as_ref()),
-            #[cfg(not(feature = "ethhash"))]
             Self::Hash(h) => ValueDigest::Hash(h.clone()),
         }
     }
 
     /// Returns the inner bytes if this digest carries a value, or `None` if
-    /// it carries only a hash. The `Hash` variant only exists in non-ethhash
-    /// builds, so in ethhash builds this function always returns `Some`.
+    /// it carries only a hash. The Ethereum scheme never produces a `Hash`
+    /// digest, so under that scheme this function always returns `Some`.
     pub fn value(&self) -> Option<&[u8]> {
         match self {
             Self::Value(v) => Some(v.as_ref()),
-            #[cfg(not(feature = "ethhash"))]
             Self::Hash(_) => None,
         }
     }
 
     /// Convert the value to a hash if it is not already a hash.
     ///
-    /// If the value is less than 32 bytes, it will be passed through as is
-    /// instead of hashing.
+    /// Under the MerkleDB scheme, a value of 32 bytes or more is replaced by
+    /// its SHA-256 hash; shorter values pass through unchanged. The Ethereum
+    /// scheme never hashes values, so this is the identity there.
     ///
-    /// If etherum hashing is enabled, this will always return the value as is.
+    /// The capping is the MerkleDB scheme's behavior, so it is gated on the
+    /// database's algorithm at runtime rather than threaded through `H`
+    /// (deferred to a follow-up PR).
     pub fn make_hash(&self) -> ValueDigest<&[u8]> {
         match self.as_ref() {
-            #[cfg(not(feature = "ethhash"))]
-            ValueDigest::Value(v) if v.len() >= 32 => {
+            ValueDigest::Value(v)
+                if v.len() >= 32 && !crate::DefaultHashMode::ALGORITHM.is_ethereum() =>
+            {
                 use sha2::{Digest, Sha256};
-                ValueDigest::Hash(HashType::from(Sha256::digest(v)))
+                ValueDigest::Hash(HashType::from(TrieHash::from(Sha256::digest(v))))
             }
 
             ValueDigest::Value(v) => ValueDigest::Value(v),
 
-            #[cfg(not(feature = "ethhash"))]
             ValueDigest::Hash(v) => ValueDigest::Hash(v),
         }
     }
@@ -145,7 +148,6 @@ impl<T: AsRef<[u8]>> ValueDigest<T> {
     pub fn map<O>(self, f: impl FnOnce(T) -> O) -> ValueDigest<O> {
         match self {
             Self::Value(v) => ValueDigest::Value(f(v)),
-            #[cfg(not(feature = "ethhash"))]
             Self::Hash(h) => ValueDigest::Hash(h),
         }
     }
@@ -155,7 +157,6 @@ impl<T: AsRef<[u8]>> AsRef<[u8]> for ValueDigest<T> {
     fn as_ref(&self) -> &[u8] {
         match self {
             Self::Value(v) => v.as_ref(),
-            #[cfg(not(feature = "ethhash"))]
             Self::Hash(h) => h.as_ref(),
         }
     }
@@ -198,4 +199,19 @@ pub trait Preimage: std::fmt::Debug {
 
     /// Write this hash preimage to `buf`.
     fn write(&self, buf: &mut impl HasUpdate);
+}
+
+/// A single blanket implementation that delegates to the compile-selected
+/// [`DefaultHashMode`].
+///
+/// Threading a generic `H: HashMode` through these call sites (so a caller can
+/// pick the scheme at runtime) is deferred to a follow-up PR.
+impl<T: Hashable> Preimage for T {
+    fn to_hash(&self) -> HashType {
+        DefaultHashMode::to_hash(self)
+    }
+
+    fn write(&self, buf: &mut impl HasUpdate) {
+        DefaultHashMode::write_preimage(self, buf);
+    }
 }

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -2,7 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 use crate::{
-    Children, HashType, HashableShunt, IntoSplitPath, Node, Path, PathComponent, SplitPath,
+    Children, DefaultHashMode, HashMode, HashType, HashableShunt, IntoSplitPath, Node, Path,
+    PathComponent, SplitPath, TrieHash,
 };
 use smallvec::SmallVec;
 
@@ -76,9 +77,10 @@ impl<A: smallvec::Array<Item = u8>> HasUpdate for SmallVec<A> {
 pub enum ValueDigest<T> {
     /// The node's value.
     Value(T),
-    #[cfg(not(feature = "ethhash"))]
     /// For MerkleDB hashing, the digest is the hash of the value if it is 32
-    /// bytes or longer.
+    /// bytes or longer. (Unused by the Ethereum scheme, which never stores a
+    /// value as a hash, but the variant exists unconditionally so both schemes
+    /// share one data type.)
     Hash(HashType),
 }
 
@@ -90,12 +92,12 @@ impl<T: AsRef<[u8]>> ValueDigest<T> {
                 // This proof proves that `key` maps to `got_value`.
                 got_value.as_ref() == expected.as_ref()
             }
-            #[cfg(not(feature = "ethhash"))]
             Self::Hash(got_hash) => {
                 use sha2::{Digest, Sha256};
                 // This proof proves that `key` maps to a value
-                // whose hash is `got_hash`.
-                *got_hash == HashType::from(Sha256::digest(expected.as_ref()))
+                // whose hash is `got_hash`. `HashType` implements
+                // `PartialEq<TrieHash>`, so compare without re-wrapping.
+                *got_hash == TrieHash::from(Sha256::digest(expected.as_ref()))
             }
         }
     }
@@ -104,39 +106,38 @@ impl<T: AsRef<[u8]>> ValueDigest<T> {
     pub fn as_ref(&self) -> ValueDigest<&[u8]> {
         match self {
             Self::Value(v) => ValueDigest::Value(v.as_ref()),
-            #[cfg(not(feature = "ethhash"))]
             Self::Hash(h) => ValueDigest::Hash(h.clone()),
         }
     }
 
     /// Returns the inner bytes if this digest carries a value, or `None` if
-    /// it carries only a hash. The `Hash` variant only exists in non-ethhash
-    /// builds, so in ethhash builds this function always returns `Some`.
+    /// it carries only a hash. The Ethereum scheme never produces a `Hash`
+    /// digest, so under that scheme this function always returns `Some`.
     pub fn value(&self) -> Option<&[u8]> {
         match self {
             Self::Value(v) => Some(v.as_ref()),
-            #[cfg(not(feature = "ethhash"))]
             Self::Hash(_) => None,
         }
     }
 
     /// Convert the value to a hash if it is not already a hash.
     ///
-    /// If the value is less than 32 bytes, it will be passed through as is
-    /// instead of hashing.
+    /// Under the MerkleDB scheme, a value of 32 bytes or more is replaced by
+    /// its SHA-256 hash; shorter values pass through unchanged. The Ethereum
+    /// scheme never hashes values, so this is the identity there.
     ///
-    /// If etherum hashing is enabled, this will always return the value as is.
+    /// The capping is the MerkleDB scheme's behavior, so it is gated on the
+    /// database's algorithm at runtime rather than threaded through `H`
+    /// (deferred to a follow-up PR).
     pub fn make_hash(&self) -> ValueDigest<&[u8]> {
         match self.as_ref() {
-            #[cfg(not(feature = "ethhash"))]
-            ValueDigest::Value(v) if v.len() >= 32 => {
+            ValueDigest::Value(v) if v.len() >= 32 && !DefaultHashMode::ALGORITHM.is_ethereum() => {
                 use sha2::{Digest, Sha256};
-                ValueDigest::Hash(HashType::from(Sha256::digest(v)))
+                ValueDigest::Hash(HashType::from(TrieHash::from(Sha256::digest(v))))
             }
 
             ValueDigest::Value(v) => ValueDigest::Value(v),
 
-            #[cfg(not(feature = "ethhash"))]
             ValueDigest::Hash(v) => ValueDigest::Hash(v),
         }
     }
@@ -145,7 +146,6 @@ impl<T: AsRef<[u8]>> ValueDigest<T> {
     pub fn map<O>(self, f: impl FnOnce(T) -> O) -> ValueDigest<O> {
         match self {
             Self::Value(v) => ValueDigest::Value(f(v)),
-            #[cfg(not(feature = "ethhash"))]
             Self::Hash(h) => ValueDigest::Hash(h),
         }
     }
@@ -155,7 +155,6 @@ impl<T: AsRef<[u8]>> AsRef<[u8]> for ValueDigest<T> {
     fn as_ref(&self) -> &[u8] {
         match self {
             Self::Value(v) => v.as_ref(),
-            #[cfg(not(feature = "ethhash"))]
             Self::Hash(h) => h.as_ref(),
         }
     }
@@ -198,4 +197,19 @@ pub trait Preimage: std::fmt::Debug {
 
     /// Write this hash preimage to `buf`.
     fn write(&self, buf: &mut impl HasUpdate);
+}
+
+/// A single blanket implementation that delegates to the compile-selected
+/// [`DefaultHashMode`].
+///
+/// Threading a generic `H: HashMode` through these call sites (so a caller can
+/// pick the scheme at runtime) is deferred to a follow-up PR.
+impl<T: Hashable> Preimage for T {
+    fn to_hash(&self) -> HashType {
+        DefaultHashMode::to_hash(self)
+    }
+
+    fn write(&self, buf: &mut impl HasUpdate) {
+        DefaultHashMode::write_preimage(self, buf);
+    }
 }

--- a/storage/src/hashers/ethhash.rs
+++ b/storage/src/hashers/ethhash.rs
@@ -3,10 +3,12 @@
 
 //! # Ethereum-compatible node hashing
 //!
-//! This module implements [`Preimage`] for firewood nodes so that the resulting
-//! root hash matches what an Ethereum Modified Merkle Patricia Trie (MPT) would
-//! produce for the same key/value set. It is only compiled when the `ethhash`
-//! feature is enabled (used for Avalanche C-Chain state).
+//! This module implements the [`EthHash`] [`HashMode`] for firewood nodes so
+//! that the resulting root hash matches what an Ethereum Modified Merkle
+//! Patricia Trie (MPT) would produce for the same key/value set. It is always
+//! compiled (both hash modes coexist in one binary); [`EthHash`] is the active
+//! mode when the `ethhash` feature selects it as `DefaultHashMode` (used for
+//! Avalanche C-Chain state).
 //!
 //! ## Why this is non-trivial
 //!
@@ -22,10 +24,10 @@
 //!    less than 32 bytes is embedded *inline* in the parent's RLP instead of
 //!    being replaced by its 32-byte hash. In firewood's [`HashType`] this is
 //!    the distinction between [`HashType::Hash`] and [`HashType::Rlp`].
-//!    [`Preimage::to_hash`] preserves whichever form fits (`< 32` → `Rlp`, else
+//!    [`HashMode::to_hash`] preserves whichever form fits (`< 32` → `Rlp`, else
 //!    `Hash`); branch encoders then inline `Rlp` children via
-//!    [`RlpItem::Raw`](crate::rlp::RlpItem::Raw) and hash-reference `Hash`
-//!    children via [`RlpItem::Bytes`](crate::rlp::RlpItem::Bytes).
+//!    [`RlpItem::Raw`] and hash-reference `Hash`
+//!    children via [`RlpItem::Bytes`].
 //! 3. **17-element branch lists** — a branch is always RLP-encoded as
 //!    `[child_0, ..., child_15, value]`. Missing children are `0x80` (empty RLP
 //!    bytes), not omitted.
@@ -46,7 +48,7 @@
 //! - **`storageRoot` is recomputed at hash time.** When computing a node's
 //!   hash, we always derive the `storageRoot` slot from the node's children
 //!   and splice it into the account RLP via
-//!   [`replace_list_field`](crate::rlp::replace_list_field), regardless of
+//!   [`replace_list_field`], regardless of
 //!   whatever value is currently in that slot. The *persisted* bytes are not
 //!   updated by this splice, so callers reading the raw value may observe a
 //!   stale or zero `storageRoot` even though the trie's root hash is correct;
@@ -57,7 +59,7 @@
 //!   equivalent Ethereum storage trie is a single leaf at the *root*. To get
 //!   the same hash, we conceptually prepend the child's branch nibble to its
 //!   partial path and re-hash it as if it were a standalone root node. See
-//!   the `children == 1` arm in [`Preimage::write`] and `hash_helper_inner`'s
+//!   the `children == 1` arm in [`HashMode::write_preimage`] and `hash_helper_inner`'s
 //!   `fake_root_extra_nibble` in `nodestore::hash`.
 //!
 //! ## Where the storage root gets spliced
@@ -65,7 +67,7 @@
 //! There are two sites that compute and splice `storageRoot` into account
 //! RLP, and they must stay in lockstep:
 //!
-//! 1. **At hash time**, during [`Preimage::write`]: we compute the storage-trie
+//! 1. **At hash time**, during [`HashMode::write_preimage`]: we compute the storage-trie
 //!    hash and splice it into the RLP used for the account node's own hash.
 //!    This makes the account's contribution to the state root correct.
 //!
@@ -81,7 +83,7 @@
 //! `fix_account_storage_root_value` runs at proof time where all storage-trie
 //! children are guaranteed to be 32-byte hashes (32-byte storage keys always
 //! yield encodings ≥ 32 bytes), so it treats [`HashType::Rlp`] as
-//! `unreachable!`; `Preimage::write` runs during hashing and must handle
+//! `unreachable!`; [`HashMode::write_preimage`] runs during hashing and must handle
 //! inline [`HashType::Rlp`] children.
 //!
 //! ## Reviewer checklist
@@ -94,22 +96,25 @@
 //! - Does it change where the account depth (64 nibbles) check lives? The two
 //!   splice sites must agree on the definition.
 //! - Does it change how [`HashType::Rlp`] vs [`HashType::Hash`] is chosen? The
-//!   32-byte cutoff in [`Preimage::to_hash`] must match what parent encoders
-//!   assume when emitting [`RlpItem::Raw`](crate::rlp::RlpItem::Raw) vs
-//!   [`RlpItem::Bytes`](crate::rlp::RlpItem::Bytes).
+//!   32-byte cutoff in [`HashMode::to_hash`] must match what parent encoders
+//!   assume when emitting [`RlpItem::Raw`] vs
+//!   [`RlpItem::Bytes`].
 //! - Does it touch the storage-root splice? Note that Coreth may append fields
-//!   beyond the standard 4, so [`replace_list_field`](crate::rlp::replace_list_field)
+//!   beyond the standard 4, so [`replace_list_field`]
 //!   only touches index 2 and leaves any trailing fields intact.
 
 use crate::eth_encoding::nibbles_to_eth_compact;
 use crate::logger::warn;
+use crate::node::ExtendableBytes;
+use crate::node::branch::Serializable;
 use crate::rlp::{NULL_RLP, RlpItem, encode_list, replace_list_field};
 use crate::{
-    BranchNode, EthHash, HashMode, HashType, Hashable, NodeHashAlgorithm, Path, Preimage, TrieHash,
-    TriePath, ValueDigest, hashednode::HasUpdate, logger::trace,
+    BranchNode, EthHash, HashMode, HashType, Hashable, NodeHashAlgorithm, Path, TrieHash, TriePath,
+    ValueDigest, hashednode::HasUpdate, logger::trace,
 };
 use sha3::{Digest, Keccak256};
 use smallvec::SmallVec;
+use std::io::{Error, Read};
 
 impl HasUpdate for Keccak256 {
     fn update<T: AsRef<[u8]>>(&mut self, data: T) {
@@ -135,18 +140,16 @@ impl HashMode for EthHash {
     fn is_valid_key(key: &Path) -> bool {
         matches!(key.0.len(), 64 | 128)
     }
-}
 
-impl<T: Hashable> Preimage for T {
-    fn to_hash(&self) -> HashType {
+    fn to_hash<T: Hashable>(node: &T) -> HashType {
         // first collect the thing that would be hashed, and if it's smaller than a hash,
         // just use it directly
         let mut collector = SmallVec::with_capacity(32);
-        self.write(&mut collector);
+        Self::write_preimage(node, &mut collector);
 
         trace!(
             "SIZE WAS {} {}",
-            self.full_path().len(),
+            node.full_path().len(),
             hex::encode(&collector),
         );
 
@@ -157,11 +160,11 @@ impl<T: Hashable> Preimage for T {
         }
     }
 
-    fn write(&self, buf: &mut impl HasUpdate) {
-        let is_account = self.full_path().len() == 64;
+    fn write_preimage<T: Hashable>(node: &T, buf: &mut impl HasUpdate) {
+        let is_account = node.full_path().len() == 64;
         trace!("is_account: {is_account}");
 
-        let child_hashes = self.children();
+        let child_hashes = node.children();
 
         let children = child_hashes.count();
 
@@ -170,8 +173,13 @@ impl<T: Hashable> Preimage for T {
             // we append two items, the partial_path, encoded, and the value
             // note that leaves must always have a value, so we know there
             // will be 2 items
-            let path = nibbles_to_eth_compact(self.partial_path(), true);
-            let value_bytes = self.value_digest().map(|ValueDigest::Value(bytes)| bytes);
+            let path = nibbles_to_eth_compact(node.partial_path(), true);
+            // The Ethereum scheme never stores a value as a hash, so a `Hash`
+            // digest is unexpected here; treat it as no value.
+            let value_bytes = node.value_digest().and_then(|vd| match vd {
+                ValueDigest::Value(bytes) => Some(bytes),
+                ValueDigest::Hash(_) => None,
+            });
 
             // For accounts, splice the empty-trie storage root hash into the
             // account RLP. If the splice fails (malformed value), fall back
@@ -190,7 +198,7 @@ impl<T: Hashable> Preimage for T {
             };
 
             let bytes = encode_list(&[RlpItem::Bytes(&path), value_item]);
-            trace!("partial path {:?}", self.partial_path().display());
+            trace!("partial path {:?}", node.partial_path().display());
             trace!("serialized leaf-rlp: {:?}", hex::encode(&bytes));
             buf.update(&bytes);
         } else {
@@ -210,7 +218,7 @@ impl<T: Hashable> Preimage for T {
             // Account nodes (depth 32) handle values differently — the value
             // lives in the account RLP, not directly in the branch — so we
             // emit Empty here and splice it in below.
-            if !is_account && let Some(ValueDigest::Value(digest)) = self.value_digest() {
+            if !is_account && let Some(ValueDigest::Value(digest)) = node.value_digest() {
                 items[BranchNode::MAX_CHILDREN] = RlpItem::Bytes(digest);
             }
             let bytes = encode_list(&items);
@@ -220,7 +228,7 @@ impl<T: Hashable> Preimage for T {
 
             let updated_bytes: Box<[u8]> = if is_account {
                 // need to get the value again
-                if let Some(ValueDigest::Value(rlp_encoded_bytes)) = self.value_digest() {
+                if let Some(ValueDigest::Value(rlp_encoded_bytes)) = node.value_digest() {
                     // rlp_encoded_bytes needs to be decoded
                     // TODO(rkuris): Handle corruption
                     // needs to be the hash of the RLP encoding of the root node that
@@ -239,7 +247,7 @@ impl<T: Hashable> Preimage for T {
                         {
                             HashType::Hash(hash) => hash.clone(),
                             HashType::Rlp(rlp_bytes) => {
-                                let path = nibbles_to_eth_compact(self.partial_path(), true);
+                                let path = nibbles_to_eth_compact(node.partial_path(), true);
                                 let bytes =
                                     encode_list(&[RlpItem::Bytes(&path), RlpItem::Raw(rlp_bytes)]);
                                 TrieHash::from(Keccak256::digest(bytes))
@@ -259,7 +267,7 @@ impl<T: Hashable> Preimage for T {
                     // treat like non-account since it didn't have a value
                     warn!(
                         "Account node {:x?} without value",
-                        self.full_path().display(),
+                        node.full_path().display(),
                     );
                     bytes
                 }
@@ -267,7 +275,7 @@ impl<T: Hashable> Preimage for T {
                 bytes
             };
 
-            let partial_path = self.partial_path();
+            let partial_path = node.partial_path();
             if partial_path.is_empty() {
                 trace!("pass 2=bytes {:02X?}", hex::encode(&updated_bytes));
                 buf.update(&updated_bytes);
@@ -292,5 +300,17 @@ impl<T: Hashable> Preimage for T {
                 buf.update(&final_bytes);
             }
         }
+    }
+
+    fn write_child_hash<W: ExtendableBytes>(hash: &HashType, buf: &mut W) -> Result<(), Error> {
+        // Delegate to the existing `HashOrRlp` codec so the on-disk bytes stay
+        // byte-for-byte frozen: `0x00` + 32 bytes for a full hash, or
+        // `len` + RLP bytes for an inline-RLP child.
+        HashType::write_to(hash, buf);
+        Ok(())
+    }
+
+    fn read_child_hash(reader: &mut impl Read) -> Result<HashType, Error> {
+        HashType::from_reader(reader)
     }
 }

--- a/storage/src/hashers/merkledb.rs
+++ b/storage/src/hashers/merkledb.rs
@@ -1,22 +1,23 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![cfg_attr(
-    not(feature = "ethhash"),
-    expect(
-        clippy::arithmetic_side_effects,
-        reason = "Found 1 occurrences after enabling the lint."
-    )
+#![expect(
+    clippy::arithmetic_side_effects,
+    reason = "Found 1 occurrences after enabling the lint."
 )]
 
-use crate::hashednode::{HasUpdate, Hashable, Preimage};
+//! Merkledb compatible hashing algorithm.
+
+use crate::hashednode::{HasUpdate, Hashable};
+use crate::node::ExtendableBytes;
+use crate::node::branch::Serializable;
 use crate::{
-    HashMode, MerkleDbHash, NodeHashAlgorithm, Path, TrieHash, TriePath, TriePathAsPackedBytes,
-    ValueDigest,
+    HashMode, HashType, MerkleDbHash, NodeHashAlgorithm, Path, TrieHash, TriePath,
+    TriePathAsPackedBytes, ValueDigest,
 };
-/// Merkledb compatible hashing algorithm.
 use integer_encoding::VarInt;
 use sha2::{Digest, Sha256};
+use std::io::{Error, Read};
 
 const MAX_VARINT_SIZE: usize = 10;
 const BITS_PER_NIBBLE: u64 = 4;
@@ -39,18 +40,16 @@ impl HashMode for MerkleDbHash {
     fn is_valid_key(key: &Path) -> bool {
         key.0.len().is_multiple_of(2)
     }
-}
 
-impl<T: Hashable> Preimage for T {
-    fn to_hash(&self) -> TrieHash {
+    fn to_hash<T: Hashable>(node: &T) -> HashType {
         let mut hasher = Sha256::new();
 
-        self.write(&mut hasher);
-        hasher.finalize().into()
+        Self::write_preimage(node, &mut hasher);
+        HashType::from(TrieHash::from(hasher.finalize()))
     }
 
-    fn write(&self, buf: &mut impl HasUpdate) {
-        let children = self.children();
+    fn write_preimage<T: Hashable>(node: &T, buf: &mut impl HasUpdate) {
+        let children = node.children();
 
         let num_children = children.count() as u64;
 
@@ -64,14 +63,34 @@ impl<T: Hashable> Preimage for T {
         }
 
         // Add value digest (if any) to hash pre-image
-        add_value_digest_to_buf(buf, self.value_digest());
+        add_value_digest_to_buf(buf, node.value_digest());
 
         // Add key length (in bits) to hash pre-image
-        let key = self.full_path();
+        let key = node.full_path();
         let key_bit_len = BITS_PER_NIBBLE * key.len() as u64;
         add_varint_to_buf(buf, key_bit_len);
         // Add key to hash pre-image
         key.as_packed_bytes().for_each(|byte| buf.update([byte]));
+    }
+
+    fn write_child_hash<W: ExtendableBytes>(hash: &HashType, buf: &mut W) -> Result<(), Error> {
+        match hash {
+            HashType::Hash(h) => {
+                // The merkledb child-hash format is a bare 32 bytes, identical
+                // to `TrieHash::write_to`.
+                h.write_to(buf);
+                Ok(())
+            }
+            HashType::Rlp(_) => Err(Error::new(
+                std::io::ErrorKind::InvalidData,
+                "merkledb child hash is RLP-encoded (database corruption)",
+            )),
+        }
+    }
+
+    fn read_child_hash(reader: &mut impl Read) -> Result<HashType, Error> {
+        // The merkledb child-hash format is a bare 32 bytes.
+        Ok(HashType::from(TrieHash::from_reader(reader)?))
     }
 }
 

--- a/storage/src/hashers/mod.rs
+++ b/storage/src/hashers/mod.rs
@@ -3,17 +3,18 @@
 
 //! # Node preimage hashing
 //!
-//! This module provides two mutually-exclusive implementations of
-//! [`Preimage`](crate::Preimage) (and therefore [`to_hash`](crate::Preimage::to_hash))
-//! for trie nodes. Exactly one is compiled in based on feature flags:
+//! This module provides the two implementations of [`HashMode`](crate::HashMode)
+//! — the per-scheme preimage hashing (`to_hash`/`write_preimage`) and child-hash
+//! codec — for trie nodes. Both are compiled into every binary so the scheme can
+//! be selected at runtime:
 //!
-//! | Feature           | Module     | Hash       | Compatibility           |
-//! |-------------------|------------|------------|-------------------------|
-//! | default (off)     | `merkledb` | SHA-256    | Avalanche `merkledb`    |
-//! | `ethhash`         | `ethhash`  | Keccak-256 | Ethereum MPT / C-Chain  |
+//! | Scheme           | Module     | Hash       | Compatibility           |
+//! |------------------|------------|------------|-------------------------|
+//! | `MerkleDbHash`   | `merkledb` | SHA-256    | Avalanche `merkledb`    |
+//! | `EthHash`        | `ethhash`  | Keccak-256 | Ethereum MPT / C-Chain  |
 //!
 //! The two encodings are **not interchangeable**: a database created under one
-//! set of flags cannot be read with the other. Root hashes, proofs, and on-disk
+//! scheme cannot be read with the other. Root hashes, proofs, and on-disk
 //! node encodings all differ.
 //!
 //! ## What these modules produce
@@ -31,15 +32,13 @@
 //!
 //! ## Where to look
 //!
-//! - Hashing the current revision: `ethhash::Preimage::write` /
-//!   `merkledb::Preimage::write`, via
+//! - Hashing the current revision: `EthHash::write_preimage` /
+//!   `MerkleDbHash::write_preimage`, via
 //!   [`NodeStore::hash_helper`](crate::NodeStore::hash_helper) in
 //!   `nodestore::hash`.
 //! - Post-hash fixups for account `storageRoot`:
 //!   `fix_account_storage_root_value` in `nodestore::hash` (proof-generation
 //!   path; only compiled with `ethhash`).
 
-#[cfg(feature = "ethhash")]
 pub(crate) mod ethhash;
-#[cfg(not(feature = "ethhash"))]
-mod merkledb;
+pub(crate) mod merkledb;

--- a/storage/src/hashers/mod.rs
+++ b/storage/src/hashers/mod.rs
@@ -3,17 +3,18 @@
 
 //! # Node preimage hashing
 //!
-//! This module provides two mutually-exclusive implementations of
-//! [`Preimage`](crate::Preimage) (and therefore [`to_hash`](crate::Preimage::to_hash))
-//! for trie nodes. Exactly one is compiled in based on feature flags:
+//! This module provides the two implementations of [`HashMode`](crate::HashMode)
+//! — the per-scheme preimage hashing (`to_hash`/`write_preimage`) and child-hash
+//! codec — for trie nodes. Both are compiled into every binary so the scheme can
+//! be selected at runtime:
 //!
-//! | Feature           | Module     | Hash       | Compatibility           |
-//! |-------------------|------------|------------|-------------------------|
-//! | default (off)     | `merkledb` | SHA-256    | Avalanche `merkledb`    |
-//! | `ethhash`         | `ethhash`  | Keccak-256 | Ethereum MPT / C-Chain  |
+//! | Scheme           | Module     | Hash       | Compatibility           |
+//! |------------------|------------|------------|-------------------------|
+//! | `MerkleDbHash`   | `merkledb` | SHA-256    | Avalanche `merkledb`    |
+//! | `EthHash`        | `ethhash`  | Keccak-256 | Ethereum MPT / C-Chain  |
 //!
 //! The two encodings are **not interchangeable**: a database created under one
-//! set of flags cannot be read with the other. Root hashes, proofs, and on-disk
+//! scheme cannot be read with the other. Root hashes, proofs, and on-disk
 //! node encodings all differ.
 //!
 //! ## What these modules produce
@@ -31,15 +32,13 @@
 //!
 //! ## Where to look
 //!
-//! - Hashing the current revision: `ethhash::Preimage::write` /
-//!   `merkledb::Preimage::write`, via
+//! - Hashing the current revision: `EthHash::write_preimage` /
+//!   `MerkleDbHash::write_preimage`, via
 //!   [`NodeStore::hash_helper`](crate::NodeStore::hash_helper) in
 //!   `nodestore::hash`.
 //! - Post-hash fixups for account `storageRoot`:
 //!   `fix_account_storage_root_value` in `nodestore::hash` (proof-generation
-//!   path; only compiled with `ethhash`).
+//!   path; only meaningful under the Ethereum scheme).
 
-#[cfg(feature = "ethhash")]
 pub(crate) mod ethhash;
-#[cfg(not(feature = "ethhash"))]
-mod merkledb;
+pub(crate) mod merkledb;

--- a/storage/src/hashmode.rs
+++ b/storage/src/hashmode.rs
@@ -8,7 +8,10 @@
 //! schemes, implemented by the two zero-sized types [`MerkleDbHash`] and
 //! [`EthHash`].
 
-use crate::{NodeHashAlgorithm, Path, TrieHash};
+use crate::hashednode::{HasUpdate, Hashable};
+use crate::node::ExtendableBytes;
+use crate::{HashType, NodeHashAlgorithm, Path, TrieHash};
+use std::io::{Error, Read};
 
 /// The node-hashing scheme, implemented by [`MerkleDbHash`] and [`EthHash`].
 ///
@@ -24,6 +27,30 @@ pub trait HashMode: Default + std::fmt::Debug + Send + Sync + 'static {
 
     /// Whether `key` is a structurally valid full trie key under this scheme.
     fn is_valid_key(key: &Path) -> bool;
+
+    /// Hash a node preimage under this scheme.
+    fn to_hash<T: Hashable>(node: &T) -> HashType;
+
+    /// Write the hash preimage of `node` to `buf` under this scheme.
+    fn write_preimage<T: Hashable>(node: &T, buf: &mut impl HasUpdate);
+
+    /// Serialize a child's hash into a node's on-disk encoding under this
+    /// scheme.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `hash` cannot be represented in this scheme's
+    /// on-disk format (e.g. an inline-RLP hash under MerkleDB, which indicates
+    /// database corruption).
+    fn write_child_hash<W: ExtendableBytes>(hash: &HashType, buf: &mut W) -> Result<(), Error>;
+
+    /// Deserialize a child's hash from a node's on-disk encoding under this
+    /// scheme.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the bytes cannot be decoded into a [`HashType`].
+    fn read_child_hash(reader: &mut impl Read) -> Result<HashType, Error>;
 }
 
 /// MerkleDB hashing: SHA-256 over a length-prefixed node encoding.
@@ -88,5 +115,82 @@ mod tests {
         assert!(DefaultHashMode::is_valid_key(&path_of_len(64)));
         assert!(DefaultHashMode::is_valid_key(&path_of_len(2)));
         assert!(!DefaultHashMode::is_valid_key(&path_of_len(3)));
+    }
+
+    #[test]
+    fn eth_child_hash_codec_round_trips_full_hash() {
+        let val = [0x11u8; 32];
+        let hash = HashType::from(val);
+        let mut buf = Vec::new();
+        EthHash::write_child_hash(&hash, &mut buf).unwrap();
+        // Frozen eth layout: leading 0x00 discriminant + 32 raw hash bytes.
+        assert_eq!(buf.len(), 33);
+        assert_eq!(buf[0], 0x00);
+        assert_eq!(&buf[1..], &val);
+
+        let decoded = EthHash::read_child_hash(&mut std::io::Cursor::new(&buf)).unwrap();
+        assert_eq!(decoded, hash);
+        assert!(matches!(decoded, HashType::Hash(_)));
+    }
+
+    #[test]
+    fn eth_child_hash_codec_round_trips_inline_rlp() {
+        let rlp = HashType::Rlp(smallvec::SmallVec::from_slice(&[0xAA, 0xBB, 0xCC]));
+        let mut buf = Vec::new();
+        EthHash::write_child_hash(&rlp, &mut buf).unwrap();
+        // Frozen eth layout: leading length byte + the RLP bytes.
+        assert_eq!(buf, vec![0x03, 0xAA, 0xBB, 0xCC]);
+
+        let decoded = EthHash::read_child_hash(&mut std::io::Cursor::new(&buf)).unwrap();
+        assert_eq!(decoded, rlp);
+        assert!(matches!(decoded, HashType::Rlp(_)));
+    }
+
+    #[test]
+    fn merkledb_child_hash_codec_round_trips_bare_32_bytes() {
+        let val = [0x22u8; 32];
+        let hash = HashType::from(val);
+        let mut buf = Vec::new();
+        MerkleDbHash::write_child_hash(&hash, &mut buf).unwrap();
+        // Frozen merkledb layout: a bare 32 bytes, no prefix.
+        assert_eq!(buf, val);
+
+        let decoded = MerkleDbHash::read_child_hash(&mut std::io::Cursor::new(&buf)).unwrap();
+        assert_eq!(decoded, hash);
+        assert!(matches!(decoded, HashType::Hash(_)));
+    }
+
+    #[test]
+    fn merkledb_child_hash_write_rejects_inline_rlp() {
+        let rlp = HashType::Rlp(smallvec::SmallVec::from_slice(&[0xAA, 0xBB]));
+        let mut buf = Vec::new();
+        assert!(MerkleDbHash::write_child_hash(&rlp, &mut buf).is_err());
+    }
+
+    #[test]
+    fn cross_mode_leaf_preimage_differs_per_scheme() {
+        use crate::{Children, HashableShunt, Path, ValueDigest};
+
+        // A single leaf with a short partial path and value. No children, so
+        // the hash does not depend on any mode-specific child-hash encoding;
+        // the difference is purely the SHA-256 vs Keccak-256 preimage.
+        let partial = Path::from(vec![0x01, 0x02, 0x03, 0x04]);
+        let value = [0xDEu8, 0xAD, 0xBE, 0xEF];
+        let no_prefix: &[crate::PathComponent] = &[];
+        let leaf = HashableShunt::new(
+            no_prefix,
+            partial.as_components(),
+            Some(ValueDigest::Value(value.as_slice())),
+            Children::new(),
+        );
+
+        let eth = EthHash::to_hash(&leaf);
+        let merkledb = MerkleDbHash::to_hash(&leaf);
+
+        // MerkleDB always produces a full 32-byte hash.
+        assert!(matches!(merkledb, HashType::Hash(_)));
+        // This leaf's eth preimage is well under 32 bytes, so eth keeps it
+        // inline as `Rlp` rather than hashing it.
+        assert!(matches!(eth, HashType::Rlp(_)));
     }
 }

--- a/storage/src/hashtype.rs
+++ b/storage/src/hashtype.rs
@@ -1,27 +1,18 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#[cfg(feature = "ethhash")]
 mod ethhash;
 mod trie_hash;
 
+pub use ethhash::HashOrRlp;
 pub use trie_hash::{InvalidTrieHashLength, TrieHash};
 
 /// The type of a hash. For ethereum compatible hashes, this might be a RLP encoded
 /// value if it's small enough to fit in less than 32 bytes. For merkledb compatible
-/// hashes, it's always a `TrieHash`.
-#[cfg(feature = "ethhash")]
-pub type HashType = ethhash::HashOrRlp;
-
-#[cfg(not(feature = "ethhash"))]
-/// The type of a hash. For non-ethereum compatible hashes, this is always a `TrieHash`.
-pub type HashType = crate::TrieHash;
+/// hashes, it's always a `TrieHash` (carried as the `Hash` variant).
+pub type HashType = HashOrRlp;
 
 /// A trait to convert a value into a [`HashType`].
-///
-/// This is used to allow different hash types to be conditionally used, e.g., when the
-/// `ethhash` feature is enabled. When not enabled, this suppresses the clippy warnings
-/// about useless `.into()` calls.
 pub trait IntoHashType {
     /// Converts the value into a `HashType`.
     #[must_use]
@@ -31,14 +22,6 @@ pub trait IntoHashType {
 impl IntoHashType for crate::TrieHash {
     #[inline]
     fn into_hash_type(self) -> HashType {
-        #[cfg(feature = "ethhash")]
-        {
-            self.into()
-        }
-
-        #[cfg(not(feature = "ethhash"))]
-        {
-            self
-        }
+        self.into()
     }
 }

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -16,9 +16,8 @@
 
 use crate::node::branch::ReadSerializable;
 use crate::nodestore::AreaIndex;
-use crate::{HashType, LinearAddress, Path, PathBuf, PathComponent, SharedNode};
+use crate::{DefaultHashMode, HashMode, LinearAddress, Path, PathBuf, PathComponent, SharedNode};
 use bitfield::bitfield;
-use branch::Serializable as _;
 pub use branch::{BranchNode, Child};
 pub use children::{Children, ChildrenSlots};
 use enum_as_inner::EnumAsInner;
@@ -284,7 +283,7 @@ impl Node {
                             .persist_info()
                             .expect("child must be hashed when serializing");
                         encoded.extend_from_slice(&address.get().to_ne_bytes());
-                        hash.write_to(encoded);
+                        DefaultHashMode::write_child_hash(hash, encoded)?;
                     }
                 } else {
                     for (position, child) in child_iter {
@@ -293,7 +292,7 @@ impl Node {
                             .persist_info()
                             .expect("child must be hashed when serializing");
                         encoded.extend_from_slice(&address.get().to_ne_bytes());
-                        hash.write_to(encoded);
+                        DefaultHashMode::write_child_hash(hash, encoded)?;
                     }
                 }
             }
@@ -384,7 +383,7 @@ impl Node {
                         serialized.read_exact(&mut address_buf)?;
                         let address = u64::from_ne_bytes(address_buf);
 
-                        let hash = HashType::from_reader(&mut serialized)?;
+                        let hash = DefaultHashMode::read_child_hash(&mut serialized)?;
 
                         *child = Some(Child::AddressWithHash(
                             LinearAddress::new(address)
@@ -408,7 +407,7 @@ impl Node {
                         serialized.read_exact(&mut address_buf)?;
                         let address = u64::from_ne_bytes(address_buf);
 
-                        let hash = HashType::from_reader(&mut serialized)?;
+                        let hash = DefaultHashMode::read_child_hash(&mut serialized)?;
 
                         children[position] = Some(Child::AddressWithHash(
                             LinearAddress::new(address)
@@ -608,6 +607,54 @@ than 126 bytes as the length would be encoded in multiple bytes.
         let deserialized = Node::from_reader(&mut cursor).unwrap();
 
         assert_eq!(node, deserialized);
+    }
+
+    /// Golden test locking the on-disk byte layout of a branch node's
+    /// child-hash region in eth mode: an 8-byte native-endian address followed
+    /// by the hash codec output (`0x00` + 32 raw bytes for a full hash). These
+    /// bytes must stay byte-for-byte stable so existing databases keep working.
+    #[cfg(feature = "ethhash")]
+    #[test]
+    fn test_eth_child_hash_region_exact_bytes() {
+        // A partial branch with a single child at slot 15, no value. Distinct
+        // per-byte values make a mismatch easy to spot in the failure hex dump.
+        let hash_bytes: [u8; 32] = std::array::from_fn(|i| i as u8);
+        let child_hash: crate::HashType = hash_bytes.into();
+        let node = Node::Branch(Box::new(BranchNode {
+            partial_path: Path::from(vec![0, 1]),
+            value: None,
+            children: Children::from_fn(|i| {
+                if i.as_u8() == 15 {
+                    Some(Child::AddressWithHash(
+                        LinearAddress::new(1).unwrap(),
+                        child_hash.clone(),
+                    ))
+                } else {
+                    None
+                }
+            }),
+        }));
+
+        let mut serialized = Vec::new();
+        node.as_bytes(&mut serialized).unwrap();
+
+        // The child record is the tail of the encoding.
+        let mut expected_tail = Vec::new();
+        expected_tail.push(15u8); // child-slot nibble varint (single byte)
+        expected_tail.extend_from_slice(&1u64.to_ne_bytes()); // address
+        expected_tail.push(0x00); // full-hash discriminant
+        expected_tail.extend_from_slice(&hash_bytes);
+
+        assert!(
+            serialized.ends_with(&expected_tail),
+            "child-hash region changed; got {}",
+            hex::encode(&serialized)
+        );
+
+        // And the whole thing must round-trip.
+        let mut cursor = std::io::Cursor::new(&serialized);
+        cursor.set_position(1);
+        assert_eq!(node, Node::from_reader(&mut cursor).unwrap());
     }
 
     #[test]

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -16,9 +16,8 @@
 
 use crate::node::branch::ReadSerializable;
 use crate::nodestore::AreaIndex;
-use crate::{HashType, LinearAddress, Path, PathBuf, PathComponent, SharedNode};
+use crate::{DefaultHashMode, HashMode, LinearAddress, Path, PathBuf, PathComponent, SharedNode};
 use bitfield::bitfield;
-use branch::Serializable as _;
 pub use branch::{BranchNode, Child};
 pub use children::{Children, ChildrenSlots, DenseChildren};
 use enum_as_inner::EnumAsInner;
@@ -284,7 +283,7 @@ impl Node {
                             .persist_info()
                             .expect("child must be hashed when serializing");
                         encoded.extend_from_slice(&address.get().to_ne_bytes());
-                        hash.write_to(encoded);
+                        DefaultHashMode::write_child_hash(hash, encoded)?;
                     }
                 } else {
                     for (position, child) in child_iter {
@@ -293,7 +292,7 @@ impl Node {
                             .persist_info()
                             .expect("child must be hashed when serializing");
                         encoded.extend_from_slice(&address.get().to_ne_bytes());
-                        hash.write_to(encoded);
+                        DefaultHashMode::write_child_hash(hash, encoded)?;
                     }
                 }
             }
@@ -384,7 +383,7 @@ impl Node {
                         serialized.read_exact(&mut address_buf)?;
                         let address = u64::from_ne_bytes(address_buf);
 
-                        let hash = HashType::from_reader(&mut serialized)?;
+                        let hash = DefaultHashMode::read_child_hash(&mut serialized)?;
 
                         *child = Some(Child::AddressWithHash(
                             LinearAddress::new(address)
@@ -408,7 +407,7 @@ impl Node {
                         serialized.read_exact(&mut address_buf)?;
                         let address = u64::from_ne_bytes(address_buf);
 
-                        let hash = HashType::from_reader(&mut serialized)?;
+                        let hash = DefaultHashMode::read_child_hash(&mut serialized)?;
 
                         children[position] = Some(Child::AddressWithHash(
                             LinearAddress::new(address)
@@ -610,6 +609,54 @@ than 126 bytes as the length would be encoded in multiple bytes.
         let deserialized = Node::from_reader(&mut cursor).unwrap();
 
         assert_eq!(node, deserialized);
+    }
+
+    /// Golden test locking the on-disk byte layout of a branch node's
+    /// child-hash region in eth mode: an 8-byte native-endian address followed
+    /// by the hash codec output (`0x00` + 32 raw bytes for a full hash). These
+    /// bytes must stay byte-for-byte stable so existing databases keep working.
+    #[cfg(feature = "ethhash")]
+    #[test]
+    fn test_eth_child_hash_region_exact_bytes() {
+        // A partial branch with a single child at slot 15, no value. Distinct
+        // per-byte values make a mismatch easy to spot in the failure hex dump.
+        let hash_bytes: [u8; 32] = std::array::from_fn(|i| i as u8);
+        let child_hash: crate::HashType = hash_bytes.into();
+        let node = Node::Branch(Box::new(BranchNode {
+            partial_path: Path::from(vec![0, 1]),
+            value: None,
+            children: Children::from_fn(|i| {
+                if i.as_u8() == 15 {
+                    Some(Child::AddressWithHash(
+                        LinearAddress::new(1).unwrap(),
+                        child_hash.clone(),
+                    ))
+                } else {
+                    None
+                }
+            }),
+        }));
+
+        let mut serialized = Vec::new();
+        node.as_bytes(&mut serialized).unwrap();
+
+        // The child record is the tail of the encoding.
+        let mut expected_tail = Vec::new();
+        expected_tail.push(15u8); // child-slot nibble varint (single byte)
+        expected_tail.extend_from_slice(&1u64.to_ne_bytes()); // address
+        expected_tail.push(0x00); // full-hash discriminant
+        expected_tail.extend_from_slice(&hash_bytes);
+
+        assert!(
+            serialized.ends_with(&expected_tail),
+            "child-hash region changed; got {}",
+            hex::encode(&serialized)
+        );
+
+        // And the whole thing must round-trip.
+        let mut cursor = std::io::Cursor::new(&serialized);
+        cursor.set_position(1);
+        assert_eq!(node, Node::from_reader(&mut cursor).unwrap());
     }
 
     #[test]

--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -404,9 +404,8 @@ fn update_account_storage_root(node: &mut Node, path_prefix: &Path) {
 
 /// Extract the `TrieHash` for the single-storage-child case. At account
 /// depth storage child encodings always exceed 32 bytes (32-byte keys), so
-/// the inline-RLP variant cannot occur in ethhash mode; without ethhash
-/// every child is already a hash.
-#[cfg(feature = "ethhash")]
+/// the inline-RLP variant cannot occur; under the merkledb scheme every child
+/// is already a 32-byte hash.
 fn single_child_storage_root(child: HashType) -> crate::TrieHash {
     match child {
         HashType::Hash(hash) => hash,
@@ -417,16 +416,9 @@ fn single_child_storage_root(child: HashType) -> crate::TrieHash {
     }
 }
 
-#[cfg(not(feature = "ethhash"))]
-const fn single_child_storage_root(child: HashType) -> crate::TrieHash {
-    // Without ethhash, `HashType` is `TrieHash`.
-    child
-}
-
 /// Encode one child slot of an account's storage branch as an [`RlpItem`].
 /// Mirrors the dispatch the ethhash hasher does inline (see
-/// `storage/src/hashers/ethhash.rs::Preimage::write`).
-#[cfg(feature = "ethhash")]
+/// `storage/src/hashers/ethhash.rs::EthHash::write_preimage`).
 fn child_to_rlp_item(child: Option<&HashType>) -> RlpItem<'_> {
     match child {
         Some(HashType::Hash(hash)) => RlpItem::Bytes(hash.as_slice()),
@@ -434,14 +426,6 @@ fn child_to_rlp_item(child: Option<&HashType>) -> RlpItem<'_> {
             "account-depth storage child cannot have inline RLP: \
              storage node encoding with 32-byte keys always exceeds 32 bytes"
         ),
-        None => RlpItem::Empty,
-    }
-}
-
-#[cfg(not(feature = "ethhash"))]
-fn child_to_rlp_item(child: Option<&HashType>) -> RlpItem<'_> {
-    match child {
-        Some(hash) => RlpItem::Bytes(hash.as_slice()),
         None => RlpItem::Empty,
     }
 }


### PR DESCRIPTION
## Why this should be merged

Runtime selection is not possible while core node and proof types change shape at compile time. Both hashing schemes need to share one in-memory data model while continuing to read and write their existing, different byte encodings.

In the stack, this turns the PR 2 abstraction into a common low-level data and codec layer. That shared representation is required before PR 5 can parse both proof formats in one binary and before PR 6 can instantiate the database stack
with either hash mode.

## How this works

This change makes `HashType` an unconditional enum that can contain either a 32-byte hash or inline RLP, and makes the hashed arm of `ValueDigest` unconditional. It expands `HashMode` with mode-specific hashing, preimage, and child-codec behavior so Ethereum retains its tagged hash/inline-RLP encoding while MerkleDB retains its bare 32-byte hash encoding.

Proof serialization also dispatches through the selected mode without changing either wire format. A defensive reconciliation guard rejects hashed value digests when the effective mode is Ethereum before trie mutation or callbacks can observe invalid state.

## How this was tested

Added codec round-trip tests for Ethereum hashes, Ethereum inline RLP, and MerkleDB hashes; rejection tests for inline RLP in MerkleDB mode; cross-mode leaf-preimage tests; an exact Ethereum child-hash serialization golden test;
and a regression test for the defensive Ethereum value-digest guard.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
