### PR TITLE
test(proofs): expand snapshot tests to cover header, key-values, and batch ops

### DIFF
--- a/firewood/src/proofs/snapshot_tests.rs
+++ b/firewood/src/proofs/snapshot_tests.rs
@@ -36,6 +36,27 @@
 //! `single_child` and `all_children` already cover the complete child
 //! encoding format. The large-value → hash behaviour is format-agnostic and
 //! is fully covered by the `merkledb` variant.
+//!
+//! ## Additional coverage
+//!
+//! The following tests lock down wire-format sections beyond individual node encoding.
+//! The payload snapshots (everything after the 32-byte header) are feature-independent
+//! for key-values and batch ops; the header snapshots are cfg-gated because the
+//! `hash_mode` byte differs between SHA-256 and Keccak-256 modes.
+//!
+//! | Test | Subject |
+//! |------|---------|
+//! | `header::merkledb::range` | 32-byte header, SHA-256 mode, range proof type |
+//! | `header::merkledb::change` | 32-byte header, SHA-256 mode, change proof type |
+//! | `header::ethhash::range` | 32-byte header, Keccak-256 mode, range proof type |
+//! | `header::ethhash::change` | 32-byte header, Keccak-256 mode, change proof type |
+//! | `key_values::empty` | Empty KV sequence: `varint(0)` |
+//! | `key_values::single_pair` | One `(key, value)` pair |
+//! | `key_values::multiple_pairs` | Two `(key, value)` pairs |
+//! | `batch_ops::put` | Single `Put` operation (opcode `0x00`) |
+//! | `batch_ops::delete` | Single `Delete` operation (opcode `0x01`) |
+//! | `batch_ops::delete_range` | Single `DeleteRange` operation (opcode `0x02`) |
+//! | `batch_ops::all_ops` | All three operations in sequence |
 
 #![expect(clippy::unwrap_used, clippy::indexing_slicing)]
 
@@ -44,7 +65,9 @@ use firewood_storage::{
 };
 
 use super::types::{Proof, ProofNode};
-use crate::api::FrozenRangeProof;
+use crate::api::{FrozenChangeProof, FrozenRangeProof};
+use crate::db::BatchOp;
+use crate::merkle::{Key, Value};
 
 /// Serializes `node` inside a minimal [`FrozenRangeProof`] and returns the bytes
 /// after the fixed 32-byte proof header.
