### PR TITLE
feat!: runtime hash-mode selection [7/9]

### DIFF
--- a/benchmark/src/create.rs
+++ b/benchmark/src/create.rs
@@ -11,9 +11,7 @@ use std::time::Instant;
 
 use fastrace::prelude::SpanContext;
 use fastrace::{Span, func_path};
-use firewood::api::{Db as _, Proposal as _};
-use firewood::db::Db;
-use firewood_storage::DefaultHashMode;
+use firewood::api::{self, DynDb};
 use log::info;
 
 use pretty_duration::pretty_duration;
@@ -24,7 +22,7 @@ use crate::{Args, TestRunner};
 pub struct Create;
 
 impl TestRunner for Create {
-    fn run(&self, db: &Db<DefaultHashMode>, args: &Args) -> Result<(), Box<dyn Error>> {
+    fn run(&self, db: &dyn DynDb, args: &Args) -> Result<(), Box<dyn Error>> {
         let keys = args.global_opts.batch_size;
         let start = Instant::now();
 
@@ -34,7 +32,9 @@ impl TestRunner for Create {
 
             let batch = Self::generate_inserts(key * keys, args.global_opts.batch_size);
 
-            let proposal = db.propose(batch).expect("proposal should succeed");
+            let proposal = db
+                .propose(api::collect_owned_batch(batch)?)
+                .expect("proposal should succeed");
             proposal.commit()?;
         }
         let duration = start.elapsed();

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -15,6 +15,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use fastrace_opentelemetry::OpenTelemetryReporter;
 use firewood::logger::trace;
+use firewood::open;
 use firewood_storage::{DefaultHashMode, HashMode};
 use log::LevelFilter;
 use sha2::{Digest, Sha256};
@@ -24,7 +25,8 @@ use std::fmt::Display;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
-use firewood::db::{BatchOp, Db, DbConfig};
+use firewood::api::DynDb;
+use firewood::db::{BatchOp, DbConfig};
 use firewood::manager::{CacheReadStrategy, RevisionManagerConfig};
 
 use fastrace::collector::Config;
@@ -158,7 +160,7 @@ enum TestName {
 }
 
 trait TestRunner {
-    fn run(&self, db: &Db<DefaultHashMode>, args: &Args) -> Result<(), Box<dyn Error>>;
+    fn run(&self, db: &dyn DynDb, args: &Args) -> Result<(), Box<dyn Error>>;
 
     fn generate_inserts(
         start: u64,
@@ -241,24 +243,24 @@ fn main() -> Result<(), Box<dyn Error>> {
         .manager(mgrcfg)
         .build();
 
-    let db = Db::new(args.global_opts.dbname.clone(), cfg).expect("db initiation should succeed");
+    let db = open(args.global_opts.dbname.clone(), cfg).expect("db initiation should succeed");
 
     match args.test_name {
         TestName::Create => {
             let runner = create::Create;
-            runner.run(&db, &args)?;
+            runner.run(db.as_ref(), &args)?;
         }
         TestName::TenKRandom => {
             let runner = tenkrandom::TenKRandom;
-            runner.run(&db, &args)?;
+            runner.run(db.as_ref(), &args)?;
         }
         TestName::Zipf(_) => {
             let runner = zipf::Zipf;
-            runner.run(&db, &args)?;
+            runner.run(db.as_ref(), &args)?;
         }
         TestName::Single => {
             let runner = single::Single;
-            runner.run(&db, &args)?;
+            runner.run(db.as_ref(), &args)?;
         }
     }
 

--- a/benchmark/src/single.rs
+++ b/benchmark/src/single.rs
@@ -11,9 +11,8 @@
 )]
 
 use crate::TestRunner;
-use firewood::api::{Db as _, Proposal as _};
-use firewood::db::{BatchOp, Db};
-use firewood_storage::DefaultHashMode;
+use firewood::api::{self, DynDb};
+use firewood::db::BatchOp;
 use log::debug;
 use pretty_duration::pretty_duration;
 use sha2::{Digest, Sha256};
@@ -24,7 +23,7 @@ use std::time::Instant;
 pub struct Single;
 
 impl TestRunner for Single {
-    fn run(&self, db: &Db<DefaultHashMode>, args: &crate::Args) -> Result<(), Box<dyn Error>> {
+    fn run(&self, db: &dyn DynDb, args: &crate::Args) -> Result<(), Box<dyn Error>> {
         let start = Instant::now();
         let inner_keys: Vec<_> = (0..args.global_opts.batch_size)
             .map(|i| Sha256::digest(i.to_ne_bytes()))
@@ -36,7 +35,9 @@ impl TestRunner for Single {
                 key,
                 value: vec![batch_id as u8],
             });
-            let proposal = db.propose(batch).expect("proposal should succeed");
+            let proposal = db
+                .propose(api::collect_owned_batch(batch)?)
+                .expect("proposal should succeed");
             proposal.commit()?;
 
             if log::log_enabled!(log::Level::Debug) && batch_id % 1000 == 999 {

--- a/benchmark/src/tenkrandom.rs
+++ b/benchmark/src/tenkrandom.rs
@@ -9,10 +9,9 @@
 use std::error::Error;
 use std::time::Instant;
 
-use firewood::api::{Db as _, Proposal as _};
-use firewood::db::{BatchOp, Db};
+use firewood::api::{self, DynDb};
+use firewood::db::BatchOp;
 use firewood::logger::debug;
-use firewood_storage::DefaultHashMode;
 
 use crate::{Args, TestRunner};
 use sha2::{Digest, Sha256};
@@ -21,7 +20,7 @@ use sha2::{Digest, Sha256};
 pub struct TenKRandom;
 
 impl TestRunner for TenKRandom {
-    fn run(&self, db: &Db<DefaultHashMode>, args: &Args) -> Result<(), Box<dyn Error>> {
+    fn run(&self, db: &dyn DynDb, args: &Args) -> Result<(), Box<dyn Error>> {
         let mut low = 0;
         let mut high = args.global_opts.number_of_batches * args.global_opts.batch_size;
         let twenty_five_pct = args.global_opts.batch_size / 4;
@@ -33,7 +32,9 @@ impl TestRunner for TenKRandom {
                 .chain(generate_deletes(low, twenty_five_pct))
                 .chain(generate_updates(low + high / 2, twenty_five_pct * 2, low))
                 .collect();
-            let proposal = db.propose(batch).expect("proposal should succeed");
+            let proposal = db
+                .propose(api::collect_owned_batch(batch)?)
+                .expect("proposal should succeed");
             proposal.commit()?;
             low += twenty_five_pct;
             high += twenty_five_pct;

--- a/benchmark/src/zipf.rs
+++ b/benchmark/src/zipf.rs
@@ -19,9 +19,8 @@
 )]
 
 use crate::TestRunner;
-use firewood::api::{Db as _, Proposal as _};
-use firewood::db::{BatchOp, Db};
-use firewood_storage::DefaultHashMode;
+use firewood::api::{self, DynDb};
+use firewood::db::BatchOp;
 use log::{debug, trace};
 use pretty_duration::pretty_duration;
 use rand::prelude::*;
@@ -40,7 +39,7 @@ pub struct Args {
 pub struct Zipf;
 
 impl TestRunner for Zipf {
-    fn run(&self, db: &Db<DefaultHashMode>, args: &crate::Args) -> Result<(), Box<dyn Error>> {
+    fn run(&self, db: &dyn DynDb, args: &crate::Args) -> Result<(), Box<dyn Error>> {
         let exponent = if let crate::TestName::Zipf(args) = &args.test_name {
             args.exponent
         } else {
@@ -72,7 +71,9 @@ impl TestRunner for Zipf {
                     distinct.len()
                 );
             }
-            let proposal = db.propose(batch).expect("proposal should succeed");
+            let proposal = db
+                .propose(api::collect_owned_batch(batch)?)
+                .expect("proposal should succeed");
             proposal.commit()?;
 
             if log::log_enabled!(log::Level::Debug) {

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -263,13 +263,13 @@ const (
 // algorithm and database options. The database directory will be created at the
 // provided path if it does not already exist.
 //
-// The [nodeHashAlgorithm] is required and must match the compile-time feature:
-//   - NodeHashAlgorithmEthereum if the ethhash feature is enabled
-//   - NodeHashAlgorithmMerkleDB if the ethhash feature is disabled
+// The [nodeHashAlgorithm] is required and selects the hashing mode for the
+// database at runtime, independent of the ethhash build feature:
+//   - EthereumNodeHashing for Ethereum-compatible Keccak-256 hashing
+//   - MerkleDBNodeHashing for MerkleDB-compatible SHA-256 hashing
 //
-// In the future, the node hash algorithm will be configurable at runtime and
-// no longer need to match compile-time features but will instead select the
-// desired hashing mode.
+// When opening an existing database, the requested algorithm must match the one
+// stamped in the file header, otherwise opening fails with a mismatch error.
 //
 // If no [Option] is provided, sensible defaults will be used.
 // See the With* functions for details about each configuration parameter and its default value.

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -58,14 +58,12 @@ const RootLength = C.sizeof_HashKey
 // Hash is the type used for all firewood hashes.
 type Hash [RootLength]byte
 
-// NodeHashAlgorithm represents the node hashing algorithm used by the database;
-// this must match the algorithm previously used to crate the database.
+// NodeHashAlgorithm represents the node hashing algorithm used by the database.
+// It is a per-database runtime choice: a single binary can open databases of
+// either algorithm. When opening an existing database, the algorithm must match
+// the one the database was created with.
 //
 // Currently, there are only two variants but more may be added in the future.
-// At this time, the node hash algorithm used when opening the database must
-// match the compile-time feature used when building the FFI library. This
-// restriction will be lifted after #1088, which enables runtime selection of
-// the node hashing algorithm.
 type NodeHashAlgorithm C.enum_NodeHashAlgorithm
 
 const (
@@ -263,13 +261,13 @@ const (
 // algorithm and database options. The database directory will be created at the
 // provided path if it does not already exist.
 //
-// The [nodeHashAlgorithm] is required and must match the compile-time feature:
-//   - NodeHashAlgorithmEthereum if the ethhash feature is enabled
-//   - NodeHashAlgorithmMerkleDB if the ethhash feature is disabled
+// The [nodeHashAlgorithm] is required and selects the database's hashing mode at
+// runtime, on a per-database basis:
+//   - EthereumNodeHashing for Ethereum-compatible (Keccak-256) hashing
+//   - MerkleDBNodeHashing for MerkleDB-compatible (SHA-256) hashing
 //
-// In the future, the node hash algorithm will be configurable at runtime and
-// no longer need to match compile-time features but will instead select the
-// desired hashing mode.
+// A single binary supports both modes. When opening an existing database, the
+// algorithm must match the one the database was created with.
 //
 // If no [Option] is provided, sensible defaults will be used.
 // See the With* functions for details about each configuration parameter and its default value.

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1715,11 +1715,12 @@ typedef struct DatabaseHandleArgs {
   /**
    * The hashing mode to use for the database.
    *
-   * This must match the compile-time feature:
-   * - [`NodeHashAlgorithm::Ethereum`] if the `ethhash` feature is enabled
-   * - [`NodeHashAlgorithm::MerkleDB`] if the `ethhash` feature is disabled
-   *
-   * Opening returns an error if this does not match the compile-time feature.
+   * This is the per-database node-hashing scheme, selected at runtime. For
+   * an existing database it must match the scheme persisted in the file
+   * header (a mismatch is an error); for a fresh database it is the scheme
+   * to create with. A single binary can open both
+   * [`NodeHashAlgorithm::Ethereum`] and [`NodeHashAlgorithm::MerkleDB`]
+   * databases regardless of the build's `ethhash` feature.
    */
   enum NodeHashAlgorithm node_hash_algorithm;
   /**

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1715,11 +1715,12 @@ typedef struct DatabaseHandleArgs {
   /**
    * The hashing mode to use for the database.
    *
-   * This must match the compile-time feature:
-   * - [`NodeHashAlgorithm::Ethereum`] if the `ethhash` feature is enabled
-   * - [`NodeHashAlgorithm::MerkleDB`] if the `ethhash` feature is disabled
-   *
-   * Opening returns an error if this does not match the compile-time feature.
+   * This is the per-database node-hashing scheme, selected at runtime. For
+   * an existing database it must match the scheme persisted in the file
+   * header (a mismatch is an error); for a fresh database it is the scheme
+   * to create with. A single binary can open both
+   * [`NodeHashAlgorithm::Ethereum`] and [`NodeHashAlgorithm::MerkleDB`]
+   * databases regardless of the database's runtime hash mode.
    */
   enum NodeHashAlgorithm node_hash_algorithm;
   /**

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
@@ -169,28 +168,19 @@ func newTestDatabase(tb testing.TB, opts ...Option) *Database {
 	return db
 }
 
-var (
-	// detectedNodeHashAlgorithm is cached after first detection to avoid repeated attempts
-	detectedNodeHashAlgorithm     NodeHashAlgorithm
-	detectedNodeHashAlgorithmOnce sync.Once
-)
+// testNodeHashAlgorithm reports the node hashing algorithm the tests should
+// create databases with. Node hashing is a per-database runtime choice (#1088),
+// so the mode is taken from TEST_FIREWOOD_HASH_MODE to stay consistent with the
+// expected roots selected in TestMain; it defaults to Ethereum when unset.
+func testNodeHashAlgorithm() NodeHashAlgorithm {
+	if os.Getenv("TEST_FIREWOOD_HASH_MODE") == firewoodKey {
+		return MerkleDBNodeHashing
+	}
+	return EthereumNodeHashing
+}
 
 func newDatabase(dbDir string, opts ...Option) (*Database, error) {
-	// Detect the correct algo once and cache it
-	detectedNodeHashAlgorithmOnce.Do(func() {
-		// Try ethhash first, if it fails try merkledb
-		tempDir := filepath.Join(os.TempDir(), fmt.Sprintf("firewood-hash-detection-%d", time.Now().UnixNano()))
-		defer os.RemoveAll(tempDir)
-
-		_, err := New(tempDir, EthereumNodeHashing, WithTruncate(true))
-		if err == nil {
-			detectedNodeHashAlgorithm = EthereumNodeHashing
-		} else {
-			detectedNodeHashAlgorithm = MerkleDBNodeHashing
-		}
-	})
-
-	f, err := New(dbDir, detectedNodeHashAlgorithm, opts...)
+	f, err := New(dbDir, testNodeHashAlgorithm(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new database in directory %q: %w", dbDir, err)
 	}
@@ -212,43 +202,33 @@ func TestUpdateSingleKV(t *testing.T) {
 func TestNodeHashAlgorithmValidation(t *testing.T) {
 	r := require.New(t)
 
-	// Try to create a database with ethhash
+	// Node hashing is a per-database runtime choice (issue #1088): a single
+	// binary can create and operate on both an Ethereum-mode database and a
+	// MerkleDB-mode database side by side, regardless of the ethhash feature.
 	dbDirEth := t.TempDir()
-	dbEth, errEth := New(dbDirEth, EthereumNodeHashing, WithTruncate(true))
+	dbEth, err := New(dbDirEth, EthereumNodeHashing, WithTruncate(true))
+	r.NoError(err)
+	_, _, ethBatch := kvForTest(1)
+	_, err = dbEth.Update(ethBatch)
+	r.NoError(err)
+	r.NoError(dbEth.Close(oneSecCtx(t)))
 
-	// Try to create a database with merkledb
 	dbDirMerkledb := t.TempDir()
-	dbMerkledb, errMerkledb := New(dbDirMerkledb, MerkleDBNodeHashing, WithTruncate(true))
+	dbMerkledb, err := New(dbDirMerkledb, MerkleDBNodeHashing, WithTruncate(true))
+	r.NoError(err)
+	_, _, merkledbBatch := kvForTest(1)
+	_, err = dbMerkledb.Update(merkledbBatch)
+	r.NoError(err)
+	r.NoError(dbMerkledb.Close(oneSecCtx(t)))
 
-	// Exactly one should succeed based on compile-time feature
-	type resultType int
-	const (
-		ethereumOnly resultType = iota
-		merkledbOnly
-		bothOrNeither
-	)
-
-	result := bothOrNeither
-	switch {
-	case errEth == nil && errMerkledb != nil:
-		result = ethereumOnly
-	case errMerkledb == nil && errEth != nil:
-		result = merkledbOnly
+	// Re-opening an existing database with a different algorithm than the one
+	// stamped in its header is rejected by the header-vs-requested gate.
+	reopened, err := New(dbDirEth, MerkleDBNodeHashing)
+	if err == nil {
+		r.NoError(reopened.Close(oneSecCtx(t)))
 	}
-
-	switch result {
-	case ethereumOnly:
-		r.NoError(dbEth.Close(oneSecCtx(t)))
-		r.Error(errMerkledb)
-		r.ErrorContains(errMerkledb, "node store hash algorithm mismatch: want to initialize with MerkleDB, but build option is for Ethereum")
-	case merkledbOnly:
-		r.NoError(dbMerkledb.Close(oneSecCtx(t)))
-		r.Error(errEth)
-		r.ErrorContains(errEth, "node store hash algorithm mismatch: want to initialize with Ethereum, but build option is for MerkleDB")
-	case bothOrNeither:
-		// Both succeeded or both failed - this should not happen
-		r.Failf("Expected exactly one hash type to succeed", "got errEth=%v, errNative=%v", errEth, errMerkledb)
-	}
+	r.Error(err)
+	r.ErrorContains(err, "node store hash algorithm mismatch: want to open with MerkleDB, but file header indicates Ethereum")
 }
 
 func TestUpdateMultiKV(t *testing.T) {

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
@@ -34,17 +33,11 @@ const (
 	errWrongParent    = "The proposal cannot be committed since it is not a direct child of the most recent commit. "
 )
 
-// expectedRoots contains the expected root hashes for different use cases across both default
-// firewood hashing and ethhash.
-// By default, TestMain infers which mode Firewood is operating in and selects the expected roots
-// accordingly (this does turn test empty database into an effective no-op).
-//
-// To test a specific hashing mode explicitly, set the environment variable:
-// TEST_FIREWOOD_HASH_MODE=ethhash or TEST_FIREWOOD_HASH_MODE=firewood
-// This will skip the inference step and enforce we use the expected roots for the specified mode.
+// A single binary supports both node-hashing algorithms. TEST_FIREWOOD_HASH_MODE
+// selects which one this test run uses ("ethhash" or "firewood"), defaulting to
+// Ethereum when unset.
 var (
-	// expectedRoots contains a mapping of expected root hashes for different test
-	// vectors.
+	// expectedRootModes contains expected roots keyed by runtime hash mode.
 	expectedRootModes = map[string]map[string]string{
 		ethhashKey: {
 			emptyKey:     emptyEthhashRoot,
@@ -55,11 +48,9 @@ var (
 			insert100Key: "f858b51ada79c4abeb6566ef1204a453030dba1cca3526d174e2cb3ce2aadc57",
 		},
 	}
-	expectedEmptyRootToMode = map[string]string{
-		emptyEthhashRoot:  ethhashKey,
-		emptyFirewoodRoot: firewoodKey,
-	}
-	expectedRoots map[string]string
+	expectedRoots             map[string]string
+	selectedHashMode          string
+	selectedNodeHashAlgorithm NodeHashAlgorithm
 )
 
 func stringToHash(t *testing.T, s string) Hash {
@@ -68,30 +59,6 @@ func stringToHash(t *testing.T, s string) Hash {
 	require.NoError(t, err)
 	require.Len(t, b, RootLength)
 	return Hash(b)
-}
-
-func inferHashingMode(ctx context.Context) (string, error) {
-	dbDir := os.TempDir()
-	db, err := newDatabase(dbDir)
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		ctx, cancel := context.WithTimeout(ctx, time.Second)
-		defer cancel()
-		_ = db.Close(ctx)
-		_ = os.Remove(dbDir)
-	}()
-
-	actualEmptyRoot := db.Root()
-	actualEmptyRootHex := hex.EncodeToString(actualEmptyRoot[:])
-
-	actualFwMode, ok := expectedEmptyRootToMode[actualEmptyRootHex]
-	if !ok {
-		return "", fmt.Errorf("unknown empty root %q, cannot infer mode", actualEmptyRootHex)
-	}
-
-	return actualFwMode, nil
 }
 
 func TestMain(m *testing.M) {
@@ -117,16 +84,11 @@ func TestMain(m *testing.M) {
 		}
 	}
 
-	// If TEST_FIREWOOD_HASH_MODE is set, use it to select the expected roots.
-	// Otherwise, infer the hash mode from an empty database.
+	// Select the runtime algorithm explicitly instead of inferring a build mode
+	// from the root of a throwaway database.
 	hashMode := os.Getenv("TEST_FIREWOOD_HASH_MODE")
 	if hashMode == "" {
-		inferredHashMode, err := inferHashingMode(context.Background())
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to infer hash mode %v\n", err)
-			os.Exit(1)
-		}
-		hashMode = inferredHashMode
+		hashMode = ethhashKey
 	}
 	selectedExpectedRoots, ok := expectedRootModes[hashMode]
 	if !ok {
@@ -134,6 +96,13 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	expectedRoots = selectedExpectedRoots
+	selectedHashMode = hashMode
+	switch hashMode {
+	case ethhashKey:
+		selectedNodeHashAlgorithm = EthereumNodeHashing
+	case firewoodKey:
+		selectedNodeHashAlgorithm = MerkleDBNodeHashing
+	}
 
 	os.Exit(m.Run())
 }
@@ -169,28 +138,16 @@ func newTestDatabase(tb testing.TB, opts ...Option) *Database {
 	return db
 }
 
-var (
-	// detectedNodeHashAlgorithm is cached after first detection to avoid repeated attempts
-	detectedNodeHashAlgorithm     NodeHashAlgorithm
-	detectedNodeHashAlgorithmOnce sync.Once
-)
+// getNodeHashAlgorithm reports the node hashing algorithm the tests should
+// create databases with. Node hashing is a per-database runtime choice, so the
+// mode is taken from TEST_FIREWOOD_HASH_MODE to stay consistent with the
+// expected roots selected in TestMain; it defaults to Ethereum when unset.
+func getNodeHashAlgorithm() NodeHashAlgorithm {
+	return selectedNodeHashAlgorithm
+}
 
 func newDatabase(dbDir string, opts ...Option) (*Database, error) {
-	// Detect the correct algo once and cache it
-	detectedNodeHashAlgorithmOnce.Do(func() {
-		// Try ethhash first, if it fails try merkledb
-		tempDir := filepath.Join(os.TempDir(), fmt.Sprintf("firewood-hash-detection-%d", time.Now().UnixNano()))
-		defer os.RemoveAll(tempDir)
-
-		_, err := New(tempDir, EthereumNodeHashing, WithTruncate(true))
-		if err == nil {
-			detectedNodeHashAlgorithm = EthereumNodeHashing
-		} else {
-			detectedNodeHashAlgorithm = MerkleDBNodeHashing
-		}
-	})
-
-	f, err := New(dbDir, detectedNodeHashAlgorithm, opts...)
+	f, err := New(dbDir, getNodeHashAlgorithm(), opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new database in directory %q: %w", dbDir, err)
 	}
@@ -212,43 +169,40 @@ func TestUpdateSingleKV(t *testing.T) {
 func TestNodeHashAlgorithmValidation(t *testing.T) {
 	r := require.New(t)
 
-	// Try to create a database with ethhash
+	// Node hashing is a per-database runtime choice: a single binary can create
+	// and operate on both an Ethereum-mode database and a MerkleDB-mode database
+	// side by side.
 	dbDirEth := t.TempDir()
-	dbEth, errEth := New(dbDirEth, EthereumNodeHashing, WithTruncate(true))
+	dbEth, err := New(dbDirEth, EthereumNodeHashing, WithTruncate(true))
+	r.NoError(err)
+	_, _, ethBatch := kvForTest(1)
+	_, err = dbEth.Update(ethBatch)
+	r.NoError(err)
+	r.NoError(dbEth.Close(oneSecCtx(t)))
 
-	// Try to create a database with merkledb
 	dbDirMerkledb := t.TempDir()
-	dbMerkledb, errMerkledb := New(dbDirMerkledb, MerkleDBNodeHashing, WithTruncate(true))
+	dbMerkledb, err := New(dbDirMerkledb, MerkleDBNodeHashing, WithTruncate(true))
+	r.NoError(err)
+	_, _, merkledbBatch := kvForTest(1)
+	_, err = dbMerkledb.Update(merkledbBatch)
+	r.NoError(err)
+	r.NoError(dbMerkledb.Close(oneSecCtx(t)))
 
-	// Exactly one should succeed based on compile-time feature
-	type resultType int
-	const (
-		ethereumOnly resultType = iota
-		merkledbOnly
-		bothOrNeither
-	)
-
-	result := bothOrNeither
-	switch {
-	case errEth == nil && errMerkledb != nil:
-		result = ethereumOnly
-	case errMerkledb == nil && errEth != nil:
-		result = merkledbOnly
+	// Re-opening an existing database with a different algorithm than the one
+	// stamped in its header is rejected by the header-vs-requested gate.
+	reopened, err := New(dbDirEth, MerkleDBNodeHashing)
+	if err == nil {
+		r.NoError(reopened.Close(oneSecCtx(t)))
 	}
+	r.Error(err)
+	r.ErrorContains(err, "node store hash algorithm mismatch: want to open with MerkleDB, but file header indicates Ethereum")
 
-	switch result {
-	case ethereumOnly:
-		r.NoError(dbEth.Close(oneSecCtx(t)))
-		r.Error(errMerkledb)
-		r.ErrorContains(errMerkledb, "node hash algorithm mismatch: hash mode expects Ethereum, config specifies MerkleDB")
-	case merkledbOnly:
-		r.NoError(dbMerkledb.Close(oneSecCtx(t)))
-		r.Error(errEth)
-		r.ErrorContains(errEth, "node hash algorithm mismatch: hash mode expects MerkleDB, config specifies Ethereum")
-	case bothOrNeither:
-		// Both succeeded or both failed - this should not happen
-		r.Failf("Expected exactly one hash type to succeed", "got errEth=%v, errNative=%v", errEth, errMerkledb)
+	reopened, err = New(dbDirMerkledb, EthereumNodeHashing)
+	if err == nil {
+		r.NoError(reopened.Close(oneSecCtx(t)))
 	}
+	r.Error(err)
+	r.ErrorContains(err, "node store hash algorithm mismatch: want to open with Ethereum, but file header indicates MerkleDB")
 }
 
 func TestUpdateMultiKV(t *testing.T) {

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -515,15 +515,13 @@ func TestRangeProofCodeHashes(t *testing.T) {
 	proof := newVerifiedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenUnbounded)
 
 	i := 0
-	mode, err := inferHashingMode(t.Context())
-	r.NoError(err)
 	for h, err := range proof.CodeHashes() {
 		i++
-		if mode == ethhashKey {
+		if selectedHashMode == ethhashKey {
 			r.NoError(err, "%T.CodeHashes()", proof)
 			r.Equal(codeHash, h)
 		} else {
-			require.ErrorContains(t, err, "feature not supported in this build: ethhash code hash iterator")
+			require.ErrorContains(t, err, "code hash iteration requires an ethereum-mode proof")
 		}
 	}
 
@@ -555,15 +553,13 @@ func TestChangeProofCodeHashes(t *testing.T) {
 	t.Cleanup(func() { r.NoError(proof.Free()) })
 
 	i := 0
-	mode, err := inferHashingMode(t.Context())
-	r.NoError(err)
 	for h, err := range proof.CodeHashes() {
 		i++
-		if mode == ethhashKey {
+		if selectedHashMode == ethhashKey {
 			r.NoError(err, "%T.CodeHashes()", proof)
 			r.Equal(codeHash, h)
 		} else {
-			require.ErrorContains(t, err, "feature not supported in this build: ethhash code hash iterator")
+			require.ErrorContains(t, err, "code hash iteration requires an ethereum-mode proof")
 		}
 	}
 

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -523,7 +523,7 @@ func TestRangeProofCodeHashes(t *testing.T) {
 			r.NoError(err, "%T.CodeHashes()", proof)
 			r.Equal(codeHash, h)
 		} else {
-			require.ErrorContains(t, err, "feature not supported in this build: ethhash code hash iterator")
+			require.ErrorContains(t, err, "feature not supported in this build: code hash iteration requires an ethereum-mode proof")
 		}
 	}
 
@@ -563,7 +563,7 @@ func TestChangeProofCodeHashes(t *testing.T) {
 			r.NoError(err, "%T.CodeHashes()", proof)
 			r.Equal(codeHash, h)
 		} else {
-			require.ErrorContains(t, err, "feature not supported in this build: ethhash code hash iterator")
+			require.ErrorContains(t, err, "feature not supported in this build: code hash iteration requires an ethereum-mode proof")
 		}
 	}
 

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -4,13 +4,10 @@
 use std::num::{NonZeroU64, NonZeroUsize};
 
 use firewood::{
-    DefaultHashMode,
-    api::{
-        self, ArcDynDbView, Db as _, DbView, FrozenChangeProof, HashKey, HashKeyExt, IntoBatchIter,
-        KeyType,
-    },
-    db::{CommittedView, Db, DbConfig},
+    api::{self, ArcDynDbView, DynDb, FrozenChangeProof, HashKey, IntoBatchIter, KeyType},
+    db::{CommittedView, DbConfig},
     manager::RevisionManagerConfig,
+    open,
 };
 
 use crate::{BatchOp, BorrowedBytes, CView, CreateProposalResult};
@@ -96,11 +93,12 @@ pub struct DatabaseHandleArgs<'a> {
 
     /// The hashing mode to use for the database.
     ///
-    /// This must match the compile-time feature:
-    /// - [`NodeHashAlgorithm::Ethereum`] if the `ethhash` feature is enabled
-    /// - [`NodeHashAlgorithm::MerkleDB`] if the `ethhash` feature is disabled
-    ///
-    /// Opening returns an error if this does not match the compile-time feature.
+    /// This is the per-database node-hashing scheme, selected at runtime. For
+    /// an existing database it must match the scheme persisted in the file
+    /// header (a mismatch is an error); for a fresh database it is the scheme
+    /// to create with. A single binary can open both
+    /// [`NodeHashAlgorithm::Ethereum`] and [`NodeHashAlgorithm::MerkleDB`]
+    /// databases regardless of the database's runtime hash mode.
     pub node_hash_algorithm: NodeHashAlgorithm,
 
     /// The maximum number of unpersisted revisions that can exist at a given time.
@@ -148,8 +146,8 @@ impl DatabaseHandleArgs<'_> {
 ///
 #[derive(Debug)]
 pub struct DatabaseHandle {
-    /// The database
-    db: Db<DefaultHashMode>,
+    /// The database, erased to the runtime-selected hash mode.
+    db: Box<dyn DynDb>,
     metrics_context: MetricsContext,
 }
 
@@ -178,7 +176,9 @@ impl DatabaseHandle {
             return Err(invalid_data("database path cannot be empty"));
         }
 
-        let db = Db::new(path, cfg)?;
+        // Select the concrete `Db<H>` at runtime from the configured algorithm,
+        // validated against the on-disk header, and hold it erased.
+        let db = open(path, cfg)?;
         Ok(Self {
             db,
             metrics_context,
@@ -190,6 +190,7 @@ impl DatabaseHandle {
     /// # Errors
     ///
     /// Never errors.
+    #[must_use]
     pub fn current_root_hash(&self) -> Option<HashKey> {
         self.db.root_hash()
     }
@@ -201,12 +202,10 @@ impl DatabaseHandle {
     /// An error is returned if there was an i/o error while reading the value.
     pub fn get_latest(&self, key: impl KeyType) -> Result<Option<Box<[u8]>>, api::Error> {
         let Some(root) = self.current_root_hash() else {
-            return Err(api::Error::RevisionNotFound {
-                provided: HashKey::default_root_hash(),
-            });
+            return Err(api::Error::RevisionNotFound { provided: None });
         };
 
-        self.db.revision(root)?.val(key)
+        self.db.revision(root)?.val(key.as_ref())
     }
 
     /// Creates and commits a proposal with the given values.
@@ -231,11 +230,9 @@ impl DatabaseHandle {
     /// accessing the database.
     pub fn get_revision(&self, root: HashKey) -> Result<GetRevisionResult<'_>, api::Error> {
         let view = self.db.view(root.clone())?;
-        let historical = match self.db.committed_view(root.clone()) {
-            Ok(rev) => Some(rev),
-            Err(api::Error::RevisionNotFound { .. }) => None,
-            Err(err) => return Err(err),
-        };
+        // The opaque committed parent is `None` when `root` names a proposal
+        // rather than a committed revision (see [`DynDb::committed_view`]).
+        let historical = self.db.committed_view(root.clone())?;
         Ok(GetRevisionResult {
             handle: RevisionHandle::new(view, historical, self.metrics_context, self),
             root_hash: root,
@@ -252,7 +249,8 @@ impl DatabaseHandle {
         parent: &CommittedView,
         batch: impl IntoBatchIter,
     ) -> Result<firewood::db::ReconstructedView<'db>, api::Error> {
-        self.db.reconstruct_from_view(parent, batch)
+        let ops = crate::proposal::collect_owned_batch(batch)?;
+        self.db.reconstruct_from_view(parent, ops)
     }
 
     pub(crate) fn view(&self, root: HashKey) -> Result<ArcDynDbView, api::Error> {
@@ -265,9 +263,19 @@ impl DatabaseHandle {
         last_key: Option<impl KeyType>,
         key_values: impl IntoIterator<Item: api::KeyValuePair>,
     ) -> Result<CreateProposalResult<'_>, api::Error> {
+        let first_key = first_key.map(|k| k.as_ref().to_vec());
+        let last_key = last_key.map(|k| k.as_ref().to_vec());
+        let key_values: api::OwnedKeyValuePairs = key_values
+            .into_iter()
+            .map(|pair| {
+                let (key, value) = api::KeyValuePair::try_into_tuple(pair)
+                    .map_err(|e| api::Error::from(e.into()))?;
+                Ok::<_, api::Error>((key.as_ref().into(), value.as_ref().into()))
+            })
+            .collect::<Result<_, api::Error>>()?;
         CreateProposalResult::new(self, || {
             self.db
-                .merge_key_value_range(first_key, last_key, key_values)
+                .merge_key_value_range(first_key.as_deref(), last_key.as_deref(), key_values)
         })
     }
 
@@ -316,7 +324,7 @@ impl DatabaseHandle {
     ///
     /// An error is returned if there was an i/o error while dumping the trie.
     pub fn dump_to_string(&self) -> Result<String, api::Error> {
-        self.db.dump_to_string().map_err(api::Error::from)
+        self.db.dump_to_string()
     }
 
     /// Closes the database gracefully.
@@ -338,8 +346,9 @@ impl<'db> CView<'db> for &'db crate::DatabaseHandle {
     fn create_proposal(
         self,
         values: impl IntoBatchIter,
-    ) -> Result<firewood::db::Proposal<'db, DefaultHashMode>, api::Error> {
-        self.db.propose(values)
+    ) -> Result<Box<dyn api::DynProposal<'db> + 'db>, api::Error> {
+        let ops = crate::proposal::collect_owned_batch(values)?;
+        self.db.propose(ops)
     }
 }
 

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -94,17 +94,26 @@ pub struct DatabaseHandleArgs<'a> {
 
     /// The hashing mode to use for the database.
     ///
-    /// This must match the compile-time feature:
-    /// - [`NodeHashAlgorithm::Ethereum`] if the `ethhash` feature is enabled
-    /// - [`NodeHashAlgorithm::MerkleDB`] if the `ethhash` feature is disabled
-    ///
-    /// Opening returns an error if this does not match the compile-time feature.
+    /// This is the per-database node-hashing scheme, selected at runtime. For
+    /// an existing database it must match the scheme persisted in the file
+    /// header (a mismatch is an error); for a fresh database it is the scheme
+    /// to create with. A single binary can open both
+    /// [`NodeHashAlgorithm::Ethereum`] and [`NodeHashAlgorithm::MerkleDB`]
+    /// databases regardless of the build's `ethhash` feature.
     pub node_hash_algorithm: NodeHashAlgorithm,
 
     /// The maximum number of unpersisted revisions that can exist at a given time.
     ///
     /// Note: `revisions` must be > `deferred_persistence_commit_count`.
     pub deferred_persistence_commit_count: u64,
+}
+
+/// A view handle that can report the node-hashing scheme of its backing
+/// database. Implemented by the concrete revision/reconstructed handles so the
+/// generic `eth_get_proof` entry points can supply the algorithm to
+/// [`firewood::eth_get_proof`], which no longer infers it from the view.
+pub(crate) trait NodeHashAlgorithmExt {
+    fn node_hash_algorithm(&self) -> firewood::NodeHashAlgorithm;
 }
 
 impl DatabaseHandleArgs<'_> {
@@ -146,7 +155,7 @@ impl DatabaseHandleArgs<'_> {
 ///
 #[derive(Debug)]
 pub struct DatabaseHandle {
-    /// The database, erased behind the object-safe write boundary.
+    /// The database, erased to the runtime-selected hash mode.
     db: Box<dyn DynDb>,
     metrics_context: MetricsContext,
 }
@@ -160,8 +169,9 @@ impl DatabaseHandle {
     pub fn new(args: DatabaseHandleArgs<'_>) -> Result<Self, api::Error> {
         let metrics_context = MetricsContext::new(args.expensive_metrics);
 
+        let algorithm: firewood::NodeHashAlgorithm = args.node_hash_algorithm.into();
         let cfg = DbConfig::builder()
-            .node_hash_algorithm(args.node_hash_algorithm.into())
+            .node_hash_algorithm(algorithm)
             .truncate(args.truncate)
             .manager(args.as_rev_manager_config()?)
             .root_store(args.root_store)
@@ -176,7 +186,9 @@ impl DatabaseHandle {
             return Err(invalid_data("database path cannot be empty"));
         }
 
-        let db: Box<dyn DynDb> = Box::new(Db::new(path, cfg)?);
+        // Select the concrete `Db<H>` at runtime from the requested algorithm,
+        // validated against the on-disk header, and hold it erased.
+        let db = Db::open(path, algorithm, cfg)?;
         Ok(Self {
             db,
             metrics_context,
@@ -191,6 +203,12 @@ impl DatabaseHandle {
     #[must_use]
     pub fn current_root_hash(&self) -> Option<HashKey> {
         self.db.root_hash()
+    }
+
+    /// Returns the node-hashing scheme this database was opened with.
+    #[must_use]
+    pub fn node_hash_algorithm(&self) -> firewood::NodeHashAlgorithm {
+        self.db.node_hash_algorithm()
     }
 
     /// Returns a value from the database for the given key from the latest root hash.

--- a/ffi/src/proofs/change.rs
+++ b/ffi/src/proofs/change.rs
@@ -79,7 +79,7 @@ impl ChangeProofContext {
             .proof
             .as_ref()
             .ok_or(api::Error::ProofError(ProofError::ProofIsNone))?;
-        CodeIteratorHandle::from_batch_ops(proof.batch_ops())
+        CodeIteratorHandle::from_batch_ops(proof.hash_mode(), proof.batch_ops())
     }
 }
 

--- a/ffi/src/proofs/code_hash.rs
+++ b/ffi/src/proofs/code_hash.rs
@@ -15,22 +15,15 @@
 //! logic, and the type-agnostic FFI exports (`fwd_code_hash_iter_next`,
 //! `fwd_code_hash_iter_free`).
 
-#[cfg(feature = "ethhash")]
-use firewood::ProofError;
-
-use firewood::api::{self, BatchOp};
+use firewood::{
+    NodeHashAlgorithm, ProofError,
+    api::{self, BatchOp},
+};
 
 use crate::{HashKey, HashResult, VoidResult};
-
 #[non_exhaustive]
 pub struct CodeIteratorHandle<'p> {
-    #[cfg(feature = "ethhash")]
     inner: BoxCodeHashIter<'p>,
-    // uninhabitable fields make the struct impossible to construct when the feature is disabled
-    #[cfg(not(feature = "ethhash"))]
-    void: std::convert::Infallible,
-    #[cfg(not(feature = "ethhash"))]
-    marker: std::marker::PhantomData<&'p ()>,
 }
 
 impl std::fmt::Debug for CodeIteratorHandle<'_> {
@@ -41,10 +34,21 @@ impl std::fmt::Debug for CodeIteratorHandle<'_> {
 
 type KeyValuePair = (Box<[u8]>, Box<[u8]>);
 
-#[cfg(feature = "ethhash")]
 type BoxCodeHashIter<'p> = Box<dyn Iterator<Item = Result<HashKey, api::Error>> + 'p>;
 
-#[cfg(feature = "ethhash")]
+/// Reject code-hash iteration on a non-Ethereum proof. Code hashes only exist
+/// in Ethereum account values; this is the runtime replacement for the former
+/// compile-time `ethhash`-feature gate.
+fn require_ethereum(algorithm: NodeHashAlgorithm) -> Result<(), api::Error> {
+    if algorithm.is_ethereum() {
+        Ok(())
+    } else {
+        Err(api::Error::FeatureNotSupported(
+            "code hash iteration requires an ethereum-mode proof".to_owned(),
+        ))
+    }
+}
+
 fn extract_code_hash(key: &[u8], value: &[u8]) -> Option<Result<HashKey, api::Error>> {
     if key.len() != 32 {
         return None;
@@ -66,10 +70,6 @@ impl Iterator for CodeIteratorHandle<'_> {
     type Item = Result<HashKey, api::Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        #[cfg(not(feature = "ethhash"))]
-        match self.void {}
-
-        #[cfg(feature = "ethhash")]
         self.inner.next()
     }
 }
@@ -90,27 +90,20 @@ impl<'p> CodeIteratorHandle<'p> {
     ///
     /// # Errors
     ///
-    /// - Returns `api::Error::FeatureNotSupported` if the `ethhash` feature
-    ///   is not enabled.
-    #[cfg_attr(not(feature = "ethhash"), allow(unused_variables))]
-    pub fn from_key_values(key_values: &'p [KeyValuePair]) -> Result<Self, api::Error> {
-        #[cfg(not(feature = "ethhash"))]
-        {
-            Err(api::Error::FeatureNotSupported(
-                "ethhash code hash iterator".to_owned(),
-            ))
-        }
-
-        #[cfg(feature = "ethhash")]
-        {
-            Ok(CodeIteratorHandle {
-                inner: Box::new(
-                    key_values
-                        .iter()
-                        .filter_map(|(key, value)| extract_code_hash(key, value)),
-                ),
-            })
-        }
+    /// - Returns `api::Error::FeatureNotSupported` if `algorithm` is not an
+    ///   ethereum-mode proof.
+    pub fn from_key_values(
+        algorithm: NodeHashAlgorithm,
+        key_values: &'p [KeyValuePair],
+    ) -> Result<Self, api::Error> {
+        require_ethereum(algorithm)?;
+        Ok(CodeIteratorHandle {
+            inner: Box::new(
+                key_values
+                    .iter()
+                    .filter_map(|(key, value)| extract_code_hash(key, value)),
+            ),
+        })
     }
 
     /// Create a new code hash iterator from the given change-proof batch
@@ -129,28 +122,19 @@ impl<'p> CodeIteratorHandle<'p> {
     ///
     /// # Errors
     ///
-    /// - Returns `api::Error::FeatureNotSupported` if the `ethhash` feature
-    ///   is not enabled.
-    #[cfg_attr(not(feature = "ethhash"), allow(unused_variables))]
+    /// - Returns `api::Error::FeatureNotSupported` if `algorithm` is not an
+    ///   ethereum-mode proof.
     pub fn from_batch_ops(
+        algorithm: NodeHashAlgorithm,
         batch_ops: &'p [BatchOp<firewood::Key, firewood::Value>],
     ) -> Result<Self, api::Error> {
-        #[cfg(not(feature = "ethhash"))]
-        {
-            Err(api::Error::FeatureNotSupported(
-                "ethhash code hash iterator".to_owned(),
-            ))
-        }
-
-        #[cfg(feature = "ethhash")]
-        {
-            Ok(CodeIteratorHandle {
-                inner: Box::new(batch_ops.iter().filter_map(|op| match op {
-                    BatchOp::Put { key, value } => extract_code_hash(key, value),
-                    _ => None,
-                })),
-            })
-        }
+        require_ethereum(algorithm)?;
+        Ok(CodeIteratorHandle {
+            inner: Box::new(batch_ops.iter().filter_map(|op| match op {
+                BatchOp::Put { key, value } => extract_code_hash(key, value),
+                _ => None,
+            })),
+        })
     }
 }
 
@@ -202,7 +186,7 @@ impl crate::MetricsContextExt for CodeIteratorHandle<'_> {
     }
 }
 
-#[cfg(all(test, feature = "ethhash"))]
+#[cfg(test)]
 mod tests {
     use super::extract_code_hash;
 

--- a/ffi/src/proofs/eth.rs
+++ b/ffi/src/proofs/eth.rs
@@ -102,7 +102,7 @@ fn eth_get_proof_on<H>(
     storage_keys: BorrowedBytes2D<'_>,
 ) -> EthProofResult
 where
-    H: api::DbView + crate::MetricsContextExt,
+    H: api::DbView + crate::MetricsContextExt + crate::NodeHashAlgorithmExt,
 {
     crate::invoke_with_handle(
         handle,
@@ -112,7 +112,8 @@ where
                 .iter()
                 .map(|key| to_trie_key(key.as_slice()))
                 .collect::<Result<Vec<[u8; 32]>, _>>()?;
-            firewood::eth_get_proof(view, &account_key, &storage_keys)
+            let algorithm = view.node_hash_algorithm();
+            firewood::eth_get_proof(view, algorithm, &account_key, &storage_keys)
         },
     )
 }

--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -129,13 +129,21 @@ impl<'db> RangeProofContext<'db> {
 
         debug_assert!(self.verification.is_none());
 
-        // Expected mode is compile-time default - any proof with a different mode is rejected up front.
+        // Expected mode is the compile-time default - any proof with a
+        // different mode is rejected up front. (This standalone verify path
+        // has no database handle in scope to recover a runtime mode from;
+        // `NodeHashAlgorithm::compile_option` was removed with runtime
+        // selection, so the cfg-selected default is spelled out here.)
         self.verification = Some(firewood::verify_range_proof_structure(
             &self.proof,
             root,
             start_key,
             end_key,
-            NodeHashAlgorithm::compile_option(),
+            if cfg!(feature = "ethhash") {
+                NodeHashAlgorithm::Ethereum
+            } else {
+                NodeHashAlgorithm::MerkleDB
+            },
             max_length,
         )?);
         Ok(())
@@ -263,7 +271,7 @@ impl<'db> RangeProofContext<'db> {
     }
 
     fn code_hash_iter(&self) -> Result<CodeIteratorHandle<'_>, api::Error> {
-        CodeIteratorHandle::from_key_values(self.proof.key_values())
+        CodeIteratorHandle::from_key_values(self.proof.hash_mode(), self.proof.key_values())
     }
 }
 

--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -4,7 +4,7 @@
 use std::num::NonZeroUsize;
 
 use firewood::{
-    KeyRange, NodeHashAlgorithm, ProofError, RangeProofVerificationContext,
+    KeyRange, ProofError, RangeProofVerificationContext,
     api::{self, DbView, FrozenRangeProof, HashKey},
 };
 use firewood_metrics::{MetricsContext, firewood_counter};
@@ -129,13 +129,16 @@ impl<'db> RangeProofContext<'db> {
 
         debug_assert!(self.verification.is_none());
 
-        // Expected mode is compile-time default - any proof with a different mode is rejected up front.
+        // This standalone verify path has no database handle in scope, so
+        // there is no caller-side mode to assert: verify under the proof's own
+        // self-describing mode. A cross-mode forgery is still caught by
+        // hashing because it cannot reproduce `root` under the wrong scheme.
         self.verification = Some(firewood::verify_range_proof_structure(
             &self.proof,
             root,
             start_key,
             end_key,
-            NodeHashAlgorithm::compile_option(),
+            self.proof.hash_mode(),
             max_length,
         )?);
         Ok(())
@@ -263,7 +266,7 @@ impl<'db> RangeProofContext<'db> {
     }
 
     fn code_hash_iter(&self) -> Result<CodeIteratorHandle<'_>, api::Error> {
-        CodeIteratorHandle::from_key_values(self.proof.key_values())
+        CodeIteratorHandle::from_key_values(self.proof.hash_mode(), self.proof.key_values())
     }
 }
 

--- a/ffi/src/proposal.rs
+++ b/ffi/src/proposal.rs
@@ -1,30 +1,30 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use firewood::{
-    DefaultHashMode,
-    api::{self, BoxKeyValueIter, DbView, HashKey, IntoBatchIter, Proposal as _},
-};
+use firewood::api::{self, BoxKeyValueIter, DbView, DynProposal, HashKey};
 
 use crate::{IteratorHandle, iterator::CreateIteratorResult, metrics::MetricsContextExt};
+
+/// Collect a batch-op iterator into an owned, dyn-boundary-friendly batch.
+pub(crate) use firewood::api::collect_owned_batch;
 
 /// An opaque wrapper around a Proposal that also retains a reference to the
 /// database handle it was created from.
 #[derive(Debug)]
 pub struct ProposalHandle<'db> {
     hash_key: Option<HashKey>,
-    proposal: firewood::db::Proposal<'db, DefaultHashMode>,
+    proposal: Box<dyn DynProposal<'db> + 'db>,
     handle: &'db crate::DatabaseHandle,
 }
 
-impl<'db> DbView for ProposalHandle<'db> {
+impl DbView for ProposalHandle<'_> {
     type Iter<'view>
-        = <firewood::db::Proposal<'db, DefaultHashMode> as DbView>::Iter<'view>
+        = BoxKeyValueIter<'view>
     where
         Self: 'view;
 
     fn node_hash_algorithm(&self) -> firewood::NodeHashAlgorithm {
-        self.proposal.node_hash_algorithm()
+        self.proposal.view().node_hash_algorithm()
     }
 
     fn root_hash(&self) -> Option<HashKey> {
@@ -32,11 +32,11 @@ impl<'db> DbView for ProposalHandle<'db> {
     }
 
     fn val<K: api::KeyType>(&self, key: K) -> Result<Option<firewood::Value>, api::Error> {
-        self.proposal.val(key)
+        self.proposal.val(key.as_ref())
     }
 
     fn single_key_proof<K: api::KeyType>(&self, key: K) -> Result<api::FrozenProof, api::Error> {
-        self.proposal.single_key_proof(key)
+        self.proposal.single_key_proof(key.as_ref())
     }
 
     fn range_proof<K: api::KeyType>(
@@ -45,14 +45,19 @@ impl<'db> DbView for ProposalHandle<'db> {
         last_key: Option<K>,
         limit: Option<std::num::NonZeroUsize>,
     ) -> Result<api::FrozenRangeProof, api::Error> {
-        self.proposal.range_proof(first_key, last_key, limit)
+        self.proposal.range_proof(
+            first_key.as_ref().map(AsRef::as_ref),
+            last_key.as_ref().map(AsRef::as_ref),
+            limit,
+        )
     }
 
     fn iter_option<K: api::KeyType>(
         &self,
         first_key: Option<K>,
     ) -> Result<Self::Iter<'_>, api::Error> {
-        self.proposal.iter_option(first_key)
+        self.proposal
+            .iter_option(first_key.as_ref().map(AsRef::as_ref))
     }
 
     fn dump_to_string(&self) -> Result<String, api::Error> {
@@ -118,7 +123,7 @@ pub struct CreateProposalResult<'db> {
 impl<'db> CreateProposalResult<'db> {
     pub(crate) fn new(
         handle: &'db crate::DatabaseHandle,
-        f: impl FnOnce() -> Result<firewood::db::Proposal<'db, DefaultHashMode>, api::Error>,
+        f: impl FnOnce() -> Result<Box<dyn DynProposal<'db> + 'db>, api::Error>,
     ) -> Result<Self, api::Error> {
         let proposal = f()?;
 
@@ -152,7 +157,7 @@ pub trait CView<'db> {
     /// proposal.
     fn handle(&self) -> &'db crate::DatabaseHandle;
 
-    /// Create a [`firewood::db::Proposal`] with the provided key-value pairs.
+    /// Create an erased proposal with the provided key-value pairs.
     ///
     /// # Errors
     ///
@@ -160,8 +165,8 @@ pub trait CView<'db> {
     /// created.
     fn create_proposal(
         self,
-        values: impl IntoBatchIter,
-    ) -> Result<firewood::db::Proposal<'db, DefaultHashMode>, api::Error>;
+        values: impl api::IntoBatchIter,
+    ) -> Result<Box<dyn DynProposal<'db> + 'db>, api::Error>;
 
     /// Create a [`ProposalHandle`] from the values.
     ///
@@ -171,7 +176,7 @@ pub trait CView<'db> {
     /// created or if the proposal is empty.
     fn create_proposal_handle(
         self,
-        values: impl IntoBatchIter,
+        values: impl api::IntoBatchIter,
     ) -> Result<CreateProposalResult<'db>, api::Error>
     where
         Self: Sized,
@@ -188,9 +193,10 @@ impl<'db> CView<'db> for &ProposalHandle<'db> {
 
     fn create_proposal(
         self,
-        values: impl IntoBatchIter,
-    ) -> Result<firewood::db::Proposal<'db, DefaultHashMode>, api::Error> {
-        self.proposal.propose(values)
+        values: impl api::IntoBatchIter,
+    ) -> Result<Box<dyn DynProposal<'db> + 'db>, api::Error> {
+        let ops = collect_owned_batch(values)?;
+        self.proposal.propose(ops)
     }
 }
 

--- a/ffi/src/reconstructed.rs
+++ b/ffi/src/reconstructed.rs
@@ -102,3 +102,9 @@ impl crate::MetricsContextExt for ReconstructedHandle<'_> {
         self.handle.metrics_context()
     }
 }
+
+impl crate::NodeHashAlgorithmExt for ReconstructedHandle<'_> {
+    fn node_hash_algorithm(&self) -> firewood::NodeHashAlgorithm {
+        self.handle.node_hash_algorithm()
+    }
+}

--- a/ffi/src/reconstructed.rs
+++ b/ffi/src/reconstructed.rs
@@ -13,9 +13,9 @@ pub struct ReconstructedHandle<'db> {
     handle: &'db DatabaseHandle,
 }
 
-impl<'db> DbView for ReconstructedHandle<'db> {
+impl DbView for ReconstructedHandle<'_> {
     type Iter<'view>
-        = <firewood::db::ReconstructedView<'db> as DbView>::Iter<'view>
+        = BoxKeyValueIter<'view>
     where
         Self: 'view;
 
@@ -76,7 +76,7 @@ impl<'db> ReconstructedHandle<'db> {
             .expect("infallible; see issue #1329");
         CreateIteratorResult(IteratorHandle::new(
             self.reconstructed.view(),
-            Box::new(it) as BoxKeyValueIter<'_>,
+            it,
             self.metrics_context(),
         ))
     }

--- a/ffi/src/revision.rs
+++ b/ffi/src/revision.rs
@@ -121,3 +121,9 @@ impl crate::MetricsContextExt for RevisionHandle<'_> {
         Some(self.metrics_context)
     }
 }
+
+impl crate::NodeHashAlgorithmExt for RevisionHandle<'_> {
+    fn node_hash_algorithm(&self) -> firewood::NodeHashAlgorithm {
+        self.handle.node_hash_algorithm()
+    }
+}

--- a/firewood/benches/defer_persist.rs
+++ b/firewood/benches/defer_persist.rs
@@ -2,9 +2,10 @@
 // See the file LICENSE.md for licensing terms.
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use firewood::api::{Db as _, Proposal as _};
-use firewood::db::{BatchOp, Db, DbConfig};
+use firewood::api;
+use firewood::db::{BatchOp, DbConfig};
 use firewood::manager::RevisionManagerConfig;
+use firewood::open;
 use firewood_storage::{DefaultHashMode, HashMode};
 use rand::{RngExt, distr::Alphanumeric};
 use std::iter::repeat_with;
@@ -26,8 +27,8 @@ fn bench_deferred_persistence<const N: usize, const COMMIT_COUNT: u64>(criterion
                     let batch_ops: Vec<_> =
                         repeat_with(|| rng.sample_iter(&Alphanumeric).take(KEY_LEN).collect())
                             .map(|key: Vec<_>| BatchOp::Put {
-                                key,
-                                value: vec![b'v'],
+                                key: key.into_boxed_slice(),
+                                value: vec![b'v'].into_boxed_slice(),
                             })
                             .take(N)
                             .collect();
@@ -44,10 +45,11 @@ fn bench_deferred_persistence<const N: usize, const COMMIT_COUNT: u64>(criterion
                                 .build(),
                         )
                         .build();
-                    let db = Db::new(tmpdir, dbcfg).unwrap();
+                    let db = open(tmpdir, dbcfg).unwrap();
 
                     for op in batch_ops {
-                        let proposal = db.propose(vec![op]).unwrap();
+                        let batch: api::OwnedBatch = Box::new([op]);
+                        let proposal = db.propose(batch).unwrap();
                         proposal.commit().unwrap();
                     }
 

--- a/firewood/benches/hashops.rs
+++ b/firewood/benches/hashops.rs
@@ -6,8 +6,9 @@
 use criterion::profiler::Profiler;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use firewood::Merkle;
-use firewood::api::{Db as _, Proposal as _};
+use firewood::api;
 use firewood::db::{BatchOp, DbConfig};
+use firewood::open;
 use firewood_storage::{DefaultHashMode, DeletedNodeTracking, HashMode, MemStore, NodeStore};
 use pprof::ProfilerGuard;
 use rand::{RngExt, distr::Alphanumeric};
@@ -104,14 +105,15 @@ fn bench_db<const N: usize>(criterion: &mut Criterion) {
         .bench_function("commit", |b| {
             b.iter_batched(
                 || {
-                    let batch_ops: Vec<_> =
+                    let batch_ops: api::OwnedBatch =
                         repeat_with(|| rng.sample_iter(&Alphanumeric).take(KEY_LEN).collect())
                             .map(|key: Vec<_>| BatchOp::Put {
-                                key,
-                                value: vec![b'v'],
+                                key: key.into_boxed_slice(),
+                                value: vec![b'v'].into_boxed_slice(),
                             })
                             .take(N)
-                            .collect();
+                            .collect::<Vec<_>>()
+                            .into_boxed_slice();
                     batch_ops
                 },
                 |batch_ops| {
@@ -121,7 +123,7 @@ fn bench_db<const N: usize>(criterion: &mut Criterion) {
                         .node_hash_algorithm(DefaultHashMode::ALGORITHM)
                         .truncate(true)
                         .build();
-                    let db = firewood::db::Db::new(db_path, cfg).unwrap();
+                    let db = open(db_path, cfg).unwrap();
 
                     db.propose(batch_ops).unwrap().commit().unwrap();
                 },

--- a/firewood/benches/proposal_reconstruct.rs
+++ b/firewood/benches/proposal_reconstruct.rs
@@ -3,8 +3,9 @@
 
 use criterion::profiler::Profiler;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use firewood::api::{Db as _, DbView as _, Proposal as _, Reconstructible as _};
-use firewood::db::{BatchOp, Db, DbConfig, UseParallel};
+use firewood::api::{self, DbView as _, Reconstructible as _};
+use firewood::db::{BatchOp, DbConfig, UseParallel};
+use firewood::open;
 use firewood_storage::{DefaultHashMode, HashMode};
 use pprof::ProfilerGuard;
 use rand::{RngExt, distr::Alphanumeric};
@@ -21,8 +22,7 @@ const PROPOSAL_ITEMS: usize = 100;
 const KEY_LEN: usize = 16;
 const VALUE_LEN: usize = 32;
 
-type BenchOp = BatchOp<Vec<u8>, Vec<u8>>;
-type BenchBatch = Vec<BenchOp>;
+type BenchBatch = api::OwnedBatch;
 
 // To enable flamegraph output:
 // cargo bench --bench proposal_reconstruct -- reconstructed_chain/nested --profile-time=5
@@ -66,12 +66,21 @@ impl Profiler for FlamegraphProfiler {
 
 fn make_batch(rng: &firewood_storage::SeededRng, count: usize) -> BenchBatch {
     repeat_with(|| {
-        let key: Vec<u8> = rng.sample_iter(&Alphanumeric).take(KEY_LEN).collect();
-        let value: Vec<u8> = rng.sample_iter(&Alphanumeric).take(VALUE_LEN).collect();
+        let key = rng
+            .sample_iter(&Alphanumeric)
+            .take(KEY_LEN)
+            .collect::<Vec<u8>>()
+            .into_boxed_slice();
+        let value = rng
+            .sample_iter(&Alphanumeric)
+            .take(VALUE_LEN)
+            .collect::<Vec<u8>>()
+            .into_boxed_slice();
         BatchOp::Put { key, value }
     })
     .take(count)
-    .collect()
+    .collect::<Vec<_>>()
+    .into_boxed_slice()
 }
 
 fn generate_batches() -> (BenchBatch, Vec<BenchBatch>) {
@@ -99,7 +108,7 @@ fn bench_proposal_chain(criterion: &mut Criterion) {
                         .node_hash_algorithm(DefaultHashMode::ALGORITHM)
                         .truncate(true)
                         .build();
-                    let db = Db::new(db_path, cfg).unwrap();
+                    let db = open(db_path, cfg).unwrap();
 
                     db.propose(initial).unwrap().commit().unwrap();
 
@@ -139,7 +148,7 @@ fn bench_reconstructed_chain(criterion: &mut Criterion) {
                         .truncate(true)
                         .use_parallel(UseParallel::Never)
                         .build();
-                    let db = Db::new(db_path, cfg).unwrap();
+                    let db = open(db_path, cfg).unwrap();
 
                     db.propose(initial).unwrap().commit().unwrap();
 
@@ -147,7 +156,7 @@ fn bench_reconstructed_chain(criterion: &mut Criterion) {
                     let first_batch = batches_iter.next().unwrap();
                     db.propose(first_batch).unwrap().commit().unwrap();
                     let root_hash = db.root_hash().unwrap();
-                    let historical = db.committed_view(root_hash).unwrap();
+                    let historical = db.committed_view(root_hash).unwrap().unwrap();
 
                     let second_batch = batches_iter.next().unwrap();
                     let mut reconstructed =

--- a/firewood/examples/insert.rs
+++ b/firewood/examples/insert.rs
@@ -11,9 +11,10 @@ use std::num::NonZeroUsize;
 use std::ops::RangeInclusive;
 use std::time::Instant;
 
-use firewood::api::{Db as _, DbView, KeyType, Proposal as _, ValueType};
-use firewood::db::{BatchOp, Db, DbConfig};
+use firewood::api::{self, DynDb, KeyType, ValueType};
+use firewood::db::{BatchOp, DbConfig};
 use firewood::manager::RevisionManagerConfig;
+use firewood::open;
 use firewood_storage::{DefaultHashMode, HashMode};
 use rand::{RngExt, distr::Alphanumeric};
 
@@ -64,7 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .manager(mgrcfg)
         .build();
 
-    let db = Db::new("firewood", cfg).expect("db initiation should succeed");
+    let db = open("firewood", cfg).expect("db initiation should succeed");
 
     let keys = args.batch_size;
     let start = Instant::now();
@@ -91,9 +92,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         let verify = get_keys_to_verify(rng, &batch, args.read_verify_percent);
 
         #[expect(clippy::unwrap_used)]
-        let proposal = db.propose(batch.clone()).unwrap();
+        let proposal = db
+            .propose(api::collect_owned_batch(batch.clone())?)
+            .unwrap();
         proposal.commit()?;
-        verify_keys(&db, verify)?;
+        verify_keys(db.as_ref(), verify)?;
     }
 
     let duration = start.elapsed();
@@ -127,10 +130,7 @@ fn get_keys_to_verify<'a, K: KeyType + 'a, V: ValueType + 'a>(
     }
 }
 
-fn verify_keys(
-    db: &impl firewood::api::Db,
-    verify: HashMap<&[u8], &[u8]>,
-) -> Result<(), firewood::api::Error> {
+fn verify_keys(db: &dyn DynDb, verify: HashMap<&[u8], &[u8]>) -> Result<(), firewood::api::Error> {
     if !verify.is_empty() {
         let hash = db.root_hash().expect("root hash should exist");
         let revision = db.revision(hash)?;

--- a/firewood/src/api.rs
+++ b/firewood/src/api.rs
@@ -6,7 +6,7 @@ use crate::merkle::parallel::CreateProposalError;
 use crate::merkle::{Key, Value};
 use crate::persist_worker::PersistError;
 use crate::{Proof, ProofError, ProofNode, RangeProof};
-use firewood_storage::{DefaultHashMode, FileIoError, HashMode, TrieHash};
+use firewood_storage::{DefaultHashMode, FileIoError, HashMode, NodeHashAlgorithm, TrieHash};
 use std::fmt::Debug;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -583,6 +583,9 @@ pub trait DynDb: Debug + Send + Sync + 'static {
     /// Propose a change to the database via an already-collected batch.
     #[expect(clippy::missing_errors_doc)]
     fn propose(&self, ops: OwnedBatch) -> Result<Box<dyn DynProposal<'_> + '_>, Error>;
+
+    /// The node-hashing scheme this database uses.
+    fn node_hash_algorithm(&self) -> NodeHashAlgorithm;
 
     /// Dump the latest revision's trie to a string.
     #[expect(clippy::missing_errors_doc)]

--- a/firewood/src/api.rs
+++ b/firewood/src/api.rs
@@ -522,6 +522,42 @@ where
     }
 }
 
+/// A shareable committed revision that can start a reconstruction chain.
+///
+/// This is the erased capability behind
+/// [`CommittedView`](crate::db::CommittedView): the blanket impl in `db.rs`
+/// covers the committed nodestore of every hash mode, so reconstruction works
+/// regardless of the mode the database was opened with.
+pub(crate) trait DynCommittedRevision: DynDbView {
+    /// Start a reconstruction chain from this committed revision by applying
+    /// `batch`, producing an erased reconstructed state.
+    fn begin_reconstruction(
+        self: Arc<Self>,
+        batch: OwnedBatch,
+    ) -> Result<ArcDynReconstructed, Error>;
+}
+
+/// A shareable reconstructed state that can continue a reconstruction chain.
+///
+/// This is the erased capability behind
+/// [`ReconstructedView`](crate::db::ReconstructedView); like
+/// [`DynCommittedRevision`], its blanket impl in `db.rs` covers every hash
+/// mode.
+pub(crate) trait DynReconstructed: DynDbView {
+    /// Continue the reconstruction chain by applying `batch` on top of this
+    /// state.
+    ///
+    /// Consumes the `Arc` so that a uniquely-held state can move its in-memory
+    /// root into the next step instead of deep-cloning it.
+    fn reconstruct_next(self: Arc<Self>, batch: OwnedBatch) -> Result<ArcDynReconstructed, Error>;
+}
+
+/// A shareable, erased committed revision usable as a reconstruction parent.
+pub(crate) type ArcDynCommittedRevision = Arc<dyn DynCommittedRevision>;
+
+/// A shareable, erased reconstructed state.
+pub(crate) type ArcDynReconstructed = Arc<dyn DynReconstructed>;
+
 /// A reconstructible database view.
 ///
 /// This trait models linear reconstruction by consuming `self` and returning
@@ -541,7 +577,7 @@ pub trait Reconstructible: DbView {
         Self: Sized;
 
     /// The underlying database
-    fn db(&self) -> &crate::db::Db<DefaultHashMode>;
+    fn db(&self) -> &dyn DynDb;
 }
 
 /// A proposal for a new revision of the database.
@@ -574,6 +610,200 @@ pub trait Proposal: DbView {
     /// A new proposal
     #[expect(clippy::missing_errors_doc)]
     fn propose(&self, data: impl IntoBatchIter) -> Result<Self::Proposal, Error>;
+}
+
+/// A batch already collected into owned key/value pairs.
+///
+/// The [`DynDb`]/[`DynProposal`] boundary cannot accept an `impl IntoBatchIter`
+/// (a generic method is not dispatchable through a vtable), so the generic
+/// batch is pre-collected into this concrete, owned shape at the boundary.
+pub type OwnedBatch = Box<[BatchOp<Box<[u8]>, Box<[u8]>>]>;
+
+/// Key/value pairs collected into an owned shape for range merging across the
+/// [`DynDb`] boundary.
+pub type OwnedKeyValuePairs = Box<[(Key, Value)]>;
+
+/// Collect a generic batch into the concrete [`OwnedBatch`] shape required at
+/// the dyn boundary.
+///
+/// # Errors
+///
+/// Returns an error if the batch iterator yields one.
+pub fn collect_owned_batch(batch: impl IntoBatchIter) -> Result<OwnedBatch, Error> {
+    batch
+        .into_batch_iter::<Error>()
+        .map(|res| {
+            res.map(|op| match op {
+                BatchOp::Put { key, value } => BatchOp::Put {
+                    key: key.as_ref().into(),
+                    value: value.as_ref().into(),
+                },
+                BatchOp::Delete { key } => BatchOp::Delete {
+                    key: key.as_ref().into(),
+                },
+                BatchOp::DeleteRange { prefix } => BatchOp::DeleteRange {
+                    prefix: prefix.as_ref().into(),
+                },
+            })
+        })
+        .collect()
+}
+
+/// The object-safe erasure of [`Db`], used to hold databases of different
+/// hash modes behind one type since [`Db`] itself is not object-safe. The
+/// blanket impl lives next to the concrete `Db<H>` in `db.rs`.
+pub trait DynDb: Debug + Send + Sync + 'static {
+    /// Object-safe version of [`Db::revision`], returning a shareable,
+    /// `'static` view instead of `Arc<Self::Historical>`.
+    #[expect(clippy::missing_errors_doc)]
+    fn revision(&self, hash: TrieHash) -> Result<ArcDynDbView, Error>;
+
+    /// Object-safe version of [`Db::root_hash`].
+    fn root_hash(&self) -> Option<TrieHash>;
+
+    /// Object-safe version of [`Db::view`](crate::db::Db::view).
+    #[expect(clippy::missing_errors_doc)]
+    fn view(&self, hash: HashKey) -> Result<ArcDynDbView, Error>;
+
+    /// Object-safe version of [`Db::propose`], taking an already-collected
+    /// [`OwnedBatch`] since a generic `impl IntoBatchIter` parameter cannot
+    /// cross a vtable.
+    #[expect(clippy::missing_errors_doc)]
+    fn propose(&self, ops: OwnedBatch) -> Result<Box<dyn DynProposal<'_> + '_>, Error>;
+
+    /// The node-hashing scheme this database uses.
+    fn node_hash_algorithm(&self) -> NodeHashAlgorithm;
+
+    /// Dump the latest revision's trie to a string.
+    #[expect(clippy::missing_errors_doc)]
+    fn dump_to_string(&self) -> Result<String, Error>;
+
+    /// Object-safe version of [`Db::change_proof`](crate::db::Db::change_proof).
+    #[expect(clippy::missing_errors_doc)]
+    fn change_proof(
+        &self,
+        start_hash: HashKey,
+        end_hash: HashKey,
+        start_key: Option<&[u8]>,
+        end_key: Option<&[u8]>,
+        limit: Option<NonZeroUsize>,
+    ) -> Result<FrozenChangeProof, Error>;
+
+    /// Object-safe version of
+    /// [`Db::verify_change_proof`](crate::db::Db::verify_change_proof).
+    #[expect(clippy::missing_errors_doc)]
+    fn verify_change_proof(
+        &self,
+        proof: &FrozenChangeProof,
+        end_root: HashKey,
+        start_key: Option<&[u8]>,
+        end_key: Option<&[u8]>,
+        max_length: Option<NonZeroUsize>,
+    ) -> Result<Box<dyn DynProposal<'_> + '_>, Error>;
+
+    /// Object-safe version of
+    /// [`Db::merge_key_value_range`](crate::db::Db::merge_key_value_range),
+    /// taking already-collected [`OwnedKeyValuePairs`].
+    #[expect(clippy::missing_errors_doc)]
+    fn merge_key_value_range(
+        &self,
+        first_key: Option<&[u8]>,
+        last_key: Option<&[u8]>,
+        key_values: OwnedKeyValuePairs,
+    ) -> Result<Box<dyn DynProposal<'_> + '_>, Error>;
+
+    /// Object-safe version of
+    /// [`Db::reconstruct_from_view`](crate::db::Db::reconstruct_from_view),
+    /// taking an already-collected [`OwnedBatch`].
+    #[expect(clippy::missing_errors_doc)]
+    fn reconstruct_from_view(
+        &self,
+        parent: &crate::db::CommittedView,
+        batch: OwnedBatch,
+    ) -> Result<crate::db::ReconstructedView<'_>, Error>;
+
+    /// Reconstruct a view from a reconstructed parent by applying batch
+    /// operations (used internally by [`Reconstructible::reconstruct`]).
+    #[expect(clippy::missing_errors_doc)]
+    fn reconstruct_from_reconstructed<'db>(
+        &'db self,
+        parent: crate::db::ReconstructedView<'db>,
+        batch: OwnedBatch,
+    ) -> Result<crate::db::ReconstructedView<'db>, Error>;
+
+    /// Object-safe version of
+    /// [`Db::committed_view`](crate::db::Db::committed_view).
+    ///
+    /// Returns `Ok(None)` when `hash` names a proposal rather than a committed
+    /// revision.
+    #[expect(clippy::missing_errors_doc)]
+    fn committed_view(&self, hash: TrieHash) -> Result<Option<crate::db::CommittedView>, Error>;
+
+    /// Object-safe version of [`Db::close`](crate::db::Db::close), consuming
+    /// the box instead of `self` by value.
+    #[expect(clippy::missing_errors_doc)]
+    fn close(self: Box<Self>) -> Result<(), Error>;
+}
+
+/// A dyn-safe version of [`Proposal`].
+///
+/// Unlike [`DynDbView`], this trait is **not** `'static`: a [`Proposal`]
+/// borrows its parent database, so it cannot outlive it. That borrow is why
+/// `DynProposal` cannot simply extend `DynDbView` (whose `'static` bound a
+/// borrowing proposal cannot satisfy); instead it carries the same read
+/// surface directly, plus the proposal-only `propose`/`commit` operations in
+/// their object-safe form (`commit` consumes the box rather than `self` by
+/// value). The proposal's shareable, `'static` view is reachable via [`DynProposal::view`].
+pub trait DynProposal<'db>: Debug + Send + Sync {
+    /// Object-safe version of [`DbView::root_hash`].
+    fn root_hash(&self) -> Option<HashKey>;
+
+    /// Object-safe version of [`DbView::val`].
+    #[expect(clippy::missing_errors_doc)]
+    fn val(&self, key: &[u8]) -> Result<Option<Value>, Error>;
+
+    /// Object-safe version of [`DbView::single_key_proof`].
+    #[expect(clippy::missing_errors_doc)]
+    fn single_key_proof(&self, key: &[u8]) -> Result<FrozenProof, Error>;
+
+    /// Object-safe version of [`DbView::range_proof`].
+    #[expect(clippy::missing_errors_doc)]
+    fn range_proof(
+        &self,
+        first_key: Option<&[u8]>,
+        last_key: Option<&[u8]>,
+        limit: Option<NonZeroUsize>,
+    ) -> Result<FrozenRangeProof, Error>;
+
+    /// Object-safe version of [`DbView::iter_option`].
+    #[expect(clippy::missing_errors_doc)]
+    fn iter_option(&self, first_key: Option<&[u8]>) -> Result<BoxKeyValueIter<'_>, Error>;
+
+    /// Object-safe version of [`DbView::dump_to_string`].
+    #[expect(clippy::missing_errors_doc)]
+    fn dump_to_string(&self) -> Result<String, Error>;
+
+    /// Returns the shareable, `'static` view backing this proposal.
+    fn view(&self) -> ArcDynDbView;
+
+    /// Object-safe version of [`Proposal::propose`].
+    ///
+    /// The returned proposal shares the parent database's `'db` lifetime, so it
+    /// may outlive the borrow of `self` (proposal chaining keeps the original
+    /// database handle alive, not the parent proposal).
+    #[expect(clippy::missing_errors_doc)]
+    fn propose(&self, ops: OwnedBatch) -> Result<Box<dyn DynProposal<'db> + 'db>, Error>;
+
+    /// Object-safe version of [`Proposal::commit`], consuming the box instead
+    /// of `self` by value.
+    #[expect(clippy::missing_errors_doc)]
+    fn commit(self: Box<Self>) -> Result<(), Error>;
+
+    /// Object-safe version of
+    /// [`Proposal::commit_with_rebase`](crate::db::Proposal::commit_with_rebase),
+    /// consuming the box instead of `self` by value.
+    #[expect(clippy::missing_errors_doc)]
+    fn commit_with_rebase(self: Box<Self>) -> Result<Option<HashKey>, Error>;
 }
 
 #[cfg(test)]

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -22,9 +22,9 @@ use crate::verify_change_proof_structure;
 use crate::manager::{ConfigManager, RevisionManager, RevisionManagerConfig};
 use firewood_metrics::{firewood_counter, firewood_histogram};
 use firewood_storage::{
-    CheckOpt, CheckerReport, Committed, CommittedParentHash, DefaultHashMode, FileBacked,
-    FileIoError, HashMode, HashedNodeReader, ImmutableProposal, Mutable, NodeHashAlgorithm,
-    NodeStore, Parentable, Propose, ReadableStorage, Reconstructed, TrieReader,
+    CheckOpt, CheckerReport, Committed, CommittedParentHash, DefaultHashMode, EthHash, FileBacked,
+    FileIoError, HashMode, HashedNodeReader, ImmutableProposal, MerkleDbHash, Mutable,
+    NodeHashAlgorithm, NodeStore, Parentable, Propose, ReadableStorage, Reconstructed, TrieReader,
 };
 use std::io::Write;
 use std::num::NonZeroUsize;
@@ -208,6 +208,10 @@ impl<H: HashMode> api::DynDb for Db<H> {
         Ok(Box::new(proposal))
     }
 
+    fn node_hash_algorithm(&self) -> NodeHashAlgorithm {
+        H::ALGORITHM
+    }
+
     fn dump_to_string(&self) -> Result<String, api::Error> {
         Db::dump_to_string(self).map_err(api::Error::from)
     }
@@ -302,21 +306,43 @@ impl<H: HashMode> api::DynDb for Db<H> {
 
 impl Db {
     /// Create a new database instance.
+    ///
+    /// Returns a `Db<DefaultHashMode>`; the hash mode is carried as a runtime
+    /// value through [`DbConfig::node_hash_algorithm`]. The requested algorithm
+    /// must match the on-disk header for an existing database (enforced at
+    /// open). To open a database whose hash mode is only known at runtime, use
+    /// [`Db::open`], which returns an erased [`api::DynDb`].
     pub fn new<P: AsRef<Path>>(db_dir: P, cfg: DbConfig) -> Result<Self, api::Error> {
-        let config_manager = ConfigManager::builder()
-            .root_dir(db_dir.as_ref().to_path_buf())
-            .node_hash_algorithm(cfg.node_hash_algorithm)
-            .create(cfg.create_if_missing)
-            .truncate(cfg.truncate)
-            .root_store(cfg.root_store)
-            .manager(cfg.manager)
-            .build();
-        let manager = RevisionManager::new(config_manager)?;
-        let db = Self {
-            manager,
-            use_parallel: cfg.use_parallel,
-        };
-        Ok(db)
+        Self::new_with_hash_mode(db_dir, cfg)
+    }
+
+    /// Open a database, selecting the concrete hash mode `H` at runtime from
+    /// `algorithm`, and return it as an erased [`api::DynDb`].
+    ///
+    /// `algorithm` is the database's node-hashing scheme: for an existing
+    /// database it is the header's persisted algorithm, and for a fresh
+    /// database it is the requested algorithm to create with. The selected `H`
+    /// is validated against the on-disk header (a mismatch is an error), so a
+    /// single binary can open both an Ethereum and a MerkleDB database.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database cannot be opened, or if `algorithm`
+    /// does not match an existing database's header.
+    pub fn open<P: AsRef<Path>>(
+        db_dir: P,
+        algorithm: NodeHashAlgorithm,
+        mut cfg: DbConfig,
+    ) -> Result<Box<dyn api::DynDb>, api::Error> {
+        cfg.node_hash_algorithm = algorithm;
+        Ok(match algorithm {
+            NodeHashAlgorithm::Ethereum => {
+                Box::new(Db::<EthHash>::new_with_hash_mode(db_dir, cfg)?)
+            }
+            NodeHashAlgorithm::MerkleDB => {
+                Box::new(Db::<MerkleDbHash>::new_with_hash_mode(db_dir, cfg)?)
+            }
+        })
     }
 
     /// Synchronously get an opaque handle to a committed historical revision.
@@ -329,6 +355,46 @@ impl Db {
         Ok(CommittedView {
             nodestore: self.manager.revision(root_hash)?,
         })
+    }
+}
+
+impl<H: HashMode> Db<H> {
+    /// Create or open a database with the hash mode fixed by the type
+    /// parameter `H`. The configured [`DbConfig::node_hash_algorithm`] must
+    /// equal `H::ALGORITHM`; the open path validates it against the header.
+    fn new_with_hash_mode<P: AsRef<Path>>(db_dir: P, cfg: DbConfig) -> Result<Self, api::Error> {
+        // The hashing scheme is `H`, but the fresh-database header is stamped
+        // from `cfg.node_hash_algorithm`. Reject a config that disagrees with
+        // `H` so we never create a header that claims one mode while hashing
+        // under another (e.g. `Db::new(cfg{Ethereum})` in a MerkleDB build).
+        if cfg.node_hash_algorithm != H::ALGORITHM {
+            return Err(api::Error::FeatureNotSupported(format!(
+                "requested node hash algorithm {:?} does not match the database \
+                 type parameter's algorithm {:?}",
+                cfg.node_hash_algorithm,
+                H::ALGORITHM,
+            )));
+        }
+        let config_manager = ConfigManager::builder()
+            .root_dir(db_dir.as_ref().to_path_buf())
+            .node_hash_algorithm(cfg.node_hash_algorithm)
+            .create(cfg.create_if_missing)
+            .truncate(cfg.truncate)
+            .root_store(cfg.root_store)
+            .manager(cfg.manager)
+            .build();
+        let manager = RevisionManager::<H>::new(config_manager)?;
+        let db = Self {
+            manager,
+            use_parallel: cfg.use_parallel,
+        };
+        Ok(db)
+    }
+
+    /// The node-hashing scheme this database uses.
+    #[must_use]
+    pub const fn node_hash_algorithm(&self) -> NodeHashAlgorithm {
+        H::ALGORITHM
     }
 }
 

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -21,9 +21,11 @@ use crate::verify_change_proof_structure;
 
 use crate::manager::{ConfigManager, RevisionManager, RevisionManagerConfig};
 use firewood_metrics::{firewood_counter, firewood_histogram};
+#[cfg(test)]
+use firewood_storage::DefaultHashMode;
 use firewood_storage::{
-    CheckOpt, CheckerReport, Committed, CommittedParentHash, DefaultHashMode, FileBacked,
-    FileIoError, HashMode, HashedNodeReader, ImmutableProposal, Mutable, NodeHashAlgorithm,
+    CheckOpt, CheckerReport, Committed, CommittedParentHash, EthHash, FileBacked, FileIoError,
+    HashMode, HashedNodeReader, ImmutableProposal, MerkleDbHash, Mutable, NodeHashAlgorithm,
     NodeStore, Parentable, Propose, ReadableStorage, Recon, Reconstructed, TrieReader,
 };
 use std::io::Write;
@@ -110,8 +112,8 @@ pub enum UseParallel {
 pub struct DbConfig {
     /// The algorithm used for hashing nodes (required).
     ///
-    /// In tests this defaults to the [`DefaultHashMode`]'s algorithm so that
-    /// the builder pairs with the compile-selected `Db<DefaultHashMode>`.
+    /// In tests this defaults to the feature-selected compatibility algorithm.
+    /// Production callers must select the algorithm explicitly.
     #[cfg_attr(test, builder(default = DefaultHashMode::ALGORITHM))]
     pub node_hash_algorithm: NodeHashAlgorithm,
     /// Whether to create the DB if it doesn't exist.
@@ -174,31 +176,128 @@ impl<H: HashMode> api::Db for Db<H> {
     }
 }
 
-impl Db<DefaultHashMode> {
-    /// Create a new database instance.
-    pub fn new<P: AsRef<Path>>(db_dir: P, cfg: DbConfig) -> Result<Self, api::Error> {
-        if cfg.node_hash_algorithm != DefaultHashMode::ALGORITHM {
-            return Err(api::Error::HashModeMismatch {
-                expected: DefaultHashMode::ALGORITHM,
-                found: cfg.node_hash_algorithm,
-            });
-        }
-
-        let config_manager = ConfigManager::builder()
-            .root_dir(db_dir.as_ref().to_path_buf())
-            .create(cfg.create_if_missing)
-            .truncate(cfg.truncate)
-            .root_store(cfg.root_store)
-            .manager(cfg.manager)
-            .build();
-        let manager = RevisionManager::new(config_manager)?;
-        let db = Self {
-            manager,
-            use_parallel: cfg.use_parallel,
-        };
-        Ok(db)
+// The dyn boundary: erase a concrete `Db<H>` to `Box<dyn DynDb>` so a single
+// binary can hold databases of different hash modes behind one type. The
+// generic batch is pre-collected into an `OwnedBatch` at the boundary because a
+// generic `impl IntoBatchIter` method is not object-safe.
+impl<H: HashMode> api::DynDb for Db<H> {
+    fn revision(&self, hash: HashKey) -> Result<ArcDynDbView, api::Error> {
+        let nodestore = self.manager.revision(hash)?;
+        Ok(nodestore as ArcDynDbView)
     }
 
+    fn root_hash(&self) -> Option<HashKey> {
+        api::Db::root_hash(self)
+    }
+
+    fn view(&self, hash: HashKey) -> Result<ArcDynDbView, api::Error> {
+        Db::view(self, hash)
+    }
+
+    fn propose(
+        &self,
+        ops: api::OwnedBatch,
+    ) -> Result<Box<dyn api::DynProposal<'_> + '_>, api::Error> {
+        let proposal = api::Db::propose(self, ops)?;
+        Ok(Box::new(proposal))
+    }
+
+    fn node_hash_algorithm(&self) -> NodeHashAlgorithm {
+        H::ALGORITHM
+    }
+
+    fn dump_to_string(&self) -> Result<String, api::Error> {
+        Db::dump_to_string(self).map_err(api::Error::from)
+    }
+
+    fn change_proof(
+        &self,
+        start_hash: HashKey,
+        end_hash: HashKey,
+        start_key: Option<&[u8]>,
+        end_key: Option<&[u8]>,
+        limit: Option<NonZeroUsize>,
+    ) -> Result<FrozenChangeProof, api::Error> {
+        Db::change_proof(self, start_hash, end_hash, start_key, end_key, limit)
+    }
+
+    fn verify_change_proof(
+        &self,
+        proof: &FrozenChangeProof,
+        end_root: HashKey,
+        start_key: Option<&[u8]>,
+        end_key: Option<&[u8]>,
+        max_length: Option<NonZeroUsize>,
+    ) -> Result<Box<dyn api::DynProposal<'_> + '_>, api::Error> {
+        let proposal =
+            Db::verify_change_proof(self, proof, end_root, start_key, end_key, max_length)?;
+        Ok(Box::new(proposal))
+    }
+
+    fn merge_key_value_range(
+        &self,
+        first_key: Option<&[u8]>,
+        last_key: Option<&[u8]>,
+        key_values: api::OwnedKeyValuePairs,
+    ) -> Result<Box<dyn api::DynProposal<'_> + '_>, api::Error> {
+        let proposal = Db::merge_key_value_range(self, first_key, last_key, key_values)?;
+        Ok(Box::new(proposal))
+    }
+
+    fn reconstruct_from_view(
+        &self,
+        parent: &CommittedView,
+        batch: api::OwnedBatch,
+    ) -> Result<ReconstructedView<'_>, api::Error> {
+        Db::reconstruct_from_view(self, parent, batch)
+    }
+
+    fn reconstruct_from_reconstructed<'db>(
+        &'db self,
+        parent: ReconstructedView<'db>,
+        batch: api::OwnedBatch,
+    ) -> Result<ReconstructedView<'db>, api::Error> {
+        Db::reconstruct_from_reconstructed(self, parent.nodestore, batch)
+    }
+
+    fn committed_view(&self, hash: HashKey) -> Result<Option<CommittedView>, api::Error> {
+        match Db::committed_view(self, hash) {
+            Ok(view) => Ok(Some(view)),
+            // `hash` names a proposal, not a committed revision.
+            Err(api::Error::RevisionNotFound { .. }) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn close(self: Box<Self>) -> Result<(), api::Error> {
+        Db::close(*self)
+    }
+}
+
+/// Open or create a database, selecting the concrete hash mode at runtime from
+/// [`DbConfig::node_hash_algorithm`], and return it as an erased [`api::DynDb`].
+/// This is the public way to construct a database; the concrete [`Db<H>`](Db)
+/// type is an implementation detail.
+///
+/// For an existing database, the configured algorithm must match the algorithm
+/// persisted in the header; a mismatch is an error. For a fresh database, it
+/// is the node-hashing scheme to create with. A single binary can open both an
+/// Ethereum and a MerkleDB database.
+///
+/// # Errors
+///
+/// Returns an error if the database cannot be opened, or if the configured node
+/// hash algorithm does not match an existing database's header.
+pub fn open<P: AsRef<Path>>(db_dir: P, cfg: DbConfig) -> Result<Box<dyn api::DynDb>, api::Error> {
+    Ok(match cfg.node_hash_algorithm {
+        NodeHashAlgorithm::Ethereum => Box::new(Db::<EthHash>::new_with_hash_mode(db_dir, cfg)?),
+        NodeHashAlgorithm::MerkleDB => {
+            Box::new(Db::<MerkleDbHash>::new_with_hash_mode(db_dir, cfg)?)
+        }
+    })
+}
+
+impl<H: HashMode> Db<H> {
     /// Synchronously get an opaque handle to a committed historical revision.
     ///
     /// # Errors
@@ -210,9 +309,34 @@ impl Db<DefaultHashMode> {
             nodestore: self.manager.revision(root_hash)?,
         })
     }
-}
 
-impl<H: HashMode> Db<H> {
+    /// Create or open a database with the hash mode fixed by `H`.
+    // In-crate tests and benchmarks need typed construction; public callers use `open`.
+    pub(crate) fn new_with_hash_mode<P: AsRef<Path>>(
+        db_dir: P,
+        cfg: DbConfig,
+    ) -> Result<Self, api::Error> {
+        if cfg.node_hash_algorithm != H::ALGORITHM {
+            return Err(api::Error::HashModeMismatch {
+                expected: H::ALGORITHM,
+                found: cfg.node_hash_algorithm,
+            });
+        }
+        let config_manager = ConfigManager::builder()
+            .root_dir(db_dir.as_ref().to_path_buf())
+            .create(cfg.create_if_missing)
+            .truncate(cfg.truncate)
+            .root_store(cfg.root_store)
+            .manager(cfg.manager)
+            .build();
+        let manager = RevisionManager::<H>::new(config_manager)?;
+        let db = Self {
+            manager,
+            use_parallel: cfg.use_parallel,
+        };
+        Ok(db)
+    }
+
     /// Synchronously get a view, either committed or proposed
     pub fn view(&self, root_hash: HashKey) -> Result<ArcDynDbView, api::Error> {
         self.manager.view(root_hash).map_err(Into::into)
@@ -372,9 +496,7 @@ impl<H: HashMode> Db<H> {
         verify_change_proof_root_hash(proof, &verification, &proposal)?;
         Ok(proposal)
     }
-}
 
-impl Db<DefaultHashMode> {
     /// Reconstruct a view from a parent view by applying batch operations.
     ///
     /// Reconstruction is currently always applied serially.
@@ -387,13 +509,15 @@ impl Db<DefaultHashMode> {
         parent: &CommittedView,
         batch: impl IntoBatchIter,
     ) -> Result<ReconstructedView<'_>, api::Error> {
-        let next_nodestore = parent.nodestore.reconstruction_child()?;
-        let mutable_nodestore =
-            RevisionManager::<DefaultHashMode>::apply_batch_recon(next_nodestore, batch)?;
+        // A `CommittedView` can only be produced by a database of its own hash
+        // mode, so a mismatch here means handles from two databases were mixed.
+        debug_assert_eq!(parent.nodestore.node_hash_algorithm(), H::ALGORITHM);
+        let nodestore =
+            Arc::clone(&parent.nodestore).begin_reconstruction(api::collect_owned_batch(batch)?)?;
 
         Ok(ReconstructedView {
             db: self,
-            nodestore: Arc::new(mutable_nodestore.into()),
+            nodestore,
         })
     }
 
@@ -407,27 +531,19 @@ impl Db<DefaultHashMode> {
     /// Returns an error if reconstruction fails.
     fn reconstruct_from_reconstructed(
         &self,
-        parent: Arc<
-            NodeStore<Reconstructed<FileBacked, DefaultHashMode>, FileBacked, DefaultHashMode>,
-        >,
+        parent: api::ArcDynReconstructed,
         batch: impl IntoBatchIter,
     ) -> Result<ReconstructedView<'_>, api::Error> {
-        let next_nodestore: NodeStore<
-            Mutable<Recon<FileBacked, DefaultHashMode>>,
-            FileBacked,
-            DefaultHashMode,
-        > = parent.into();
-        let mutable_nodestore =
-            RevisionManager::<DefaultHashMode>::apply_batch_recon(next_nodestore, batch)?;
+        // See `reconstruct_from_view`: a mismatch means mixed-database handles.
+        debug_assert_eq!(parent.node_hash_algorithm(), H::ALGORITHM);
+        let nodestore = parent.reconstruct_next(api::collect_owned_batch(batch)?)?;
 
         Ok(ReconstructedView {
             db: self,
-            nodestore: Arc::new(mutable_nodestore.into()),
+            nodestore,
         })
     }
-}
 
-impl<H: HashMode> Db<H> {
     /// Generate a change proof between two revisions identified by their root hashes.
     ///
     /// Returns the proof that covers key-value changes between `start_hash` and
@@ -494,25 +610,66 @@ pub struct Proposal<'db, H> {
 /// Opaque handle to a historical committed revision.
 ///
 /// Use this as the parent argument to [`Db::reconstruct_from_view`]. The
-/// handle remains pinned to the compile-selected mode so this refactor
-/// preserves the existing reconstruction API.
+/// revision's hash mode is erased so the handle works for every mode without
+/// naming it.
 pub struct CommittedView {
-    nodestore: Arc<NodeStore<Committed, FileBacked, DefaultHashMode>>,
+    nodestore: api::ArcDynCommittedRevision,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 /// A user-visible reconstructed view.
+///
+/// The reconstructed state's hash mode is erased so the view can be produced
+/// from a runtime-selected `Db<H>` in any hash mode without naming `H`.
 pub struct ReconstructedView<'db> {
-    nodestore:
-        Arc<NodeStore<Reconstructed<FileBacked, DefaultHashMode>, FileBacked, DefaultHashMode>>,
-    db: &'db Db<DefaultHashMode>,
+    nodestore: api::ArcDynReconstructed,
+    db: &'db dyn api::DynDb,
+}
+
+impl Clone for ReconstructedView<'_> {
+    fn clone(&self) -> Self {
+        Self {
+            nodestore: self.nodestore.clone(),
+            db: self.db,
+        }
+    }
 }
 
 impl ReconstructedView<'_> {
     /// Returns the view backing this reconstructed state.
     #[must_use]
     pub fn view(&self) -> ArcDynDbView {
-        self.nodestore.clone()
+        Arc::clone(&self.nodestore) as ArcDynDbView
+    }
+}
+
+// The erased reconstruction capabilities. These blanket impls cover every
+// hash mode `H`, which is what lets the non-generic `CommittedView` and
+// `ReconstructedView` handles work for any mode.
+impl<H: HashMode> api::DynCommittedRevision for NodeStore<Committed, FileBacked, H> {
+    fn begin_reconstruction(
+        self: Arc<Self>,
+        batch: api::OwnedBatch,
+    ) -> Result<api::ArcDynReconstructed, api::Error> {
+        let mutable = self.reconstruction_child()?;
+        let mutable = RevisionManager::<H>::apply_batch_recon(mutable, batch)?;
+        let reconstructed: NodeStore<Reconstructed<FileBacked, H>, FileBacked, H> = mutable.into();
+        Ok(Arc::new(reconstructed))
+    }
+}
+
+impl<H: HashMode> api::DynReconstructed for NodeStore<Reconstructed<FileBacked, H>, FileBacked, H> {
+    fn reconstruct_next(
+        self: Arc<Self>,
+        batch: api::OwnedBatch,
+    ) -> Result<api::ArcDynReconstructed, api::Error> {
+        // Convert through `From<Arc<NodeStore<Reconstructed<_>, _, _>>>` so a
+        // uniquely-held `Arc` moves the in-memory root (`Arc::try_unwrap` fast
+        // path) instead of deep-cloning the subtree on every chain step.
+        let mutable: NodeStore<Mutable<Recon<FileBacked, H>>, FileBacked, H> = self.into();
+        let mutable = RevisionManager::<H>::apply_batch_recon(mutable, batch)?;
+        let reconstructed: NodeStore<Reconstructed<FileBacked, H>, FileBacked, H> = mutable.into();
+        Ok(Arc::new(reconstructed))
     }
 }
 
@@ -565,6 +722,72 @@ impl<'db, H: HashMode> api::Proposal for Proposal<'db, H> {
 
     fn commit(self) -> Result<(), api::Error> {
         Ok(self.db.manager.commit(self.nodestore)?)
+    }
+}
+
+// The dyn boundary for proposals. A borrowing `Proposal<'_, H>` cannot be
+// `DynDbView` (that trait is `'static`), so its read surface is mirrored here
+// by delegating to the proposal's `DbView` impl, and `view()` exposes the
+// `'static` `ArcDynDbView` for the iterator/reconstruct paths.
+impl<'db, H: HashMode> api::DynProposal<'db> for Proposal<'db, H> {
+    fn root_hash(&self) -> Option<HashKey> {
+        api::DbView::root_hash(self)
+    }
+
+    fn val(&self, key: &[u8]) -> Result<Option<Value>, api::Error> {
+        api::DbView::val(self, key)
+    }
+
+    fn single_key_proof(&self, key: &[u8]) -> Result<FrozenProof, api::Error> {
+        api::DbView::single_key_proof(self, key)
+    }
+
+    fn range_proof(
+        &self,
+        first_key: Option<&[u8]>,
+        last_key: Option<&[u8]>,
+        limit: Option<NonZeroUsize>,
+    ) -> Result<FrozenRangeProof, api::Error> {
+        api::DbView::range_proof(self, first_key, last_key, limit)
+    }
+
+    fn iter_option(
+        &self,
+        first_key: Option<&[u8]>,
+    ) -> Result<api::BoxKeyValueIter<'_>, api::Error> {
+        // NOTE: `Result::map` does not work here because the compiler cannot
+        // correctly infer the unsizing coercion (see the `DynDbView` blanket).
+        match api::DbView::iter_option(self, first_key) {
+            Ok(iter) => Ok(Box::new(iter)),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn dump_to_string(&self) -> Result<String, api::Error> {
+        api::DbView::dump_to_string(self)
+    }
+
+    fn view(&self) -> ArcDynDbView {
+        Proposal::view(self)
+    }
+
+    fn propose(
+        &self,
+        ops: api::OwnedBatch,
+    ) -> Result<Box<dyn api::DynProposal<'db> + 'db>, api::Error> {
+        // `create_proposal` builds a fresh nodestore borrowing the parent
+        // `Db<H>` (lifetime `'db`), not `self`, so the result genuinely lives
+        // for `'db` even though it is created through `&self`.
+        let proposal = self.create_proposal(ops)?;
+        Ok(Box::new(proposal))
+    }
+
+    fn commit(self: Box<Self>) -> Result<(), api::Error> {
+        api::Proposal::commit(*self)
+    }
+
+    fn commit_with_rebase(self: Box<Self>) -> Result<Option<HashKey>, api::Error> {
+        Proposal::commit_with_rebase(*self)
     }
 }
 
@@ -656,27 +879,24 @@ impl<H: HashMode> Proposal<'_, H> {
 
 impl api::DbView for ReconstructedView<'_> {
     type Iter<'view>
-        = MerkleKeyValueIter<
-        'view,
-        NodeStore<Reconstructed<FileBacked, DefaultHashMode>, FileBacked, DefaultHashMode>,
-    >
+        = api::BoxKeyValueIter<'view>
     where
         Self: 'view;
 
     fn node_hash_algorithm(&self) -> NodeHashAlgorithm {
-        DefaultHashMode::ALGORITHM
+        self.nodestore.node_hash_algorithm()
     }
 
     fn root_hash(&self) -> Option<api::HashKey> {
-        api::DbView::root_hash(&*self.nodestore)
+        self.nodestore.root_hash()
     }
 
     fn val<K: KeyType>(&self, key: K) -> Result<Option<Value>, api::Error> {
-        api::DbView::val(&*self.nodestore, key)
+        self.nodestore.val(key.as_ref())
     }
 
     fn single_key_proof<K: KeyType>(&self, key: K) -> Result<FrozenProof, api::Error> {
-        api::DbView::single_key_proof(&*self.nodestore, key)
+        self.nodestore.single_key_proof(key.as_ref())
     }
 
     fn range_proof<K: KeyType>(
@@ -685,18 +905,25 @@ impl api::DbView for ReconstructedView<'_> {
         last_key: Option<K>,
         limit: Option<NonZeroUsize>,
     ) -> Result<FrozenRangeProof, api::Error> {
-        api::DbView::range_proof(&*self.nodestore, first_key, last_key, limit)
+        self.nodestore.range_proof(
+            first_key.as_ref().map(AsRef::as_ref),
+            last_key.as_ref().map(AsRef::as_ref),
+            limit,
+        )
     }
 
     fn iter_option<K: KeyType>(&self, first_key: Option<K>) -> Result<Self::Iter<'_>, api::Error> {
-        api::DbView::iter_option(&*self.nodestore, first_key)
+        self.nodestore
+            .iter_option(first_key.as_ref().map(AsRef::as_ref))
     }
 
     fn dump_to_string(&self) -> Result<String, api::Error> {
-        api::DbView::dump_to_string(&*self.nodestore)
+        self.nodestore.dump_to_string()
     }
 }
 
+// The owning database is reached through the erased [`api::DynDb`] so
+// reconstruction works off a runtime-selected `Db<H>` in any hash mode.
 impl<'a> api::Reconstructible for ReconstructedView<'a> {
     type Reconstructed = ReconstructedView<'a>;
 
@@ -704,11 +931,12 @@ impl<'a> api::Reconstructible for ReconstructedView<'a> {
     where
         Self: Sized,
     {
-        self.db
-            .reconstruct_from_reconstructed(self.nodestore, batch)
+        let ops = api::collect_owned_batch(batch)?;
+        let db = self.db;
+        db.reconstruct_from_reconstructed(self, ops)
     }
 
-    fn db(&self) -> &Db<DefaultHashMode> {
+    fn db(&self) -> &dyn api::DynDb {
         self.db
     }
 }
@@ -732,7 +960,7 @@ mod test {
     use crate::db::{Db, Proposal, UseParallel};
     use crate::manager::RevisionManagerConfig;
 
-    use super::{BatchOp, DbConfig};
+    use super::{BatchOp, DbConfig, open};
 
     /// A chunk of an iterator, provided by [`IterExt::chunk_fold`] to the folding
     /// function.
@@ -775,6 +1003,175 @@ mod test {
         fn wait_persisted(&self) {
             self.manager.wait_persisted();
         }
+    }
+
+    fn runtime_mode_puts(pairs: &[(&str, &str)]) -> api::OwnedBatch {
+        pairs
+            .iter()
+            .map(|(key, value)| BatchOp::Put {
+                key: key.as_bytes().into(),
+                value: value.as_bytes().into(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn runtime_hash_modes_work_side_by_side() {
+        let ethereum_dir = tempfile::tempdir().unwrap();
+        let ethereum_db = open(
+            ethereum_dir.path(),
+            DbConfig::builder()
+                .node_hash_algorithm(NodeHashAlgorithm::Ethereum)
+                .build(),
+        )
+        .unwrap();
+
+        let merkledb_dir = tempfile::tempdir().unwrap();
+        let merkledb_db = open(
+            merkledb_dir.path(),
+            DbConfig::builder()
+                .node_hash_algorithm(NodeHashAlgorithm::MerkleDB)
+                .build(),
+        )
+        .unwrap();
+
+        // Both implementations remain live behind the same object-safe interface.
+        assert_eq!(
+            ethereum_db.node_hash_algorithm(),
+            NodeHashAlgorithm::Ethereum
+        );
+        assert_eq!(
+            ethereum_db.root_hash().map(hex::encode).as_deref(),
+            Some("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
+        );
+
+        assert_eq!(
+            merkledb_db.node_hash_algorithm(),
+            NodeHashAlgorithm::MerkleDB
+        );
+        assert_eq!(merkledb_db.root_hash(), None);
+
+        ethereum_db
+            .propose(runtime_mode_puts(&[("a", "1")]))
+            .unwrap()
+            .commit()
+            .unwrap();
+        merkledb_db
+            .propose(runtime_mode_puts(&[("a", "1")]))
+            .unwrap()
+            .commit()
+            .unwrap();
+
+        let ethereum_root = ethereum_db.root_hash().expect("committed trie has a root");
+        assert_eq!(
+            hex::encode(ethereum_root.clone()),
+            "59b697a4db0c475540486215c1e8f64945a4a0ad8d291de6cd9021c4fbf639dd"
+        );
+        let ethereum_proof = ethereum_db
+            .view(ethereum_root)
+            .unwrap()
+            .range_proof(None, None, None)
+            .unwrap();
+        assert_eq!(ethereum_proof.hash_mode(), NodeHashAlgorithm::Ethereum);
+
+        let merkledb_root = merkledb_db.root_hash().expect("committed trie has a root");
+        assert_eq!(
+            hex::encode(merkledb_root.clone()),
+            "1ffe11ce995a9c07021d6f8a8c5b1817e6375dd0ea27296b91a8d48db2858bc9"
+        );
+        let merkledb_proof = merkledb_db
+            .view(merkledb_root)
+            .unwrap()
+            .range_proof(None, None, None)
+            .unwrap();
+        assert_eq!(merkledb_proof.hash_mode(), NodeHashAlgorithm::MerkleDB);
+
+        ethereum_db.close().unwrap();
+        merkledb_db.close().unwrap();
+
+        // The persisted header restores the selected algorithm and root.
+        let ethereum_db = open(
+            ethereum_dir.path(),
+            DbConfig::builder()
+                .node_hash_algorithm(NodeHashAlgorithm::Ethereum)
+                .build(),
+        )
+        .unwrap();
+        assert_eq!(
+            ethereum_db.node_hash_algorithm(),
+            NodeHashAlgorithm::Ethereum
+        );
+        assert_eq!(
+            ethereum_db.root_hash().map(hex::encode).as_deref(),
+            Some("59b697a4db0c475540486215c1e8f64945a4a0ad8d291de6cd9021c4fbf639dd")
+        );
+
+        let merkledb_db = open(
+            merkledb_dir.path(),
+            DbConfig::builder()
+                .node_hash_algorithm(NodeHashAlgorithm::MerkleDB)
+                .build(),
+        )
+        .unwrap();
+        assert_eq!(
+            merkledb_db.node_hash_algorithm(),
+            NodeHashAlgorithm::MerkleDB
+        );
+        assert_eq!(
+            merkledb_db.root_hash().map(hex::encode).as_deref(),
+            Some("1ffe11ce995a9c07021d6f8a8c5b1817e6375dd0ea27296b91a8d48db2858bc9")
+        );
+
+        ethereum_db.close().unwrap();
+        merkledb_db.close().unwrap();
+    }
+
+    #[test]
+    fn reconstructed_views_preserve_runtime_hash_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open(
+            dir.path(),
+            DbConfig::builder()
+                .node_hash_algorithm(DefaultHashMode::ALGORITHM)
+                .build(),
+        )
+        .unwrap();
+
+        db.propose(runtime_mode_puts(&[("a", "1")]))
+            .unwrap()
+            .commit()
+            .unwrap();
+
+        let root = db.root_hash().expect("committed trie has a root");
+        let committed = db
+            .committed_view(root)
+            .unwrap()
+            .expect("root is a committed revision");
+        let reconstructed = db
+            .reconstruct_from_view(&committed, runtime_mode_puts(&[]))
+            .unwrap();
+        assert_eq!(
+            reconstructed.node_hash_algorithm(),
+            DefaultHashMode::ALGORITHM
+        );
+
+        let reconstructed = reconstructed
+            .reconstruct(runtime_mode_puts(&[("b", "2")]))
+            .unwrap();
+        assert_eq!(
+            reconstructed.node_hash_algorithm(),
+            DefaultHashMode::ALGORITHM
+        );
+        assert_eq!(
+            reconstructed.val(b"a").unwrap().as_deref(),
+            Some(b"1".as_slice())
+        );
+        assert_eq!(
+            reconstructed.val(b"b").unwrap().as_deref(),
+            Some(b"2".as_slice())
+        );
+
+        db.close().unwrap();
     }
 
     /// Reconstruction always uses the serial path (`apply_batch_recon`), but the base
@@ -1999,7 +2396,16 @@ mod test {
     fn test_nonexistent_directory() {
         let tmpdir = tempfile::tempdir().unwrap();
 
-        assert!(Db::new(tmpdir, DbConfig::builder().create_if_missing(false).build()).is_err());
+        assert!(
+            Db::<DefaultHashMode>::new_with_hash_mode(
+                tmpdir,
+                DbConfig::builder()
+                    .node_hash_algorithm(DefaultHashMode::ALGORITHM)
+                    .create_if_missing(false)
+                    .build(),
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -2013,7 +2419,7 @@ mod test {
             .node_hash_algorithm(configured_algorithm)
             .build();
 
-        let error = Db::new(tmpdir.path(), config).unwrap_err();
+        let error = Db::<DefaultHashMode>::new_with_hash_mode(tmpdir.path(), config).unwrap_err();
         assert!(matches!(
             error,
             api::Error::HashModeMismatch {
@@ -2377,12 +2783,17 @@ mod test {
 
     impl TestDb {
         pub fn new() -> Self {
-            TestDb::new_with_config(DbConfig::builder().build())
+            TestDb::new_with_config(
+                DbConfig::builder()
+                    .node_hash_algorithm(DefaultHashMode::ALGORITHM)
+                    .build(),
+            )
         }
 
         pub fn new_with_config(dbconfig: DbConfig) -> Self {
             let tmpdir = tempfile::tempdir().unwrap();
-            let db = Db::new(tmpdir.as_ref(), dbconfig.clone()).unwrap();
+            let db = Db::<DefaultHashMode>::new_with_hash_mode(tmpdir.as_ref(), dbconfig.clone())
+                .unwrap();
             TestDb {
                 db: Some(db),
                 tmpdir,
@@ -2397,7 +2808,11 @@ mod test {
         pub fn reopen(mut self) -> Self {
             self.db.take().unwrap().close().unwrap();
 
-            let db = Db::new(self.tmpdir.path(), self.dbconfig.clone()).unwrap();
+            let db = Db::<DefaultHashMode>::new_with_hash_mode(
+                self.tmpdir.path(),
+                self.dbconfig.clone(),
+            )
+            .unwrap();
             self.db = Some(db);
             self
         }
@@ -2414,8 +2829,15 @@ mod test {
         pub fn replace(mut self) -> Self {
             self.db.take().unwrap().close().unwrap();
 
-            self.dbconfig = DbConfig::builder().truncate(true).build();
-            let db = Db::new(self.tmpdir.path(), self.dbconfig.clone()).unwrap();
+            self.dbconfig = DbConfig::builder()
+                .node_hash_algorithm(DefaultHashMode::ALGORITHM)
+                .truncate(true)
+                .build();
+            let db = Db::<DefaultHashMode>::new_with_hash_mode(
+                self.tmpdir.path(),
+                self.dbconfig.clone(),
+            )
+            .unwrap();
             self.db = Some(db);
             self
         }

--- a/firewood/src/eth_proof.rs
+++ b/firewood/src/eth_proof.rs
@@ -17,7 +17,6 @@
 use firewood_storage::{
     NodeHashAlgorithm, PackedPathRef, PathComponent, TriePathFromPackedBytes, ValueDigest,
 };
-#[cfg(feature = "ethhash")]
 use firewood_storage::{RlpList, TrieHash};
 
 use crate::api::{DbView, Error, HashKey, HashKeyExt};
@@ -49,7 +48,6 @@ const KECCAK_EMPTY: [u8; 32] = [
 /// if any of the first four account fields is not encoded as bytes. Returns
 /// [`ProofError::InvalidAccountCodeHashLength`] if the `codeHash` field is not
 /// 32 bytes.
-#[cfg(feature = "ethhash")]
 pub fn account_code_hash(value: &[u8]) -> Result<Option<HashKey>, ProofError> {
     let code_hash_slice = RlpList::parse(value)
         .and_then(|list| list.nth_bytes(3))
@@ -144,13 +142,14 @@ pub struct EthStorageProof {
 ///   error if the on-disk account value cannot be parsed.
 pub fn eth_get_proof<V>(
     view: &V,
+    algorithm: NodeHashAlgorithm,
     account_key: &[u8; 32],
     storage_keys: &[[u8; 32]],
 ) -> Result<EthProof, Error>
 where
     V: DbView + ?Sized,
 {
-    if !NodeHashAlgorithm::compile_option().is_ethereum() {
+    if !algorithm.is_ethereum() {
         return Err(Error::FeatureNotSupported(
             "eth_get_proof requires ethereum hash mode".into(),
         ));
@@ -422,19 +421,25 @@ fn nibbles_match_packed(nibbles: &[PathComponent], packed: &[u8]) -> bool {
     nibbles.iter().copied().eq(packed_ref)
 }
 
-/// The negative half of [`eth_get_proof`]'s runtime mode gate: a merkledb-mode
-/// (non-ethhash) build must refuse to emit eth proofs. The positive half lives
-/// in the `ethhash`-gated `tests` module below.
-#[cfg(all(test, not(feature = "ethhash")))]
+/// The negative half of [`eth_get_proof`]'s runtime mode gate: passing the
+/// MerkleDB algorithm must refuse to emit eth proofs. Now that the algorithm is
+/// a runtime argument this runs in both feature configs. The positive half
+/// lives in the `ethhash`-gated `tests` module below.
+#[cfg(test)]
 mod merkledb_gate_tests {
     use super::*;
     use crate::merkle::tests::init_merkle;
 
     #[test]
-    fn eth_get_proof_rejected_without_ethhash() {
+    fn eth_get_proof_rejected_in_merkledb_mode() {
         let merkle = init_merkle(std::iter::empty::<(&[u8], &[u8])>());
-        let err = eth_get_proof(merkle.nodestore(), &[0u8; 32], &[])
-            .expect_err("merkledb-mode database must not emit eth proofs");
+        let err = eth_get_proof(
+            merkle.nodestore(),
+            NodeHashAlgorithm::MerkleDB,
+            &[0u8; 32],
+            &[],
+        )
+        .expect_err("merkledb-mode database must not emit eth proofs");
         assert!(
             matches!(err, Error::FeatureNotSupported(_)),
             "expected FeatureNotSupported, got {err:?}"
@@ -475,12 +480,11 @@ mod tests {
         ])
     }
 
-    /// Confirm an ethhash build passes the runtime mode gate. The gate's
-    /// *negative* path is covered by `merkledb_gate_tests` below, which only
-    /// compiles without the `ethhash` feature.
+    /// Confirm the runtime mode gate accepts the Ethereum algorithm (the
+    /// positive path). The negative path is covered by `merkledb_gate_tests`.
     #[test]
     fn mode_gate_passes_under_ethhash() {
-        assert!(NodeHashAlgorithm::compile_option().is_ethereum());
+        assert!(NodeHashAlgorithm::Ethereum.is_ethereum());
     }
 
     /// `KECCAK_EMPTY` is a hardcoded literal; confirm it really is
@@ -524,7 +528,8 @@ mod tests {
         // Empty trie; ask for any account.
         let merkle = init_merkle(std::iter::empty::<(&[u8], &[u8])>());
         let key = [0x11u8; 32];
-        let proof = eth_get_proof(merkle.nodestore(), &key, &[]).unwrap();
+        let proof =
+            eth_get_proof(merkle.nodestore(), NodeHashAlgorithm::Ethereum, &key, &[]).unwrap();
         assert_eq!(proof.nonce, 0);
         assert_eq!(proof.balance, [0u8; 32]);
         assert_eq!(proof.code_hash, KECCAK_EMPTY);
@@ -540,7 +545,8 @@ mod tests {
         let balance = [0x12, 0x34];
         let value = account_rlp(7, &balance);
         let merkle = init_merkle([(key.as_slice(), value.as_ref())]);
-        let proof = eth_get_proof(merkle.nodestore(), &key, &[]).unwrap();
+        let proof =
+            eth_get_proof(merkle.nodestore(), NodeHashAlgorithm::Ethereum, &key, &[]).unwrap();
         assert_eq!(proof.nonce, 7);
         // balance is right-aligned in 32 bytes.
         assert_eq!(proof.balance[30..], balance);
@@ -568,7 +574,13 @@ mod tests {
         ]);
 
         // Inclusion: requested slot equals stored slot.
-        let proof = eth_get_proof(merkle.nodestore(), &account_key, &[slot_key]).unwrap();
+        let proof = eth_get_proof(
+            merkle.nodestore(),
+            NodeHashAlgorithm::Ethereum,
+            &account_key,
+            &[slot_key],
+        )
+        .unwrap();
         assert_eq!(proof.storage_proofs.len(), 1);
         let entry = &proof.storage_proofs[0];
         assert_eq!(entry.key, slot_key);
@@ -582,7 +594,13 @@ mod tests {
 
         // Exclusion: ask for a different slot under the same account.
         let other = [0xbbu8; 32];
-        let proof = eth_get_proof(merkle.nodestore(), &account_key, &[other]).unwrap();
+        let proof = eth_get_proof(
+            merkle.nodestore(),
+            NodeHashAlgorithm::Ethereum,
+            &account_key,
+            &[other],
+        )
+        .unwrap();
         let entry = &proof.storage_proofs[0];
         assert_eq!(entry.value, None);
         assert_eq!(entry.proof.len(), 1, "still emits the lone leaf node");
@@ -704,7 +722,13 @@ mod tests {
             (acc2.as_slice(), v2.as_ref()),
         ]);
 
-        let proof = eth_get_proof(merkle.nodestore(), &missing, &[]).unwrap();
+        let proof = eth_get_proof(
+            merkle.nodestore(),
+            NodeHashAlgorithm::Ethereum,
+            &missing,
+            &[],
+        )
+        .unwrap();
         assert_eq!(proof.nonce, 0);
         assert_eq!(proof.balance, [0u8; 32]);
         assert_eq!(proof.code_hash, KECCAK_EMPTY);
@@ -744,7 +768,8 @@ mod tests {
         ]);
         let root_hash = merkle.nodestore().root_hash().unwrap();
         let root: [u8; 32] = root_hash.as_ref().try_into().unwrap();
-        let proof = eth_get_proof(merkle.nodestore(), &acc1, &[]).unwrap();
+        let proof =
+            eth_get_proof(merkle.nodestore(), NodeHashAlgorithm::Ethereum, &acc1, &[]).unwrap();
         let recovered =
             mpt_proof_value(&proof.account_proof, &root, &acc1).expect("acc1 should be present");
         // The recovered bytes should match what firewood persisted for the
@@ -772,7 +797,13 @@ mod tests {
             (full_b.as_slice(), b"val-b".as_slice()),
         ]);
 
-        let proof = eth_get_proof(merkle.nodestore(), &account_key, &[slot_a, slot_b]).unwrap();
+        let proof = eth_get_proof(
+            merkle.nodestore(),
+            NodeHashAlgorithm::Ethereum,
+            &account_key,
+            &[slot_a, slot_b],
+        )
+        .unwrap();
         assert_eq!(proof.storage_proofs.len(), 2);
         assert_eq!(
             proof.storage_proofs[0].value.as_deref(),
@@ -822,7 +853,13 @@ mod tests {
         ]);
 
         // Inclusion: both slots are present and must verify end-to-end.
-        let proof = eth_get_proof(merkle.nodestore(), &account_key, &[slot_a, slot_b]).unwrap();
+        let proof = eth_get_proof(
+            merkle.nodestore(),
+            NodeHashAlgorithm::Ethereum,
+            &account_key,
+            &[slot_a, slot_b],
+        )
+        .unwrap();
         assert_eq!(proof.storage_proofs.len(), 2);
         assert_eq!(
             proof.storage_proofs[0].value.as_deref(),
@@ -851,8 +888,13 @@ mod tests {
         let mut miss_shared = [0x00u8; 32];
         miss_shared[0] = 0x02;
         let miss_other = [0xffu8; 32];
-        let proof =
-            eth_get_proof(merkle.nodestore(), &account_key, &[miss_shared, miss_other]).unwrap();
+        let proof = eth_get_proof(
+            merkle.nodestore(),
+            NodeHashAlgorithm::Ethereum,
+            &account_key,
+            &[miss_shared, miss_other],
+        )
+        .unwrap();
         for entry in &proof.storage_proofs {
             assert_eq!(
                 entry.value, None,

--- a/firewood/src/eth_proof.rs
+++ b/firewood/src/eth_proof.rs
@@ -14,13 +14,12 @@
 //! themselves. This matches go-ethereum's behavior and keeps a single
 //! error type on the public API.
 
-#[cfg(all(test, feature = "ethhash"))]
-use firewood_storage::NodeHashAlgorithm;
-use firewood_storage::{PackedPathRef, PathComponent, TriePathFromPackedBytes, ValueDigest};
-#[cfg(feature = "ethhash")]
+use firewood_storage::{
+    EthHash, HashMode, PackedPathRef, PathComponent, TriePathFromPackedBytes, ValueDigest,
+};
 use firewood_storage::{RlpList, TrieHash};
 
-use crate::api::{DbView, Error, HashKey, HashKeyExt};
+use crate::api::{DbView, Error, HashKey};
 use crate::proofs::ProofError;
 use crate::proofs::eth::{
     ACCOUNT_DEPTH_NIBBLES, AccountFields, account_storage_root_rlp, proof_node_to_mpt_rlp,
@@ -49,7 +48,6 @@ const KECCAK_EMPTY: [u8; 32] = [
 /// if any of the first four account fields is not encoded as bytes. Returns
 /// [`ProofError::InvalidAccountCodeHashLength`] if the `codeHash` field is not
 /// 32 bytes.
-#[cfg(feature = "ethhash")]
 pub fn account_code_hash(value: &[u8]) -> Result<Option<HashKey>, ProofError> {
     let code_hash_slice = RlpList::parse(value)
         .and_then(|list| list.nth_bytes(3))
@@ -85,20 +83,15 @@ pub struct EthProof {
 impl Default for EthProof {
     /// "Absent account" shape: zero `nonce` and `balance`, `code_hash` =
     /// `keccak("")` (the empty-code hash), `storage_hash` =
-    /// [`HashKey::default_root_hash`] (the empty-trie root in eth mode).
-    /// Matches what an ethereum verifier expects to see for a missing
-    /// account.
-    ///
-    /// Under merkledb mode `default_root_hash` returns `None`, so
-    /// `storage_hash` falls back to all zeros. Callers should not reach
-    /// this case — [`eth_get_proof`] gates on `is_ethereum()` before any
-    /// `EthProof` is constructed.
+    /// [`EthHash::default_root_hash`] (the Ethereum empty-trie root). This
+    /// shape is Ethereum-only: [`eth_get_proof`] gates on `is_ethereum()`
+    /// before constructing an `EthProof`.
     fn default() -> Self {
         Self {
             nonce: 0,
             balance: [0u8; 32],
             code_hash: KECCAK_EMPTY,
-            storage_hash: HashKey::default_root_hash()
+            storage_hash: EthHash::default_root_hash()
                 .as_deref()
                 .copied()
                 .unwrap_or_default(),
@@ -126,6 +119,7 @@ pub struct EthStorageProof {
 /// Trie keys here are the already-keccak-hashed 32-byte forms (firewood
 /// stores accounts at `keccak256(address)` and slots at
 /// `keccak256(address) ++ keccak256(slot_key)` — callers do the hashing).
+/// The hashing mode is obtained from [`DbView::node_hash_algorithm`].
 ///
 /// # Returns
 ///
@@ -475,13 +469,6 @@ mod tests {
             RlpItem::Bytes(&[0u8; 32]), // storageRoot — fixed up by firewood
             RlpItem::Bytes(code_hash),
         ])
-    }
-
-    /// Confirm an ethhash build passes the runtime mode gate. The gate's
-    /// *negative* path is covered by `merkledb_gate_tests` above.
-    #[test]
-    fn mode_gate_passes_under_ethhash() {
-        assert!(NodeHashAlgorithm::compile_option().is_ethereum());
     }
 
     /// `KECCAK_EMPTY` is a hardcoded literal; confirm it really is

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -157,7 +157,6 @@ pub mod proofs;
 pub mod eth_proof;
 
 // Re-export commonly used proof types at the crate root for ergonomic access
-#[cfg(feature = "ethhash")]
 pub use eth_proof::account_code_hash;
 pub use eth_proof::{EthProof, EthStorageProof, eth_get_proof};
 pub use merkle::{Key, Value, verify_change_proof_root_hash, verify_range_proof};

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -118,6 +118,8 @@
 /// Database module for Firewood.
 pub mod db;
 
+pub use db::open;
+
 /// Iterator module, for both node and key-value streams
 pub mod iter;
 
@@ -157,7 +159,6 @@ pub mod proofs;
 pub mod eth_proof;
 
 // Re-export commonly used proof types at the crate root for ergonomic access
-#[cfg(feature = "ethhash")]
 pub use eth_proof::account_code_hash;
 pub use eth_proof::{EthProof, EthStorageProof, eth_get_proof};
 pub use merkle::{Key, Value, verify_change_proof_root_hash, verify_range_proof};
@@ -185,9 +186,6 @@ pub use firewood_storage::logger;
 
 /// Hashing mode used for trie nodes.
 pub use firewood_storage::NodeHashAlgorithm;
-
-#[doc(hidden)]
-pub use firewood_storage::DefaultHashMode;
 
 /// Root or node hash used by Firewood tries.
 ///

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -169,7 +169,7 @@ impl<H: HashMode> RevisionManager<H> {
     /// [`ConfigManager::node_hash_algorithm`]; for an existing database that
     /// is the header's persisted algorithm (validated at open via
     /// `validate_open`), and for a fresh database it is the requested
-    /// algorithm.
+    /// algorithm. [`crate::db::Db::open`] selects the right `H` at runtime.
     pub fn new(config: ConfigManager) -> Result<Self, RevisionManagerError> {
         let commit_count = config.manager.deferred_persistence_commit_count.get();
         if (config.manager.max_revisions as u64) <= commit_count {

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -605,11 +605,14 @@ mod tests {
     impl TestDb {
         pub fn new() -> Self {
             let tmpdir = tempfile::tempdir().unwrap();
-            let dbconfig = DbConfig::builder().truncate(true).build();
+            let dbconfig = DbConfig::builder()
+                .node_hash_algorithm(DefaultHashMode::ALGORITHM)
+                .truncate(true)
+                .build();
             let dbpath: PathBuf = [tmpdir.path().to_path_buf(), PathBuf::from("testdb")]
                 .iter()
                 .collect();
-            let db = Db::new(dbpath, dbconfig.clone()).unwrap();
+            let db = Db::<DefaultHashMode>::new_with_hash_mode(dbpath, dbconfig).unwrap();
             TestDb { db }
         }
     }

--- a/firewood/src/merkle/tests/change/mod.rs
+++ b/firewood/src/merkle/tests/change/mod.rs
@@ -34,7 +34,13 @@ fn verify_change_proof_structure(
 
 pub(super) fn new_db() -> (Db<DefaultHashMode>, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
-    let db = Db::new(dir.path(), DbConfig::builder().build()).unwrap();
+    let db = Db::<DefaultHashMode>::new_with_hash_mode(
+        dir.path(),
+        DbConfig::builder()
+            .node_hash_algorithm(DefaultHashMode::ALGORITHM)
+            .build(),
+    )
+    .unwrap();
     (db, dir)
 }
 

--- a/firewood/src/merkle/tests/ethhash_fuzz.rs
+++ b/firewood/src/merkle/tests/ethhash_fuzz.rs
@@ -35,7 +35,9 @@ use crate::api::{
 use crate::db::{Db, DbConfig};
 use crate::merkle::{Key, Value, verify_change_proof_root_hash, verify_range_proof};
 use crate::verify_change_proof_structure;
-use firewood_storage::{DefaultHashMode, NodeHashAlgorithm, SeededRng, replace_list_field};
+use firewood_storage::{
+    DefaultHashMode, HashMode, NodeHashAlgorithm, SeededRng, replace_list_field,
+};
 use rand::seq::SliceRandom;
 
 /// An account's key paired with its sorted, distinct storage-slot bytes (byte
@@ -278,7 +280,13 @@ fn build_shaped_db(rng: &SeededRng) -> ShapedFixture {
         }
     }
     let dir = tempfile::tempdir().unwrap();
-    let db = Db::new(dir.path(), DbConfig::builder().build()).unwrap();
+    let db = Db::<DefaultHashMode>::new_with_hash_mode(
+        dir.path(),
+        DbConfig::builder()
+            .node_hash_algorithm(DefaultHashMode::ALGORITHM)
+            .build(),
+    )
+    .unwrap();
     let start_batch: Vec<BatchOp<Vec<u8>, Vec<u8>>> = state
         .iter()
         .map(|(k, v)| BatchOp::Put {

--- a/firewood/tests/two_modes.rs
+++ b/firewood/tests/two_modes.rs
@@ -1,0 +1,234 @@
+// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+//! Issue #1088 acceptance test: a single process (one binary, regardless of the
+//! `ethhash` feature) opens both an Ethereum-mode database and a MerkleDB-mode
+//! database side by side, writes the same key/value set to each, and confirms
+//! each reproduces its own frozen root vector.
+//!
+//! The root vectors are the seven-key vectors frozen in
+//! `storage/src/tries/kvp.rs` (`test_hashed_trie`, "seven keys").
+
+#![expect(clippy::unwrap_used)]
+
+use firewood::api::{DynDb, FrozenRangeProof, OwnedBatch};
+use firewood::db::{BatchOp, Db, DbConfig};
+use firewood::verify_range_proof;
+use firewood_storage::NodeHashAlgorithm;
+
+/// The shared key/value set written to both databases.
+const KVS: &[(&str, &str)] = &[
+    ("a", "1"),
+    ("ab", "2"),
+    ("ac", "3"),
+    ("b", "4"),
+    ("ba", "5"),
+    ("bb", "6"),
+    ("c", "7"),
+];
+
+/// Frozen MerkleDB (sha256) root for `KVS` via the full `Db` commit path.
+///
+/// NOTE: this differs from the storage-layer `kvp.rs` "seven keys" merkledb
+/// vector (`697e76…`). MerkleDB hashing is computed over firewood's *physical*
+/// trie structure, and the production `Db`/Merkle path builds a structurally
+/// different (but semantically equivalent) trie than the `KeyValueTrieRoot`
+/// test builder used in `kvp.rs`. The Ethereum root below is the canonical
+/// (structure-independent) MPT root, so it matches the `kvp.rs` vector and
+/// anchors trie correctness; this is the deterministic MerkleDB root the full
+/// `Db` produces for `KVS`.
+const MERKLEDB_ROOT_HEX: &str = "7d2f1289f4552d1f7b2c5cb007b3ae5296fae6d0b70de83ebe7cf0866ec7969c";
+
+/// Frozen Ethereum (keccak256) root for `KVS` (kvp.rs "seven keys").
+const ETHEREUM_ROOT_HEX: &str = "3fa832b90f7f1a053a48a4528d1e446cc679fbcf376d0ef8703748d64030e19d";
+
+fn batch() -> OwnedBatch {
+    KVS.iter()
+        .map(|(k, v)| BatchOp::Put {
+            key: k.as_bytes().into(),
+            value: v.as_bytes().into(),
+        })
+        .collect()
+}
+
+fn open(path: &std::path::Path, algorithm: NodeHashAlgorithm) -> Box<dyn DynDb> {
+    let cfg = DbConfig::builder()
+        .node_hash_algorithm(algorithm)
+        .truncate(false)
+        .build();
+    Db::open(path, algorithm, cfg).unwrap()
+}
+
+/// Create a database in `algorithm` mode, write `KVS`, and return the committed
+/// root hash (as hex).
+fn write_and_root(path: &std::path::Path, algorithm: NodeHashAlgorithm) -> String {
+    let db = open(path, algorithm);
+    let proposal = db.propose(batch()).unwrap();
+    proposal.commit().unwrap();
+    let root = db.root_hash().expect("non-empty trie has a root");
+    let hex = hex::encode(root);
+    db.close().unwrap();
+    hex
+}
+
+#[test]
+fn eth_and_merkledb_databases_open_in_one_process() {
+    let eth_dir = tempfile::tempdir().unwrap();
+    let merkledb_dir = tempfile::tempdir().unwrap();
+
+    // Both modes are constructed and written in this single process.
+    let eth_root = write_and_root(eth_dir.path(), NodeHashAlgorithm::Ethereum);
+    let merkledb_root = write_and_root(merkledb_dir.path(), NodeHashAlgorithm::MerkleDB);
+
+    assert_eq!(
+        eth_root, ETHEREUM_ROOT_HEX,
+        "ethereum database must reproduce the frozen keccak root"
+    );
+    assert_eq!(
+        merkledb_root, MERKLEDB_ROOT_HEX,
+        "merkledb database must reproduce the frozen sha256 root"
+    );
+    assert_ne!(
+        eth_root, merkledb_root,
+        "the two schemes must hash the same data differently"
+    );
+
+    // Reopening each database honors the header's persisted algorithm and
+    // reproduces the same root (header-honoring + determinism).
+    let eth_db = open(eth_dir.path(), NodeHashAlgorithm::Ethereum);
+    assert_eq!(eth_db.node_hash_algorithm(), NodeHashAlgorithm::Ethereum);
+    assert_eq!(hex::encode(eth_db.root_hash().unwrap()), ETHEREUM_ROOT_HEX);
+    eth_db.close().unwrap();
+
+    let merkledb_db = open(merkledb_dir.path(), NodeHashAlgorithm::MerkleDB);
+    assert_eq!(
+        merkledb_db.node_hash_algorithm(),
+        NodeHashAlgorithm::MerkleDB
+    );
+    assert_eq!(
+        hex::encode(merkledb_db.root_hash().unwrap()),
+        MERKLEDB_ROOT_HEX
+    );
+    merkledb_db.close().unwrap();
+}
+
+/// Canonical empty Ethereum trie root: `keccak256(0x80)` (RLP of the empty
+/// string). This is the value a fresh `Db<EthHash>` must report regardless of
+/// the binary's `ethhash` feature.
+const ETHEREUM_EMPTY_ROOT_HEX: &str =
+    "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421";
+
+/// Cross-mode proof regression guard (majors #1/#2): in one process, generate a
+/// range proof and a single-key proof from BOTH a `Db<EthHash>` and a
+/// `Db<MerkleDbHash>`, assert each carries its DB's runtime `hash_mode()`, and
+/// round-trip-verify each (serialize -> `from_slice` -> verify with the DB's
+/// mode). A mode pin to the compile default would either mis-stamp the proof
+/// (failing the `hash_mode` assertion) or encode the wrong wire format (failing
+/// round-trip verification / panicking on a cross-mode inline-RLP child).
+#[test]
+fn cross_mode_proofs_roundtrip_in_one_process() {
+    let eth_dir = tempfile::tempdir().unwrap();
+    let merkledb_dir = tempfile::tempdir().unwrap();
+
+    // Populate both databases with the same data.
+    let _ = write_and_root(eth_dir.path(), NodeHashAlgorithm::Ethereum);
+    let _ = write_and_root(merkledb_dir.path(), NodeHashAlgorithm::MerkleDB);
+
+    for (dir, algorithm) in [
+        (eth_dir.path(), NodeHashAlgorithm::Ethereum),
+        (merkledb_dir.path(), NodeHashAlgorithm::MerkleDB),
+    ] {
+        let db = open(dir, algorithm);
+        let root = db.root_hash().expect("non-empty trie has a root");
+        let view = db.view(root.clone()).unwrap();
+
+        // --- Range proof over the full key set ---
+        let range_proof = view.range_proof(None, None, None).unwrap();
+        assert_eq!(
+            range_proof.hash_mode(),
+            algorithm,
+            "range proof must be stamped with the source DB's runtime mode ({algorithm:?})",
+        );
+
+        // Round-trip through the self-describing wire format.
+        let mut bytes = Vec::new();
+        range_proof.write_to_vec(&mut bytes);
+        let parsed = FrozenRangeProof::from_slice(&bytes)
+            .expect("range proof must round-trip through its own wire format");
+        assert_eq!(
+            parsed.hash_mode(),
+            algorithm,
+            "parsed range proof must resolve the same mode from its header",
+        );
+
+        // Verify the parsed proof against the DB's root using the DB's mode.
+        verify_range_proof(None::<&[u8]>, None::<&[u8]>, &root, algorithm, &parsed)
+            .expect("cross-mode range proof must verify with the DB's mode");
+
+        // --- Single-key proof (guards the emission/value-digest path) ---
+        let &(probe_key, probe_value) = KVS.first().expect("KVS is non-empty");
+        let single = view.single_key_proof(probe_key.as_bytes()).unwrap();
+        single
+            .verify(
+                probe_key.as_bytes(),
+                Some(probe_value.as_bytes()),
+                &root,
+                algorithm,
+            )
+            .expect("cross-mode single-key inclusion proof must verify with the DB's mode");
+
+        db.close().unwrap();
+    }
+}
+
+/// Empty-trie root regression guard (major #4): in one binary, a fresh
+/// `Db<EthHash>` reports `Some(keccak256(0x80))` and a fresh `Db<MerkleDbHash>`
+/// reports `None`. A compile-default empty-root resolution would report the
+/// wrong value for the non-default mode.
+#[test]
+fn empty_trie_root_per_mode() {
+    let eth_dir = tempfile::tempdir().unwrap();
+    let merkledb_dir = tempfile::tempdir().unwrap();
+
+    let eth_db = open(eth_dir.path(), NodeHashAlgorithm::Ethereum);
+    let eth_root = eth_db
+        .root_hash()
+        .expect("empty Ethereum trie reports the keccak256(0x80) empty root");
+    assert_eq!(
+        hex::encode(eth_root),
+        ETHEREUM_EMPTY_ROOT_HEX,
+        "empty Db<EthHash> must report the canonical Ethereum empty root",
+    );
+    eth_db.close().unwrap();
+
+    let merkledb_db = open(merkledb_dir.path(), NodeHashAlgorithm::MerkleDB);
+    assert!(
+        merkledb_db.root_hash().is_none(),
+        "empty Db<MerkleDbHash> must report None for its empty root",
+    );
+    merkledb_db.close().unwrap();
+}
+
+/// Opening a database with the wrong requested algorithm must be rejected by the
+/// header-vs-requested `validate_open` gate.
+#[test]
+fn opening_with_wrong_algorithm_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Create a MerkleDB database.
+    let _ = write_and_root(dir.path(), NodeHashAlgorithm::MerkleDB);
+
+    // Re-opening it as Ethereum must fail (header says MerkleDB).
+    let cfg = DbConfig::builder()
+        .node_hash_algorithm(NodeHashAlgorithm::Ethereum)
+        .create_if_missing(false)
+        .truncate(false)
+        .build();
+    let err = Db::open(dir.path(), NodeHashAlgorithm::Ethereum, cfg)
+        .expect_err("opening a MerkleDB database as Ethereum must fail");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("mismatch") || msg.contains("Unsupported"),
+        "expected a hash-algorithm mismatch error, got: {msg}"
+    );
+}

--- a/fwdctl/README.md
+++ b/fwdctl/README.md
@@ -22,6 +22,8 @@ To use
 * `fwdctl delete`: Delete a key/value pair from the database.
 * `fwdctl root`: Get the root hash of the key/value trie.
 * `fwdctl dump`: Dump the contents of the key/value store.
+* `fwdctl import`: Import key/value pairs into an existing database.
+* `fwdctl replay`: Replay recorded operations against an existing database.
 * `fwdctl launch` (requires `--features launch`): Launch and manage AWS benchmark runs.
 
 ## Key input modes
@@ -78,11 +80,17 @@ For full launch usage, defaults, and scenario configuration, see [README.launch.
 * fwdctl create
 
 ```sh
-# Check available options when creating a database, including the defaults.
+# Check available options when creating a database.
 $ fwdctl create -h
-# Create a new, blank instance of firewood using the default directory name "firewood".
-$ fwdctl create firewood
+# Create a new MerkleDB-compatible database in the default "firewood" directory.
+$ fwdctl create --hash-mode merkle-db
+# Create an Ethereum-compatible database at a specific path.
+$ fwdctl create --db eth-firewood --hash-mode ethereum
 ```
+
+The hashing mode is required when creating a database and is persisted in its
+header. All other commands, including `import` and `replay`, require an existing
+database and detect its hashing mode from that header.
 
 * fwdctl get KEY
 

--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -9,8 +9,8 @@ use askama::Template;
 use clap::Args;
 use firewood::api;
 use firewood_storage::{
-    CacheReadStrategy, CheckOpt, DBStats, DefaultHashMode, DeletedNodeTracking, FileBacked,
-    NodeStore, NodeStoreHeader,
+    CacheReadStrategy, CheckOpt, DBStats, DeletedNodeTracking, EthHash, FileBacked, HashMode,
+    MerkleDbHash, NodeHashAlgorithm, NodeStore, NodeStoreHeader,
 };
 use indicatif::{ProgressBar, ProgressFinish, ProgressStyle};
 use nonzero_ext::nonzero;
@@ -44,6 +44,13 @@ pub struct Options {
 }
 
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
+    match opts.database.node_hash_algorithm()? {
+        NodeHashAlgorithm::Ethereum => run_with_hash_mode::<EthHash>(opts),
+        NodeHashAlgorithm::MerkleDB => run_with_hash_mode::<MerkleDbHash>(opts),
+    }
+}
+
+fn run_with_hash_mode<H: HashMode>(opts: &Options) -> Result<(), api::Error> {
     let db_path = PathBuf::from(&opts.database.dbpath).join("firewood.db");
     let node_cache_memory_limit = nonzero!(1usize);
     let free_list_cache_size = nonzero!(1usize);
@@ -55,7 +62,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
         false,
         false,                         // don't create if missing
         CacheReadStrategy::WritesOnly, // we scan the database once - no need to cache anything
-        opts.database.node_hash_algorithm.into(),
+        H::ALGORITHM,
     )?;
     let storage = Arc::new(fb);
 
@@ -80,8 +87,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     } else {
         DeletedNodeTracking::Enabled
     };
-    let nodestore: NodeStore<_, _, DefaultHashMode> =
-        NodeStore::open(&header, storage, deleted_node_tracking)?;
+    let nodestore: NodeStore<_, _, H> = NodeStore::open(&header, storage, deleted_node_tracking)?;
     let check_report = nodestore.check(&header, check_ops);
 
     println!("Errors ({}): ", check_report.errors.len());

--- a/fwdctl/src/create.rs
+++ b/fwdctl/src/create.rs
@@ -56,7 +56,15 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let db_config = new(opts);
     log::debug!("database configuration parameters: \n{db_config:?}\n");
 
-    let db: Box<dyn api::DynDb> = Box::new(Db::new(opts.database.dbpath.clone(), db_config)?);
+    // Use the runtime-selecting `open` so the concrete hash mode matches the
+    // requested algorithm (a fresh DB has no header to honor). `Db::new` would
+    // force `Db<DefaultHashMode>` and reject a requested mode that differs from
+    // the compile default.
+    let db = Db::open(
+        opts.database.dbpath.clone(),
+        opts.database.node_hash_algorithm.into(),
+        db_config,
+    )?;
     println!(
         "created firewood database in {}",
         opts.database.dbpath.display()

--- a/fwdctl/src/create.rs
+++ b/fwdctl/src/create.rs
@@ -1,16 +1,46 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use clap::{Args, value_parser};
+use clap::{Args, ValueEnum, value_parser};
 use firewood::api;
-use firewood::db::{Db, DbConfig};
+use firewood::db::DbConfig;
+use firewood::open;
 
 use crate::DatabasePath;
+
+// Clap-facing mirror of firewood_storage::NodeHashAlgorithm. Keeping ValueEnum
+// here avoids adding a Clap dependency to the storage crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
+enum HashModeArg {
+    #[value(name = "merkle-db")]
+    MerkleDB,
+    #[value(name = "ethereum")]
+    Ethereum,
+}
+
+impl From<HashModeArg> for firewood_storage::NodeHashAlgorithm {
+    fn from(hash_mode: HashModeArg) -> Self {
+        match hash_mode {
+            HashModeArg::MerkleDB => Self::MerkleDB,
+            HashModeArg::Ethereum => Self::Ethereum,
+        }
+    }
+}
 
 #[derive(Args, Debug)]
 pub struct Options {
     #[command(flatten)]
     pub database: DatabasePath,
+
+    /// The node hash algorithm to persist in the new database header.
+    #[arg(
+        long,
+        visible_alias = "hash-mode",
+        value_enum,
+        required = true,
+        help = "The node hash algorithm for the new database"
+    )]
+    node_hash_algorithm: HashModeArg,
 
     #[arg(
         long,
@@ -47,7 +77,7 @@ pub struct Options {
 
 pub(super) fn new(opts: &Options) -> DbConfig {
     DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(opts.node_hash_algorithm.into())
         .truncate(opts.truncate)
         .build()
 }
@@ -56,7 +86,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let db_config = new(opts);
     log::debug!("database configuration parameters: \n{db_config:?}\n");
 
-    let db = Db::new(opts.database.dbpath.clone(), db_config)?;
+    let db = open(opts.database.dbpath.clone(), db_config)?;
     println!(
         "created firewood database in {}",
         opts.database.dbpath.display()

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -2,8 +2,9 @@
 // See the file LICENSE.md for licensing terms.
 
 use clap::Args;
-use firewood::api::{self, Db as _, Proposal as _};
-use firewood::db::{BatchOp, Db, DbConfig};
+use firewood::api;
+use firewood::db::{BatchOp, DbConfig};
+use firewood::open;
 
 use crate::{DatabasePath, key::KeyArgument};
 
@@ -20,14 +21,17 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("deleting key {opts:?}");
     let key = opts.key.database_key()?;
     let hex_key = hex::encode(&key);
+    let algorithm = opts.database.node_hash_algorithm()?;
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(algorithm)
         .create_if_missing(false)
         .truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
+    let db = open(opts.database.dbpath.clone(), cfg.build())?;
 
-    let batch: Vec<BatchOp<Vec<u8>, Vec<u8>>> = vec![BatchOp::Delete { key }];
+    let batch: api::OwnedBatch = Box::new([BatchOp::Delete {
+        key: key.into_boxed_slice(),
+    }]);
     let proposal = db.propose(batch)?;
     proposal.commit()?;
 

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -20,12 +20,13 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("deleting key {opts:?}");
     let key = opts.key.database_key()?;
     let hex_key = hex::encode(&key);
+    let algorithm = opts.database.resolve_node_hash_algorithm();
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(algorithm)
         .create_if_missing(false)
         .truncate(false);
 
-    let db: Box<dyn api::DynDb> = Box::new(Db::new(opts.database.dbpath.clone(), cfg.build())?);
+    let db = Db::open(opts.database.dbpath.clone(), algorithm, cfg.build())?;
 
     let batch: api::OwnedBatch = Box::new([BatchOp::Delete {
         key: key.into_boxed_slice(),

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -141,11 +141,12 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
         }
     }
 
+    let algorithm = opts.database.resolve_node_hash_algorithm();
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(algorithm)
         .create_if_missing(false)
         .truncate(false);
-    let db: Box<dyn DynDb> = Box::new(Db::new(opts.database.dbpath.clone(), cfg.build())?);
+    let db = Db::open(opts.database.dbpath.clone(), algorithm, cfg.build())?;
     let latest_hash = db.root_hash();
     let Some(latest_hash) = latest_hash else {
         println!("Database is empty");

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -1,11 +1,10 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 use clap::Args;
-use firewood::api::{self, Db as _};
-use firewood::db::{Db, DbConfig};
-use firewood::iter::MerkleKeyValueIter;
+use firewood::api::{self, DynDb};
+use firewood::db::DbConfig;
+use firewood::open;
 use firewood::{Key, Value};
-use firewood_storage::DefaultHashMode;
 use firewood_storage::FileIoError;
 use std::borrow::Cow;
 use std::error::Error;
@@ -143,11 +142,12 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
         }
     }
 
+    let algorithm = opts.database.node_hash_algorithm()?;
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(algorithm)
         .create_if_missing(false)
         .truncate(false);
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
+    let db = open(opts.database.dbpath.clone(), cfg.build())?;
     let latest_hash = db.root_hash();
     let Some(latest_hash) = latest_hash else {
         println!("Database is empty");
@@ -156,7 +156,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let latest_rev = db.revision(latest_hash)?;
 
     let Some(mut output_handler) =
-        create_output_handler(opts, &db).expect("Error creating output handler")
+        create_output_handler(opts, db.as_ref()).expect("Error creating output handler")
     else {
         // dot format is generated in the handler
         return db.close();
@@ -170,7 +170,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let stop_key = opts.stop_key.clone().or(opts.stop_key_hex.clone());
     let mut key_count: u32 = 0;
 
-    let mut iter = MerkleKeyValueIter::from_key(&latest_rev, start_key);
+    let mut iter = latest_rev.iter_option(Some(start_key.as_ref()))?;
 
     while let Some(item) = iter.next() {
         match item {
@@ -319,7 +319,7 @@ impl OutputHandler for StdoutOutputHandler {
 
 fn create_output_handler(
     opts: &Options,
-    db: &Db<DefaultHashMode>,
+    db: &dyn DynDb,
 ) -> Result<Option<Box<dyn OutputHandler + Send + Sync>>, Box<dyn Error>> {
     let hex = opts.hex;
     let mut file_name = opts.output_file_name.clone();
@@ -354,7 +354,8 @@ fn create_output_handler(
             let file = File::create(file_name)?;
             let mut writer = BufWriter::new(file);
             // For dot format, we generate the output immediately since it doesn't use streaming
-            db.dump(&mut writer)?;
+            let dot = db.dump_to_string()?;
+            std::io::Write::write_all(&mut writer, dot.as_bytes())?;
             Ok(None)
         }
     }

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -20,12 +20,13 @@ pub struct Options {
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("get key value pair {opts:?}");
     let key = opts.key.database_key()?;
+    let algorithm = opts.database.resolve_node_hash_algorithm();
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(algorithm)
         .create_if_missing(false)
         .truncate(false);
 
-    let db: Box<dyn api::DynDb> = Box::new(Db::new(opts.database.dbpath.clone(), cfg.build())?);
+    let db = Db::open(opts.database.dbpath.clone(), algorithm, cfg.build())?;
 
     let hash = db.root_hash();
 

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -3,8 +3,9 @@
 
 use clap::Args;
 
-use firewood::api::{self, Db as _, DbView as _};
-use firewood::db::{Db, DbConfig};
+use firewood::api;
+use firewood::db::DbConfig;
+use firewood::open;
 
 use crate::{DatabasePath, key::KeyArgument};
 
@@ -20,12 +21,13 @@ pub struct Options {
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("get key value pair {opts:?}");
     let key = opts.key.database_key()?;
+    let algorithm = opts.database.node_hash_algorithm()?;
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(algorithm)
         .create_if_missing(false)
         .truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
+    let db = open(opts.database.dbpath.clone(), cfg.build())?;
 
     let hash = db.root_hash();
 

--- a/fwdctl/src/graph.rs
+++ b/fwdctl/src/graph.rs
@@ -3,8 +3,9 @@
 
 use clap::Args;
 use firewood::api;
-use firewood::db::{Db, DbConfig};
-use std::io::stdout;
+use firewood::db::DbConfig;
+use firewood::open;
+use std::io::{Write, stdout};
 
 use crate::DatabasePath;
 
@@ -17,11 +18,11 @@ pub struct Options {
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("dump database {opts:?}");
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(opts.database.node_hash_algorithm()?)
         .create_if_missing(false)
         .truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
-    db.dump(&mut stdout())?;
+    let db = open(opts.database.dbpath.clone(), cfg.build())?;
+    stdout().write_all(db.dump_to_string()?.as_bytes())?;
     db.close()
 }

--- a/fwdctl/src/import.rs
+++ b/fwdctl/src/import.rs
@@ -2,9 +2,9 @@
 // See the file LICENSE.md for licensing terms.
 
 use clap::Args;
-use firewood::api::{self, Db as _, Proposal as _};
-use firewood::db::{BatchOp, Db, DbConfig};
-use firewood_storage::DefaultHashMode;
+use firewood::api::{self, DynDb};
+use firewood::db::{BatchOp, DbConfig};
+use firewood::open;
 use humantime::{format_duration, parse_duration};
 use std::fs::File;
 use std::path::PathBuf;
@@ -79,11 +79,11 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("import database {opts:?}");
 
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
-        .create_if_missing(true)
+        .node_hash_algorithm(opts.database.node_hash_algorithm()?)
+        .create_if_missing(false)
         .truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
+    let db = open(opts.database.dbpath.clone(), cfg.build())?;
 
     let reader: Box<dyn std::io::Read> = if let Some(path) = &opts.input_file_name {
         Box::new(File::open(path)?)
@@ -101,13 +101,13 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
 
     match opts.input_format {
         InputFormat::Csv => {
-            process_csv(opts, reader, &db, &mut state, start_time)?;
+            process_csv(opts, reader, db.as_ref(), &mut state, start_time)?;
         }
     }
 
     // Insert remaining ops
     if !state.batch_ops.is_empty() {
-        commit_batch(&mut state.batch_ops, &db, &mut state.total_imported)?;
+        commit_batch(&mut state.batch_ops, db.as_ref(), &mut state.total_imported)?;
     }
 
     let total_duration = start_time.elapsed();
@@ -139,7 +139,7 @@ fn parse_string(s: &str, hex: bool) -> Result<Vec<u8>, api::Error> {
 fn process_csv(
     opts: &Options,
     reader: Box<dyn std::io::Read>,
-    db: &Db<DefaultHashMode>,
+    db: &dyn DynDb,
     state: &mut ImportState,
     start_time: Instant,
 ) -> Result<(), api::Error> {
@@ -233,11 +233,11 @@ fn maybe_log_status(
 
 fn commit_batch(
     batch_ops: &mut Vec<BatchOp<Vec<u8>, Vec<u8>>>,
-    db: &Db<DefaultHashMode>,
+    db: &dyn DynDb,
     total_imported: &mut usize,
 ) -> Result<(), api::Error> {
     let remaining = batch_ops.len();
-    let proposal = db.propose(batch_ops.drain(..))?;
+    let proposal = db.propose(api::collect_owned_batch(batch_ops.drain(..))?)?;
     proposal.commit()?;
     // Use wrapping_add because overflow is practically unreachable here
     *total_imported = total_imported.wrapping_add(remaining);

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -24,12 +24,13 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("inserting key value pair {opts:?}");
     let key = opts.key.database_key()?;
     let hex_key = hex::encode(&key);
+    let algorithm = opts.database.resolve_node_hash_algorithm();
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(algorithm)
         .create_if_missing(false)
         .truncate(false);
 
-    let db: Box<dyn api::DynDb> = Box::new(Db::new(opts.database.dbpath.clone(), cfg.build())?);
+    let db = Db::open(opts.database.dbpath.clone(), algorithm, cfg.build())?;
 
     let batch: api::OwnedBatch = Box::new([BatchOp::Put {
         key: key.into_boxed_slice(),

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -2,8 +2,9 @@
 // See the file LICENSE.md for licensing terms.
 
 use clap::Args;
-use firewood::api::{self, Db as _, Proposal as _};
-use firewood::db::{BatchOp, Db, DbConfig};
+use firewood::api;
+use firewood::db::{BatchOp, DbConfig};
+use firewood::open;
 
 use crate::{DatabasePath, key::KeyArgument};
 
@@ -24,17 +25,18 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("inserting key value pair {opts:?}");
     let key = opts.key.database_key()?;
     let hex_key = hex::encode(&key);
+    let algorithm = opts.database.node_hash_algorithm()?;
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(algorithm)
         .create_if_missing(false)
         .truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
+    let db = open(opts.database.dbpath.clone(), cfg.build())?;
 
-    let batch: Vec<BatchOp<Vec<u8>, Vec<u8>>> = vec![BatchOp::Put {
-        key,
-        value: opts.value.bytes().collect(),
-    }];
+    let batch: api::OwnedBatch = Box::new([BatchOp::Put {
+        key: key.into_boxed_slice(),
+        value: opts.value.clone().into_bytes().into_boxed_slice(),
+    }]);
     let proposal = db.propose(batch)?;
     proposal.commit()?;
 

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
 use firewood::api;
 
 pub mod check;
@@ -22,33 +22,6 @@ pub mod launch;
 pub mod replay;
 pub mod root;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
-pub enum NodeHashAlgorithm {
-    #[value(name = "merkle-db")]
-    MerkleDB,
-    #[value(name = "ethereum")]
-    Ethereum,
-}
-
-impl Default for NodeHashAlgorithm {
-    fn default() -> Self {
-        if firewood_storage::NodeHashAlgorithm::compile_option().is_ethereum() {
-            NodeHashAlgorithm::Ethereum
-        } else {
-            NodeHashAlgorithm::MerkleDB
-        }
-    }
-}
-
-impl From<NodeHashAlgorithm> for firewood_storage::NodeHashAlgorithm {
-    fn from(algorithm: NodeHashAlgorithm) -> Self {
-        match algorithm {
-            NodeHashAlgorithm::MerkleDB => firewood_storage::NodeHashAlgorithm::MerkleDB,
-            NodeHashAlgorithm::Ethereum => firewood_storage::NodeHashAlgorithm::Ethereum,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Parser)]
 pub struct DatabasePath {
     /// The database path. Defaults to firewood
@@ -61,16 +34,24 @@ pub struct DatabasePath {
         help = "Name of the database directory"
     )]
     pub dbpath: PathBuf,
+}
 
-    /// The node hash algorithm to use when opening the database.
-    #[arg(
-        long,
-        value_enum,
-        required = false,
-        default_value_t = NodeHashAlgorithm::default(),
-        help = "The node hash algorithm to use when opening the database",
-    )]
-    pub node_hash_algorithm: NodeHashAlgorithm,
+impl DatabasePath {
+    /// Reads the node-hashing scheme from the existing database header.
+    ///
+    /// All commands other than `create` require a database to exist so its
+    /// persisted scheme remains the single source of truth.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database file or its header cannot be read.
+    pub(crate) fn node_hash_algorithm(
+        &self,
+    ) -> Result<firewood_storage::NodeHashAlgorithm, firewood_storage::FileIoError> {
+        firewood_storage::NodeStoreHeader::read_node_hash_algorithm_from_file(
+            self.dbpath.join("firewood.db"),
+        )
+    }
 }
 
 #[derive(Parser)]

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -22,22 +22,16 @@ pub mod launch;
 pub mod replay;
 pub mod root;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
+// The node-hashing scheme is now a per-database runtime choice. For a fresh
+// database the default is the binary's compile-time scheme (`DefaultHashMode`);
+// for an existing database the header's scheme is auto-detected and honored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, ValueEnum)]
 pub enum NodeHashAlgorithm {
+    #[default]
     #[value(name = "merkle-db")]
     MerkleDB,
     #[value(name = "ethereum")]
     Ethereum,
-}
-
-impl Default for NodeHashAlgorithm {
-    fn default() -> Self {
-        if firewood_storage::NodeHashAlgorithm::compile_option().is_ethereum() {
-            NodeHashAlgorithm::Ethereum
-        } else {
-            NodeHashAlgorithm::MerkleDB
-        }
-    }
 }
 
 impl From<NodeHashAlgorithm> for firewood_storage::NodeHashAlgorithm {
@@ -46,6 +40,17 @@ impl From<NodeHashAlgorithm> for firewood_storage::NodeHashAlgorithm {
             NodeHashAlgorithm::MerkleDB => firewood_storage::NodeHashAlgorithm::MerkleDB,
             NodeHashAlgorithm::Ethereum => firewood_storage::NodeHashAlgorithm::Ethereum,
         }
+    }
+}
+
+/// The `--hash-mode` default for a fresh database: the binary's compile-time
+/// scheme (`DefaultHashMode`). An existing database's persisted header is
+/// honored instead (see [`DatabasePath::resolve_node_hash_algorithm`]).
+const fn default_node_hash_algorithm() -> NodeHashAlgorithm {
+    use firewood_storage::HashMode;
+    match <firewood_storage::DefaultHashMode as HashMode>::ALGORITHM {
+        firewood_storage::NodeHashAlgorithm::Ethereum => NodeHashAlgorithm::Ethereum,
+        firewood_storage::NodeHashAlgorithm::MerkleDB => NodeHashAlgorithm::MerkleDB,
     }
 }
 
@@ -63,14 +68,54 @@ pub struct DatabasePath {
     pub dbpath: PathBuf,
 
     /// The node hash algorithm to use when opening the database.
+    ///
+    /// Also available under the `--hash-mode` alias. For an existing database
+    /// the header's scheme is honored; this selects the scheme for a fresh
+    /// database (or which concrete mode to open with).
     #[arg(
         long,
+        visible_alias = "hash-mode",
         value_enum,
         required = false,
-        default_value_t = NodeHashAlgorithm::default(),
+        default_value_t = default_node_hash_algorithm(),
         help = "The node hash algorithm to use when opening the database",
     )]
     pub node_hash_algorithm: NodeHashAlgorithm,
+}
+
+impl DatabasePath {
+    /// The node-hashing scheme to open the database with.
+    ///
+    /// For an existing database the persisted header scheme is auto-detected
+    /// and honored, so read commands work without the user passing
+    /// `--hash-mode`/`--node-hash-algorithm`. If the database file is absent or
+    /// cannot be read, the requested (`--hash-mode`) value is used (e.g. for a
+    /// fresh database).
+    #[must_use]
+    pub fn resolve_node_hash_algorithm(&self) -> firewood_storage::NodeHashAlgorithm {
+        use firewood_storage::{
+            CacheReadStrategy, FileBacked, NodeHashAlgorithm as StorageAlgorithm, NodeStoreHeader,
+        };
+        use nonzero_ext::nonzero;
+
+        let requested: StorageAlgorithm = self.node_hash_algorithm.into();
+        let db_file = self.dbpath.join("firewood.db");
+
+        // Peek the header read-only (no advisory lock) to learn the on-disk
+        // scheme; fall back to the requested scheme for a fresh/unreadable DB.
+        FileBacked::new(
+            db_file,
+            nonzero!(1usize),
+            nonzero!(1usize),
+            false,
+            false,
+            CacheReadStrategy::WritesOnly,
+            requested,
+        )
+        .ok()
+        .and_then(|fb| NodeStoreHeader::peek_node_hash_algorithm(&fb).ok())
+        .unwrap_or(requested)
+    }
 }
 
 #[derive(Parser)]

--- a/fwdctl/src/replay.rs
+++ b/fwdctl/src/replay.rs
@@ -7,8 +7,9 @@ use std::path::PathBuf;
 use std::time::Instant;
 
 use clap::Args;
-use firewood::api::{self, Db as DbApi};
-use firewood::db::{Db, DbConfig};
+use firewood::api;
+use firewood::db::DbConfig;
+use firewood::open;
 use firewood_replay::replay_from_file;
 
 use crate::DatabasePath;
@@ -38,7 +39,7 @@ pub struct Options {
     )]
     pub max_commits: Option<u64>,
 
-    /// Truncate the database before replaying (default: true for new databases).
+    /// Truncate the database before replaying.
     #[arg(
         long,
         required = false,
@@ -56,19 +57,24 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
         opts.database.dbpath.display()
     );
 
+    // Detect the mode before opening so truncation preserves the database's
+    // persisted hashing scheme.
+    let node_hash_algorithm = opts.database.node_hash_algorithm()?;
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(node_hash_algorithm)
+        .create_if_missing(false)
         .truncate(opts.truncate)
         .build();
-    let db = Db::new(opts.database.dbpath.clone(), cfg)?;
+    let db = open(opts.database.dbpath.clone(), cfg)?;
 
     let start = Instant::now();
 
-    let result = replay_from_file(&opts.replay_log, &db, opts.max_commits).map_err(|e| {
-        api::Error::InternalError(Box::new(std::io::Error::other(format!(
-            "replay failed: {e}"
-        ))))
-    })?;
+    let result =
+        replay_from_file(&opts.replay_log, db.as_ref(), opts.max_commits).map_err(|e| {
+            api::Error::InternalError(Box::new(std::io::Error::other(format!(
+                "replay failed: {e}"
+            ))))
+        })?;
 
     let elapsed = start.elapsed();
 
@@ -80,7 +86,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     }
 
     // Print the root hash from the database for verification
-    if let Some(root) = DbApi::root_hash(&db) {
+    if let Some(root) = db.root_hash() {
         println!("Database root: {}", hex::encode(root));
     }
 

--- a/fwdctl/src/root.rs
+++ b/fwdctl/src/root.rs
@@ -15,12 +15,13 @@ pub struct Options {
 }
 
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
+    let algorithm = opts.database.resolve_node_hash_algorithm();
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(algorithm)
         .create_if_missing(false)
         .truncate(false);
 
-    let db: Box<dyn api::DynDb> = Box::new(Db::new(opts.database.dbpath.clone(), cfg.build())?);
+    let db = Db::open(opts.database.dbpath.clone(), algorithm, cfg.build())?;
 
     let hash = db.root_hash();
 

--- a/fwdctl/src/root.rs
+++ b/fwdctl/src/root.rs
@@ -3,8 +3,9 @@
 
 use clap::Args;
 
-use firewood::api::{self, Db as _};
-use firewood::db::{Db, DbConfig};
+use firewood::api;
+use firewood::db::DbConfig;
+use firewood::open;
 
 use crate::DatabasePath;
 
@@ -15,12 +16,13 @@ pub struct Options {
 }
 
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
+    let algorithm = opts.database.node_hash_algorithm()?;
     let cfg = DbConfig::builder()
-        .node_hash_algorithm(opts.database.node_hash_algorithm.into())
+        .node_hash_algorithm(algorithm)
         .create_if_missing(false)
         .truncate(false);
 
-    let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
+    let db = open(opts.database.dbpath.clone(), cfg.build())?;
 
     let hash = db.root_hash();
 

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -25,11 +25,23 @@ fn with_tmpdir(test: impl FnOnce(&Path)) {
     test(tmpdir.path());
 }
 
+/// Creates a database in the build's compatibility mode for legacy CLI tests.
+/// Tests that exercise runtime selection use `create_db_with_hash_mode` instead.
 fn create_db(db_path: &Path) {
+    let hash_mode = if cfg!(feature = "ethhash") {
+        "ethereum"
+    } else {
+        "merkle-db"
+    };
+    create_db_with_hash_mode(db_path, hash_mode);
+}
+
+fn create_db_with_hash_mode(db_path: &Path, hash_mode: &str) {
     cargo_bin_cmd!()
         .arg("create")
         .arg("--db")
         .arg(db_path)
+        .args(["--hash-mode", hash_mode])
         .assert()
         .success();
 }
@@ -265,6 +277,19 @@ fn fwdctl_prints_version() {
 #[test]
 fn fwdctl_creates_database() {
     with_tmpdir(create_db);
+}
+
+#[test]
+fn fwdctl_create_requires_hash_mode() {
+    with_tmpdir(|db_path| {
+        cargo_bin_cmd!()
+            .arg("create")
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("--node-hash-algorithm"));
+    });
 }
 
 #[test]
@@ -623,42 +648,50 @@ fn test_slow_fwdctl_dump_with_hex() {
 
 #[test]
 fn fwdctl_check_empty_db() {
-    with_tmpdir(|db_path| {
-        create_db(db_path);
+    for hash_mode in ["merkle-db", "ethereum"] {
+        with_tmpdir(|db_path| {
+            create_db_with_hash_mode(db_path, hash_mode);
 
-        cargo_bin_cmd!()
-            .arg("check")
-            .arg("--db")
-            .arg(db_path)
-            .assert()
-            .success();
-    });
+            // `check` must infer the mode from the existing database header.
+            cargo_bin_cmd!()
+                .arg("check")
+                .arg("--db")
+                .arg(db_path)
+                .assert()
+                .success();
+        });
+    }
 }
 
 #[test]
 fn test_slow_fwdctl_check_db_with_data() {
     use rand::{RngExt, distr::Alphanumeric};
 
-    with_tmpdir(|db_path| {
-        let rng = firewood_storage::SeededRng::from_env_or_random();
-        let mut sample_iter = rng.sample_iter(Alphanumeric).map(char::from);
+    for hash_mode in ["merkle-db", "ethereum"] {
+        with_tmpdir(|db_path| {
+            let rng = firewood_storage::SeededRng::from_env_or_random();
+            let mut sample_iter = rng.sample_iter(Alphanumeric).map(char::from);
 
-        create_db(db_path);
+            create_db_with_hash_mode(db_path, hash_mode);
 
-        // TODO(#2047): bulk loading data instead of inserting one by one
-        for _ in 0..4 {
-            let key = sample_iter.by_ref().take(64).collect::<String>();
-            let value = sample_iter.by_ref().take(10).collect::<String>();
-            insert_key_value(db_path, &key, &value);
-        }
+            // TODO(#2047): bulk loading data instead of inserting one by one
+            for _ in 0..4 {
+                let key = sample_iter.by_ref().take(64).collect::<String>();
+                let value = sample_iter.by_ref().take(10).collect::<String>();
+                insert_key_value(db_path, &key, &value);
+            }
 
-        cargo_bin_cmd!()
-            .arg("check")
-            .arg("--db")
-            .arg(db_path)
-            .assert()
-            .success();
-    });
+            // Exercise mode-specific hash recomputation after inferring the
+            // mode from the existing database header.
+            cargo_bin_cmd!()
+                .arg("check")
+                .arg("--db")
+                .arg(db_path)
+                .arg("--hash-check")
+                .assert()
+                .success();
+        });
+    }
 }
 
 #[test]
@@ -683,6 +716,7 @@ fn test_slow_fwdctl_import_csv() {
             .success();
 
         let db_path2 = tmp_dir.join("db2");
+        create_db(&db_path2);
         cargo_bin_cmd!()
             .arg("import")
             .arg("--db")
@@ -732,6 +766,7 @@ fn test_slow_fwdctl_import_csv_hex() {
             .success();
 
         let db_path2 = tmp_dir.join("db2");
+        create_db(&db_path2);
         cargo_bin_cmd!()
             .arg("import")
             .arg("--db")
@@ -802,6 +837,7 @@ fn test_slow_fwdctl_import_large_random_database() {
 
         // Import it into db1
         let db_path1 = tmp_dir.join("db1");
+        create_db(&db_path1);
         cargo_bin_cmd!()
             .arg("import")
             .arg("--db")
@@ -828,6 +864,7 @@ fn test_slow_fwdctl_import_large_random_database() {
 
         // Import dump_file2 into db2
         let db_path2 = tmp_dir.join("db2");
+        create_db(&db_path2);
         cargo_bin_cmd!()
             .arg("import")
             .arg("--db")

--- a/replay/src/lib.rs
+++ b/replay/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! This crate provides:
 //! - Serializable types representing database operations ([`DbOperation`])
-//! - An engine to replay operations against a [`Db`] instance
+//! - An engine to replay operations against a [`DynDb`] instance
 //!
 //! The log format uses length-prefixed `MessagePack` segments, allowing streaming
 //! writes and reads without loading the entire log into memory.
@@ -23,10 +23,10 @@ use std::collections::HashMap;
 use std::io::{self, Read};
 use std::time::Instant;
 
-use firewood::api::{self, Db as DbApi, DbView as DbViewApi, Proposal as ProposalApi};
-use firewood::db::{BatchOp, Db, Proposal};
+use firewood::api::{self, DynDb};
+use firewood::db::BatchOp;
 use firewood_metrics::firewood_histogram;
-use firewood_storage::{DefaultHashMode, InvalidTrieHashLength};
+use firewood_storage::InvalidTrieHashLength;
 
 pub mod registry;
 use serde::{Deserialize, Serialize};
@@ -178,35 +178,36 @@ pub enum ReplayError {
     UnknownProposal(ProposalId),
 }
 
-/// Alias for the batch operation type used in replay.
-type BoxedBatchOp = BatchOp<Box<[u8]>, Box<[u8]>>;
+/// Type-erased proposal handle used while replaying proposal chains.
+type DynProposalBox<'db> = Box<dyn api::DynProposal<'db> + 'db>;
 
 /// Consumes a `Vec` of [`KeyValueOp`] and converts them to firewood batch operations.
 ///
 /// Takes ownership to avoid cloning keys and values in the hot path.
-fn into_batch_ops(pairs: Vec<KeyValueOp>) -> Vec<BoxedBatchOp> {
+fn into_batch_ops(pairs: Vec<KeyValueOp>) -> api::OwnedBatch {
     pairs
         .into_iter()
         .map(|op| match op.value {
             Some(value) => BatchOp::Put { key: op.key, value },
             None => BatchOp::DeleteRange { prefix: op.key },
         })
-        .collect()
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
 }
 
 /// Retrieves a proposal reference from the map, returning an error if not found.
 fn get_proposal<'a, 'db>(
-    proposals: &'a HashMap<ProposalId, Proposal<'db, DefaultHashMode>>,
+    proposals: &'a HashMap<ProposalId, DynProposalBox<'db>>,
     id: ProposalId,
-) -> Result<&'a Proposal<'db, DefaultHashMode>, ReplayError> {
+) -> Result<&'a DynProposalBox<'db>, ReplayError> {
     proposals.get(&id).ok_or(ReplayError::UnknownProposal(id))
 }
 
 /// Removes and returns a proposal from the map, returning an error if not found.
 fn take_proposal<'db>(
-    proposals: &mut HashMap<ProposalId, Proposal<'db, DefaultHashMode>>,
+    proposals: &mut HashMap<ProposalId, DynProposalBox<'db>>,
     id: ProposalId,
-) -> Result<Proposal<'db, DefaultHashMode>, ReplayError> {
+) -> Result<DynProposalBox<'db>, ReplayError> {
     proposals
         .remove(&id)
         .ok_or(ReplayError::UnknownProposal(id))
@@ -216,28 +217,28 @@ fn take_proposal<'db>(
 ///
 /// Returns the root hash if the operation was a commit that produced one.
 fn apply_operation<'db>(
-    db: &'db Db<DefaultHashMode>,
-    proposals: &mut HashMap<ProposalId, Proposal<'db, DefaultHashMode>>,
+    db: &'db dyn DynDb,
+    proposals: &mut HashMap<ProposalId, DynProposalBox<'db>>,
     operation: DbOperation,
 ) -> Result<Option<Box<[u8]>>, ReplayError> {
     match operation {
         DbOperation::GetLatest(GetLatest { key }) => {
-            if let Some(root) = DbApi::root_hash(db) {
-                let view = DbApi::revision(db, root)?;
-                let _ = DbViewApi::val(&*view, key)?;
+            if let Some(root) = db.root_hash() {
+                let view = db.revision(root)?;
+                let _ = view.val(&key)?;
             }
             Ok(None)
         }
 
         DbOperation::GetFromProposal(GetFromProposal { proposal_id, key }) => {
             let proposal = get_proposal(proposals, proposal_id)?;
-            let _ = DbViewApi::val(proposal, key)?;
+            let _ = proposal.val(&key)?;
             Ok(None)
         }
 
         DbOperation::Batch(Batch { pairs }) => {
             let ops = into_batch_ops(pairs);
-            let proposal = DbApi::propose(db, ops)?;
+            let proposal = db.propose(ops)?;
             proposal.commit()?;
             Ok(None)
         }
@@ -248,7 +249,7 @@ fn apply_operation<'db>(
         }) => {
             let ops = into_batch_ops(pairs);
             let start = Instant::now();
-            let proposal = DbApi::propose(db, ops)?;
+            let proposal = db.propose(ops)?;
             firewood_histogram!(cheap: PROPOSE_DURATION_SECONDS)
                 .record(start.elapsed().as_secs_f64());
             proposals.insert(returned_proposal_id, proposal);
@@ -263,7 +264,7 @@ fn apply_operation<'db>(
             let ops = into_batch_ops(pairs);
             let start = Instant::now();
             let parent = get_proposal(proposals, proposal_id)?;
-            let new_proposal = ProposalApi::propose(parent, ops)?;
+            let new_proposal = parent.propose(ops)?;
             firewood_histogram!(cheap: PROPOSE_DURATION_SECONDS)
                 .record(start.elapsed().as_secs_f64());
             proposals.insert(returned_proposal_id, new_proposal);
@@ -308,10 +309,10 @@ fn apply_operation<'db>(
 /// - The log references an unknown proposal ID
 pub fn replay_from_reader<R: Read>(
     mut reader: R,
-    db: &Db<DefaultHashMode>,
+    db: &dyn DynDb,
     max_commits: Option<u64>,
 ) -> Result<Option<Box<[u8]>>, ReplayError> {
-    let mut proposals: HashMap<ProposalId, Proposal<'_, DefaultHashMode>> = HashMap::new();
+    let mut proposals: HashMap<ProposalId, DynProposalBox<'_>> = HashMap::new();
     let mut last_commit_hash = None;
     let mut commit_count = 0u64;
     let max = max_commits.unwrap_or(u64::MAX);
@@ -363,7 +364,7 @@ pub fn replay_from_reader<R: Read>(
 /// See [`replay_from_reader`] for detailed error conditions.
 pub fn replay_from_file(
     path: impl AsRef<std::path::Path>,
-    db: &Db<DefaultHashMode>,
+    db: &dyn DynDb,
     max_commits: Option<u64>,
 ) -> Result<Option<Box<[u8]>>, ReplayError> {
     let file = std::fs::File::open(path)?;
@@ -375,11 +376,12 @@ mod tests {
     use super::*;
     use firewood::db::DbConfig;
     use firewood::manager::RevisionManagerConfig;
+    use firewood::open;
     use firewood_storage::NodeHashAlgorithm;
     use std::io::Cursor;
     use tempfile::tempdir;
 
-    fn create_test_db() -> (tempfile::TempDir, Db<DefaultHashMode>) {
+    fn create_test_db() -> (tempfile::TempDir, Box<dyn DynDb>) {
         let tmpdir = tempdir().expect("create tempdir");
         let db_path = tmpdir.path().join("test.db");
         let algorithm = if cfg!(feature = "ethhash") {
@@ -392,7 +394,7 @@ mod tests {
             .truncate(true)
             .manager(RevisionManagerConfig::builder().build())
             .build();
-        let db = Db::new(&db_path, cfg).expect("db creation should succeed");
+        let db = open(&db_path, cfg).expect("db creation should succeed");
         (tmpdir, db)
     }
 
@@ -419,15 +421,13 @@ mod tests {
         let log = ReplayLog::new(vec![DbOperation::Batch(Batch { pairs })]);
         let buf = serialize_log(&log);
 
-        replay_from_reader(Cursor::new(buf), &db, None).expect("replay");
+        replay_from_reader(Cursor::new(buf), db.as_ref(), None).expect("replay");
 
-        let root = DbApi::root_hash(&db).expect("non-empty");
-        let view = DbApi::revision(&db, root).expect("revision");
+        let root = db.root_hash().expect("non-empty");
+        let view = db.revision(root).expect("revision");
 
         for i in 0u8..5 {
-            let val = DbViewApi::val(&*view, vec![i].as_slice())
-                .expect("val")
-                .expect("exists");
+            let val = view.val(vec![i].as_slice()).expect("val").expect("exists");
             assert_eq!(*val, [i.wrapping_add(100)]);
         }
     }
@@ -457,15 +457,13 @@ mod tests {
         let log = ReplayLog::new(ops);
         let buf = serialize_log(&log);
 
-        replay_from_reader(Cursor::new(buf), &db, None).expect("replay");
+        replay_from_reader(Cursor::new(buf), db.as_ref(), None).expect("replay");
 
-        let root = DbApi::root_hash(&db).expect("non-empty");
-        let view = DbApi::revision(&db, root).expect("revision");
+        let root = db.root_hash().expect("non-empty");
+        let view = db.revision(root).expect("revision");
 
         for i in 0u8..3 {
-            let val = DbViewApi::val(&*view, vec![i].as_slice())
-                .expect("val")
-                .expect("exists");
+            let val = view.val(vec![i].as_slice()).expect("val").expect("exists");
             assert_eq!(*val, [i.wrapping_mul(2)]);
         }
     }
@@ -503,13 +501,13 @@ mod tests {
         let log = ReplayLog::new(ops);
         let buf = serialize_log(&log);
 
-        replay_from_reader(Cursor::new(buf), &db, None).expect("replay");
+        replay_from_reader(Cursor::new(buf), db.as_ref(), None).expect("replay");
 
-        let root = DbApi::root_hash(&db).expect("non-empty");
-        let view = DbApi::revision(&db, root).expect("revision");
+        let root = db.root_hash().expect("non-empty");
+        let view = db.revision(root).expect("revision");
 
-        let v1 = DbViewApi::val(&*view, [1]).expect("val").expect("exists");
-        let v2 = DbViewApi::val(&*view, [2]).expect("val").expect("exists");
+        let v1 = view.val(&[1]).expect("val").expect("exists");
+        let v2 = view.val(&[2]).expect("val").expect("exists");
         assert_eq!(*v1, [10]);
         assert_eq!(*v2, [20]);
     }
@@ -517,7 +515,7 @@ mod tests {
     #[test]
     fn replay_empty_log_succeeds() {
         let (_tmpdir, db) = create_test_db();
-        let result = replay_from_reader(Cursor::new(Vec::new()), &db, None);
+        let result = replay_from_reader(Cursor::new(Vec::new()), db.as_ref(), None);
         assert!(result.is_ok());
         assert!(result.expect("ok").is_none());
     }

--- a/storage/src/hashmode.rs
+++ b/storage/src/hashmode.rs
@@ -82,10 +82,14 @@ mod tests {
 
     #[test]
     fn default_hash_mode_matches_compile_option() {
-        assert_eq!(
-            DefaultHashMode::ALGORITHM,
-            NodeHashAlgorithm::compile_option()
-        );
+        // `DefaultHashMode` must stay coupled to the `ethhash` feature: it is
+        // the cfg-selected default `H` until the flag is removed (PR 6).
+        let expected = if cfg!(feature = "ethhash") {
+            NodeHashAlgorithm::Ethereum
+        } else {
+            NodeHashAlgorithm::MerkleDB
+        };
+        assert_eq!(DefaultHashMode::ALGORITHM, expected);
     }
 
     #[test]

--- a/storage/src/hashmode.rs
+++ b/storage/src/hashmode.rs
@@ -72,24 +72,23 @@ pub type DefaultHashMode = EthHash;
 #[cfg(not(feature = "ethhash"))]
 pub type DefaultHashMode = MerkleDbHash;
 
+const _: () = {
+    // `DefaultHashMode` must stay coupled to the `ethhash` feature: it is
+    // the cfg-selected default `H` until the flag is removed.
+    let expected = if cfg!(feature = "ethhash") {
+        NodeHashAlgorithm::Ethereum
+    } else {
+        NodeHashAlgorithm::MerkleDB
+    };
+    assert!(DefaultHashMode::ALGORITHM as u8 == expected as u8);
+};
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn path_of_len(len: usize) -> Path {
         Path((0..len).map(|_| 0u8).collect())
-    }
-
-    #[test]
-    fn default_hash_mode_matches_compile_option() {
-        // `DefaultHashMode` must stay coupled to the `ethhash` feature: it is
-        // the cfg-selected default `H` until the flag is removed.
-        let expected = if cfg!(feature = "ethhash") {
-            NodeHashAlgorithm::Ethereum
-        } else {
-            NodeHashAlgorithm::MerkleDB
-        };
-        assert_eq!(DefaultHashMode::ALGORITHM, expected);
     }
 
     #[test]

--- a/storage/src/hashmode.rs
+++ b/storage/src/hashmode.rs
@@ -82,10 +82,14 @@ mod tests {
 
     #[test]
     fn default_hash_mode_matches_compile_option() {
-        assert_eq!(
-            DefaultHashMode::ALGORITHM,
-            NodeHashAlgorithm::compile_option()
-        );
+        // `DefaultHashMode` must stay coupled to the `ethhash` feature: it is
+        // the cfg-selected default `H` until the flag is removed.
+        let expected = if cfg!(feature = "ethhash") {
+            NodeHashAlgorithm::Ethereum
+        } else {
+            NodeHashAlgorithm::MerkleDB
+        };
+        assert_eq!(DefaultHashMode::ALGORITHM, expected);
     }
 
     #[test]

--- a/storage/src/nodestore/hash_algo.rs
+++ b/storage/src/nodestore/hash_algo.rs
@@ -8,10 +8,10 @@ pub struct NodeHashAlgorithmTryFromIntError(u64);
 
 /// The hash algorithm used by the node store.
 ///
-/// This must currently match the compile-time option. However, it will eventually
-/// be made a runtime option when initializing the node store. Therefore, the
-/// option is required when initializing and opening the node store to ensure
-/// compatibility and to detect any mismatches.
+/// This is a per-database runtime choice persisted in the file header. A
+/// database created under one scheme is opened under that same scheme
+/// regardless of the build's `ethhash` feature; the requested algorithm is
+/// validated against the header at open time (`validate_open`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NodeHashAlgorithm {
     /// Use the MerkleDB node hashing algorithm, with sha256 as the hash function.
@@ -22,36 +22,8 @@ pub enum NodeHashAlgorithm {
 }
 
 impl NodeHashAlgorithm {
-    /// Returns the hash algorithm selected by the current build.
-    ///
-    /// Today this is decided at compile time by the `ethhash` feature; when
-    /// the algorithm becomes runtime-selectable (issue #1088), this is the
-    /// single function that switches over and every caller picks up the new
-    /// behavior automatically.
-    #[must_use]
-    #[inline]
-    pub const fn compile_option() -> Self {
-        if cfg!(feature = "ethhash") {
-            NodeHashAlgorithm::Ethereum
-        } else {
-            NodeHashAlgorithm::MerkleDB
-        }
-    }
-
-    /// Returns whether this hash algorithm matches the one selected by the
-    /// current build (see [`Self::compile_option`]).
-    #[must_use]
-    pub const fn matches_compile_option(self) -> bool {
-        self.is_ethereum() == Self::compile_option().is_ethereum()
-    }
-
     /// Returns whether this is the Ethereum hash algorithm (Keccak-256,
     /// account-aware nodes).
-    ///
-    /// Callers that need to gate ethereum-mode proofs or encoding should
-    /// read `NodeHashAlgorithm::compile_option().is_ethereum()` instead of
-    /// checking the `ethhash` feature directly. When this enum becomes
-    /// runtime-selectable, every caller picks up the new behavior for free.
     #[must_use]
     pub const fn is_ethereum(self) -> bool {
         matches!(self, NodeHashAlgorithm::Ethereum)
@@ -61,23 +33,6 @@ impl NodeHashAlgorithm {
         match self {
             NodeHashAlgorithm::MerkleDB => "MerkleDB",
             NodeHashAlgorithm::Ethereum => "Ethereum",
-        }
-    }
-
-    // TODO(#1088): remove this after implementing runtime selection of hash algorithms
-    pub(crate) fn validate_init(self) -> std::io::Result<()> {
-        if self.matches_compile_option() {
-            Ok(())
-        } else {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Unsupported,
-                format!(
-                    "node store hash algorithm mismatch: want to initialize with {}, \
-                     but build option is for {}",
-                    self.name(),
-                    Self::compile_option().name()
-                ),
-            ))
         }
     }
 

--- a/storage/src/nodestore/header.rs
+++ b/storage/src/nodestore/header.rs
@@ -275,7 +275,9 @@ pub struct NodeStoreHeader {
     /// The hash of the area sizes used in this database to prevent someone from changing the
     /// area sizes and trying to read old databases with the wrong area sizes.
     area_size_hash: [u8; 32],
-    /// Whether ethhash was enabled when this database was created.
+    /// The node-hashing scheme this database was created with, as a
+    /// [`NodeHashAlgorithm`] discriminant (`0` = MerkleDB, `1` = Ethereum).
+    /// This is the per-database runtime selector honored at open time.
     node_hash_algorithm: u64,
     /// The merkle root hash of the entire database when it was last committed.
     ///
@@ -329,11 +331,6 @@ impl NodeStoreHeader {
     pub fn read_from_storage<S: crate::linear::ReadableStorage>(
         storage: &S,
     ) -> Result<Self, crate::FileIoError> {
-        // TODO(#1088): remove this after implementing runtime selection of hash algorithms
-        storage.node_hash_algorithm().validate_init().map_err(|e| {
-            storage.file_io_error(e, 0, Some("NodeHashAlgorithm::validate_init".to_owned()))
-        })?;
-
         let mut this = bytemuck::zeroed::<Self>();
         let header_bytes = bytemuck::bytes_of_mut(&mut this);
         storage
@@ -347,6 +344,36 @@ impl NodeStoreHeader {
         })?;
 
         Ok(this)
+    }
+
+    /// Reads only the node-hashing scheme persisted in the header, without
+    /// validating it against any requested algorithm.
+    ///
+    /// This is the auto-detection primitive: it lets a caller learn an existing
+    /// database's scheme so it can open with the matching one, instead of
+    /// having to guess and hit a `validate_open` mismatch.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the header cannot be read or the persisted
+    /// discriminant is not a known [`NodeHashAlgorithm`].
+    pub fn peek_node_hash_algorithm<S: crate::linear::ReadableStorage>(
+        storage: &S,
+    ) -> Result<NodeHashAlgorithm, crate::FileIoError> {
+        let mut this = bytemuck::zeroed::<Self>();
+        let header_bytes = bytemuck::bytes_of_mut(&mut this);
+        storage
+            .stream_from(0)?
+            .read_exact(header_bytes)
+            .map_err(|e| {
+                storage.file_io_error(
+                    e,
+                    0,
+                    Some("NodeStoreHeader::peek_node_hash_algorithm".to_owned()),
+                )
+            })?;
+        this.node_hash_algorithm()
+            .map_err(|e| storage.file_io_error(e, 0, Some("node_hash_algorithm".to_owned())))
     }
 
     /// Creates a new header with default values and no root address.
@@ -435,6 +462,22 @@ impl NodeStoreHeader {
     #[must_use]
     pub const fn root_address(&self) -> Option<LinearAddress> {
         self.root_address
+    }
+
+    /// The node-hashing scheme this database was created with, decoded from the
+    /// persisted header discriminant.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the persisted discriminant is not a known
+    /// [`NodeHashAlgorithm`] value.
+    pub fn node_hash_algorithm(&self) -> Result<NodeHashAlgorithm, Error> {
+        NodeHashAlgorithm::try_from(self.node_hash_algorithm).map_err(|err| {
+            Error::new(
+                ErrorKind::InvalidData,
+                format!("hash mode flag in database header is invalid: {err}"),
+            )
+        })
     }
 
     /// Get the root hash.
@@ -531,7 +574,6 @@ impl NodeStoreHeader {
     }
 
     fn validate_node_hash_algorithm(&self, expected: NodeHashAlgorithm) -> Result<(), Error> {
-        expected.validate_init()?;
         NodeHashAlgorithm::try_from(self.node_hash_algorithm)
             .map_err(|err| {
                 std::io::Error::new(
@@ -580,7 +622,7 @@ mod tests {
 
     #[test]
     fn test_header_new() {
-        let header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
+        let header = NodeStoreHeader::new(<crate::DefaultHashMode as crate::HashMode>::ALGORITHM);
 
         // Check the header is correctly initialized.
         assert_eq!(header.version, Version::new());

--- a/storage/src/nodestore/header.rs
+++ b/storage/src/nodestore/header.rs
@@ -25,7 +25,9 @@
 //!
 
 use bytemuck_derive::{Pod, Zeroable};
+use std::fs::File;
 use std::io::{Error, ErrorKind, Read};
+use std::path::Path;
 
 use super::alloc::FreeLists;
 use super::primitives::{AREA_SIZES_HASH, LinearAddress};
@@ -275,7 +277,9 @@ pub struct NodeStoreHeader {
     /// The hash of the area sizes used in this database to prevent someone from changing the
     /// area sizes and trying to read old databases with the wrong area sizes.
     area_size_hash: [u8; 32],
-    /// Whether ethhash was enabled when this database was created.
+    /// The node-hashing scheme this database was created with, as a
+    /// [`NodeHashAlgorithm`] discriminant (`0` = MerkleDB, `1` = Ethereum).
+    /// This is the per-database runtime selector honored at open time.
     node_hash_algorithm: u64,
     /// The merkle root hash of the entire database when it was last committed.
     ///
@@ -329,16 +333,10 @@ impl NodeStoreHeader {
     pub fn read_from_storage<S: crate::linear::ReadableStorage>(
         storage: &S,
     ) -> Result<Self, crate::FileIoError> {
-        // TODO(#1088): remove this after implementing runtime selection of hash algorithms
-        storage.node_hash_algorithm().validate_init().map_err(|e| {
-            storage.file_io_error(e, 0, Some("NodeHashAlgorithm::validate_init".to_owned()))
-        })?;
-
         let mut this = bytemuck::zeroed::<Self>();
-        let header_bytes = bytemuck::bytes_of_mut(&mut this);
         storage
             .stream_from(0)?
-            .read_exact(header_bytes)
+            .read_exact(bytemuck::bytes_of_mut(&mut this))
             .map_err(|e| {
                 storage.file_io_error(e, 0, Some("NodeStoreHeader::read_from_storage".to_owned()))
             })?;
@@ -347,6 +345,40 @@ impl NodeStoreHeader {
         })?;
 
         Ok(this)
+    }
+
+    /// Reads only the node-hashing scheme persisted in the header, without
+    /// validating it against any requested algorithm.
+    ///
+    /// This is the auto-detection primitive: it lets a caller learn an existing
+    /// database's scheme so it can open with the matching one, instead of
+    /// having to guess and hit a `validate_open` mismatch.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the header cannot be read or the persisted
+    /// discriminant is not a known [`NodeHashAlgorithm`].
+    pub fn read_node_hash_algorithm_from_file(
+        path: impl AsRef<Path>,
+    ) -> Result<NodeHashAlgorithm, crate::FileIoError> {
+        let path = path.as_ref();
+        let context = "NodeStoreHeader::read_node_hash_algorithm_from_file";
+        let mut file = File::open(path).map_err(|e| {
+            crate::FileIoError::new(e, Some(path.to_path_buf()), 0, Some(context.to_owned()))
+        })?;
+        let mut header = bytemuck::zeroed::<Self>();
+        file.read_exact(bytemuck::bytes_of_mut(&mut header))
+            .map_err(|e| {
+                crate::FileIoError::new(e, Some(path.to_path_buf()), 0, Some(context.to_owned()))
+            })?;
+        header.node_hash_algorithm().map_err(|e| {
+            crate::FileIoError::new(
+                e,
+                Some(path.to_path_buf()),
+                0,
+                Some("node_hash_algorithm".to_owned()),
+            )
+        })
     }
 
     /// Creates a new header with default values and no root address.
@@ -435,6 +467,22 @@ impl NodeStoreHeader {
     #[must_use]
     pub const fn root_address(&self) -> Option<LinearAddress> {
         self.root_address
+    }
+
+    /// The node-hashing scheme this database was created with, decoded from the
+    /// persisted header discriminant.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the persisted discriminant is not a known
+    /// [`NodeHashAlgorithm`] value.
+    fn node_hash_algorithm(&self) -> Result<NodeHashAlgorithm, Error> {
+        NodeHashAlgorithm::try_from(self.node_hash_algorithm).map_err(|err| {
+            Error::new(
+                ErrorKind::InvalidData,
+                format!("hash mode flag in database header is invalid: {err}"),
+            )
+        })
     }
 
     /// Get the root hash.
@@ -531,7 +579,6 @@ impl NodeStoreHeader {
     }
 
     fn validate_node_hash_algorithm(&self, expected: NodeHashAlgorithm) -> Result<(), Error> {
-        expected.validate_init()?;
         NodeHashAlgorithm::try_from(self.node_hash_algorithm)
             .map_err(|err| {
                 std::io::Error::new(
@@ -562,6 +609,7 @@ const fn const_copy(src: &[u8], dst: &mut [u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{DefaultHashMode, HashMode};
     use test_case::test_case;
 
     #[test]
@@ -580,11 +628,34 @@ mod tests {
 
     #[test]
     fn test_header_new() {
-        let header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
+        let header = NodeStoreHeader::new(DefaultHashMode::ALGORITHM);
 
         // Check the header is correctly initialized.
         assert_eq!(header.version, Version::new());
         let empty_free_list = FreeLists::default();
         assert_eq!(*header.free_lists(), empty_free_list);
+    }
+
+    #[test_case(NodeHashAlgorithm::MerkleDB)]
+    #[test_case(NodeHashAlgorithm::Ethereum)]
+    fn reads_node_hash_algorithm_from_file(node_hash_algorithm: NodeHashAlgorithm) {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let path = tmpdir.path().join("firewood.db");
+        let header = NodeStoreHeader::new(node_hash_algorithm);
+        std::fs::write(&path, bytemuck::bytes_of(&header)).unwrap();
+
+        assert_eq!(
+            NodeStoreHeader::read_node_hash_algorithm_from_file(path).unwrap(),
+            node_hash_algorithm
+        );
+    }
+
+    #[test]
+    fn rejects_mismatched_node_hash_algorithm() {
+        let header = NodeStoreHeader::new(NodeHashAlgorithm::MerkleDB);
+
+        let error = header.validate(NodeHashAlgorithm::Ethereum).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::Unsupported);
     }
 }


### PR DESCRIPTION
## Why this should be merged

The typed stack can represent either hashing scheme, but callers still need a single stable type that can open and operate on databases whose mode is chosen at runtime. The FFI, CLI, and other mode-agnostic consumers should not need to duplicate every operation over `Db<EthHash>` and `Db<MerkleDbHash>`.

This is the point in the stack where a single Firewood binary can open and operate on Ethereum and MerkleDB databases at the same time. Each database still uses exactly one mode, recorded in its header, but the mode is no longer fixed for the process as a whole.

In the stack, this is the user-visible payoff of the preceding refactors: it erases the typed implementation from PR 6 behind a runtime-selected interface used by the FFI, CLI, and other mode-agnostic callers. PR 8 then broadens
dual-mode test coverage, and PR 9 removes the now-obsolete compile-time feature and compatibility bridge.

## How this works

This change adds object-safe database, proposal, committed-revision, and reconstruction traits, plus owned batch and boxed iterator boundaries where generic methods are not object-safe. The new `firewood::open` entry point reads `DbConfig::node_hash_algorithm`, constructs the corresponding typed database, and returns `Box<dyn DynDb>`. Existing database headers are validated against the requested mode before use.

The FFI, `fwdctl`, replay, benchmark, proof, and reconstruction paths are moved onto the erased boundary. Runtime mode information remains available on views, and Ethereum-only operations explicitly reject MerkleDB databases rather than relying on compile-time availability.

The `ethhash` feature remains temporarily in this PR as a compatibility bridge; it no longer prevents the binary from serving both modes. The following test PR exercises both implementations in one binary, and the final PR removes the
feature and the remaining compile-time compatibility shims entirely.

## How this was tested

Database tests open Ethereum and MerkleDB databases side by side, verify empty and committed roots, check proof metadata, and confirm persisted headers restore the selected mode after reopening. Reconstruction is tested through `DefaultHashMode` under both CI feature configurations. Unit tests also cover configured hash-mode mismatches and header validation.

## Breaking Changes

_Note_: `fwdctl` create now requires an explicit `--hash-mode <merkle-db|ethereum>`. Every other database command requires an existing database and detects its hashing mode from the persisted header. In particular, `import` and `replay` no longer create databases; run `fwdctl create` first. `replay` still truncates the existing database by default while preserving its selected hashing mode.

- [x] firewood
- [x] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [x] fwdctl
