### PR TITLE
build: resolve malformed LC_DYSYMTAB when linking to firewood on MacOS

### DIFF
--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -85,6 +85,18 @@ jobs:
       - name: Build for ${{ matrix.target }}
         run: cargo build-static-ffi --target ${{ matrix.target }}
 
+      # see https://github.com/golang/go/issues/61229#issuecomment-1988965927
+      # the generated archive has a malformed LC_DYSYMTAB which the Apple linker doesn't
+      # like. `ld -r` makes the archive "relocatable" and fixes the malformed LC_DYSYMTAB.
+      - name: Cleanup malformed LC_DYSYMTAB
+        if: matrix.os == 'macos-26'
+        run: |
+          lib_path="target/aarch64-apple-darwin/maxperf/libfirewood_ffi.a"
+          tmp_path="${lib_path}.tmp"
+          cp "$lib_path" "$tmp_path"
+          ld -r -arch arm64 -o "$lib_path" "$tmp_path"
+          rm "$tmp_path"
+
       - name: Upload binary
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -264,7 +264,7 @@ jobs:
       - name: Cleanup malformed LC_DYSYMTAB
         if: matrix.os == 'macos-26'
         run: |
-          lib_path="target/maxperf/libfirewood_ffi.a"
+          lib_path="target/debug/libfirewood_ffi.a"
           tmp_path="${lib_path}.tmp"
           cp "$lib_path" "$tmp_path"
           ld -r -arch arm64 -o "$lib_path" "$tmp_path"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -258,6 +258,17 @@ jobs:
       - name: Build Firewood FFI
         working-directory: ffi
         run: cargo build --locked
+      # see https://github.com/golang/go/issues/61229#issuecomment-1988965927
+      # the generated archive has a malformed LC_DYSYMTAB which the Apple linker doesn't
+      # like. `ld -r` makes the archive "relocatable" and fixes the malformed LC_DYSYMTAB.
+      - name: Cleanup malformed LC_DYSYMTAB
+        if: matrix.os == 'macos-26'
+        run: |
+          lib_path="target/maxperf/libfirewood_ffi.a"
+          tmp_path="${lib_path}.tmp"
+          cp "$lib_path" "$tmp_path"
+          ld -r -arch arm64 -o "$lib_path" "$tmp_path"
+          rm "$tmp_path"
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -255,6 +255,8 @@ jobs:
         with:
           save-if: "false"
           shared-key: "debug-no-features"
+      - if: matrix.os == 'macos-26'
+        run: echo 'MACOSX_DEPLOYMENT_TARGET=15.0' >> "$GITHUB_ENV"
       - name: Build Firewood FFI
         working-directory: ffi
         run: cargo build --locked


### PR DESCRIPTION
Closes: #1941

## Why this should be merged

## How this works

## How this was tested

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
