### PR TITLE
docs(storage): document FileBacked struct and its fields

### DIFF
--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -35,17 +35,56 @@ use crate::{CacheReadStrategy, CachedNode, LinearAddress, MaybePersistedNode, Sh
 
 use super::{FileIoError, OffsetReader, ReadableStorage, WritableStorage};
 
-/// A [`ReadableStorage`] and [`WritableStorage`] backed by a file
+/// A [`ReadableStorage`] and [`WritableStorage`] backed by a single on-disk file.
+///
+/// This is the persistent storage backend for a node store. It owns the open
+/// file handle — which can be advisory-locked via [`Self::lock`] to stop another
+/// process from opening the same database — along with two in-memory LRU caches
+/// that sit in front of it: one for trie nodes and one for free-list links.
+///
+/// Reads and writes go through positioned (`pread`/`pwrite`) syscalls, so they
+/// share no file cursor and take no per-handle lock; the caches absorb most
+/// reads so that the hot path rarely touches disk. The only serialization
+/// points are the two cache mutexes and, on the `io-uring` path, the ring's
+/// internal lock.
 #[derive(Debug)]
 pub struct FileBacked {
+    /// Path of the on-disk database file.
     filename: PathBuf,
+    /// In-memory cache of trie nodes keyed by their on-disk [`LinearAddress`].
+    ///
+    /// This cache is *memory-bounded* (its capacity is a byte budget, not an
+    /// entry count) and sits on the hot read path: every node lookup checks it
+    /// before falling back to disk. Reads populate it according to
+    /// [`Self::cache_read_strategy`]; writes always populate it.
     cache: Mutex<MemLruCache<LinearAddress, CachedNode>>,
+    /// In-memory cache of free-list links, mapping a freed node's
+    /// [`LinearAddress`] to the address of the next free node in that list
+    /// ([`None`] marks the end of the list).
+    ///
+    /// This cache is *entry-count bounded* and accelerates node allocation by
+    /// avoiding a disk read to walk the free list. A lookup is destructive: a
+    /// cache hit pops the entry, since allocating from the free list consumes it.
     free_list_cache: Mutex<EntryLruCache<LinearAddress, Option<LinearAddress>>>,
+    /// Policy controlling which reads get inserted into [`Self::cache`]
+    /// (no reads, branch reads only, or all reads). Writes are always cached
+    /// regardless of this setting.
     cache_read_strategy: CacheReadStrategy,
+    /// The node hashing algorithm (MerkleDB or Ethereum) this file was opened
+    /// with. Reported via [`ReadableStorage::node_hash_algorithm`] so callers
+    /// can detect a mismatch between the file and the running build.
     node_hash_algorithm: crate::NodeHashAlgorithm,
-    // keep before `fd` so that it is dropped first (fields are dropped in the order they are declared)
+    /// `io_uring` proxy used to submit batched writes to the file
+    /// (see [`WritableStorage::write_batch`]). The proxy owns only the
+    /// `io_uring` instance, not the descriptor — `fd` is passed by `RawFd` into
+    /// each `write_batch` call.
+    ///
+    /// Declared before `fd` so that it is dropped first (struct fields are
+    /// dropped in declaration order).
     #[cfg(feature = "io-uring")]
     ring: super::io_uring::IoUringProxy,
+    /// The open file handle backing this storage, wrapped so that the advisory
+    /// lock taken by [`Self::lock`] is released when the handle is dropped.
     fd: UnlockOnDrop,
 }
 


### PR DESCRIPTION
## Why this should be merged

While looking at the caching policy for trie nodes, I noticed that the `FileBacked` type was lacking documentation - given that important Firewood operations funnel down to this type, I figured we should document it better.

## How this works

Adds documentation to the `FileBacked` type and its fields.

## How this was tested

CI.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
