### PR TITLE
docs: add Cursor Cloud dev environment notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,3 +231,35 @@ See [`CODE_REVIEW.md`](./CODE_REVIEW.md) for the complete set of code review che
 
 - [Auto-generated docs](https://ava-labs.github.io/firewood/firewood/)
 - [Issue tracker](https://github.com/ava-labs/firewood/issues)
+
+## Cursor Cloud specific instructions
+
+The Cloud VM snapshot ships with the toolchains this repo needs already installed:
+the stable Rust toolchain (>= MSRV 1.94.0, edition 2024) as the rustup default,
+Go 1.25.x on `PATH` (matching `ffi/go.mod`), and `cargo-nextest`. The startup
+update script only runs `cargo fetch --locked` to refresh Rust dependencies; Go
+modules are fetched on demand by `go test`. If a future toolchain bump makes the
+default `rustc`/`go` too old, upgrade with `rustup default stable` /
+`/usr/local/go` (the `cargo`/`go`/`nextest` installs are baked into the snapshot,
+not the update script).
+
+Standard build/lint/test/doc commands live in the "PR Strategy" section above and
+in `.github/workflows/ci.yaml`; use those verbatim. The primary feature set for
+local work is `--features ethhash,logger`.
+
+Non-obvious gotchas:
+
+- `fwdctl` takes the database path via a per-subcommand `-d/--db` flag, not a
+  global option (e.g. `fwdctl insert -d my.db key value`). The default node hash
+  algorithm is `ethereum`.
+- Go FFI (`ffi/`) tests link the Rust **staticlib**, so you must build it first
+  (`cargo build` inside `ffi/`, or `cargo build -p firewood-ffi`) before
+  `go test ./...`. Go looks in `target/{maxperf,release,debug}`.
+- `TEST_FIREWOOD_HASH_MODE` must match how the staticlib was built: use
+  `firewood` (SHA-256, default features) or `ethhash` (Keccak-256, requires
+  building with `--features ethhash`). A mismatch causes hash assertion failures.
+  CI runs Go tests with `GOEXPERIMENT=cgocheck2`.
+- The default `cargo nextest` profile skips tests prefixed `test_slow_`; run with
+  `--profile ci` to include them.
+- Running `cargo run --example insert` from the repo root creates a scratch
+  `firewood/firewood.db` directory — delete it before committing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this should be merged

Sets up and documents the Cloud Agent development environment for Firewood so
future agents start with a working, reproducible setup. The only code change is a
new `## Cursor Cloud specific instructions` section in `AGENTS.md` capturing
non-obvious startup/run caveats discovered while validating the environment.

Merging this lets future cloud agents "remember" these caveats (staticlib build
ordering, hash-mode matching, `fwdctl` flag placement, slow-test profile).

## How this works

- Toolchains are baked into the VM snapshot: stable Rust (1.96.1, >= MSRV
  1.94.0, edition 2024) as the rustup default, Go 1.25.10 on `PATH` (matching
  `ffi/go.mod`), and `cargo-nextest`.
- The startup update script is minimal and idempotent: `cargo fetch --locked`.
- `AGENTS.md` documents durable gotchas rather than one-off install steps.

## How this was tested

All commands run with the primary `--features ethhash,logger` feature set unless
noted:

- Build: `cargo build --frozen --features ethhash,logger --workspace --all-targets` — success
- Lint: `cargo fmt --check` clean; `cargo clippy --frozen --features ethhash,logger --workspace --all-targets -- -D warnings` clean
- Test: `cargo nextest run --frozen --features ethhash,logger --all-targets` — 812 passed, 16 skipped
- Run (library/example): `cargo run --example insert` — inserted 100 batches
- Run (CLI hello-world): `fwdctl create/insert/get/root/dump/delete` round-trip succeeded
- FFI: `cargo build -p firewood-ffi` then `GOEXPERIMENT=cgocheck2 TEST_FIREWOOD_HASH_MODE=firewood go test ./...` in `ffi/` — ok
- Docs lint: `markdownlint-cli2 AGENTS.md` — 0 errors

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c1312c6-9ea9-418b-858a-5de96cb493ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c1312c6-9ea9-418b-858a-5de96cb493ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