@@ -173,5 +196,181 @@ mod ethhash {
         let all: Vec<u8> = (0u8..16).collect();
         let node = make_node(&[0], 0, None, &all);
         insta::assert_snapshot!(hex::encode(node_bytes(&node)));
+    }
+}
+
+/// Serializes a [`FrozenRangeProof`] with empty node lists and the given key-value
+/// pairs. Returns all bytes including the 32-byte proof header.
+fn range_proof_bytes(kvs: &[(&[u8], &[u8])]) -> Vec<u8> {
+    let kv_pairs: Box<[(Key, Value)]> = kvs
+        .iter()
+        .map(|(k, v)| (Box::from(*k), Box::from(*v)))
+        .collect();
+    let proof = FrozenRangeProof::new(
+        Proof::new(Box::<[ProofNode]>::from([])),
+        Proof::new(Box::<[ProofNode]>::from([])),
+        kv_pairs,
+    );
+    let mut out = Vec::new();
+    proof.write_to_vec(&mut out);
+    out
+}
+
+/// Serializes a [`FrozenChangeProof`] with empty node lists and the given batch
+/// operations. Returns all bytes including the 32-byte proof header.
+fn change_proof_bytes(ops: Box<[BatchOp<Key, Value>]>) -> Vec<u8> {
+    let proof = FrozenChangeProof::new(
+        Proof::new(Box::<[ProofNode]>::from([])),
+        Proof::new(Box::<[ProofNode]>::from([])),
+        ops,
+    );
+    let mut out = Vec::new();
+    proof.write_to_vec(&mut out);
+    out
+}
+
+/// Header encoding tests — snapshots the full 32-byte proof header.
+///
+/// The `hash_mode` byte is `0x00` for SHA-256 (merkledb) and `0x01` for
+/// Keccak-256 (ethhash), so the header bytes differ between feature modes.
+/// Tests are nested inside cfg-gated submodules following the same convention
+/// as the node tests above.
+mod header {
+    use super::*;
+
+    fn range_header() -> Vec<u8> {
+        range_proof_bytes(&[])[..32].to_vec()
+    }
+
+    fn change_header() -> Vec<u8> {
+        change_proof_bytes(Box::new([]))[..32].to_vec()
+    }
+
+    #[cfg(not(feature = "ethhash"))]
+    mod merkledb {
+        use super::*;
+
+        /// Range proof header: magic `fwdproof`, version `0x00`, `hash_mode` `0x00`
+        /// (SHA-256), branch_factor `0x10`, proof_type `0x01` (range), 20 zero
+        /// reserved bytes.
+        #[test]
+        fn range() {
+            insta::assert_snapshot!(hex::encode(range_header()));
+        }
+
+        /// Change proof header: same as range but proof_type `0x02` (change).
+        #[test]
+        fn change() {
+            insta::assert_snapshot!(hex::encode(change_header()));
+        }
+    }
+
+    #[cfg(feature = "ethhash")]
+    mod ethhash {
+        use super::*;
+
+        /// Range proof header, Keccak-256 mode: `hash_mode` byte is `0x01`
+        /// instead of `0x00`.
+        #[test]
+        fn range() {
+            insta::assert_snapshot!(hex::encode(range_header()));
+        }
+
+        /// Change proof header, Keccak-256 mode.
+        #[test]
+        fn change() {
+            insta::assert_snapshot!(hex::encode(change_header()));
+        }
+    }
+}
+
+/// Key-value pair encoding tests — snapshots `bytes[32..]` of a [`FrozenRangeProof`]
+/// with empty node lists. Key-value encoding uses raw byte slices and is identical
+/// under both hash modes; no cfg-gating is needed.
+///
+/// The payload begins with `varint(0)` twice (empty start- and end-proof counts),
+/// then `varint(N)` followed by N length-prefixed `(key, value)` pairs.
+mod key_values {
+    use super::*;
+
+    /// No key-value pairs: the KV sequence is encoded as a single `varint(0)`.
+    #[test]
+    fn empty() {
+        insta::assert_snapshot!(hex::encode(&range_proof_bytes(&[])[32..]));
+    }
+
+    /// Single pair `b"key1"` → `b"value1"`.
+    #[test]
+    fn single_pair() {
+        insta::assert_snapshot!(hex::encode(
+            &range_proof_bytes(&[(b"key1", b"value1")])[32..]
+        ));
+    }
+
+    /// Two pairs in sequence: `b"key1"`→`b"val1"`, `b"key2"`→`b"val2"`.
+    #[test]
+    fn multiple_pairs() {
+        insta::assert_snapshot!(hex::encode(
+            &range_proof_bytes(&[(b"key1", b"val1"), (b"key2", b"val2")])[32..]
+        ));
+    }
+}
+
+/// Batch operation encoding tests — snapshots `bytes[32..]` of a
+/// [`FrozenChangeProof`] with empty node lists. Batch ops use fixed opcodes
+/// and raw byte slices; encoding is identical under both hash modes.
+///
+/// The payload begins with `varint(0)` twice (empty start- and end-proof counts),
+/// then `varint(N)` followed by N operations. Each operation starts with a 1-byte
+/// opcode: `0x00` = `Put`, `0x01` = `Delete`, `0x02` = `DeleteRange`.
+mod batch_ops {
+    use super::*;
+
+    /// Single `Put` operation: opcode `0x00`, key length-prefixed, then value
+    /// length-prefixed.
+    #[test]
+    fn put() {
+        let ops = Box::new([BatchOp::Put {
+            key: Box::from(b"key1".as_slice()),
+            value: Box::from(b"val1".as_slice()),
+        }]);
+        insta::assert_snapshot!(hex::encode(&change_proof_bytes(ops)[32..]));
+    }
+
+    /// Single `Delete` operation: opcode `0x01`, then key length-prefixed.
+    #[test]
+    fn delete() {
+        let ops = Box::new([BatchOp::Delete {
+            key: Box::from(b"key2".as_slice()),
+        }]);
+        insta::assert_snapshot!(hex::encode(&change_proof_bytes(ops)[32..]));
+    }
+
+    /// Single `DeleteRange` operation: opcode `0x02`, then prefix length-prefixed.
+    #[test]
+    fn delete_range() {
+        let ops = Box::new([BatchOp::DeleteRange {
+            prefix: Box::from(b"key3".as_slice()),
+        }]);
+        insta::assert_snapshot!(hex::encode(&change_proof_bytes(ops)[32..]));
+    }
+
+    /// All three operations in sequence. Matches the proof constructed by
+    /// `create_valid_change_proof()` in `tests.rs`.
+    #[test]
+    fn all_ops() {
+        let ops = Box::new([
+            BatchOp::Put {
+                key: Box::from(b"key1".as_slice()),
+                value: Box::from(b"val1".as_slice()),
+            },
+            BatchOp::Delete {
+                key: Box::from(b"key2".as_slice()),
+            },
+            BatchOp::DeleteRange {
+                prefix: Box::from(b"key3".as_slice()),
+            },
+        ]);
+        insta::assert_snapshot!(hex::encode(&change_proof_bytes(ops)[32..]));
     }
 }

