### PR TITLE
refactor(proofs): dispatch proof parsing on the self-describing header byte [5/9]

### DIFF
--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -4,7 +4,7 @@
 use std::num::NonZeroUsize;
 
 use firewood::{
-    KeyRange, ProofError, RangeProofVerificationContext,
+    KeyRange, NodeHashAlgorithm, ProofError, RangeProofVerificationContext,
     api::{self, DbView, FrozenRangeProof, HashKey},
 };
 use firewood_metrics::{MetricsContext, firewood_counter};
@@ -129,11 +129,13 @@ impl<'db> RangeProofContext<'db> {
 
         debug_assert!(self.verification.is_none());
 
+        // Expected mode is compile-time default - any proof with a different mode is rejected up front.
         self.verification = Some(firewood::verify_range_proof_structure(
             &self.proof,
             root,
             start_key,
             end_key,
+            NodeHashAlgorithm::compile_option(),
             max_length,
         )?);
         Ok(())

--- a/firewood/benches/proofs.rs
+++ b/firewood/benches/proofs.rs
@@ -16,7 +16,9 @@ use criterion::{Criterion, criterion_group, criterion_main};
 use firewood::Merkle;
 use firewood::api::DbView as _;
 use firewood::verify_range_proof_structure;
-use firewood_storage::{DeletedNodeTracking, MemStore, NodeStore, SeededRng};
+use firewood_storage::{
+    DefaultHashMode, DeletedNodeTracking, HashMode, MemStore, NodeStore, SeededRng,
+};
 use rand::{RngExt, distr::Alphanumeric};
 
 #[expect(clippy::unwrap_used, clippy::indexing_slicing)]
@@ -66,8 +68,15 @@ fn bench_proofs(criterion: &mut Criterion) {
     group.bench_function("range_proof/verify", |b| {
         let proof = view.range_proof(Some(first), Some(last), limit).unwrap();
         b.iter(|| {
-            verify_range_proof_structure(&proof, root_hash.clone(), Some(first), Some(last), limit)
-                .unwrap();
+            verify_range_proof_structure(
+                &proof,
+                root_hash.clone(),
+                Some(first),
+                Some(last),
+                DefaultHashMode::ALGORITHM,
+                limit,
+            )
+            .unwrap();
         });
     });
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -336,8 +336,15 @@ impl Db {
         end_key: Option<&[u8]>,
         max_length: Option<NonZeroUsize>,
     ) -> Result<Proposal<'_>, api::Error> {
-        let verification =
-            verify_change_proof_structure(proof, end_root.clone(), start_key, end_key, max_length)?;
+        // Expected mode is the compile default - a proof with a different mode is rejected.
+        let verification = verify_change_proof_structure(
+            proof,
+            end_root.clone(),
+            start_key,
+            end_key,
+            NodeHashAlgorithm::compile_option(),
+            max_length,
+        )?;
         let parent = self.manager.current_revision();
         let proposal = self.apply_change_proof_to_parent(proof, &*parent)?;
         verify_change_proof_root_hash(proof, &verification, &proposal)?;

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -22,9 +22,9 @@ use crate::verify_change_proof_structure;
 use crate::manager::{ConfigManager, RevisionManager, RevisionManagerConfig};
 use firewood_metrics::{firewood_counter, firewood_histogram};
 use firewood_storage::{
-    CheckOpt, CheckerReport, Committed, CommittedParentHash, FileBacked, FileIoError,
-    HashedNodeReader, ImmutableProposal, NodeHashAlgorithm, NodeStore, Parentable, ReadableStorage,
-    Reconstructed, TrieReader,
+    CheckOpt, CheckerReport, Committed, CommittedParentHash, DefaultHashMode, FileBacked,
+    FileIoError, HashMode, HashedNodeReader, ImmutableProposal, NodeHashAlgorithm, NodeStore,
+    Parentable, ReadableStorage, Reconstructed, TrieReader,
 };
 use std::io::Write;
 use std::num::NonZeroUsize;
@@ -342,7 +342,7 @@ impl Db {
             end_root.clone(),
             start_key,
             end_key,
-            NodeHashAlgorithm::compile_option(),
+            DefaultHashMode::ALGORITHM,
             max_length,
         )?;
         let parent = self.manager.current_revision();

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -338,8 +338,15 @@ impl Db {
         end_key: Option<&[u8]>,
         max_length: Option<NonZeroUsize>,
     ) -> Result<Proposal<'_>, api::Error> {
-        let verification =
-            verify_change_proof_structure(proof, end_root.clone(), start_key, end_key, max_length)?;
+        // Expected mode is the compile default - a proof with a different mode is rejected.
+        let verification = verify_change_proof_structure(
+            proof,
+            end_root.clone(),
+            start_key,
+            end_key,
+            NodeHashAlgorithm::compile_option(),
+            max_length,
+        )?;
         let parent = self.manager.current_revision();
         let proposal = self.apply_change_proof_to_parent(proof, &*parent)?;
         verify_change_proof_root_hash(proof, &verification, &proposal)?;

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -29,8 +29,8 @@ use firewood_storage::MemStore;
 use firewood_storage::{
     BranchNode, Child, Children, DefaultHashMode, DeletedNodeTracking, FileIoError, HashMode,
     HashType, HashableShunt, HashedNodeReader, ImmutableProposal, LeafNode, MaybePersistedNode,
-    Mutable, MutableKind, NibblesIterator, Node, NodeStore, Path, PathBuf, PathComponent, Propose,
-    ReadableStorage, SharedNode, TrieHash, TrieReader, U4, ValueDigest,
+    Mutable, MutableKind, NibblesIterator, Node, NodeHashAlgorithm, NodeStore, Path, PathBuf,
+    PathComponent, Propose, ReadableStorage, SharedNode, TrieHash, TrieReader, U4, ValueDigest,
 };
 use firewood_storage::{
     hash_node_as_storage_trie_root_for_node, hash_node_as_storage_trie_root_parts,
@@ -771,17 +771,36 @@ fn right_edge<'a>(
 /// this loop is the canonical way to assemble full-range coverage from
 /// truncated proofs.
 ///
+/// # Node Hashing Algorithm
+///
+/// `algorithm` is the hash mode the caller expects the proof to be encoded
+/// with. If the proof's own self-describing mode (resolved from its header byte
+/// at parse time) disagrees, verification is rejected up front with
+/// [`ProofError::HashModeMismatch`].
+///
 /// # Errors
 ///
 /// Returns [`api::Error::ProofError`] if the proof is structurally invalid,
-/// keys are outside the requested range, boundary proofs fail verification,
-/// or the reconstructed root hash doesn't match.
+/// the proof's hash mode does not match `algorithm`, keys are outside the
+/// requested range, boundary proofs fail verification, or the reconstructed
+/// root hash doesn't match.
 pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     first_key: Option<impl KeyType>,
     last_key: Option<impl KeyType>,
     root_hash: &TrieHash,
+    algorithm: NodeHashAlgorithm,
     proof: &RangeProof<impl KeyType, impl ValueType, H>,
 ) -> Result<(), api::Error> {
+    // Reject a proof whose self-describing mode disagrees with the caller's
+    // expectation before any hashing happens. Node hashing below still follows
+    // the compile default, so only matching-mode proofs may proceed.
+    if proof.hash_mode() != algorithm {
+        return Err(api::Error::ProofError(ProofError::HashModeMismatch {
+            expected: algorithm,
+            found: proof.hash_mode(),
+        }));
+    }
+
     let first_key_bytes: Option<&[u8]> = first_key.as_ref().map(AsRef::as_ref);
     let last_key_bytes: Option<&[u8]> = last_key.as_ref().map(AsRef::as_ref);
 

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -29,8 +29,8 @@ use firewood_storage::MemStore;
 use firewood_storage::{
     BranchNode, Child, Children, DefaultHashMode, DeletedNodeTracking, FileIoError, HashMode,
     HashType, HashableShunt, HashedNodeReader, ImmutableProposal, LeafNode, MaybePersistedNode,
-    Mutable, MutableKind, NibblesIterator, Node, NodeStore, Path, PathBuf, PathComponent, Propose,
-    ReadableStorage, SharedNode, TrieHash, TrieReader, U4, ValueDigest,
+    Mutable, MutableKind, NibblesIterator, Node, NodeHashAlgorithm, NodeStore, Path, PathBuf,
+    PathComponent, Propose, ReadableStorage, SharedNode, TrieHash, TrieReader, U4, ValueDigest,
 };
 use firewood_storage::{
     hash_node_as_storage_trie_root_for_node, hash_node_as_storage_trie_root_parts,
@@ -773,17 +773,36 @@ fn right_edge<'a>(
 /// this loop is the canonical way to assemble full-range coverage from
 /// truncated proofs.
 ///
+/// # Node Hashing Algorithm
+///
+/// `algorithm` is the hash mode the caller expects the proof to be encoded
+/// with. If the proof's own self-describing mode (resolved from its header byte
+/// at parse time) disagrees, verification is rejected up front with
+/// [`ProofError::HashModeMismatch`].
+///
 /// # Errors
 ///
 /// Returns [`api::Error::ProofError`] if the proof is structurally invalid,
-/// keys are outside the requested range, boundary proofs fail verification,
-/// or the reconstructed root hash doesn't match.
+/// the proof's hash mode does not match `algorithm`, keys are outside the
+/// requested range, boundary proofs fail verification, or the reconstructed
+/// root hash doesn't match.
 pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     first_key: Option<impl KeyType>,
     last_key: Option<impl KeyType>,
     root_hash: &TrieHash,
+    algorithm: NodeHashAlgorithm,
     proof: &RangeProof<impl KeyType, impl ValueType, H>,
 ) -> Result<(), api::Error> {
+    // Reject a proof whose self-describing mode disagrees with the caller's
+    // expectation before any hashing happens. Node hashing below still follows
+    // the compile default, so only matching-mode proofs may proceed.
+    if proof.hash_mode() != algorithm {
+        return Err(api::Error::ProofError(ProofError::HashModeMismatch {
+            expected: algorithm,
+            found: proof.hash_mode(),
+        }));
+    }
+
     let first_key_bytes: Option<&[u8]> = first_key.as_ref().map(AsRef::as_ref);
     let last_key_bytes: Option<&[u8]> = last_key.as_ref().map(AsRef::as_ref);
 

--- a/firewood/src/merkle/tests/change/fuzz_common.rs
+++ b/firewood/src/merkle/tests/change/fuzz_common.rs
@@ -9,7 +9,7 @@ use crate::api::{BatchOp, FrozenChangeProof, FrozenRangeProof, HashKey};
 use crate::db::Db;
 use crate::merkle::{Key, Value};
 use crate::{ChangeProof, Proof, ProofNode, verify_change_proof_structure};
-use firewood_storage::SeededRng;
+use firewood_storage::{NodeHashAlgorithm, SeededRng};
 
 /// Build a `FrozenChangeProof` from mutated parts.
 pub(in crate::merkle::tests) fn build_change_proof(
@@ -47,7 +47,16 @@ pub(in crate::merkle::tests) fn change_proof_rejected(
     first: Option<&[u8]>,
     last: Option<&[u8]>,
 ) -> bool {
-    match verify_change_proof_structure(proof, end_root.clone(), first, last, None) {
+    // This module is ethhash-gated (only the ethhash-shaped fuzzer uses it),
+    // so every proof it sees is Ethereum-mode.
+    match verify_change_proof_structure(
+        proof,
+        end_root.clone(),
+        first,
+        last,
+        NodeHashAlgorithm::Ethereum,
+        None,
+    ) {
         Err(_) => true,
         Ok(ctx) => verify_and_check(db, proof, &ctx, start_root.clone()).is_err(),
     }

--- a/firewood/src/merkle/tests/change/mod.rs
+++ b/firewood/src/merkle/tests/change/mod.rs
@@ -2,11 +2,33 @@
 // See the file LICENSE.md for licensing terms.
 
 use super::*;
-use crate::api::{self, BatchOp, Db as DbTrait, DbView, FrozenChangeProof, Proposal as _};
+use crate::ChangeProofVerificationContext;
+use crate::api::{self, BatchOp, Db as DbTrait, DbView, FrozenChangeProof, HashKey, Proposal as _};
 use crate::db::{Db, DbConfig};
 use crate::merkle::verify_change_proof_root_hash;
-use crate::{ChangeProofVerificationContext, verify_change_proof_structure};
-use firewood_storage::PathComponentSliceExt;
+use firewood_storage::{NodeHashAlgorithm, PathComponentSliceExt};
+
+/// Test wrapper around [`crate::verify_change_proof_structure`] that supplies
+/// the compile-default hash mode as the expected `algorithm` (the mode every
+/// proof built in the test binary carries). Defined here so the many existing
+/// call sites in the change-proof test submodules (which `use super::*`) need
+/// not pass the mode explicitly.
+fn verify_change_proof_structure(
+    proof: &FrozenChangeProof,
+    end_root: HashKey,
+    start_key: Option<&[u8]>,
+    end_key: Option<&[u8]>,
+    max_length: Option<std::num::NonZeroUsize>,
+) -> Result<ChangeProofVerificationContext, api::Error> {
+    crate::verify_change_proof_structure(
+        proof,
+        end_root,
+        start_key,
+        end_key,
+        NodeHashAlgorithm::compile_option(),
+        max_length,
+    )
+}
 
 // ── Test infrastructure ────────────────────────────────────────────────────
 

--- a/firewood/src/merkle/tests/change/mod.rs
+++ b/firewood/src/merkle/tests/change/mod.rs
@@ -6,7 +6,7 @@ use crate::ChangeProofVerificationContext;
 use crate::api::{self, BatchOp, Db as DbTrait, DbView, FrozenChangeProof, HashKey, Proposal as _};
 use crate::db::{Db, DbConfig};
 use crate::merkle::verify_change_proof_root_hash;
-use firewood_storage::{NodeHashAlgorithm, PathComponentSliceExt};
+use firewood_storage::{DefaultHashMode, HashMode, PathComponentSliceExt};
 
 /// Test wrapper around [`crate::verify_change_proof_structure`] that supplies
 /// the compile-default hash mode as the expected `algorithm` (the mode every
@@ -25,7 +25,7 @@ fn verify_change_proof_structure(
         end_root,
         start_key,
         end_key,
-        NodeHashAlgorithm::compile_option(),
+        DefaultHashMode::ALGORITHM,
         max_length,
     )
 }

--- a/firewood/src/merkle/tests/ethhash_fuzz.rs
+++ b/firewood/src/merkle/tests/ethhash_fuzz.rs
@@ -35,7 +35,7 @@ use crate::api::{
 use crate::db::{Db, DbConfig};
 use crate::merkle::{Key, Value, verify_change_proof_root_hash, verify_range_proof};
 use crate::verify_change_proof_structure;
-use firewood_storage::{SeededRng, replace_list_field};
+use firewood_storage::{NodeHashAlgorithm, SeededRng, replace_list_field};
 use rand::seq::SliceRandom;
 
 /// An account's key paired with its sorted, distinct storage-slot bytes (byte
@@ -473,7 +473,8 @@ fn check_valid_range_proof(
         .range_proof(first, last, None)
         .unwrap_or_else(|e| panic!("range_proof should succeed ({locator}): {e}"));
     let range_proof = maybe_serialize_round_trip_range(rng, range_proof);
-    verify_range_proof(first, last, root, &range_proof)
+    // This fuzzer is ethhash-gated, so every proof it builds is Ethereum-mode.
+    verify_range_proof(first, last, root, NodeHashAlgorithm::Ethereum, &range_proof)
         .unwrap_or_else(|e| panic!("valid range proof should verify ({locator}): {e}"));
     range_proof
 }
@@ -494,8 +495,15 @@ fn check_valid_change_proof(
         .change_proof(start_root.clone(), end_root.clone(), first, last, None)
         .unwrap_or_else(|e| panic!("change_proof should succeed ({locator}): {e}"));
     let change_proof = maybe_serialize_round_trip_change(rng, change_proof);
-    let ctx = verify_change_proof_structure(&change_proof, end_root.clone(), first, last, None)
-        .unwrap_or_else(|e| panic!("valid change proof structure should verify ({locator}): {e}"));
+    let ctx = verify_change_proof_structure(
+        &change_proof,
+        end_root.clone(),
+        first,
+        last,
+        NodeHashAlgorithm::Ethereum,
+        None,
+    )
+    .unwrap_or_else(|e| panic!("valid change proof structure should verify ({locator}): {e}"));
     let parent = db.revision(start_root.clone()).unwrap();
     let proposal = db
         .apply_change_proof_to_parent(&change_proof, &*parent)
@@ -801,7 +809,14 @@ fn test_slow_ethhash_proof_fuzz() {
             ] {
                 if let Some(tampered) = tampered {
                     assert!(
-                        verify_range_proof(first, last, end_root, &tampered).is_err(),
+                        verify_range_proof(
+                            first,
+                            last,
+                            end_root,
+                            NodeHashAlgorithm::Ethereum,
+                            &tampered
+                        )
+                        .is_err(),
                         "tampered range proof must be rejected ({kind}, {locator})"
                     );
                 }
@@ -811,7 +826,8 @@ fn test_slow_ethhash_proof_fuzz() {
             // proof must still be accepted (recomputed at hash time).
             if let Some(forged) = forge_range_storage_root(&range, &rng) {
                 assert!(
-                    verify_range_proof(first, last, end_root, &forged).is_ok(),
+                    verify_range_proof(first, last, end_root, NodeHashAlgorithm::Ethereum, &forged)
+                        .is_ok(),
                     "forged storageRoot range proof must be accepted ({locator})"
                 );
             }

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -25,8 +25,9 @@ use crate::{
 };
 use crate::{ProofError, ProofNode};
 use firewood_storage::{
-    Committed, DeletedNodeTracking, DenseChildren, MemStore, Mutable, NodeHashAlgorithm, NodeStore,
-    NodeStoreHeader, PathComponent, Propose, RootReader, TrieHash, ValueDigest,
+    Committed, DefaultHashMode, DeletedNodeTracking, DenseChildren, HashMode, MemStore, Mutable,
+    NodeHashAlgorithm, NodeStore, NodeStoreHeader, PathComponent, Propose, RootReader, TrieHash,
+    ValueDigest,
 };
 
 /// Test wrapper around [`crate::merkle::verify_range_proof`] that supplies the
@@ -43,7 +44,7 @@ fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
         first_key,
         last_key,
         root_hash,
-        NodeHashAlgorithm::compile_option(),
+        DefaultHashMode::ALGORITHM,
         proof,
     )
 }

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -18,11 +18,35 @@ use std::collections::HashMap;
 use std::fmt::Write;
 
 use super::*;
+use crate::proofs::range::RangeProof;
+use crate::{
+    ProofCollection,
+    api::{Error, KeyType, ValueType},
+};
 use crate::{ProofError, ProofNode};
 use firewood_storage::{
     Children, Committed, DeletedNodeTracking, MemStore, Mutable, NodeHashAlgorithm, NodeStore,
     NodeStoreHeader, PathComponent, Propose, RootReader, TrieHash, ValueDigest,
 };
+
+/// Test wrapper around [`crate::merkle::verify_range_proof`] that supplies the
+/// compile-default hash mode as the expected `algorithm` (the mode every proof
+/// built in the test binary carries). Shadows the glob-imported real function
+/// so the many existing call sites need not pass the mode explicitly.
+fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
+    first_key: Option<impl KeyType>,
+    last_key: Option<impl KeyType>,
+    root_hash: &TrieHash,
+    proof: &RangeProof<impl KeyType, impl ValueType, H>,
+) -> Result<(), Error> {
+    crate::merkle::verify_range_proof(
+        first_key,
+        last_key,
+        root_hash,
+        NodeHashAlgorithm::compile_option(),
+        proof,
+    )
+}
 
 // Returns n random key-value pairs.
 fn generate_random_kvs(rng: &firewood_storage::SeededRng, n: usize) -> Vec<(Vec<u8>, Vec<u8>)> {

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -18,11 +18,35 @@ use std::collections::HashMap;
 use std::fmt::Write;
 
 use super::*;
+use crate::proofs::range::RangeProof;
+use crate::{
+    ProofCollection,
+    api::{Error, KeyType, ValueType},
+};
 use crate::{ProofError, ProofNode};
 use firewood_storage::{
     Committed, DeletedNodeTracking, DenseChildren, MemStore, Mutable, NodeHashAlgorithm, NodeStore,
     NodeStoreHeader, PathComponent, Propose, RootReader, TrieHash, ValueDigest,
 };
+
+/// Test wrapper around [`crate::merkle::verify_range_proof`] that supplies the
+/// compile-default hash mode as the expected `algorithm` (the mode every proof
+/// built in the test binary carries). Shadows the glob-imported real function
+/// so the many existing call sites need not pass the mode explicitly.
+fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
+    first_key: Option<impl KeyType>,
+    last_key: Option<impl KeyType>,
+    root_hash: &TrieHash,
+    proof: &RangeProof<impl KeyType, impl ValueType, H>,
+) -> Result<(), Error> {
+    crate::merkle::verify_range_proof(
+        first_key,
+        last_key,
+        root_hash,
+        NodeHashAlgorithm::compile_option(),
+        proof,
+    )
+}
 
 // Returns n random key-value pairs.
 fn generate_random_kvs(rng: &firewood_storage::SeededRng, n: usize) -> Vec<(Vec<u8>, Vec<u8>)> {

--- a/firewood/src/proofs/change.rs
+++ b/firewood/src/proofs/change.rs
@@ -3,6 +3,8 @@
 
 use std::{fmt::Debug, num::NonZeroUsize};
 
+use firewood_storage::{DefaultHashMode, HashMode, NodeHashAlgorithm};
+
 use crate::{
     Proof, ProofCollection, ProofError,
     api::{self, FrozenChangeProof, HashKey},
@@ -20,6 +22,11 @@ pub struct ChangeProof<K: AsRef<[u8]> + Debug, V: AsRef<[u8]> + Debug, H> {
     start_proof: Proof<H>,
     end_proof: Proof<H>,
     batch_ops: Box<[BatchOp<K, V>]>,
+    /// The hash algorithm this proof was constructed or parsed with. For proofs
+    /// built in this binary it is the compile default; for proofs parsed via
+    /// [`FrozenChangeProof::from_slice`](crate::api::FrozenChangeProof::from_slice)
+    /// it is resolved from the self-describing header byte.
+    hash_mode: NodeHashAlgorithm,
 }
 
 impl<K, V, H> std::fmt::Debug for ChangeProof<K, V, H>
@@ -34,6 +41,7 @@ where
             .field("start_proof", &self.start_proof)
             .field("end_proof", &self.end_proof)
             .field("batch_ops", &self.batch_ops)
+            .field("hash_mode", &self.hash_mode)
             .finish()
     }
 }
@@ -52,11 +60,39 @@ where
         end_proof: Proof<H>,
         key_values: Box<[BatchOp<K, V>]>,
     ) -> Self {
+        // Proofs built in this binary carry the compile-default mode; the parse
+        // path stamps the resolved header mode via `new_with_hash_mode`.
+        Self::with_hash_mode(
+            start_proof,
+            end_proof,
+            key_values,
+            DefaultHashMode::ALGORITHM,
+        )
+    }
+
+    /// Like [`ChangeProof::new`], but records the [`NodeHashAlgorithm`] the proof
+    /// was encoded with. Used by the parse path
+    /// ([`FrozenChangeProof::from_slice`](crate::api::FrozenChangeProof::from_slice))
+    /// to stamp the mode resolved from the self-describing header byte.
+    #[must_use]
+    pub(crate) const fn with_hash_mode(
+        start_proof: Proof<H>,
+        end_proof: Proof<H>,
+        key_values: Box<[BatchOp<K, V>]>,
+        hash_mode: NodeHashAlgorithm,
+    ) -> Self {
         Self {
             start_proof,
             end_proof,
             batch_ops: key_values,
+            hash_mode,
         }
+    }
+
+    /// The hash algorithm this proof was constructed or parsed with.
+    #[must_use]
+    pub const fn hash_mode(&self) -> NodeHashAlgorithm {
+        self.hash_mode
     }
 
     /// Returns a reference to the start proof, which may be empty.
@@ -300,10 +336,18 @@ fn compute_right_edge_key<'a>(
 /// - Start and end proof hash chain verification against `end_root`
 /// - End proof inclusion/exclusion consistency with the last batch operation
 ///
+/// # Node Hashing Algorithm
+///
+/// `algorithm` is the hash mode the caller expects the proof to be encoded
+/// with. If the proof's own self-describing mode (from its header byte)
+/// disagrees, verification is rejected up front with
+/// [`ProofError::HashModeMismatch`] before any node hashing happens.
+///
 /// # Errors
 ///
-/// Returns [`api::Error::ProofError`] if the proof is structurally invalid
-/// or boundary proof hash chains fail verification.
+/// Returns [`api::Error::ProofError`] if the proof is structurally invalid,
+/// the proof's hash mode does not match `algorithm`, or boundary proof hash
+/// chains fail verification.
 ///
 /// On success, returns a [`ChangeProofVerificationContext`] capturing the
 /// verification parameters for use by downstream root hash verification.
@@ -312,8 +356,18 @@ pub fn verify_change_proof_structure(
     end_root: HashKey,
     start_key: Option<&[u8]>,
     end_key: Option<&[u8]>,
+    algorithm: NodeHashAlgorithm,
     max_length: Option<NonZeroUsize>,
 ) -> Result<ChangeProofVerificationContext, api::Error> {
+    // Reject a proof whose self-describing mode disagrees with the caller's
+    // expectation before any hashing happens.
+    if proof.hash_mode() != algorithm {
+        return Err(api::Error::ProofError(ProofError::HashModeMismatch {
+            expected: algorithm,
+            found: proof.hash_mode(),
+        }));
+    }
+
     let batch_ops = proof.batch_ops();
 
     // --- O(1) checks first ---

--- a/firewood/src/proofs/de.rs
+++ b/firewood/src/proofs/de.rs
@@ -37,7 +37,7 @@ impl FrozenRangeProof {
         let mut reader = ProofReader::new(data);
 
         let header = reader.read_header()?;
-        let (_, algorithm) = header
+        let validated_header = header
             .validate(Some(ProofType::Range))
             .map_err(ReadError::InvalidHeader)?;
 
@@ -45,7 +45,10 @@ impl FrozenRangeProof {
             0 => {
                 // Body reads dispatch on the proof's own self-describing mode
                 // so this binary reads either wire format.
-                let mut reader = V0Reader::new(reader.into_body(algorithm), header);
+                let mut reader = V0Reader::new(
+                    reader.into_body(validated_header.node_hash_algorithm),
+                    header,
+                );
                 let this = reader.read_v0_item()?;
                 if reader.remainder().is_empty() {
                     Ok(this)
@@ -100,7 +103,7 @@ impl FrozenChangeProof {
         let mut reader = ProofReader::new(data);
 
         let header = reader.read_header()?;
-        let (_, algorithm) = header
+        let validated_header = header
             .validate(Some(ProofType::Change))
             .map_err(ReadError::InvalidHeader)?;
 
@@ -114,7 +117,10 @@ impl FrozenChangeProof {
 
         // Body reads dispatch on the proof's own self-describing mode so this
         // binary reads either wire format.
-        let mut reader = V0Reader::new(reader.into_body(algorithm), header);
+        let mut reader = V0Reader::new(
+            reader.into_body(validated_header.node_hash_algorithm),
+            header,
+        );
         let this = reader.read_v0_item()?;
         if reader.remainder().is_empty() {
             Ok(this)

--- a/firewood/src/proofs/de.rs
+++ b/firewood/src/proofs/de.rs
@@ -8,7 +8,7 @@
 //! validation of the format.
 
 use super::{
-    header::{Header, InvalidHeader},
+    header::InvalidHeader,
     reader::{ProofReader, ReadError, ReadItem, V0Reader, Version0},
     types::{Proof, ProofNode, ProofType},
 };
@@ -19,9 +19,7 @@ use crate::{
     merkle::{Key, Value},
     proofs::magic::{BATCH_DELETE, BATCH_DELETE_RANGE, BATCH_PUT},
 };
-use firewood_storage::{
-    DefaultHashMode, HashMode, HashType, PathBuf, TrieHash, TriePathFromUnpackedBytes, ValueDigest,
-};
+use firewood_storage::{HashType, PathBuf, TrieHash, TriePathFromUnpackedBytes, ValueDigest};
 use integer_encoding::VarInt;
 use std::num::NonZeroUsize;
 
@@ -38,14 +36,16 @@ impl FrozenRangeProof {
     pub fn from_slice(data: &[u8]) -> Result<Self, ReadError> {
         let mut reader = ProofReader::new(data);
 
-        let header = reader.read_item::<Header>()?;
-        header
+        let header = reader.read_header()?;
+        let (_, algorithm) = header
             .validate(Some(ProofType::Range))
             .map_err(ReadError::InvalidHeader)?;
 
         match header.version {
             0 => {
-                let mut reader = V0Reader::new(reader, header);
+                // Body reads dispatch on the proof's own self-describing mode
+                // so this binary reads either wire format.
+                let mut reader = V0Reader::new(reader.into_body(algorithm), header);
                 let this = reader.read_v0_item()?;
                 if reader.remainder().is_empty() {
                     Ok(this)
@@ -99,8 +99,8 @@ impl FrozenChangeProof {
     pub fn from_slice(data: &[u8]) -> Result<Self, ReadError> {
         let mut reader = ProofReader::new(data);
 
-        let header = reader.read_item::<Header>()?;
-        header
+        let header = reader.read_header()?;
+        let (_, algorithm) = header
             .validate(Some(ProofType::Change))
             .map_err(ReadError::InvalidHeader)?;
 
@@ -112,7 +112,9 @@ impl FrozenChangeProof {
             ));
         }
 
-        let mut reader = V0Reader::new(reader, header);
+        // Body reads dispatch on the proof's own self-describing mode so this
+        // binary reads either wire format.
+        let mut reader = V0Reader::new(reader.into_body(algorithm), header);
         let this = reader.read_v0_item()?;
         if reader.remainder().is_empty() {
             Ok(this)
@@ -132,10 +134,11 @@ impl Version0 for FrozenRangeProof {
         let end_proof = reader.read_v0_item()?;
         let key_values = reader.read_v0_item()?;
 
-        Ok(Self::new(
+        Ok(Self::with_hash_mode(
             Proof::new(start_proof),
             Proof::new(end_proof),
             key_values,
+            reader.node_hash_algorithm(),
         ))
     }
 }
@@ -146,10 +149,11 @@ impl Version0 for FrozenChangeProof {
         let end_proof = reader.read_v0_item()?;
         let key_values = reader.read_v0_item()?;
 
-        Ok(Self::new(
+        Ok(Self::with_hash_mode(
             Proof::new(start_proof),
             Proof::new(end_proof),
             key_values,
+            reader.node_hash_algorithm(),
         ))
     }
 }
@@ -228,16 +232,6 @@ impl Version0 for (Box<[u8]>, Box<[u8]>) {
 
     fn read_v0_item(reader: &mut V0Reader<'_>) -> Result<Self, ReadError> {
         Ok((reader.read_item()?, reader.read_item()?))
-    }
-}
-
-impl<'a> ReadItem<'a> for Header {
-    fn read_item(reader: &mut ProofReader<'a>) -> Result<Self, ReadError> {
-        reader
-            .read_chunk::<{ size_of::<Header>() }>()
-            .map_err(|err| err.set_item("header"))
-            .copied()
-            .map(bytemuck::cast)
     }
 }
 
@@ -346,9 +340,10 @@ impl<'a> ReadItem<'a> for ChildMask {
 impl<'a> ReadItem<'a> for HashType {
     fn read_item(reader: &mut ProofReader<'a>) -> Result<Self, ReadError> {
         // The two schemes use different proof wire layouts for a child hash;
-        // dispatch on the database's algorithm so each format is read back the
-        // way it was written.
-        if DefaultHashMode::ALGORITHM.is_ethereum() {
+        // dispatch on the proof's own self-describing mode (resolved from the
+        // header byte and threaded onto the reader) so each format is read back
+        // the way it was written, regardless of the compile default.
+        if reader.node_hash_algorithm().is_ethereum() {
             match reader
                 .read_item::<u8>()
                 .map_err(|err| err.set_item("hash type discriminant"))?

--- a/firewood/src/proofs/de.rs
+++ b/firewood/src/proofs/de.rs
@@ -8,7 +8,7 @@
 //! validation of the format.
 
 use super::{
-    header::{Header, InvalidHeader},
+    header::InvalidHeader,
     reader::{ProofReader, ReadError, ReadItem, V0Reader, Version0},
     types::{Proof, ProofNode, ProofType},
 };
@@ -20,8 +20,7 @@ use crate::{
     proofs::magic::{BATCH_DELETE, BATCH_DELETE_RANGE, BATCH_PUT},
 };
 use firewood_storage::{
-    Children, DefaultHashMode, HashMode, HashType, PathBuf, TrieHash, TriePathFromUnpackedBytes,
-    ValueDigest,
+    Children, HashType, PathBuf, TrieHash, TriePathFromUnpackedBytes, ValueDigest,
 };
 use integer_encoding::VarInt;
 use std::num::NonZeroUsize;
@@ -39,14 +38,16 @@ impl FrozenRangeProof {
     pub fn from_slice(data: &[u8]) -> Result<Self, ReadError> {
         let mut reader = ProofReader::new(data);
 
-        let header = reader.read_item::<Header>()?;
-        header
+        let header = reader.read_header()?;
+        let (_, algorithm) = header
             .validate(Some(ProofType::Range))
             .map_err(ReadError::InvalidHeader)?;
 
         match header.version {
             0 => {
-                let mut reader = V0Reader::new(reader, header);
+                // Body reads dispatch on the proof's own self-describing mode
+                // so this binary reads either wire format.
+                let mut reader = V0Reader::new(reader.into_body(algorithm), header);
                 let this = reader.read_v0_item()?;
                 if reader.remainder().is_empty() {
                     Ok(this)
@@ -100,8 +101,8 @@ impl FrozenChangeProof {
     pub fn from_slice(data: &[u8]) -> Result<Self, ReadError> {
         let mut reader = ProofReader::new(data);
 
-        let header = reader.read_item::<Header>()?;
-        header
+        let header = reader.read_header()?;
+        let (_, algorithm) = header
             .validate(Some(ProofType::Change))
             .map_err(ReadError::InvalidHeader)?;
 
@@ -113,7 +114,9 @@ impl FrozenChangeProof {
             ));
         }
 
-        let mut reader = V0Reader::new(reader, header);
+        // Body reads dispatch on the proof's own self-describing mode so this
+        // binary reads either wire format.
+        let mut reader = V0Reader::new(reader.into_body(algorithm), header);
         let this = reader.read_v0_item()?;
         if reader.remainder().is_empty() {
             Ok(this)
@@ -133,10 +136,11 @@ impl Version0 for FrozenRangeProof {
         let end_proof = reader.read_v0_item()?;
         let key_values = reader.read_v0_item()?;
 
-        Ok(Self::new(
+        Ok(Self::with_hash_mode(
             Proof::new(start_proof),
             Proof::new(end_proof),
             key_values,
+            reader.node_hash_algorithm(),
         ))
     }
 }
@@ -147,10 +151,11 @@ impl Version0 for FrozenChangeProof {
         let end_proof = reader.read_v0_item()?;
         let key_values = reader.read_v0_item()?;
 
-        Ok(Self::new(
+        Ok(Self::with_hash_mode(
             Proof::new(start_proof),
             Proof::new(end_proof),
             key_values,
+            reader.node_hash_algorithm(),
         ))
     }
 }
@@ -227,16 +232,6 @@ impl Version0 for (Box<[u8]>, Box<[u8]>) {
 
     fn read_v0_item(reader: &mut V0Reader<'_>) -> Result<Self, ReadError> {
         Ok((reader.read_item()?, reader.read_item()?))
-    }
-}
-
-impl<'a> ReadItem<'a> for Header {
-    fn read_item(reader: &mut ProofReader<'a>) -> Result<Self, ReadError> {
-        reader
-            .read_chunk::<{ size_of::<Header>() }>()
-            .map_err(|err| err.set_item("header"))
-            .copied()
-            .map(bytemuck::cast)
     }
 }
 
@@ -345,9 +340,10 @@ impl<'a> ReadItem<'a> for ChildMask {
 impl<'a> ReadItem<'a> for HashType {
     fn read_item(reader: &mut ProofReader<'a>) -> Result<Self, ReadError> {
         // The two schemes use different proof wire layouts for a child hash;
-        // dispatch on the database's algorithm so each format is read back the
-        // way it was written.
-        if DefaultHashMode::ALGORITHM.is_ethereum() {
+        // dispatch on the proof's own self-describing mode (resolved from the
+        // header byte and threaded onto the reader) so each format is read back
+        // the way it was written, regardless of the compile default.
+        if reader.node_hash_algorithm().is_ethereum() {
             match reader
                 .read_item::<u8>()
                 .map_err(|err| err.set_item("hash type discriminant"))?

--- a/firewood/src/proofs/header.rs
+++ b/firewood/src/proofs/header.rs
@@ -38,12 +38,16 @@ const _: () = {
     assert!(size_of::<Header>() == 32);
 };
 
-impl From<ProofType> for Header {
-    fn from(proof_type: ProofType) -> Self {
+impl From<(ProofType, NodeHashAlgorithm)> for Header {
+    fn from((proof_type, hash_mode): (ProofType, NodeHashAlgorithm)) -> Self {
+        let hash_mode = match hash_mode {
+            NodeHashAlgorithm::MerkleDB => magic::MERKLEDB_HASH_MODE,
+            NodeHashAlgorithm::Ethereum => magic::ETHEREUM_HASH_MODE,
+        };
         Self {
             magic: *magic::PROOF_HEADER,
             version: magic::PROOF_VERSION,
-            hash_mode: magic::HASH_MODE,
+            hash_mode,
             branch_factor: magic::BRANCH_FACTOR,
             proof_type: proof_type as u8,
             _reserved: [0; 20],

--- a/firewood/src/proofs/header.rs
+++ b/firewood/src/proofs/header.rs
@@ -7,6 +7,8 @@
 //! The header contains metadata about the proof format including version, hash mode,
 //! branching factor, and proof type, enabling quick validation before deserialization.
 
+use firewood_storage::NodeHashAlgorithm;
+
 use super::{magic, types::ProofType};
 
 /// A fixed-size header at the beginning of every serialized proof.
@@ -50,19 +52,26 @@ impl From<ProofType> for Header {
 }
 
 impl Header {
-    /// Validates the header, returning the discovered proof type if valid.
+    /// Validates the header, returning the discovered proof type and the
+    /// resolved [`NodeHashAlgorithm`] the proof was encoded with.
     ///
-    /// If `expected_type` is `Some`, the proof type must match (in which case the return
-    /// value can be ignored).
+    /// If `expected_type` is `Some`, the proof type must match (in which case the
+    /// returned proof type can be ignored). The resolved algorithm is taken from
+    /// the self-describing `hash_mode` header byte: any known mode (`0` =
+    /// MerkleDB, `1` = Ethereum) is accepted so a single binary can parse either
+    /// wire format; only a truly-unknown byte is rejected.
+    /// .
     ///
     /// # Errors
     ///
-    /// Returns an [`InvalidHeader`] if the header is invalid. See the enum variants for
-    /// possible reasons.
+    /// Returns:
+    /// - [`InvalidHeader`] if the header is invalid. See the enum variants for
+    ///   possible reasons.
+    /// - [`InvalidHeader::UnsupportedHashMode`] if the header's `hash_mode` byte is unrecognized.
     pub(super) fn validate(
         &self,
         expected_type: Option<ProofType>,
-    ) -> Result<ProofType, InvalidHeader> {
+    ) -> Result<(ProofType, NodeHashAlgorithm), InvalidHeader> {
         if self.magic != *magic::PROOF_HEADER {
             return Err(InvalidHeader::InvalidMagic { found: self.magic });
         }
@@ -73,11 +82,12 @@ impl Header {
             });
         }
 
-        if self.hash_mode != magic::HASH_MODE {
-            return Err(InvalidHeader::UnsupportedHashMode {
+        // Resolve the self-describing hash-mode byte into an algorithm.
+        let algorithm = NodeHashAlgorithm::try_from(u64::from(self.hash_mode)).map_err(|_| {
+            InvalidHeader::UnsupportedHashMode {
                 found: self.hash_mode,
-            });
-        }
+            }
+        })?;
 
         if self.branch_factor != magic::BRANCH_FACTOR {
             return Err(InvalidHeader::UnsupportedBranchFactor {
@@ -96,7 +106,7 @@ impl Header {
                     expected: Some(expected),
                 })
             }
-            (Some(found), _) => Ok(found),
+            (Some(found), _) => Ok((found, algorithm)),
         }
     }
 }
@@ -119,12 +129,13 @@ pub enum InvalidHeader {
         /// The version byte found instead of a supported version.
         found: u8,
     },
-    /// The proof was encoded for an unsupported hash mode.
+    /// The proof was encoded for an unknown hash mode (a byte that maps to no
+    /// known [`NodeHashAlgorithm`]).
     #[error(
-        "unsupported hash mode: found {found:02x} ({}); expected {:02x} ({})",
+        "unsupported hash mode: found {found:02x} ({}); expected {:02x} (sha256) or {:02x} (keccak256)",
         magic::hash_mode_name(*found),
-        magic::HASH_MODE,
-        magic::hash_mode_name(magic::HASH_MODE)
+        0u8,
+        1u8,
     )]
     UnsupportedHashMode {
         /// The flag indicating which hash mode created this proof.

--- a/firewood/src/proofs/header.rs
+++ b/firewood/src/proofs/header.rs
@@ -38,6 +38,15 @@ const _: () = {
     assert!(size_of::<Header>() == 32);
 };
 
+/// Fields resolved from a successfully validated proof header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct ValidatedHeader {
+    /// The type of proof encoded in the body.
+    pub(super) proof_type: ProofType,
+    /// The node-hashing algorithm used to encode the proof body.
+    pub(super) node_hash_algorithm: NodeHashAlgorithm,
+}
+
 impl From<(ProofType, NodeHashAlgorithm)> for Header {
     fn from((proof_type, hash_mode): (ProofType, NodeHashAlgorithm)) -> Self {
         let hash_mode = match hash_mode {
@@ -56,8 +65,7 @@ impl From<(ProofType, NodeHashAlgorithm)> for Header {
 }
 
 impl Header {
-    /// Validates the header, returning the discovered proof type and the
-    /// resolved [`NodeHashAlgorithm`] the proof was encoded with.
+    /// Validates the header and returns its resolved fields.
     ///
     /// If `expected_type` is `Some`, the proof type must match (in which case the
     /// returned proof type can be ignored). The resolved algorithm is taken from
@@ -75,7 +83,7 @@ impl Header {
     pub(super) fn validate(
         &self,
         expected_type: Option<ProofType>,
-    ) -> Result<(ProofType, NodeHashAlgorithm), InvalidHeader> {
+    ) -> Result<ValidatedHeader, InvalidHeader> {
         if self.magic != *magic::PROOF_HEADER {
             return Err(InvalidHeader::InvalidMagic { found: self.magic });
         }
@@ -110,7 +118,10 @@ impl Header {
                     expected: Some(expected),
                 })
             }
-            (Some(found), _) => Ok((found, algorithm)),
+            (Some(found), _) => Ok(ValidatedHeader {
+                proof_type: found,
+                node_hash_algorithm: algorithm,
+            }),
         }
     }
 }

--- a/firewood/src/proofs/mod.rs
+++ b/firewood/src/proofs/mod.rs
@@ -327,18 +327,16 @@ pub(super) mod magic {
     pub const PROOF_VERSION: u8 = 0;
 
     /// Hash mode identifier for SHA-256 hashing
-    #[cfg(not(feature = "ethhash"))]
-    pub const HASH_MODE: u8 = 0;
+    pub const MERKLEDB_HASH_MODE: u8 = 0;
 
     /// Hash mode identifier for Keccak-256 hashing (Ethereum-compatible)
-    #[cfg(feature = "ethhash")]
-    pub const HASH_MODE: u8 = 1;
+    pub const ETHEREUM_HASH_MODE: u8 = 1;
 
     /// Returns the human-readable name for a hash mode identifier.
     pub const fn hash_mode_name(v: u8) -> &'static str {
         match v {
-            0 => "sha256",
-            1 => "keccak256",
+            MERKLEDB_HASH_MODE => "sha256",
+            ETHEREUM_HASH_MODE => "keccak256",
             _ => "unknown",
         }
     }

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -58,6 +58,8 @@
 
 use std::num::NonZeroUsize;
 
+use firewood_storage::{DefaultHashMode, HashMode, NodeHashAlgorithm};
+
 use crate::api::{self, FrozenRangeProof, HashKey};
 use crate::merkle::verify_range_proof;
 use crate::proofs::ProofError;
@@ -92,6 +94,11 @@ pub struct RangeProofVerificationContext {
 /// the cryptographic range-proof verification via
 /// [`verify_range_proof`].
 ///
+/// # Node Hashing Algorithm
+///
+/// `algorithm` is the hash mode the caller expects; it is forwarded to
+/// [`verify_range_proof`], which rejects a header-mode-mismatched proof.
+///
 /// # Errors
 ///
 /// Returns [`api::Error::ProofError`] with
@@ -103,6 +110,7 @@ pub fn verify_range_proof_structure(
     root: HashKey,
     start_key: Option<&[u8]>,
     end_key: Option<&[u8]>,
+    algorithm: NodeHashAlgorithm,
     max_length: Option<NonZeroUsize>,
 ) -> Result<RangeProofVerificationContext, api::Error> {
     if let Some(max) = max_length
@@ -113,7 +121,7 @@ pub fn verify_range_proof_structure(
         ));
     }
 
-    verify_range_proof(start_key, end_key, &root, proof)?;
+    verify_range_proof(start_key, end_key, &root, algorithm, proof)?;
 
     Ok(RangeProofVerificationContext {
         root,
@@ -181,6 +189,12 @@ pub struct RangeProof<K, V, H> {
     start_proof: Proof<H>,
     end_proof: Proof<H>,
     key_values: Box<[(K, V)]>,
+    /// The hash algorithm this proof was constructed or parsed with. For proofs
+    /// built in this binary it is the compile default; for proofs parsed via
+    /// [`FrozenRangeProof::from_slice`](crate::api::FrozenRangeProof::from_slice)
+    /// it is resolved from the self-describing header byte.
+    /// [`ProofError::HashModeMismatch`]).
+    hash_mode: NodeHashAlgorithm,
 }
 
 impl<K, V, H> std::fmt::Debug for RangeProof<K, V, H>
@@ -195,6 +209,7 @@ where
             .field("start_proof", &self.start_proof)
             .field("end_proof", &self.end_proof)
             .field("key_values", &self.key_values)
+            .field("hash_mode", &self.hash_mode)
             .finish()
     }
 }
@@ -233,11 +248,38 @@ where
         end_proof: Proof<H>,
         key_values: Box<[(K, V)]>,
     ) -> Self {
+        // Proofs built in this binary carry the compile-default mode.
+        Self::with_hash_mode(
+            start_proof,
+            end_proof,
+            key_values,
+            DefaultHashMode::ALGORITHM,
+        )
+    }
+
+    /// Like [`RangeProof::new`], but records the [`NodeHashAlgorithm`] the proof
+    /// was encoded with. Used by the parse path
+    /// ([`FrozenRangeProof::from_slice`](crate::api::FrozenRangeProof::from_slice))
+    /// to stamp the mode resolved from the self-describing header byte.
+    #[must_use]
+    pub(crate) const fn with_hash_mode(
+        start_proof: Proof<H>,
+        end_proof: Proof<H>,
+        key_values: Box<[(K, V)]>,
+        hash_mode: NodeHashAlgorithm,
+    ) -> Self {
         Self {
             start_proof,
             end_proof,
             key_values,
+            hash_mode,
         }
+    }
+
+    /// The hash algorithm this proof was constructed or parsed with.
+    #[must_use]
+    pub const fn hash_mode(&self) -> NodeHashAlgorithm {
+        self.hash_mode
     }
 
     /// Returns a reference to the start proof, which may be empty.

--- a/firewood/src/proofs/reader.rs
+++ b/firewood/src/proofs/reader.rs
@@ -7,6 +7,8 @@
 //! including the `ProofReader` type for sequential reading and traits for
 //! deserializing individual proof components.
 
+use firewood_storage::NodeHashAlgorithm;
+
 use super::header::{Header, InvalidHeader};
 use std::num::NonZeroUsize;
 pub(super) trait ReadItem<'a>: Sized {
@@ -21,17 +23,69 @@ pub(super) trait Version0: Sized {
     fn read_v0_item(reader: &mut V0Reader<'_>) -> Result<Self, ReadError>;
 }
 
-pub(super) struct ProofReader<'a> {
+/// Marker for a reader that has not yet learned the proof's hash algorithm
+/// from the header. It exists only so that body reads are
+/// inexpressible during the header phase.
+pub(super) struct NoAlgorithm;
+
+pub(super) struct ProofReader<'a, M = NodeHashAlgorithm> {
     data: &'a [u8],
     offset: usize,
+    /// The hash algorithm the proof being read was encoded with, resolved from
+    /// the self-describing `hash_mode` header byte. During the header phase
+    /// this is [`NoAlgorithm`]: no placeholder mode ever exists.
+    mode: M,
+}
+
+impl<'a> ProofReader<'a, NoAlgorithm> {
+    /// Creates a reader for parsing the fixed-size header, before the proof's
+    /// own hash mode is known. Body items cannot be read until the resolved
+    /// algorithm is supplied via [`ProofReader::into_body`].
+    #[must_use]
+    pub const fn new(data: &'a [u8]) -> Self {
+        Self {
+            data,
+            offset: 0,
+            mode: NoAlgorithm,
+        }
+    }
+
+    /// Parses the fixed-size proof header — the only item that can be read
+    /// before the proof's hash algorithm is known.
+    pub fn read_header(&mut self) -> Result<Header, ReadError> {
+        self.read_chunk::<{ size_of::<Header>() }>()
+            .map_err(|err| err.set_item("header"))
+            .copied()
+            .map(bytemuck::cast)
+    }
+
+    /// Transitions to the body phase with the hash algorithm resolved from the
+    /// validated header, so body reads dispatch on the proof's own mode.
+    /// Consuming `self` keeps the phases exclusive: the only way to read body
+    /// items is to supply the algorithm first.
+    #[must_use]
+    pub const fn into_body(self, algorithm: NodeHashAlgorithm) -> ProofReader<'a> {
+        ProofReader {
+            data: self.data,
+            offset: self.offset,
+            mode: algorithm,
+        }
+    }
 }
 
 impl<'a> ProofReader<'a> {
+    /// The hash algorithm the proof being read was encoded with.
     #[must_use]
-    pub const fn new(data: &'a [u8]) -> Self {
-        Self { data, offset: 0 }
+    pub const fn node_hash_algorithm(&self) -> NodeHashAlgorithm {
+        self.mode
     }
 
+    pub(super) fn read_item<T: ReadItem<'a>>(&mut self) -> Result<T, ReadError> {
+        T::read_item(self)
+    }
+}
+
+impl<'a, M> ProofReader<'a, M> {
     pub fn read_chunk<const N: usize>(&mut self) -> Result<&'a [u8; N], ReadError> {
         if let Some((chunk, _)) = self.remainder().split_first_chunk::<N>() {
             #[expect(clippy::arithmetic_side_effects)]
@@ -59,10 +113,6 @@ impl<'a> ProofReader<'a> {
         } else {
             Err(self.incomplete_item("byte slice", n))
         }
-    }
-
-    pub(super) fn read_item<T: ReadItem<'a>>(&mut self) -> Result<T, ReadError> {
-        T::read_item(self)
     }
 
     pub fn remainder(&self) -> &'a [u8] {

--- a/firewood/src/proofs/ser.rs
+++ b/firewood/src/proofs/ser.rs
@@ -7,7 +7,9 @@
 //! It provides efficient encoding of proof nodes, child bitmaps, and range proofs
 //! for transmission or persistent storage.
 
-use firewood_storage::{DefaultHashMode, HashMode, PathBuf, PathComponentSliceExt, ValueDigest};
+use firewood_storage::{
+    EthHash, MerkleDbHash, NodeHashAlgorithm, PathBuf, PathComponentSliceExt, ValueDigest,
+};
 use integer_encoding::VarInt;
 
 use super::{
@@ -78,15 +80,40 @@ impl FrozenRangeProof {
     ///
     /// Variable-length integers are encoded using unsigned LEB128.
     pub fn write_to_vec(&self, out: &mut Vec<u8>) {
-        Header::from(ProofType::Range).write_item(out);
-        self.write_item(out);
+        // The proof's hash mode determines the child-hash wire layout and the
+        // value-digest hashing rule; use its self-describing mode rather than
+        // the compile default.
+        let mut w = ProofWriter {
+            out,
+            mode: self.hash_mode(),
+        };
+        Header::from((ProofType::Range, w.mode)).write_item(&mut w);
+        self.write_item(&mut w);
     }
 }
 
 impl FrozenChangeProof {
     pub fn write_to_vec(&self, out: &mut Vec<u8>) {
-        Header::from(ProofType::Change).write_item(out);
-        self.write_item(out);
+        let mut w = ProofWriter {
+            out,
+            mode: self.hash_mode(),
+        };
+        Header::from((ProofType::Change, w.mode)).write_item(&mut w);
+        self.write_item(&mut w);
+    }
+}
+
+/// Mirrors `ProofReader`: carries the output buffer and the hash mode the proof
+/// is encoded with. Mode-dependent items (`ValueDigest`, `HashType`) consult
+/// `node_hash_algorithm()`; everything else just writes.
+struct ProofWriter<'a> {
+    out: &'a mut Vec<u8>,
+    mode: NodeHashAlgorithm,
+}
+
+impl ProofWriter<'_> {
+    const fn node_hash_algorithm(&self) -> NodeHashAlgorithm {
+        self.mode
     }
 }
 
@@ -104,42 +131,42 @@ impl PushVarInt for Vec<u8> {
 }
 
 trait WriteItem {
-    fn write_item(&self, out: &mut Vec<u8>);
+    fn write_item(&self, w: &mut ProofWriter<'_>);
 }
 
 impl WriteItem for FrozenRangeProof {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        self.start_proof().write_item(out);
-        self.end_proof().write_item(out);
-        self.key_values().write_item(out);
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        self.start_proof().write_item(w);
+        self.end_proof().write_item(w);
+        self.key_values().write_item(w);
     }
 }
 
 impl WriteItem for FrozenChangeProof {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        self.start_proof().write_item(out);
-        self.end_proof().write_item(out);
-        self.batch_ops().write_item(out);
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        self.start_proof().write_item(w);
+        self.end_proof().write_item(w);
+        self.batch_ops().write_item(w);
     }
 }
 
 impl WriteItem for [BatchOp<Key, Value>] {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        out.push_var_int(self.len());
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        w.out.push_var_int(self.len());
         for item in self {
             match item {
                 BatchOp::Put { key, value } => {
-                    out.push(BATCH_PUT);
-                    key.write_item(out);
-                    value.write_item(out);
+                    w.out.push(BATCH_PUT);
+                    key.write_item(w);
+                    value.write_item(w);
                 }
                 BatchOp::Delete { key } => {
-                    out.push(BATCH_DELETE);
-                    key.write_item(out);
+                    w.out.push(BATCH_DELETE);
+                    key.write_item(w);
                 }
                 BatchOp::DeleteRange { prefix } => {
-                    out.push(BATCH_DELETE_RANGE);
-                    prefix.write_item(out);
+                    w.out.push(BATCH_DELETE_RANGE);
+                    prefix.write_item(w);
                 }
             }
         }
@@ -147,101 +174,108 @@ impl WriteItem for [BatchOp<Key, Value>] {
 }
 
 impl WriteItem for ProofNode {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        self.key.write_item(out);
-        out.push_var_int(self.partial_len);
-        self.value_digest.write_item(out);
-        out.extend_from_slice(&self.child_hashes.bitmap().to_le_bytes());
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        self.key.write_item(w);
+        w.out.push_var_int(self.partial_len);
+        self.value_digest.write_item(w);
+        w.out
+            .extend_from_slice(&self.child_hashes.bitmap().to_le_bytes());
         for (_, child) in self.child_hashes.iter_present() {
-            child.write_item(out);
+            child.write_item(w);
         }
     }
 }
 
 impl WriteItem for PathBuf {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        out.push_var_int(self.len());
-        out.extend_from_slice(self.as_byte_slice());
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        w.out.push_var_int(self.len());
+        w.out.extend_from_slice(self.as_byte_slice());
     }
 }
 
 impl<T: WriteItem> WriteItem for Option<T> {
-    fn write_item(&self, out: &mut Vec<u8>) {
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
         if let Some(v) = self {
-            out.push(1);
-            v.write_item(out);
+            w.out.push(1);
+            v.write_item(w);
         } else {
-            out.push(0);
+            w.out.push(0);
         }
     }
 }
 
 impl<T: WriteItem> WriteItem for [T] {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        out.push_var_int(self.len());
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        w.out.push_var_int(self.len());
         for item in self {
-            item.write_item(out);
+            item.write_item(w);
         }
     }
 }
 
 impl WriteItem for [u8] {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        out.push_var_int(self.len());
-        out.extend_from_slice(self);
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        w.out.push_var_int(self.len());
+        w.out.extend_from_slice(self);
     }
 }
 
 impl<T: AsRef<[u8]>> WriteItem for ValueDigest<T> {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        match self.make_hash() {
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        // The value-digest hashing rule (cap large values under MerkleDB,
+        // identity under Ethereum) is selected by the writer's runtime mode.
+        let hashed = match w.node_hash_algorithm() {
+            NodeHashAlgorithm::Ethereum => self.make_hash::<EthHash>(),
+            NodeHashAlgorithm::MerkleDB => self.make_hash::<MerkleDbHash>(),
+        };
+        match hashed {
             ValueDigest::Value(v) => {
-                out.push(0);
-                v.write_item(out);
+                w.out.push(0);
+                v.write_item(w);
             }
             // Only produced by the merkledb scheme (large values hashed); the
             // Ethereum scheme never emits a `Hash` digest.
             ValueDigest::Hash(h) => {
-                out.push(1);
-                h.write_item(out);
+                w.out.push(1);
+                h.write_item(w);
             }
         }
     }
 }
 
 impl WriteItem for Header {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(bytemuck::bytes_of(self));
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        w.out.extend_from_slice(bytemuck::bytes_of(self));
     }
 }
 
 impl WriteItem for firewood_storage::TrieHash {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(self.as_ref());
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        w.out.extend_from_slice(self.as_ref());
     }
 }
 
 impl WriteItem for firewood_storage::HashType {
-    fn write_item(&self, out: &mut Vec<u8>) {
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
         // The two schemes use different proof wire layouts for a child hash;
-        // dispatch on the database's algorithm so each format is preserved
-        // byte-for-byte.
-        if DefaultHashMode::ALGORITHM.is_ethereum() {
+        // dispatch on the writer's runtime algorithm so each format is
+        // preserved byte-for-byte.
+        if w.node_hash_algorithm().is_ethereum() {
             match self {
                 firewood_storage::HashType::Hash(h) => {
-                    out.push(0);
-                    h.write_item(out);
+                    w.out.push(0);
+                    h.write_item(w);
                 }
                 firewood_storage::HashType::Rlp(h) => {
-                    out.push(1);
-                    h.write_item(out);
+                    w.out.push(1);
+                    h.write_item(w);
                 }
             }
         } else {
             // MerkleDB child hashes are always a bare 32-byte hash, with no
             // discriminant byte.
             match self {
-                firewood_storage::HashType::Hash(h) => h.write_item(out),
+                firewood_storage::HashType::Hash(h) => h.write_item(w),
                 firewood_storage::HashType::Rlp(_) => {
                     unreachable!("merkledb child hash is never inline RLP")
                 }
@@ -251,15 +285,15 @@ impl WriteItem for firewood_storage::HashType {
 }
 
 impl WriteItem for ChildMask {
-    fn write_item(&self, out: &mut Vec<u8>) {
-        out.extend_from_slice(&self.to_le_bytes());
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
+        w.out.extend_from_slice(&self.to_le_bytes());
     }
 }
 
 impl<K: AsRef<[u8]>, V: AsRef<[u8]>> WriteItem for (K, V) {
-    fn write_item(&self, out: &mut Vec<u8>) {
+    fn write_item(&self, w: &mut ProofWriter<'_>) {
         let (key, value) = self;
-        key.as_ref().write_item(out);
-        value.as_ref().write_item(out);
+        key.as_ref().write_item(w);
+        value.as_ref().write_item(w);
     }
 }

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -4,13 +4,16 @@
 use integer_encoding::VarInt;
 use test_case::test_case;
 
-use firewood_storage::{Children, PathComponent, SeededRng, TrieHash, ValueDigest, logger::debug};
+use firewood_storage::{
+    Children, HashType, NodeHashAlgorithm, PathComponent, SeededRng, TrieHash, ValueDigest,
+    logger::debug,
+};
 
 use super::{
     header::InvalidHeader,
     magic,
-    reader::ReadError,
-    types::{Proof, ProofNode, ProofType},
+    reader::{ProofReader, ReadError},
+    types::{Proof, ProofError, ProofNode, ProofType},
 };
 use crate::api::{FrozenChangeProof, FrozenRangeProof};
 use crate::db::BatchOp;
@@ -994,8 +997,15 @@ mod box_array_deserialization_tests {
     }
 
     fn v0_reader(data: &[u8]) -> V0Reader<'_> {
-        let inner = ProofReader::new(data);
-        V0Reader::new(inner, Header::from(ProofType::Range))
+        // Resolve the algorithm from the header itself, mirroring the
+        // production validate-then-into_body flow. (These tests exercise
+        // mode-independent reads, so any consistent mode works.)
+        let header = Header::from(ProofType::Range);
+        let (_, algorithm) = header
+            .validate(Some(ProofType::Range))
+            .expect("default header should be valid");
+        let inner = ProofReader::new(data).into_body(algorithm);
+        V0Reader::new(inner, header)
     }
 
     #[test]
@@ -1083,4 +1093,162 @@ mod box_array_deserialization_tests {
             })
         ));
     }
+}
+
+#[test]
+fn test_header_validate_accepts_both_hash_modes() {
+    let (_, base) = create_valid_range_proof();
+
+    for (byte, expected) in [
+        (0u8, NodeHashAlgorithm::MerkleDB),
+        (1u8, NodeHashAlgorithm::Ethereum),
+    ] {
+        let mut data = base.clone();
+        data[9] = byte;
+
+        let mut reader = ProofReader::new(&data);
+        let header = reader
+            .read_header()
+            .expect("header should parse successfully");
+
+        let (proof_type, algorithm) = header
+            .validate(Some(ProofType::Range))
+            .expect("hash_mode should validate");
+
+        assert_eq!(proof_type, ProofType::Range);
+        assert_eq!(
+            algorithm, expected,
+            "hash_mode {byte} should resolve to {expected:?}"
+        );
+    }
+
+    // A byte that maps to no known algorithm is still rejected.
+    let mut data = base;
+    data[9] = 99;
+    let mut reader = ProofReader::new(&data);
+    let header = reader
+        .read_header()
+        .expect("header should parse successfully");
+
+    match header.validate(Some(ProofType::Range)) {
+        Err(InvalidHeader::UnsupportedHashMode { found: 99 }) => {}
+        other => panic!("expected UnsupportedHashMode {{ found: 99 }}, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_hash_type_read_dispatches_on_threaded_mode() {
+    let raw = [0x11u8; 32];
+
+    // Ethereum wire layout: a 0x00 discriminant followed by the 32 hash bytes.
+    let mut eth_bytes = vec![0x00u8];
+    eth_bytes.extend_from_slice(&raw);
+    let mut eth_reader = ProofReader::new(&eth_bytes).into_body(NodeHashAlgorithm::Ethereum);
+    let decoded = eth_reader
+        .read_item::<HashType>()
+        .expect("eth HashType should decode under Ethereum mode");
+    assert_eq!(decoded, HashType::from(TrieHash::from(raw)));
+    assert!(eth_reader.remainder().is_empty(), "all eth bytes consumed");
+
+    // MerkleDB wire layout: bare 32 bytes, no discriminant.
+    let mut mdb_reader = ProofReader::new(&raw).into_body(NodeHashAlgorithm::MerkleDB);
+    let decoded = mdb_reader
+        .read_item::<HashType>()
+        .expect("merkledb HashType should decode under MerkleDB mode");
+    assert_eq!(decoded, HashType::from(TrieHash::from(raw)));
+    assert!(
+        mdb_reader.remainder().is_empty(),
+        "all merkledb bytes consumed"
+    );
+}
+
+#[test]
+fn test_verify_range_proof_rejects_hash_mode_mismatch() {
+    let (proof, _) = create_valid_range_proof();
+    let other_mode = if proof.hash_mode().is_ethereum() {
+        NodeHashAlgorithm::MerkleDB
+    } else {
+        NodeHashAlgorithm::Ethereum
+    };
+
+    // Root hash and keys are irrelevant: the guard fires before any hashing or
+    // structural checks. Use a placeholder root.
+    let result = crate::merkle::verify_range_proof(
+        Some(&[2u8]),
+        Some(&[8u8]),
+        &TrieHash::from([0u8; 32]),
+        other_mode,
+        &proof,
+    );
+
+    match result {
+        Err(crate::api::Error::ProofError(ProofError::HashModeMismatch { expected, found })) => {
+            assert_eq!(expected, other_mode);
+            assert_eq!(found, proof.hash_mode());
+        }
+        other => panic!("expected HashModeMismatch, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_verify_change_proof_structure_rejects_hash_mode_mismatch() {
+    let (proof, _) = create_valid_change_proof();
+    let other_mode = if proof.hash_mode().is_ethereum() {
+        NodeHashAlgorithm::MerkleDB
+    } else {
+        NodeHashAlgorithm::Ethereum
+    };
+
+    // The guard fires before any hashing or structural checks; end_root and keys
+    // are placeholders.
+    let result = crate::verify_change_proof_structure(
+        &proof,
+        TrieHash::from([0u8; 32]),
+        Some(&[2u8]),
+        Some(&[8u8]),
+        other_mode,
+        None,
+    );
+
+    match result {
+        Err(crate::api::Error::ProofError(ProofError::HashModeMismatch { expected, found })) => {
+            assert_eq!(expected, other_mode);
+            assert_eq!(found, proof.hash_mode());
+        }
+        other => panic!("expected HashModeMismatch, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_value_digest_hash_read_arm_is_unconditional() {
+    // ValueDigest::Hash wire layout: 0x01 digest discriminant + a HashType.
+    // In MerkleDB mode the HashType is a bare 32-byte hash (no inner
+    // discriminant), so this is the canonical on-wire shape of a Hash digest.
+    let mut bytes = vec![0x01u8];
+    bytes.extend_from_slice(&[0x22u8; 32]);
+
+    let mut reader = ProofReader::new(&bytes).into_body(NodeHashAlgorithm::MerkleDB);
+    let decoded = reader
+        .read_item::<ValueDigest<&[u8]>>()
+        .expect("0x01 Hash discriminant must be accepted unconditionally");
+    match decoded {
+        ValueDigest::Hash(h) => assert_eq!(h, HashType::from(TrieHash::from([0x22u8; 32]))),
+        ValueDigest::Value(_) => panic!("expected ValueDigest::Hash"),
+    }
+    assert!(reader.remainder().is_empty(), "all bytes consumed");
+
+    // Across modes: an Ethereum-seeded reader also accepts the 0x01 digest
+    // discriminant unconditionally; the inner HashType then follows the eth
+    // encoding (0x00 Hash discriminant + 32 bytes).
+    let mut eth_bytes = vec![0x01u8, 0x00u8];
+    eth_bytes.extend_from_slice(&[0x33u8; 32]);
+    let mut eth_reader = ProofReader::new(&eth_bytes).into_body(NodeHashAlgorithm::Ethereum);
+    let eth_decoded = eth_reader
+        .read_item::<ValueDigest<&[u8]>>()
+        .expect("0x01 Hash discriminant must be accepted in eth mode too");
+    match eth_decoded {
+        ValueDigest::Hash(h) => assert_eq!(h, HashType::from(TrieHash::from([0x33u8; 32]))),
+        ValueDigest::Value(_) => panic!("expected ValueDigest::Hash"),
+    }
+    assert!(eth_reader.remainder().is_empty(), "all bytes consumed");
 }

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -1052,10 +1052,10 @@ mod box_array_deserialization_tests {
         // production validate-then-into_body flow. (These tests exercise
         // mode-independent reads, so any consistent mode works.)
         let header = Header::from((ProofType::Range, DefaultHashMode::ALGORITHM));
-        let (_, algorithm) = header
+        let validated_header = header
             .validate(Some(ProofType::Range))
             .expect("default header should be valid");
-        let inner = ProofReader::new(data).into_body(algorithm);
+        let inner = ProofReader::new(data).into_body(validated_header.node_hash_algorithm);
         V0Reader::new(inner, header)
     }
 
@@ -1162,13 +1162,13 @@ fn test_header_validate_accepts_both_hash_modes() {
             .read_header()
             .expect("header should parse successfully");
 
-        let (proof_type, algorithm) = header
+        let validated_header = header
             .validate(Some(ProofType::Range))
             .expect("hash_mode should validate");
 
-        assert_eq!(proof_type, ProofType::Range);
+        assert_eq!(validated_header.proof_type, ProofType::Range);
         assert_eq!(
-            algorithm, expected,
+            validated_header.node_hash_algorithm, expected,
             "hash_mode {byte} should resolve to {expected:?}"
         );
     }

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -5,14 +5,15 @@ use integer_encoding::VarInt;
 use test_case::test_case;
 
 use firewood_storage::{
-    DenseChildren, PathComponent, SeededRng, TrieHash, ValueDigest, logger::debug,
+    DenseChildren, HashType, NodeHashAlgorithm, PathComponent, SeededRng, TrieHash, ValueDigest,
+    logger::debug,
 };
 
 use super::{
     header::InvalidHeader,
     magic,
-    reader::ReadError,
-    types::{Proof, ProofNode, ProofType},
+    reader::{ProofReader, ReadError},
+    types::{Proof, ProofError, ProofNode, ProofType},
 };
 use crate::api::{FrozenChangeProof, FrozenRangeProof};
 use crate::db::BatchOp;
@@ -1000,8 +1001,15 @@ mod box_array_deserialization_tests {
     }
 
     fn v0_reader(data: &[u8]) -> V0Reader<'_> {
-        let inner = ProofReader::new(data);
-        V0Reader::new(inner, Header::from(ProofType::Range))
+        // Resolve the algorithm from the header itself, mirroring the
+        // production validate-then-into_body flow. (These tests exercise
+        // mode-independent reads, so any consistent mode works.)
+        let header = Header::from(ProofType::Range);
+        let (_, algorithm) = header
+            .validate(Some(ProofType::Range))
+            .expect("default header should be valid");
+        let inner = ProofReader::new(data).into_body(algorithm);
+        V0Reader::new(inner, header)
     }
 
     #[test]
@@ -1089,4 +1097,162 @@ mod box_array_deserialization_tests {
             })
         ));
     }
+}
+
+#[test]
+fn test_header_validate_accepts_both_hash_modes() {
+    let (_, base) = create_valid_range_proof();
+
+    for (byte, expected) in [
+        (0u8, NodeHashAlgorithm::MerkleDB),
+        (1u8, NodeHashAlgorithm::Ethereum),
+    ] {
+        let mut data = base.clone();
+        data[9] = byte;
+
+        let mut reader = ProofReader::new(&data);
+        let header = reader
+            .read_header()
+            .expect("header should parse successfully");
+
+        let (proof_type, algorithm) = header
+            .validate(Some(ProofType::Range))
+            .expect("hash_mode should validate");
+
+        assert_eq!(proof_type, ProofType::Range);
+        assert_eq!(
+            algorithm, expected,
+            "hash_mode {byte} should resolve to {expected:?}"
+        );
+    }
+
+    // A byte that maps to no known algorithm is still rejected.
+    let mut data = base;
+    data[9] = 99;
+    let mut reader = ProofReader::new(&data);
+    let header = reader
+        .read_header()
+        .expect("header should parse successfully");
+
+    match header.validate(Some(ProofType::Range)) {
+        Err(InvalidHeader::UnsupportedHashMode { found: 99 }) => {}
+        other => panic!("expected UnsupportedHashMode {{ found: 99 }}, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_hash_type_read_dispatches_on_threaded_mode() {
+    let raw = [0x11u8; 32];
+
+    // Ethereum wire layout: a 0x00 discriminant followed by the 32 hash bytes.
+    let mut eth_bytes = vec![0x00u8];
+    eth_bytes.extend_from_slice(&raw);
+    let mut eth_reader = ProofReader::new(&eth_bytes).into_body(NodeHashAlgorithm::Ethereum);
+    let decoded = eth_reader
+        .read_item::<HashType>()
+        .expect("eth HashType should decode under Ethereum mode");
+    assert_eq!(decoded, HashType::from(TrieHash::from(raw)));
+    assert!(eth_reader.remainder().is_empty(), "all eth bytes consumed");
+
+    // MerkleDB wire layout: bare 32 bytes, no discriminant.
+    let mut mdb_reader = ProofReader::new(&raw).into_body(NodeHashAlgorithm::MerkleDB);
+    let decoded = mdb_reader
+        .read_item::<HashType>()
+        .expect("merkledb HashType should decode under MerkleDB mode");
+    assert_eq!(decoded, HashType::from(TrieHash::from(raw)));
+    assert!(
+        mdb_reader.remainder().is_empty(),
+        "all merkledb bytes consumed"
+    );
+}
+
+#[test]
+fn test_verify_range_proof_rejects_hash_mode_mismatch() {
+    let (proof, _) = create_valid_range_proof();
+    let other_mode = if proof.hash_mode().is_ethereum() {
+        NodeHashAlgorithm::MerkleDB
+    } else {
+        NodeHashAlgorithm::Ethereum
+    };
+
+    // Root hash and keys are irrelevant: the guard fires before any hashing or
+    // structural checks. Use a placeholder root.
+    let result = crate::merkle::verify_range_proof(
+        Some(&[2u8]),
+        Some(&[8u8]),
+        &TrieHash::from([0u8; 32]),
+        other_mode,
+        &proof,
+    );
+
+    match result {
+        Err(crate::api::Error::ProofError(ProofError::HashModeMismatch { expected, found })) => {
+            assert_eq!(expected, other_mode);
+            assert_eq!(found, proof.hash_mode());
+        }
+        other => panic!("expected HashModeMismatch, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_verify_change_proof_structure_rejects_hash_mode_mismatch() {
+    let (proof, _) = create_valid_change_proof();
+    let other_mode = if proof.hash_mode().is_ethereum() {
+        NodeHashAlgorithm::MerkleDB
+    } else {
+        NodeHashAlgorithm::Ethereum
+    };
+
+    // The guard fires before any hashing or structural checks; end_root and keys
+    // are placeholders.
+    let result = crate::verify_change_proof_structure(
+        &proof,
+        TrieHash::from([0u8; 32]),
+        Some(&[2u8]),
+        Some(&[8u8]),
+        other_mode,
+        None,
+    );
+
+    match result {
+        Err(crate::api::Error::ProofError(ProofError::HashModeMismatch { expected, found })) => {
+            assert_eq!(expected, other_mode);
+            assert_eq!(found, proof.hash_mode());
+        }
+        other => panic!("expected HashModeMismatch, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_value_digest_hash_read_arm_is_unconditional() {
+    // ValueDigest::Hash wire layout: 0x01 digest discriminant + a HashType.
+    // In MerkleDB mode the HashType is a bare 32-byte hash (no inner
+    // discriminant), so this is the canonical on-wire shape of a Hash digest.
+    let mut bytes = vec![0x01u8];
+    bytes.extend_from_slice(&[0x22u8; 32]);
+
+    let mut reader = ProofReader::new(&bytes).into_body(NodeHashAlgorithm::MerkleDB);
+    let decoded = reader
+        .read_item::<ValueDigest<&[u8]>>()
+        .expect("0x01 Hash discriminant must be accepted unconditionally");
+    match decoded {
+        ValueDigest::Hash(h) => assert_eq!(h, HashType::from(TrieHash::from([0x22u8; 32]))),
+        ValueDigest::Value(_) => panic!("expected ValueDigest::Hash"),
+    }
+    assert!(reader.remainder().is_empty(), "all bytes consumed");
+
+    // Across modes: an Ethereum-seeded reader also accepts the 0x01 digest
+    // discriminant unconditionally; the inner HashType then follows the eth
+    // encoding (0x00 Hash discriminant + 32 bytes).
+    let mut eth_bytes = vec![0x01u8, 0x00u8];
+    eth_bytes.extend_from_slice(&[0x33u8; 32]);
+    let mut eth_reader = ProofReader::new(&eth_bytes).into_body(NodeHashAlgorithm::Ethereum);
+    let eth_decoded = eth_reader
+        .read_item::<ValueDigest<&[u8]>>()
+        .expect("0x01 Hash discriminant must be accepted in eth mode too");
+    match eth_decoded {
+        ValueDigest::Hash(h) => assert_eq!(h, HashType::from(TrieHash::from([0x33u8; 32]))),
+        ValueDigest::Value(_) => panic!("expected ValueDigest::Hash"),
+    }
+    assert!(eth_reader.remainder().is_empty(), "all bytes consumed");
 }

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -5,8 +5,8 @@ use integer_encoding::VarInt;
 use test_case::test_case;
 
 use firewood_storage::{
-    DenseChildren, HashType, NodeHashAlgorithm, PathComponent, SeededRng, TrieHash, ValueDigest,
-    logger::debug,
+    DefaultHashMode, DenseChildren, HashMode, HashType, NodeHashAlgorithm, PathComponent,
+    SeededRng, TrieHash, ValueDigest, logger::debug,
 };
 
 use super::{
@@ -28,8 +28,8 @@ fn create_valid_range_proof() -> (FrozenRangeProof, Vec<u8>) {
     (proof, serialized)
 }
 
-fn create_valid_change_proof() -> (FrozenChangeProof, Vec<u8>) {
-    let proof = FrozenChangeProof::new(
+fn create_valid_change_proof(hash_mode: NodeHashAlgorithm) -> (FrozenChangeProof, Vec<u8>) {
+    let proof = FrozenChangeProof::with_hash_mode(
         Proof::new(Box::<[ProofNode]>::from([])),
         Proof::new(Box::<[ProofNode]>::from([])),
         Box::new([
@@ -44,6 +44,7 @@ fn create_valid_change_proof() -> (FrozenChangeProof, Vec<u8>) {
                 prefix: Box::from(b"key3".as_slice()),
             },
         ]),
+        hash_mode,
     );
     let mut serialized = Vec::new();
     proof.write_to_vec(&mut serialized);
@@ -59,13 +60,59 @@ fn test_range_proof_roundtrip() {
     assert_eq!(serialized, re_serialized);
 }
 
-#[test]
-fn test_change_proof_roundtrip() {
-    let (_, serialized) = create_valid_change_proof();
+#[test_case(NodeHashAlgorithm::MerkleDB; "merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum; "ethereum")]
+fn test_change_proof_roundtrip(hash_mode: NodeHashAlgorithm) {
+    let (_, serialized) = create_valid_change_proof(hash_mode);
     let parsed = FrozenChangeProof::from_slice(&serialized).expect("roundtrip should succeed");
+    assert_eq!(parsed.hash_mode(), hash_mode);
     let mut re_serialized = Vec::new();
     parsed.write_to_vec(&mut re_serialized);
     assert_eq!(serialized, re_serialized);
+}
+
+const fn hash_mode_byte(hash_mode: NodeHashAlgorithm) -> u8 {
+    match hash_mode {
+        NodeHashAlgorithm::MerkleDB => magic::MERKLEDB_HASH_MODE,
+        NodeHashAlgorithm::Ethereum => magic::ETHEREUM_HASH_MODE,
+    }
+}
+
+/// Ensures mode-dependent proof-node fields round-trip using the proof's recorded hash mode.
+#[test_case(NodeHashAlgorithm::MerkleDB; "merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum; "ethereum")]
+fn test_mode_dependent_proof_node_roundtrip(hash_mode: NodeHashAlgorithm) {
+    let mut node = make_proof_node(&[1], 0, Some(vec![0xabu8; 32].into_boxed_slice()), &[]);
+    node.child_hashes.insert(
+        PathComponent::try_new(7).unwrap().0,
+        TrieHash::from([0xabu8; 32]).into(),
+    );
+
+    let range = FrozenRangeProof::with_hash_mode(
+        Proof::new(Box::new([node])),
+        Proof::new(Box::<[ProofNode]>::from([])),
+        Box::new([]),
+        hash_mode,
+    );
+    let mut serialized = Vec::new();
+    range.write_to_vec(&mut serialized);
+
+    let parsed = FrozenRangeProof::from_slice(&serialized)
+        .expect("range proof should parse in its recorded mode");
+    assert_eq!(parsed.hash_mode(), hash_mode);
+    let value_digest = parsed
+        .start_proof()
+        .first()
+        .and_then(|node| node.value_digest.as_ref())
+        .expect("fixture should contain a value digest");
+    assert_eq!(
+        matches!(value_digest, ValueDigest::Hash(_)),
+        hash_mode == NodeHashAlgorithm::MerkleDB
+    );
+
+    let mut reserialized = Vec::new();
+    parsed.write_to_vec(&mut reserialized);
+    assert_eq!(reserialized, serialized);
 }
 
 #[test_case(
@@ -285,7 +332,7 @@ fn test_empty_proof() {
     let bytes = [
         b'f', b'w', b'd', b'p', b'r', b'o', b'o', b'f', // magic
         0, // version
-        magic::HASH_MODE,
+        hash_mode_byte(DefaultHashMode::ALGORITHM),
         magic::BRANCH_FACTOR,
         ProofType::Range as u8,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // reserved
@@ -338,7 +385,7 @@ fn test_change_proof_invalid_header(
     mutator: impl FnOnce(&mut Vec<u8>),
     expected: impl FnOnce(&InvalidHeader) -> bool,
 ) {
-    let (_, mut data) = create_valid_change_proof();
+    let (_, mut data) = create_valid_change_proof(DefaultHashMode::ALGORITHM);
 
     mutator(&mut data);
 
@@ -375,7 +422,7 @@ fn test_change_proof_incomplete_item(
     expected_len: usize,
     found_len: usize,
 ) {
-    let (_, mut data) = create_valid_change_proof();
+    let (_, mut data) = create_valid_change_proof(DefaultHashMode::ALGORITHM);
 
     mutator(&mut data);
 
@@ -432,7 +479,7 @@ fn test_change_proof_invalid_item(
     expected: &'static str,
     found: &'static str,
 ) {
-    let (proof, mut data) = create_valid_change_proof();
+    let (proof, mut data) = create_valid_change_proof(DefaultHashMode::ALGORITHM);
 
     mutator(&proof, &mut data);
 
@@ -738,7 +785,7 @@ fn test_change_proof_incomplete_batch_op_discriminant() {
     // Layout of create_valid_change_proof() after the 32-byte header:
     //   [32]=0x00 (start_proof count=0)  [33]=0x00 (end_proof count=0)
     //   [34]=0x03 (batch_ops count=3)    [35]=0x00 (first BatchOp discriminant)
-    let (_, mut data) = create_valid_change_proof();
+    let (_, mut data) = create_valid_change_proof(DefaultHashMode::ALGORITHM);
     data.truncate(35); // cut before the first BatchOp discriminant byte
     match FrozenChangeProof::from_slice(&data) {
         Err(ReadError::InvalidItem {
@@ -1004,7 +1051,7 @@ mod box_array_deserialization_tests {
         // Resolve the algorithm from the header itself, mirroring the
         // production validate-then-into_body flow. (These tests exercise
         // mode-independent reads, so any consistent mode works.)
-        let header = Header::from(ProofType::Range);
+        let header = Header::from((ProofType::Range, DefaultHashMode::ALGORITHM));
         let (_, algorithm) = header
             .validate(Some(ProofType::Range))
             .expect("default header should be valid");
@@ -1104,8 +1151,8 @@ fn test_header_validate_accepts_both_hash_modes() {
     let (_, base) = create_valid_range_proof();
 
     for (byte, expected) in [
-        (0u8, NodeHashAlgorithm::MerkleDB),
-        (1u8, NodeHashAlgorithm::Ethereum),
+        (magic::MERKLEDB_HASH_MODE, NodeHashAlgorithm::MerkleDB),
+        (magic::ETHEREUM_HASH_MODE, NodeHashAlgorithm::Ethereum),
     ] {
         let mut data = base.clone();
         data[9] = byte;
@@ -1196,7 +1243,7 @@ fn test_verify_range_proof_rejects_hash_mode_mismatch() {
 
 #[test]
 fn test_verify_change_proof_structure_rejects_hash_mode_mismatch() {
-    let (proof, _) = create_valid_change_proof();
+    let (proof, _) = create_valid_change_proof(DefaultHashMode::ALGORITHM);
     let other_mode = if proof.hash_mode().is_ethereum() {
         NodeHashAlgorithm::MerkleDB
     } else {

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -51,8 +51,8 @@ use crate::proofs::eth::ACCOUNT_DEPTH_NIBBLES;
 use firewood_storage::hash_node_as_storage_trie_root_parts;
 use firewood_storage::{
     Children, DefaultHashMode, DenseChildren, FileIoError, HashMode, HashType, Hashable,
-    IntoSplitPath, NibblesIterator, Path, PathBuf, PathComponent, PathIterItem, Preimage, RlpError,
-    SplitPath, TrieHash, TriePath, ValueDigest,
+    IntoSplitPath, NibblesIterator, NodeHashAlgorithm, Path, PathBuf, PathComponent, PathIterItem,
+    Preimage, RlpError, SplitPath, TrieHash, TriePath, ValueDigest,
 };
 use thiserror::Error;
 
@@ -301,6 +301,18 @@ pub enum ProofError {
     /// boundary index, so the proof must include that child.
     #[error("exclusion proof missing child at boundary index")]
     ExclusionProofMissingChild,
+
+    /// The proof's self-describing hash mode (from its header byte) does not
+    /// match the mode the verifier was asked to verify against. Distinct from
+    /// [`InvalidHeader::UnsupportedHashMode`](super::InvalidHeader::UnsupportedHashMode),
+    /// which means the header byte maps to no known algorithm at all.
+    #[error("proof hash mode mismatch (expected {expected:?}, found {found:?})")]
+    HashModeMismatch {
+        /// The hash algorithm the verifier was asked to verify against.
+        expected: NodeHashAlgorithm,
+        /// The hash algorithm the proof was actually encoded with.
+        found: NodeHashAlgorithm,
+    },
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -51,8 +51,8 @@ use crate::proofs::eth::ACCOUNT_DEPTH_NIBBLES;
 use firewood_storage::hash_node_as_storage_trie_root_parts;
 use firewood_storage::{
     Children, DefaultHashMode, FileIoError, HashMode, HashType, Hashable, IntoSplitPath,
-    NibblesIterator, Path, PathBuf, PathComponent, PathIterItem, Preimage, RlpError, SplitPath,
-    TrieHash, TriePath, ValueDigest,
+    NibblesIterator, NodeHashAlgorithm, Path, PathBuf, PathComponent, PathIterItem, Preimage,
+    RlpError, SplitPath, TrieHash, TriePath, ValueDigest,
 };
 use thiserror::Error;
 
@@ -296,6 +296,18 @@ pub enum ProofError {
     /// boundary index, so the proof must include that child.
     #[error("exclusion proof missing child at boundary index")]
     ExclusionProofMissingChild,
+
+    /// The proof's self-describing hash mode (from its header byte) does not
+    /// match the mode the verifier was asked to verify against. Distinct from
+    /// [`InvalidHeader::UnsupportedHashMode`](super::InvalidHeader::UnsupportedHashMode),
+    /// which means the header byte maps to no known algorithm at all.
+    #[error("proof hash mode mismatch (expected {expected:?}, found {found:?})")]
+    HashModeMismatch {
+        /// The hash algorithm the verifier was asked to verify against.
+        expected: NodeHashAlgorithm,
+        /// The hash algorithm the proof was actually encoded with.
+        found: NodeHashAlgorithm,
+    },
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/storage/src/hashednode.rs
+++ b/storage/src/hashednode.rs
@@ -120,18 +120,18 @@ impl<T: AsRef<[u8]>> ValueDigest<T> {
         }
     }
 
-    /// Convert the value to a hash if it is not already a hash.
+    /// Convert the value to a hash if it is not already a hash, under the
+    /// scheme `H`.
     ///
     /// Under the MerkleDB scheme, a value of 32 bytes or more is replaced by
     /// its SHA-256 hash; shorter values pass through unchanged. The Ethereum
     /// scheme never hashes values, so this is the identity there.
     ///
-    /// The capping is the MerkleDB scheme's behavior, so it is gated on the
-    /// database's algorithm at runtime rather than threaded through `H`
-    /// (deferred to a follow-up PR).
-    pub fn make_hash(&self) -> ValueDigest<&[u8]> {
+    /// The capping is the MerkleDB scheme's behavior, selected by the scheme
+    /// `H` rather than the compile-time default.
+    pub fn make_hash<H: HashMode>(&self) -> ValueDigest<&[u8]> {
         match self.as_ref() {
-            ValueDigest::Value(v) if v.len() >= 32 && !DefaultHashMode::ALGORITHM.is_ethereum() => {
+            ValueDigest::Value(v) if v.len() >= 32 && !H::ALGORITHM.is_ethereum() => {
                 use sha2::{Digest, Sha256};
                 ValueDigest::Hash(HashType::from(TrieHash::from(Sha256::digest(v))))
             }

--- a/storage/src/hashers/merkledb.rs
+++ b/storage/src/hashers/merkledb.rs
@@ -107,7 +107,7 @@ fn add_value_digest_to_buf<H: HasUpdate, T: AsRef<[u8]>>(
     let value_exists: u8 = 1;
     buf.update([value_exists]);
 
-    add_len_and_value_to_buf(buf, value_digest.make_hash());
+    add_len_and_value_to_buf(buf, value_digest.make_hash::<crate::MerkleDbHash>());
 }
 
 #[inline]


### PR DESCRIPTION
## Why this should be merged

Proofs already identify their hashing scheme in the header, but parsing still depends on the binary's compile-time mode. That can decode the proof body with the wrong grammar and prevents one process from safely parsing proofs from both schemes.

In the stack, this is the first runtime dispatch boundary: proof bytes select their parser from their own header, using the common representation established by PRs 3 and 4. It deliberately stops short of runtime database selection; PR 6
makes the typed database core mode-generic, and PR 7 exposes that capability to mode-agnostic callers.

## How this works

This change makes header validation resolve a `NodeHashAlgorithm` and threads that value into a body-phase `ProofReader`. Reads of mode-dependent values then dispatch on the algorithm carried by the reader. Unknown header values are rejected, while verification APIs take the caller's expected algorithm and fail with `HashModeMismatch` before hashing when it differs from the proof's self-described mode.

This PR is intentionally limited to parsing and early validation. Trie hashing continues to use the compile-selected implementation until the typed stack is genericized in the next PR. Consequently, a proof can be parsed regardless of its header mode in this PR, but it can only be cryptographically validated when that mode matches the binary's compile-time mode. The database and FFI call sites therefore pass the compile-selected mode as their expectation, and the mismatch guard rejects an opposite-mode proof before it can be hashed with the wrong algorithm.

PR 6 removes this binary-level restriction by dispatching proof hashing and the typed database stack through the supplied runtime algorithm. From that point onward, the remaining mismatch guard compares the proof header with the validation context: standalone verification can use the proof's own mode, while database-bound change-proof verification requires the proof mode to match that database's mode. PR 7 then exposes both typed implementations
through one runtime-selected, object-safe binary.

## How this was tested

Added tests for accepting both known header modes, rejecting unknown modes, decoding `HashType` with the threaded runtime mode, rejecting range- and change-proof mode mismatches, and parsing hashed value digests independently of the compile-time feature.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
