### PR TITLE
ci: run clippy on a pinned nightly, gate maxperf, and add a weekly nightly lint

### DIFF
--- a/.github/workflows/attach-static-libs.yaml
+++ b/.github/workflows/attach-static-libs.yaml
@@ -66,8 +66,10 @@ jobs:
             pre-build-cmd: echo "MACOSX_DEPLOYMENT_TARGET=15.0" >> "$GITHUB_ENV"
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2
         with:
           shared-key: ${{ matrix.target }}
 

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -14,8 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2
         with:
           shared-key: "maxperf-ethhash-logger-test_utils"
           cache-all-crates: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,8 +99,9 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable (channel via input)
         with:
+          toolchain: nightly-2026-07-05
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:
@@ -129,11 +130,14 @@ jobs:
             profile-args: "--features ethhash,logger"
           - profile-key: debug-all-features
             profile-args: "--all-features"
+          - profile-key: maxperf-ethhash-logger
+            profile-args: "--profile maxperf --features ethhash,logger"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable (channel via input)
         with:
+          toolchain: nightly-2026-07-05
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,10 +42,11 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
+          toolchain: stable
           components: clippy
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2
         with:
           shared-key: ${{ matrix.profile-key }}
           cache-all-crates: true
@@ -62,8 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
+          toolchain: stable
           components: rustfmt
       - name: Check license headers
         uses: viperproject/check-license-header@e06c65614fa9f32e099838df4dd25440c5344b32 # @v2
@@ -99,7 +101,7 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable (channel via input)
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: nightly-2026-07-05
           components: clippy
@@ -135,7 +137,7 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable (channel via input)
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: nightly-2026-07-05
           components: clippy
@@ -169,7 +171,9 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
       - uses: taiki-e/install-action@a7cecc7ff99ae8eda4fc89463cb7ab6aaa619b43 # @nextest
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:
@@ -199,7 +203,9 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:
           save-if: "false"
@@ -214,7 +220,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:
           save-if: "false"
@@ -254,7 +262,9 @@ jobs:
         os: [ubuntu-latest, macos-26]
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:
           save-if: "false"
@@ -281,7 +291,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:
           save-if: "false"
@@ -321,7 +333,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:
           save-if: "false"
@@ -356,7 +370,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:
           save-if: "false"

--- a/.github/workflows/default-branch-cache.yaml
+++ b/.github/workflows/default-branch-cache.yaml
@@ -16,10 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
+          toolchain: stable
           components: clippy,rustfmt
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2
         with:
           save-if: "false"
           shared-key: "debug-no-features"

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -35,9 +35,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: main # Always build docs from main
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
       # caution: this is the same restore as in ci.yaml
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2
         with:
           save-if: "false"
       - uses: actions/setup-go@v6

--- a/.github/workflows/lint-nightly.yaml
+++ b/.github/workflows/lint-nightly.yaml
@@ -1,0 +1,39 @@
+name: lint-nightly
+on:
+  schedule:
+    # Mondays 06:00 UTC — surfaces new/changed nightly clippy lints out of band,
+    # decoupled from PR gating (which runs pinned nightly-2026-07-05).
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+jobs:
+  rust-lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile-key: debug-no-default-features
+            profile-args: "--no-default-features"
+          - profile-key: debug-no-features
+            profile-args: ""
+          - profile-key: debug-no-features
+            profile-args: ""
+            os: macos-26
+          - profile-key: debug-ethhash-logger
+            profile-args: "--features ethhash,logger"
+          - profile-key: debug-all-features
+            profile-args: "--all-features"
+          - profile-key: maxperf-ethhash-logger
+            profile-args: "--profile maxperf --features ethhash,logger"
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable (channel via input)
+        with:
+          toolchain: nightly
+          components: clippy
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
+        with:
+          save-if: "false"
+          shared-key: ${{ matrix.profile-key }}
+      - name: Clippy
+        run: cargo clippy --locked ${{ matrix.profile-args }} --workspace --all-targets -- -D warnings

--- a/.github/workflows/lint-nightly.yaml
+++ b/.github/workflows/lint-nightly.yaml
@@ -27,11 +27,11 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable (channel via input)
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: nightly
           components: clippy
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2
         with:
           save-if: "false"
           shared-key: ${{ matrix.profile-key }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,9 @@ jobs:
     if: github.repository == 'ava-labs/firewood' && startsWith(github.event.release.tag_name, 'v')
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # @stable
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
       ## NOTE: keep these packages sorted in reverse topological order!
       ## cargo tree --workspace -e all | grep firewood
       - name: publish firewood-macros crate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,8 @@ Before submitting/updating a PR, run the following
 ```bash
 cargo fmt                                                               # Format code
 cargo nextest run --workspace --features ethhash,logger --all-targets   # Run tests
-cargo clippy --workspace --features ethhash,logger --all-targets        # Linter
+cargo clippy --workspace --features ethhash,logger --all-targets                    # Linter
+cargo clippy --profile maxperf --features ethhash,logger --workspace --all-targets  # Linter (maxperf: debug-assertions off)
 cargo doc --no-deps                                                     # Ensure docs build
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,8 +144,8 @@ Before submitting/updating a PR, run the following
 ```bash
 cargo fmt                                                               # Format code
 cargo nextest run --workspace --features ethhash,logger --all-targets   # Run tests
-cargo clippy --workspace --features ethhash,logger --all-targets                    # Linter
-cargo clippy --profile maxperf --features ethhash,logger --workspace --all-targets  # Linter (maxperf: debug-assertions off)
+cargo +nightly-2026-07-05 clippy --workspace --features ethhash,logger --all-targets                    # Linter
+cargo +nightly-2026-07-05 clippy --profile maxperf --features ethhash,logger --workspace --all-targets  # Linter (maxperf: debug-assertions off)
 cargo doc --no-deps                                                     # Ensure docs build
 ```
 

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -6,10 +6,6 @@
     reason = "Found 8 occurrences after enabling the lint."
 )]
 #![expect(
-    clippy::from_iter_instead_of_collect,
-    reason = "Found 1 occurrences after enabling the lint."
-)]
-#![expect(
     clippy::inline_always,
     reason = "Found 1 occurrences after enabling the lint."
 )]


### PR DESCRIPTION
## Why this should be merged

Clippy gated on the floating `@stable` toolchain, so a Rust/clippy release could change the enabled-lint surface and break CI unrelated to any code change. This pins the clippy jobs to a fixed nightly for a deterministic surface, adds a weekly floating-`nightly` run to catch drift out of band, and gates the `maxperf` profile — built and tested in CI but never linted (its release settings turn off `debug-assertions`/`overflow-checks`). Groundwork for adopting stricter clippy lint groups (nursery, then `restriction`) next.

## How this works

Only the clippy jobs move to the pinned nightly; every other job stays on `stable`. See the commit history for specifics.

## How this was tested

`actionlint` clean; `cargo +nightly-2026-07-05 clippy … -D warnings` clean across the host-runnable configs (`--all-features`/io-uring is Linux-only → CI); `cargo fmt --check` clean; `cargo nextest` 810/810.

## Operational notes

- New status check `rust-lint (maxperf-ethhash-logger)` — add it to the branch-protection required checks.
- `lint-nightly` is `schedule`/`workflow_dispatch`-only (no PR run) — `workflow_dispatch` it once after merge.
- Local clippy now needs `rustup toolchain install nightly-2026-07-05 --component clippy`.

## Breaking Changes

None — CI/tooling only.