### PR TITLE
fix(storage): validate AreaIndex::TryFrom<usize> against NUM_AREA_SIZES

### DIFF
--- a/storage/src/nodestore/primitives.rs
+++ b/storage/src/nodestore/primitives.rs
@@ -153,18 +153,16 @@ impl TryFrom<usize> for AreaIndex {
     type Error = Error;
 
     fn try_from(index: usize) -> Result<Self, Self::Error> {
-        let index_u8: u8 = index.try_into().map_err(|_| {
-            Error::new(
-                ErrorKind::InvalidData,
-                format!("Area index out of bounds: {index}"),
-            )
-        })?;
-        AreaIndex::new(index_u8).ok_or_else(|| {
-            Error::new(
-                ErrorKind::InvalidData,
-                format!("Area index out of bounds: {index}"),
-            )
-        })
+        index
+            .try_into()
+            .ok()
+            .and_then(AreaIndex::new)
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorKind::InvalidData,
+                    format!("Area index out of bounds: {index}"),
+                )
+            })
     }
 }
 

--- a/storage/src/nodestore/primitives.rs
+++ b/storage/src/nodestore/primitives.rs
@@ -123,10 +123,6 @@ impl AreaIndex {
     }
 
     /// Get the size of an area index (used by the checker)
-    ///
-    /// # Panics
-    ///
-    /// Panics if `index` is out of bounds for the `AREA_SIZES` array.
     #[must_use]
     pub const fn size(self) -> u64 {
         #[expect(clippy::indexing_slicing)]
@@ -157,8 +153,13 @@ impl TryFrom<usize> for AreaIndex {
     type Error = Error;
 
     fn try_from(index: usize) -> Result<Self, Self::Error> {
-        let index_u8: Result<u8, _> = index.try_into();
-        index_u8.map(AreaIndex).map_err(|_| {
+        let index_u8: u8 = index.try_into().map_err(|_| {
+            Error::new(
+                ErrorKind::InvalidData,
+                format!("Area index out of bounds: {index}"),
+            )
+        })?;
+        AreaIndex::new(index_u8).ok_or_else(|| {
             Error::new(
                 ErrorKind::InvalidData,
                 format!("Area index out of bounds: {index}"),
@@ -322,5 +323,11 @@ mod tests {
         let hash: TrieHash = hasher.finalize().into();
 
         assert_eq!(AREA_SIZES_HASH, *hash);
+    }
+
+    #[test]
+    fn test_area_index_try_from_usize_out_of_bounds() {
+        assert!(AreaIndex::try_from(AreaIndex::NUM_AREA_SIZES).is_err());
+        assert!(AreaIndex::try_from(usize::MAX).is_err());
     }
 }


### PR DESCRIPTION
## Why this should be merged

A valid `AreaIndex` must index within `AREA_SIZES` (`< NUM_AREA_SIZES`), and `AreaIndex::new` / `TryFrom<u8>` enforce that — but `TryFrom<usize>` only checked that the value fit in a `u8`, skipping the bounds check. So `AreaIndex::try_from(100usize)` returned `Ok` of an out-of-range index that then panicked in `size()`. Closes #2118.

## How this works

`TryFrom<usize>` now routes through `AreaIndex::new`, returning `Err` for indices `>= NUM_AREA_SIZES`. `AreaIndex` is therefore always in bounds, so `size()` can no longer panic in non-test code (its `# Panics` doc is dropped) and its `indexing_slicing` suppression is now well-founded.

## How this was tested

Added a regression test asserting `AreaIndex::try_from(NUM_AREA_SIZES)` and `try_from(usize::MAX)` both return `Err`. `cargo nextest run` and `cargo clippy -- -D warnings` pass.

## Breaking Changes

`AreaIndex::try_from(usize)` now returns `Err` for indices `>= NUM_AREA_SIZES` instead of an `Ok` that panics on use. Technically this is a breaking change even though it was invalid to begin with.