--- a/firewood/src/proofs/snapshot_tests.rs
+++ b/firewood/src/proofs/snapshot_tests.rs
@@ -251,14 +251,14 @@ mod header {
         use super::*;
 
         /// Range proof header: magic `fwdproof`, version `0x00`, `hash_mode` `0x00`
-        /// (SHA-256), branch_factor `0x10`, proof_type `0x01` (range), 20 zero
+        /// (SHA-256), `branch_factor` `0x10`, `proof_type` `0x01` (range), 20 zero
         /// reserved bytes.
         #[test]
         fn range() {
             insta::assert_snapshot!(hex::encode(range_header()));
         }
 
-        /// Change proof header: same as range but proof_type `0x02` (change).
+        /// Change proof header: same as range but `proof_type` `0x02` (change).
         #[test]
         fn change() {
             insta::assert_snapshot!(hex::encode(change_header()));

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__batch_ops__all_ops.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__batch_ops__all_ops.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(&change_proof_bytes(ops)[32..])"
+---
+00000300046b6579310476616c3101046b65793202046b657933

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__batch_ops__delete.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__batch_ops__delete.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(&change_proof_bytes(ops)[32..])"
+---
+00000101046b657932

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__batch_ops__delete_range.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__batch_ops__delete_range.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(&change_proof_bytes(ops)[32..])"
+---
+00000102046b657933

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__batch_ops__put.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__batch_ops__put.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(&change_proof_bytes(ops)[32..])"
+---
+00000100046b6579310476616c31

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__header__ethhash__change.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__header__ethhash__change.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(change_header())"
+---
+66776470726f6f66000110020000000000000000000000000000000000000000

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__header__ethhash__range.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__header__ethhash__range.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(range_header())"
+---
+66776470726f6f66000110010000000000000000000000000000000000000000

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__header__merkledb__change.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__header__merkledb__change.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(change_header())"
+---
+66776470726f6f66000010020000000000000000000000000000000000000000

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__header__merkledb__range.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__header__merkledb__range.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(range_header())"
+---
+66776470726f6f66000010010000000000000000000000000000000000000000

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__key_values__empty.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__key_values__empty.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(&range_proof_bytes(&[])[32..])"
+---
+000000

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__key_values__multiple_pairs.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__key_values__multiple_pairs.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(&range_proof_bytes(&[(b\"key1\", b\"val1\"),\n(b\"key2\", b\"val2\")])[32..])"
+---
+000002046b6579310476616c31046b6579320476616c32

--- a/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__key_values__single_pair.snap
+++ b/firewood/src/proofs/snapshots/firewood__proofs__snapshot_tests__key_values__single_pair.snap
@@ -1,0 +1,5 @@
+---
+source: firewood/src/proofs/snapshot_tests.rs
+expression: "hex::encode(&range_proof_bytes(&[(b\"key1\", b\"value1\")])[32..])"
+---
+000001046b6579310676616c756531

--- a/justfile
+++ b/justfile
@@ -2,12 +2,14 @@
 default:
     ./scripts/run-just.sh --list
 
-# Regenerate proof-node wire serialization snapshots for both hash modes.
+# Regenerate proof wire serialization snapshots for both hash modes.
 #
-# Run this after any intentional change to the ProofNode binary format (ser.rs,
-# de.rs, childmask, or header). The recipe writes snapshots for the MerkleDB
-# (SHA-256) mode first, then for the Ethereum (Keccak-256, ethhash) mode.
-# Existing snapshots are overwritten when their content changes.
+# Run this after any intentional change to the proof binary format (ser.rs,
+# de.rs, childmask, or header). Covers ProofNode encoding, the 32-byte proof
+# header, key-value pair encoding, and BatchOp encoding. The recipe writes
+# snapshots for the MerkleDB (SHA-256) mode first, then for the Ethereum
+# (Keccak-256, ethhash) mode. Existing snapshots are overwritten when their
+# content changes.
 #
 # After running, review the diffs in src/proofs/snapshots/ and commit them
 # alongside the format change.


### PR DESCRIPTION
Extends the insta snapshot test suite started in #2100 to lock
down the remaining V0 wire-format sections that were not yet snapshot-tested.

## Why this should be merged

The earlier PR pinned ProofNode encoding. The proof header, key-value pair
encoding, and BatchOp encoding were left without snapshot coverage, meaning an
accidental format change in those paths could go undetected until a round-trip
test caught the mismatch at runtime.

## How this works

Adds two helper functions (`range_proof_bytes`, `change_proof_bytes`) that
serialize minimal proofs with empty node lists, then adds three new test
modules:

- `header` — snapshots the full 32-byte header for Range and Change proof
  types; cfg-gated into `merkledb`/`ethhash` submodules because the
  `hash_mode` byte differs between SHA-256 and Keccak-256 modes.
- `key_values` — snapshots `bytes[32..]` for range proofs carrying 0, 1, and
  2 key-value pairs; feature-independent, no cfg-gating.
- `batch_ops` — snapshots `bytes[32..]` for change proofs carrying a single
  `Put`, `Delete`, `DeleteRange`, and all three in sequence; also
  feature-independent.

Updates the `justfile` recipe comment to reflect the broader coverage.

## How this was tested

`just snapshot-proof-nodes` writes all 11 new snapshot files. `cargo nextest
run -p firewood --features logger --all-targets` passes 415 tests.
