### PR TITLE
chore(clippy): allow unwrap and indexing in tests

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -3,6 +3,9 @@
 
 msrv = "1.94"
 
+allow-unwrap-in-tests = true
+allow-indexing-slicing-in-tests = true
+
 doc-valid-idents = [
   "MerkleDB",
   # this list must end with ".." so that it does not truncate the default list

--- a/firewood-macros/src/lib.rs
+++ b/firewood-macros/src/lib.rs
@@ -147,8 +147,6 @@ fn generate_metrics_wrapper(input_fn: &ItemFn, ident: &syn::Ident) -> proc_macro
 
 #[cfg(test)]
 mod tests {
-    #![expect(clippy::unwrap_used)]
-
     use super::*;
 
     #[test]

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -642,8 +642,6 @@ impl<'a> api::Reconstructible for ReconstructedView<'a> {
 
 #[cfg(test)]
 mod test {
-    #![expect(clippy::unwrap_used)]
-
     use core::iter::Take;
     use std::collections::HashMap;
     use std::iter::Peekable;

--- a/firewood/src/db/tests.rs
+++ b/firewood/src/db/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![expect(clippy::unwrap_used)]
-
 mod concurrent_rebase;
 mod merge;
 

--- a/firewood/src/db/tests/concurrent_rebase.rs
+++ b/firewood/src/db/tests/concurrent_rebase.rs
@@ -71,7 +71,10 @@ const MAX_REVISIONS: usize = 16;
 // Keys must be 32 bytes (64 nibbles) so the checker accepts them under
 // the `ethhash` feature, where valid keys are sized like Ethereum account
 // or storage trie entries.
-#[expect(clippy::indexing_slicing, clippy::disallowed_methods)]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "copy_from_slice panics on a length mismatch, but here it always writes an 8-byte range into a fixed 32-byte key"
+)]
 fn key(thread_idx: usize, commit_idx: usize, key_idx: usize) -> Vec<u8> {
     let mut k = vec![0u8; 32];
     k[..8].copy_from_slice(&(thread_idx as u64).to_be_bytes());
@@ -251,17 +254,14 @@ fn test_concurrent_rebase_overlapping_paths() {
 
     // Seed with a meaningful initial trie so subsequent proposals' COWs hit
     // shared branches at upper levels.
-    let mut seed: Vec<BatchOp<Vec<u8>, Vec<u8>>> = Vec::with_capacity(64);
+    let mut seed = Vec::with_capacity(64);
     for i in 0u8..64 {
-        let mut k = vec![0u8; 32];
-        #[expect(clippy::indexing_slicing, reason = "k is a 32-byte vec")]
-        {
-            k[0] = i.wrapping_mul(4); // spread across the first nibble
-            k[31] = i;
-        }
+        let mut k = [0u8; 32];
+        k[0] = i.wrapping_mul(4); // spread across the first nibble
+        k[31] = i;
         seed.push(BatchOp::Put {
             key: k,
-            value: vec![i; 8],
+            value: [i; 8],
         });
     }
     db.propose(seed).unwrap().commit().unwrap();
@@ -471,14 +471,11 @@ fn test_empty_parent_rebase_after_reap() {
     let filler_count = TIGHT_MAX_REVISIONS.wrapping_add(2);
     let mut filler_keys = Vec::with_capacity(filler_count);
     for i in 0..filler_count {
-        let mut k = vec![0u8; 32];
-        #[expect(clippy::indexing_slicing, reason = "k is a 32-byte vec")]
-        {
-            k[0] = 0x80; // distinct first nibble from p_key (0xaa)
-            k[31] = i as u8;
-        }
-        let v = vec![i as u8; 8];
-        filler_keys.push((k.clone(), v.clone()));
+        let mut k = [0u8; 32];
+        k[0] = 0x80; // distinct first nibble from p_key (0xaa)
+        k[31] = i as u8;
+        let v = [i as u8; 8];
+        filler_keys.push((k, v));
         db.propose(vec![BatchOp::Put { key: k, value: v }])
             .expect("propose filler")
             .commit()

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -650,7 +650,6 @@ impl<I: Iterator<Item = T>, T: KeyValuePair, K: KeyType> Iterator for FilteredKe
 }
 
 #[cfg(test)]
-#[expect(clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::merkle::Merkle;
@@ -1003,7 +1002,6 @@ mod tests {
         let mut iter = merkle.key_value_iter_from_key(start.unwrap_or_default());
 
         // we iterate twice because we should get a None then start over
-        #[expect(clippy::indexing_slicing)]
         for k in start.map(|r| r[0]).unwrap_or_default()..=u8::MAX {
             let next = iter.next().map(|kv| {
                 let (k, v) = kv.unwrap();

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -702,7 +702,6 @@ impl RevisionManager {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use firewood_storage::RootReader;
 

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -562,7 +562,10 @@ impl<'a, T: HashedNodeReader> PreOrderIterator<'a, T> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, clippy::arithmetic_side_effects)]
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "test helpers use plain `+= 1` counters rather than checked/wrapping arithmetic"
+)]
 mod tests {
     use crate::{
         Proof,
@@ -999,7 +1002,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::indexing_slicing)]
     fn test_diff_interleaved_keys() {
         // m1: a, c, e
         // m2: b, c, d, f
@@ -1854,7 +1856,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(clippy::indexing_slicing)]
     fn test_change_proof_into_iterator() {
         let key_values: Box<[BatchOp<Key, Value>]> = Box::new([
             BatchOp::Put {

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -406,7 +406,6 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use firewood_storage::{DeletedNodeTracking, MemStore};
 

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -1,8 +1,6 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![expect(clippy::indexing_slicing, clippy::unwrap_used)]
-
 mod change;
 mod collapse;
 #[cfg(feature = "ethhash")]

--- a/firewood/src/proofs/change.rs
+++ b/firewood/src/proofs/change.rs
@@ -466,9 +466,6 @@ pub fn verify_change_proof_structure(
 
 #[cfg(test)]
 mod tests {
-    #![expect(clippy::unwrap_used, reason = "Tests can use unwrap")]
-    #![expect(clippy::indexing_slicing, reason = "Tests can use indexing")]
-
     use super::*;
     use crate::merkle::{Key, Value};
 

--- a/firewood/src/proofs/eth.rs
+++ b/firewood/src/proofs/eth.rs
@@ -295,7 +295,6 @@ fn proof_child_rlp_item(child: Option<&HashType>) -> RlpItem<'_> {
 }
 
 #[cfg(test)]
-#[expect(clippy::indexing_slicing, clippy::unwrap_used)]
 mod tests {
     use super::*;
     use firewood_storage::{IntoHashType, PathBuf, RlpList, TrieHash, TriePathFromUnpackedBytes};

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -318,9 +318,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    #![expect(clippy::unwrap_used, reason = "Tests can use unwrap")]
-    #![expect(clippy::indexing_slicing, reason = "Tests can use indexing")]
-
     use crate::api::TryIntoBatch;
 
     use super::*;

--- a/firewood/src/proofs/snapshot_tests.rs
+++ b/firewood/src/proofs/snapshot_tests.rs
@@ -72,8 +72,6 @@
 //! | [`batch_op`] | `delete_range` | Single `DeleteRange` operation (opcode `0x02`) |
 //! | [`batch_op`] | `all_ops` | All three operations in sequence |
 
-#![expect(clippy::unwrap_used, clippy::indexing_slicing)]
-
 use test_case::test_case;
 
 use firewood_storage::{Children, IntoHashType, PathComponent, TrieHash, ValueDigest};

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -1,8 +1,6 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![expect(clippy::unwrap_used, clippy::indexing_slicing)]
-
 use integer_encoding::VarInt;
 use test_case::test_case;
 

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -1,7 +1,10 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-#![allow(clippy::unwrap_used)]
+#![expect(
+    clippy::unwrap_used,
+    reason = "integration test binary; unwrap failures surface as test failures"
+)]
 
 use predicates::prelude::*;
 use std::fmt::Write;

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -714,8 +714,6 @@ pub mod __private {
 
 #[cfg(test)]
 mod tests {
-    #![expect(clippy::unwrap_used)]
-
     use super::*;
 
     fn isolated<F, R>(f: F) -> R

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -740,8 +740,6 @@ fn update_progress_bar(progress_bar: Option<&ProgressBar>, range_set: &LinearAdd
 
 #[cfg(test)]
 mod test {
-    #![expect(clippy::unwrap_used)]
-
     use nonzero_ext::nonzero;
 
     use super::*;

--- a/storage/src/checker/range_set.rs
+++ b/storage/src/checker/range_set.rs
@@ -588,7 +588,6 @@ mod test_range_set {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used)]
 mod test_linear_address_range_set {
 
     use crate::{FreeListParent, PathComponent, TrieNodeParent, area_index};

--- a/storage/src/iter.rs
+++ b/storage/src/iter.rs
@@ -64,8 +64,6 @@ fn write_all_with_sep(
 
 #[cfg(test)]
 mod tests {
-    #![expect(clippy::unwrap_used)]
-
     use super::*;
     use test_case::test_case;
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -482,7 +482,6 @@ pub fn format_node_value<W: std::io::Write + ?Sized>(
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used)]
 mod format_node_value_tests {
     use super::*;
 

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -382,8 +382,6 @@ impl std::ops::DerefMut for UnlockOnDrop {
 
 #[cfg(test)]
 mod test {
-    #![expect(clippy::unwrap_used)]
-
     use crate::NodeHashAlgorithm;
 
     use super::*;

--- a/storage/src/linear/memory.rs
+++ b/storage/src/linear/memory.rs
@@ -81,7 +81,6 @@ impl ReadableStorage for MemStore {
     }
 }
 
-#[expect(clippy::unwrap_used)]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -540,8 +540,6 @@ mod snapshot_tests;
 
 #[cfg(test)]
 mod test {
-    #![expect(clippy::unwrap_used)]
-
     use crate::node::{BranchNode, LeafNode, Node};
     use crate::{Child, Children, LinearAddress, NibblesIterator, Path};
     use test_case::test_case;

--- a/storage/src/node/path.rs
+++ b/storage/src/node/path.rs
@@ -105,7 +105,7 @@ impl Path {
     /// Creates a Path from a [Iterator] or other iterator that returns
     /// nibbles
     pub fn from_nibbles_iterator<T: Iterator<Item = u8>>(nibbles_iter: T) -> Self {
-        Path(SmallVec::from_iter(nibbles_iter))
+        Path(nibbles_iter.into_iter().collect())
     }
 
     /// Creates an empty Path

--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -247,7 +247,6 @@ enum MaybePersisted {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used)]
 mod test {
     use nonzero_ext::nonzero;
 

--- a/storage/src/node/snapshot_tests.rs
+++ b/storage/src/node/snapshot_tests.rs
@@ -56,8 +56,6 @@
 //! | `hash_or_rlp` | `keccak_hash` | Full 32-byte hash: `[0x00] + 32 bytes` |
 //! | `hash_or_rlp` | `rlp_bytes` | Short RLP: length byte + payload bytes |
 
-#![expect(clippy::unwrap_used)]
-
 use test_case::test_case;
 
 use crate::IntoHashType;

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -632,7 +632,6 @@ fn read_bincode_varint_u64_le(reader: &mut impl Read) -> std::io::Result<u64> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used)]
 pub mod test_utils {
     use super::*;
 
@@ -696,7 +695,6 @@ pub mod test_utils {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::DeletedNodeTracking;

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -1499,7 +1499,6 @@ where
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used)]
 #[expect(clippy::cast_possible_truncation)]
 mod tests {
 

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -303,7 +303,6 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
 }
 
 #[cfg(test)]
-#[expect(clippy::unwrap_used, clippy::indexing_slicing)]
 mod tests {
     use super::*;
     use crate::{

--- a/storage/src/path/packed.rs
+++ b/storage/src/path/packed.rs
@@ -254,8 +254,6 @@ impl<T: TriePath + ?Sized> TriePathAsPackedBytes for T {
 
 #[cfg(test)]
 mod tests {
-    #![expect(clippy::unwrap_used)]
-
     use test_case::test_case;
 
     use super::*;

--- a/storage/src/rlp.rs
+++ b/storage/src/rlp.rs
@@ -464,11 +464,6 @@ const fn minimal_be_len(n: usize) -> usize {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::unwrap_used,
-    clippy::indexing_slicing,
-    reason = "tests use unwrap and direct indexing to keep assertions readable"
-)]
 mod tests {
     use super::*;
     use test_case::test_case;

--- a/storage/src/root_store.rs
+++ b/storage/src/root_store.rs
@@ -176,7 +176,6 @@ impl RootStore {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::CacheReadStrategy;

--- a/storage/src/tries/kvp.rs
+++ b/storage/src/tries/kvp.rs
@@ -450,8 +450,6 @@ impl<T: std::fmt::Debug> std::fmt::Debug for DebugChildren<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    #![expect(clippy::unwrap_used)]
-
     use test_case::test_case;
 
     use super::*;
@@ -472,7 +470,10 @@ mod tests {
     ///
     /// [upstream]: https://github.com/rust-lang/rust/issues/76560
     const fn from_ascii<const FROM: usize, const TO: usize>(hex: &[u8; FROM]) -> [u8; TO] {
-        #![expect(clippy::arithmetic_side_effects, clippy::indexing_slicing)]
+        #![expect(
+            clippy::arithmetic_side_effects,
+            reason = "the loop counter is incremented with a plain `+= 1` rather than a wrapping/checked call"
+        )]
 
         const fn from_hex_char(c: u8) -> u8 {
             match c {


### PR DESCRIPTION
## Why this should be merged

`unwrap()` and slice indexing are acceptable in tests, but each use was suppressed inline throughout the test suite. Turning on clippy's `allow-unwrap-in-tests` / `allow-indexing-slicing-in-tests` stops those two lints firing in `#[cfg(test)]`, so the per-site suppressions can be deleted — shrinking the surface the broader `#[allow]` → `#[expect]` cleanup has to touch.

## How this works

Behavior-neutral. With the flags on, the in-test `#[expect(clippy::unwrap_used)]` / `#[expect(clippy::indexing_slicing)]` become unfulfilled and are removed (multi-lint attributes keep their still-firing lints, with a reason); the three redundant test-module `#[allow(clippy::unwrap_used)]` go too. `fwdctl/tests/cli.rs` is an integration binary whose unwraps sit in non-`#[test]` helpers the flags don't cover, so it keeps a file-scoped, reasoned `#[expect]`. A final style commit collapses the scoping blocks left vestigial by the narrowed attributes. Stacked on #2116.

## How this was tested

`cargo clippy --workspace --all-targets -- -D warnings` on the pinned nightly across the feature matrix — an over-removal (a lint left firing) or an under-removal (an unfulfilled `#[expect]`) would fail the gate. `cargo nextest run --workspace --features ethhash,logger --all-targets` passes.

## Breaking Changes

none.