### PR TITLE
test: run every applicable test under both hash modes [8/9]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "test-case",
  "trybuild",
 ]
 
@@ -1973,6 +1974,7 @@ dependencies = [
  "derive-where",
  "enum-as-inner",
  "fastrace",
+ "firewood-macros",
  "firewood-metrics",
  "fjall",
  "git-version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "test-case",
  "trybuild",
 ]
 
@@ -1967,6 +1968,7 @@ dependencies = [
  "derive-where",
  "enum-as-inner",
  "fastrace",
+ "firewood-macros",
  "firewood-metrics",
  "fjall",
  "git-version",

--- a/firewood-macros/Cargo.toml
+++ b/firewood-macros/Cargo.toml
@@ -23,8 +23,14 @@ syn = { version = "2.0", features = ["full", "extra-traits"] }
 [dev-dependencies]
 # Workspace dependencies
 firewood-metrics.workspace = true
+test-case.workspace = true
 # Regular dependencies
 trybuild = "1.0"
 
 [lints]
 workspace = true
+
+# test-case is only referenced from the trybuild fixtures under
+# tests/compile_pass/, which cargo-machete does not scan.
+[package.metadata.cargo-machete]
+ignored = ["test-case"]

--- a/firewood-macros/src/lib.rs
+++ b/firewood-macros/src/lib.rs
@@ -1,11 +1,12 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-//! Proc macros for Firewood metrics
+//! Proc macros for Firewood.
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
 use syn::{ItemFn, ReturnType, parse_macro_input};
 
 /// Arguments for the `#[metrics]` attribute: a single identifier naming a counter constant in
@@ -145,6 +146,225 @@ fn generate_metrics_wrapper(input_fn: &ItemFn, ident: &syn::Ident) -> proc_macro
     }
 }
 
+/// Hash modes a test runs under, parsed from `#[hash_mode(...)]` arguments.
+struct HashModeArgs {
+    eth: bool,
+    merkledb: bool,
+}
+
+impl Parse for HashModeArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let idents = Punctuated::<syn::Ident, syn::Token![,]>::parse_terminated(input)?;
+        if idents.is_empty() {
+            // Bare `#[hash_mode]`: the default is to run under BOTH modes; a
+            // single-mode annotation is the deliberate, documented exception.
+            return Ok(HashModeArgs {
+                eth: true,
+                merkledb: true,
+            });
+        }
+        let mut args = HashModeArgs {
+            eth: false,
+            merkledb: false,
+        };
+        for ident in &idents {
+            let slot = match ident.to_string().as_str() {
+                "eth" => &mut args.eth,
+                "merkledb" => &mut args.merkledb,
+                other => {
+                    return Err(syn::Error::new_spanned(
+                        ident,
+                        format!("unknown hash mode `{other}`; expected `eth` or `merkledb`"),
+                    ));
+                }
+            };
+            if *slot {
+                return Err(syn::Error::new_spanned(
+                    ident,
+                    format!("duplicate hash mode `{ident}`"),
+                ));
+            }
+            *slot = true;
+        }
+        Ok(args)
+    }
+}
+
+/// Runs a single test body under one or more hash modes, monomorphizing it over
+/// the `HashMode` type rather than gating it on a compile-time feature.
+///
+/// The hash scheme is a runtime, per-database choice (issue #1088), so both
+/// `EthHash` and `MerkleDbHash` are compiled into one binary. This macro makes a
+/// generic test helper and emits one real `#[test]` wrapper per requested mode,
+/// each instantiating the helper with the concrete hash-mode ZST:
+///
+/// - `#[hash_mode]`                → both wrappers
+/// - `#[hash_mode(eth)]`           → `#[test] fn {name}_eth() { {name}::<EthHash>() }`
+/// - `#[hash_mode(merkledb)]`      → `#[test] fn {name}_merkledb() { {name}::<MerkleDbHash>() }`
+/// - `#[hash_mode(eth, merkledb)]` → both wrappers
+///
+/// # Contract
+///
+/// The annotated item MUST be a generic function whose **first type parameter is
+/// the hash mode**, e.g. `fn name<H: HashMode>()`. The function MUST NOT carry
+/// its own `#[test]` attribute — this macro emits the `#[test]` wrappers itself
+/// (a generic function cannot be a `#[test]` directly). The original function is
+/// re-emitted once, un-`#[test]`ed, as a generic helper (visibility unchanged); any other
+/// attributes (docs, `#[expect(...)]`, …) stay on the helper, while
+/// `#[should_panic]` / `#[ignore]` are forwarded onto each wrapper so they
+/// behave as expected.
+///
+/// Value parameters are allowed on the helper, e.g. `fn name<H: HashMode>(a:
+/// T, b: U)`. Each wrapper repeats the exact same parameter list and forwards
+/// the arguments by name to the helper. Only **plain identifier patterns**
+/// are supported (`a: T`, not `(a, b): (T, U)` or `Foo { a, b }: Foo`) —
+/// anything else is a compile error, since the macro needs a name to forward
+/// under each mode's wrapper.
+///
+/// # Composing with `#[test_case]`
+///
+/// This macro composes with the [`test-case`](https://docs.rs/test-case)
+/// crate: `#[test_case(...)]` attributes on the helper are moved onto each
+/// per-mode wrapper instead of staying on the helper, and `#[test]` is
+/// omitted from wrappers that carry `#[test_case]` attrs (`test-case`
+/// generates its own test-harness attribute, so adding `#[test]` as well
+/// would conflict). For this to work, `#[hash_mode]` MUST be the **outermost**
+/// attribute — i.e. listed first, above any `#[test_case(...)]` attrs — so it
+/// runs before `test-case` expands and can see its attributes:
+///
+/// ```rust,ignore
+/// #[hash_mode]
+/// #[test_case(1, 2; "small")]
+/// #[test_case(10, 20; "large")]
+/// fn adds<H: HashMode>(a: u32, b: u32) {
+///     assert!(a < b);
+/// }
+/// ```
+///
+/// The concrete ZST names (`EthHash` / `MerkleDbHash`) are emitted **unqualified**,
+/// so each call site must bring them into scope itself, e.g.
+/// `use firewood_storage::{EthHash, MerkleDbHash};` (or `use crate::{…}` inside
+/// the storage crate). This keeps the macro agnostic to the crate it expands in.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// use firewood_macros::hash_mode;
+/// use firewood_storage::{EthHash, HashMode};
+///
+/// #[hash_mode(eth)]
+/// fn only_under_ethhash<H: HashMode>() { /* body uses `H` */ }
+/// ```
+#[proc_macro_attribute]
+pub fn hash_mode(args: TokenStream, input: TokenStream) -> TokenStream {
+    let parsed = match syn::parse::<HashModeArgs>(args) {
+        Ok(a) => a,
+        Err(e) => return e.to_compile_error().into(),
+    };
+    let input_fn = parse_macro_input!(input as ItemFn);
+    hash_mode_expand(&parsed, input_fn).into()
+}
+
+/// Expands an annotated generic test function into a private helper plus one
+/// `#[test]` wrapper per requested mode. Factored out so it can be unit-tested
+/// without a `proc_macro` context.
+fn hash_mode_expand(args: &HashModeArgs, mut input_fn: ItemFn) -> proc_macro2::TokenStream {
+    // The helper must be generic over the hash mode (see the `# Contract`
+    // section above). Check this up front and emit a targeted, unconditional
+    // error: wrapper bodies are emitted behind `#[test]`, whose contents
+    // rustc elides entirely outside `--test` builds, so an error that only
+    // surfaced from inside a wrapper (e.g. a bad turbofish) would never be
+    // seen by a plain `cargo build`/trybuild `pass`/`compile_fail` check.
+    if input_fn.sig.generics.type_params().next().is_none() {
+        return syn::Error::new_spanned(
+            &input_fn.sig,
+            "#[hash_mode] requires a generic function with a hash-mode type parameter, \
+             e.g. `fn name<H: HashMode>()`",
+        )
+        .to_compile_error();
+    }
+
+    // Partition attributes: test-behavior attrs and test_case cases ride the
+    // wrappers; everything else (docs, #[expect]) stays on the helper. The
+    // macro emits the `#[test]` wrappers itself, so any `#[test]` the author
+    // left on the helper is dropped outright (a generic fn cannot be a
+    // `#[test]` directly).
+    let mut forwarded_attrs = Vec::new();
+    let mut test_case_attrs = Vec::new();
+    input_fn.attrs.retain(|attr| {
+        if attr.path().is_ident("test") {
+            return false;
+        }
+        if attr.path().is_ident("should_panic") || attr.path().is_ident("ignore") {
+            forwarded_attrs.push(attr.clone());
+            return false;
+        }
+        if attr.path().is_ident("test_case") {
+            test_case_attrs.push(attr.clone());
+            return false;
+        }
+        true
+    });
+
+    // Value parameters: wrappers repeat them and forward by name. Only plain
+    // identifier patterns are supported — anything else is a macro error.
+    let mut param_idents = Vec::new();
+    for arg in &input_fn.sig.inputs {
+        match arg {
+            syn::FnArg::Typed(pat_ty) => match &*pat_ty.pat {
+                syn::Pat::Ident(pi) => param_idents.push(pi.ident.clone()),
+                other => {
+                    return syn::Error::new_spanned(
+                        other,
+                        "#[hash_mode] helpers may only use plain identifier parameters",
+                    )
+                    .to_compile_error();
+                }
+            },
+            syn::FnArg::Receiver(r) => {
+                return syn::Error::new_spanned(r, "#[hash_mode] does not support methods")
+                    .to_compile_error();
+            }
+        }
+    }
+
+    let helper_ident = input_fn.sig.ident.clone();
+    let params = input_fn.sig.inputs.clone();
+    let output = input_fn.sig.output.clone();
+    // `#[test]` only when test-case is not supplying its own harness attr.
+    let test_attr = test_case_attrs.is_empty().then(|| quote! { #[test] });
+
+    let mut modes: Vec<&'static str> = Vec::new();
+    if args.eth {
+        modes.push("eth");
+    }
+    if args.merkledb {
+        modes.push("merkledb");
+    }
+
+    let wrappers = modes.into_iter().map(|mode| {
+        let (suffix, zst) = match mode {
+            "eth" => ("eth", format_ident!("EthHash")),
+            // parsing guarantees only `eth` / `merkledb` reach here.
+            _ => ("merkledb", format_ident!("MerkleDbHash")),
+        };
+        let wrapper_ident = format_ident!("{}_{}", helper_ident, suffix);
+        quote! {
+            #(#forwarded_attrs)*
+            #(#test_case_attrs)*
+            #test_attr
+            fn #wrapper_ident(#params) #output {
+                #helper_ident::<#zst>(#(#param_idents),*)
+            }
+        }
+    });
+
+    quote! {
+        #input_fn
+        #(#wrappers)*
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -205,5 +425,209 @@ mod tests {
         );
         assert!(generated_code.contains("counter"));
         assert!(generated_code.contains("histogram"));
+    }
+
+    #[test]
+    fn test_hash_mode_args_parsing() {
+        let eth: HashModeArgs = syn::parse2(quote::quote! { eth }).unwrap();
+        assert!(eth.eth && !eth.merkledb);
+
+        let merkledb: HashModeArgs = syn::parse2(quote::quote! { merkledb }).unwrap();
+        assert!(!merkledb.eth && merkledb.merkledb);
+
+        let both: HashModeArgs = syn::parse2(quote::quote! { eth, merkledb }).unwrap();
+        assert!(both.eth && both.merkledb);
+    }
+
+    #[test]
+    fn test_hash_mode_bare_args_mean_both_modes() {
+        let parsed: HashModeArgs = syn::parse2(quote::quote! {}).unwrap();
+        assert!(parsed.eth && parsed.merkledb);
+    }
+
+    #[test]
+    fn test_hash_mode_invalid_args() {
+        // unknown mode
+        assert!(syn::parse2::<HashModeArgs>(quote::quote! { sha256 }).is_err());
+        // duplicate mode
+        assert!(syn::parse2::<HashModeArgs>(quote::quote! { eth, eth }).is_err());
+    }
+
+    #[test]
+    fn test_hash_mode_expand_emits_per_mode_wrappers() {
+        use syn::parse_quote;
+
+        let eth: ItemFn = parse_quote! {
+            #[test]
+            fn my_test<H: HashMode>() {}
+        };
+        let expanded = hash_mode_expand(
+            &HashModeArgs {
+                eth: true,
+                merkledb: false,
+            },
+            eth,
+        )
+        .to_string();
+        // The `#[test]` is stripped from the helper and re-emitted on the wrapper.
+        assert!(expanded.contains("fn my_test < H : HashMode >"));
+        assert!(expanded.contains("fn my_test_eth ()"));
+        assert!(expanded.contains("my_test :: < EthHash > ()"));
+        assert!(!expanded.contains("my_test_merkledb"));
+
+        let merkledb: ItemFn = parse_quote! {
+            fn my_test<H: HashMode>() {}
+        };
+        let expanded = hash_mode_expand(
+            &HashModeArgs {
+                eth: false,
+                merkledb: true,
+            },
+            merkledb,
+        )
+        .to_string();
+        assert!(expanded.contains("fn my_test_merkledb ()"));
+        assert!(expanded.contains("my_test :: < MerkleDbHash > ()"));
+        assert!(!expanded.contains("my_test_eth"));
+
+        let both: ItemFn = parse_quote! {
+            fn my_test<H: HashMode>() {}
+        };
+        let expanded = hash_mode_expand(
+            &HashModeArgs {
+                eth: true,
+                merkledb: true,
+            },
+            both,
+        )
+        .to_string();
+        assert!(expanded.contains("fn my_test_eth ()"));
+        assert!(expanded.contains("fn my_test_merkledb ()"));
+    }
+
+    #[test]
+    fn test_hash_mode_forwards_should_panic_to_wrapper() {
+        use syn::parse_quote;
+
+        let input: ItemFn = parse_quote! {
+            #[should_panic]
+            #[test]
+            fn boom<H: HashMode>() {}
+        };
+        let expanded = hash_mode_expand(
+            &HashModeArgs {
+                eth: true,
+                merkledb: false,
+            },
+            input,
+        )
+        .to_string();
+        // `#[should_panic]` rides on the emitted `#[test]` wrapper, not the helper.
+        let wrapper_pos = expanded
+            .find("fn boom_eth ()")
+            .expect("wrapper should be emitted");
+        let should_panic_pos = expanded
+            .find("should_panic")
+            .expect("should_panic should be forwarded");
+        assert!(should_panic_pos < wrapper_pos);
+    }
+
+    #[test]
+    fn test_hash_mode_forwards_return_type_to_wrapper() {
+        use syn::parse_quote;
+
+        let input: ItemFn = parse_quote! {
+            fn t<H: HashMode>() -> Result<(), String> { Ok(()) }
+        };
+        let expanded = hash_mode_expand(
+            &HashModeArgs {
+                eth: true,
+                merkledb: false,
+            },
+            input,
+        )
+        .to_string();
+        assert!(expanded.contains("fn t_eth () -> Result < () , String >"));
+    }
+
+    #[test]
+    fn test_hash_mode_moves_test_case_attrs_to_wrappers() {
+        use syn::parse_quote;
+
+        let input: ItemFn = parse_quote! {
+            #[test_case(1, 2; "small")]
+            #[test_case(10, 20; "large")]
+            fn t<H: HashMode>(a: u32, b: u32) { let _ = (a, b); }
+        };
+        let expanded = hash_mode_expand(
+            &HashModeArgs {
+                eth: true,
+                merkledb: true,
+            },
+            input,
+        )
+        .to_string();
+        // Attrs are gone from the helper (helper renders first) and present twice per wrapper.
+        assert_eq!(expanded.matches("test_case").count(), 4);
+        // Wrappers keep the value params and forward them.
+        assert!(expanded.contains("fn t_eth (a : u32 , b : u32)"));
+        assert!(expanded.contains("t :: < EthHash > (a , b)"));
+        // No #[test] on test_case wrappers (test-case generates its own).
+        assert!(!expanded.contains("# [test] fn t_eth"));
+    }
+
+    #[test]
+    fn test_hash_mode_plain_value_params_still_get_test_attr() {
+        use syn::parse_quote;
+
+        // No test_case attrs + no params -> wrapper keeps plain #[test].
+        let input: ItemFn = parse_quote! { fn t<H: HashMode>() {} };
+        let expanded = hash_mode_expand(
+            &HashModeArgs {
+                eth: true,
+                merkledb: false,
+            },
+            input,
+        )
+        .to_string();
+        assert!(expanded.contains("# [test]"));
+    }
+
+    #[test]
+    fn test_hash_mode_rejects_receiver_param() {
+        use syn::parse_quote;
+
+        // syn parses a receiver in a free-fn signature even though rustc would
+        // reject it; the macro must turn it into a targeted compile error.
+        let input: ItemFn = parse_quote! { fn t<H: HashMode>(&self, a: u32) {} };
+        let expanded = hash_mode_expand(
+            &HashModeArgs {
+                eth: true,
+                merkledb: true,
+            },
+            input,
+        )
+        .to_string();
+        assert!(expanded.contains("compile_error"));
+        assert!(expanded.contains("does not support methods"));
+    }
+
+    #[test]
+    fn test_hash_mode_rejects_lifetime_only_generics() {
+        use syn::parse_quote;
+
+        // Lifetime parameters alone don't satisfy the hash-mode contract: the
+        // helper needs a *type* parameter to instantiate with the mode ZST.
+        let input: ItemFn = parse_quote! { fn t<'a>(x: &'a u32) { let _ = x; } };
+        let expanded = hash_mode_expand(
+            &HashModeArgs {
+                eth: true,
+                merkledb: true,
+            },
+            input,
+        )
+        .to_string();
+        assert!(expanded.contains("compile_error"));
+        assert!(expanded.contains("requires a generic function with a hash-mode type parameter"));
     }
 }

--- a/firewood-macros/src/lib.rs
+++ b/firewood-macros/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-//! Proc macros for Firewood metrics
+//! Proc macros for Firewood.
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
@@ -142,6 +142,193 @@ fn generate_metrics_wrapper(input_fn: &ItemFn, ident: &syn::Ident) -> proc_macro
     }
 }
 
+/// Arguments for `#[hash_mode]`.
+///
+/// The macro deliberately accepts no arguments: it always runs a test under
+/// both hash modes. Tests that only apply to one mode should be ordinary
+/// `#[test]` functions that select the concrete hash type explicitly.
+#[derive(Debug)]
+struct HashModeArgs;
+
+impl Parse for HashModeArgs {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.is_empty() {
+            Ok(Self)
+        } else {
+            Err(input.error(
+                "#[hash_mode] does not accept arguments; use #[test] and select the concrete hash mode explicitly for a single-mode test",
+            ))
+        }
+    }
+}
+
+/// Runs a single test body under both hash modes, monomorphizing it over
+/// the `HashMode` type rather than gating it on a compile-time feature.
+///
+/// The hash scheme is a runtime, per-database choice (issue #1088), so both
+/// `EthHash` and `MerkleDbHash` are compiled into one binary. This macro makes a
+/// generic test helper and emits two real `#[test]` wrappers, each
+/// instantiating the helper with a concrete hash-mode ZST:
+///
+/// - `#[hash_mode]` → `#[test] fn {name}_eth() { {name}::<EthHash>() }`
+///   and `#[test] fn {name}_merkledb() { {name}::<MerkleDbHash>() }`
+///
+/// Arguments are rejected. A test that only applies to one hash mode should
+/// use `#[test]` and name the concrete hash type directly.
+///
+/// # Contract
+///
+/// The annotated item MUST be a generic function whose **first type parameter is
+/// the hash mode**, e.g. `fn name<H: HashMode>()`. The function MUST NOT carry
+/// its own `#[test]` attribute — this macro emits the `#[test]` wrappers itself
+/// (a generic function cannot be a `#[test]` directly). The original function is
+/// re-emitted once, un-`#[test]`ed, as a generic helper (visibility unchanged); any other
+/// attributes (docs, `#[expect(...)]`, …) stay on the helper, while
+/// `#[should_panic]` / `#[ignore]` are forwarded onto each wrapper so they
+/// behave as expected.
+///
+/// Value parameters are allowed on the helper, e.g. `fn name<H: HashMode>(a:
+/// T, b: U)`. Each wrapper repeats the exact same parameter list and forwards
+/// the arguments by name to the helper. Only **plain identifier patterns**
+/// are supported (`a: T`, not `(a, b): (T, U)` or `Foo { a, b }: Foo`) —
+/// anything else is a compile error, since the macro needs a name to forward
+/// under each mode's wrapper.
+///
+/// # Composing with `#[test_case]`
+///
+/// This macro composes with the [`test-case`](https://docs.rs/test-case)
+/// crate: `#[test_case(...)]` attributes on the helper are moved onto each
+/// per-mode wrapper instead of staying on the helper, and `#[test]` is
+/// omitted from wrappers that carry `#[test_case]` attrs (`test-case`
+/// generates its own test-harness attribute, so adding `#[test]` as well
+/// would conflict). For this to work, `#[hash_mode]` MUST be the **outermost**
+/// attribute — i.e. listed first, above any `#[test_case(...)]` attrs — so it
+/// runs before `test-case` expands and can see its attributes:
+///
+/// ```rust,ignore
+/// #[hash_mode]
+/// #[test_case(1, 2; "small")]
+/// #[test_case(10, 20; "large")]
+/// fn adds<H: HashMode>(a: u32, b: u32) {
+///     assert!(a < b);
+/// }
+/// ```
+///
+/// The concrete ZST names (`EthHash` / `MerkleDbHash`) are emitted **unqualified**,
+/// so each call site must bring them into scope itself, e.g.
+/// `use firewood_storage::{EthHash, MerkleDbHash};` (or `use crate::{…}` inside
+/// the storage crate). This keeps the macro agnostic to the crate it expands in.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// use firewood_macros::hash_mode;
+/// use firewood_storage::{EthHash, HashMode, MerkleDbHash};
+///
+/// #[hash_mode]
+/// fn under_both_hash_modes<H: HashMode>() { /* body uses `H` */ }
+/// ```
+#[proc_macro_attribute]
+pub fn hash_mode(args: TokenStream, input: TokenStream) -> TokenStream {
+    if let Err(e) = syn::parse::<HashModeArgs>(args) {
+        return e.to_compile_error().into();
+    }
+    let input_fn = parse_macro_input!(input as ItemFn);
+    hash_mode_expand(input_fn).into()
+}
+
+/// Expands an annotated generic test function into a private helper plus two
+/// `#[test]` wrappers. Factored out so it can be unit-tested
+/// without a `proc_macro` context.
+fn hash_mode_expand(mut input_fn: ItemFn) -> proc_macro2::TokenStream {
+    // The helper must be generic over the hash mode (see the `# Contract`
+    // section above). Check this up front and emit a targeted, unconditional
+    // error: wrapper bodies are emitted behind `#[test]`, whose contents
+    // rustc elides entirely outside `--test` builds, so an error that only
+    // surfaced from inside a wrapper (e.g. a bad turbofish) would never be
+    // seen by a plain `cargo build`/trybuild `pass`/`compile_fail` check.
+    if input_fn.sig.generics.type_params().next().is_none() {
+        return syn::Error::new_spanned(
+            &input_fn.sig,
+            "#[hash_mode] requires a generic function with a hash-mode type parameter, \
+             e.g. `fn name<H: HashMode>()`",
+        )
+        .to_compile_error();
+    }
+
+    // Partition attributes: test-behavior attrs and test_case cases ride the
+    // wrappers; everything else (docs, #[expect]) stays on the helper. The
+    // macro emits the `#[test]` wrappers itself, so any `#[test]` the author
+    // left on the helper is dropped outright (a generic fn cannot be a
+    // `#[test]` directly).
+    let mut forwarded_attrs = Vec::new();
+    let mut test_case_attrs = Vec::new();
+    input_fn.attrs.retain(|attr| {
+        if attr.path().is_ident("test") {
+            return false;
+        }
+        if attr.path().is_ident("should_panic") || attr.path().is_ident("ignore") {
+            forwarded_attrs.push(attr.clone());
+            return false;
+        }
+        if attr.path().is_ident("test_case") {
+            test_case_attrs.push(attr.clone());
+            return false;
+        }
+        true
+    });
+
+    // Value parameters: wrappers repeat them and forward by name. Only plain
+    // identifier patterns are supported — anything else is a macro error.
+    let mut param_idents = Vec::new();
+    for arg in &input_fn.sig.inputs {
+        match arg {
+            syn::FnArg::Typed(pat_ty) => match &*pat_ty.pat {
+                syn::Pat::Ident(pi) => param_idents.push(pi.ident.clone()),
+                other => {
+                    return syn::Error::new_spanned(
+                        other,
+                        "#[hash_mode] helpers may only use plain identifier parameters",
+                    )
+                    .to_compile_error();
+                }
+            },
+            syn::FnArg::Receiver(r) => {
+                return syn::Error::new_spanned(r, "#[hash_mode] does not support methods")
+                    .to_compile_error();
+            }
+        }
+    }
+
+    let helper_ident = input_fn.sig.ident.clone();
+    let params = input_fn.sig.inputs.clone();
+    let output = input_fn.sig.output.clone();
+    // `#[test]` only when test-case is not supplying its own harness attr.
+    let test_attr = test_case_attrs.is_empty().then(|| quote! { #[test] });
+
+    let wrappers = ["eth", "merkledb"].into_iter().map(|mode| {
+        let (suffix, zst) = match mode {
+            "eth" => ("eth", format_ident!("EthHash")),
+            // The fixed mode list guarantees only `eth` / `merkledb` reach here.
+            _ => ("merkledb", format_ident!("MerkleDbHash")),
+        };
+        let wrapper_ident = format_ident!("{}_{}", helper_ident, suffix);
+        quote! {
+            #(#forwarded_attrs)*
+            #(#test_case_attrs)*
+            #test_attr
+            fn #wrapper_ident(#params) #output {
+                #helper_ident::<#zst>(#(#param_idents),*)
+            }
+        }
+    });
+
+    quote! {
+        #input_fn
+        #(#wrappers)*
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -203,5 +390,117 @@ mod tests {
         );
         assert!(generated_code.contains("counter"));
         assert!(generated_code.contains("histogram"));
+    }
+
+    #[test]
+    fn test_hash_mode_accepts_no_arguments() {
+        syn::parse2::<HashModeArgs>(quote::quote! {}).unwrap();
+    }
+
+    #[test]
+    fn test_hash_mode_rejects_arguments() {
+        let error = syn::parse2::<HashModeArgs>(quote::quote! { eth }).unwrap_err();
+        assert!(error.to_string().contains("does not accept arguments"));
+    }
+
+    #[test]
+    fn test_hash_mode_expand_emits_per_mode_wrappers() {
+        use syn::parse_quote;
+
+        let input: ItemFn = parse_quote! {
+            #[test]
+            fn my_test<H: HashMode>() {}
+        };
+        let expanded = hash_mode_expand(input).to_string();
+        // The `#[test]` is stripped from the helper and re-emitted on the wrapper.
+        assert!(expanded.contains("fn my_test < H : HashMode >"));
+        assert!(expanded.contains("fn my_test_eth ()"));
+        assert!(expanded.contains("my_test :: < EthHash > ()"));
+        assert!(expanded.contains("fn my_test_merkledb ()"));
+        assert!(expanded.contains("my_test :: < MerkleDbHash > ()"));
+    }
+
+    #[test]
+    fn test_hash_mode_forwards_should_panic_to_wrapper() {
+        use syn::parse_quote;
+
+        let input: ItemFn = parse_quote! {
+            #[should_panic]
+            #[test]
+            fn boom<H: HashMode>() {}
+        };
+        let expanded = hash_mode_expand(input).to_string();
+        // `#[should_panic]` rides on the emitted `#[test]` wrapper, not the helper.
+        let wrapper_pos = expanded
+            .find("fn boom_eth ()")
+            .expect("wrapper should be emitted");
+        let should_panic_pos = expanded
+            .find("should_panic")
+            .expect("should_panic should be forwarded");
+        assert!(should_panic_pos < wrapper_pos);
+    }
+
+    #[test]
+    fn test_hash_mode_forwards_return_type_to_wrapper() {
+        use syn::parse_quote;
+
+        let input: ItemFn = parse_quote! {
+            fn t<H: HashMode>() -> Result<(), String> { Ok(()) }
+        };
+        let expanded = hash_mode_expand(input).to_string();
+        assert!(expanded.contains("fn t_eth () -> Result < () , String >"));
+    }
+
+    #[test]
+    fn test_hash_mode_moves_test_case_attrs_to_wrappers() {
+        use syn::parse_quote;
+
+        let input: ItemFn = parse_quote! {
+            #[test_case(1, 2; "small")]
+            #[test_case(10, 20; "large")]
+            fn t<H: HashMode>(a: u32, b: u32) { let _ = (a, b); }
+        };
+        let expanded = hash_mode_expand(input).to_string();
+        // Attrs are gone from the helper (helper renders first) and present twice per wrapper.
+        assert_eq!(expanded.matches("test_case").count(), 4);
+        // Wrappers keep the value params and forward them.
+        assert!(expanded.contains("fn t_eth (a : u32 , b : u32)"));
+        assert!(expanded.contains("t :: < EthHash > (a , b)"));
+        // No #[test] on test_case wrappers (test-case generates its own).
+        assert!(!expanded.contains("# [test] fn t_eth"));
+    }
+
+    #[test]
+    fn test_hash_mode_plain_value_params_still_get_test_attr() {
+        use syn::parse_quote;
+
+        // No test_case attrs + no params -> wrapper keeps plain #[test].
+        let input: ItemFn = parse_quote! { fn t<H: HashMode>() {} };
+        let expanded = hash_mode_expand(input).to_string();
+        assert!(expanded.contains("# [test]"));
+    }
+
+    #[test]
+    fn test_hash_mode_rejects_receiver_param() {
+        use syn::parse_quote;
+
+        // syn parses a receiver in a free-fn signature even though rustc would
+        // reject it; the macro must turn it into a targeted compile error.
+        let input: ItemFn = parse_quote! { fn t<H: HashMode>(&self, a: u32) {} };
+        let expanded = hash_mode_expand(input).to_string();
+        assert!(expanded.contains("compile_error"));
+        assert!(expanded.contains("does not support methods"));
+    }
+
+    #[test]
+    fn test_hash_mode_rejects_lifetime_only_generics() {
+        use syn::parse_quote;
+
+        // Lifetime parameters alone don't satisfy the hash-mode contract: the
+        // helper needs a *type* parameter to instantiate with the mode ZST.
+        let input: ItemFn = parse_quote! { fn t<'a>(x: &'a u32) { let _ = x; } };
+        let expanded = hash_mode_expand(input).to_string();
+        assert!(expanded.contains("compile_error"));
+        assert!(expanded.contains("requires a generic function with a hash-mode type parameter"));
     }
 }

--- a/firewood-macros/tests/compile_fail/hash_mode_arguments.rs
+++ b/firewood-macros/tests/compile_fail/hash_mode_arguments.rs
@@ -1,0 +1,6 @@
+use firewood_macros::hash_mode;
+
+#[hash_mode(eth)]
+fn only_eth<H>() {}
+
+fn main() {}

--- a/firewood-macros/tests/compile_fail/hash_mode_arguments.stderr
+++ b/firewood-macros/tests/compile_fail/hash_mode_arguments.stderr
@@ -1,0 +1,5 @@
+error: #[hash_mode] does not accept arguments; use #[test] and select the concrete hash mode explicitly for a single-mode test
+ --> tests/compile_fail/hash_mode_arguments.rs:3:13
+  |
+3 | #[hash_mode(eth)]
+  |             ^^^

--- a/firewood-macros/tests/compile_fail/hash_mode_non_generic.rs
+++ b/firewood-macros/tests/compile_fail/hash_mode_non_generic.rs
@@ -1,0 +1,6 @@
+use firewood_macros::hash_mode;
+
+#[hash_mode]
+fn t() {}
+
+fn main() {}

--- a/firewood-macros/tests/compile_fail/hash_mode_non_generic.stderr
+++ b/firewood-macros/tests/compile_fail/hash_mode_non_generic.stderr
@@ -1,0 +1,5 @@
+error: #[hash_mode] requires a generic function with a hash-mode type parameter, e.g. `fn name<H: HashMode>()`
+ --> tests/compile_fail/hash_mode_non_generic.rs:4:1
+  |
+4 | fn t() {}
+  | ^^^^^^

--- a/firewood-macros/tests/compile_fail/hash_mode_pattern_param.rs
+++ b/firewood-macros/tests/compile_fail/hash_mode_pattern_param.rs
@@ -1,0 +1,14 @@
+use firewood_macros::hash_mode;
+
+trait HashMode {}
+struct EthHash;
+struct MerkleDbHash;
+impl HashMode for EthHash {}
+impl HashMode for MerkleDbHash {}
+
+#[hash_mode]
+fn t<H: HashMode>((a, b): (u32, u32)) {
+    let _ = (a, b);
+}
+
+fn main() {}

--- a/firewood-macros/tests/compile_fail/hash_mode_pattern_param.stderr
+++ b/firewood-macros/tests/compile_fail/hash_mode_pattern_param.stderr
@@ -1,0 +1,5 @@
+error: #[hash_mode] helpers may only use plain identifier parameters
+  --> tests/compile_fail/hash_mode_pattern_param.rs:10:19
+   |
+10 | fn t<H: HashMode>((a, b): (u32, u32)) {
+   |                   ^^^^^^

--- a/firewood-macros/tests/compile_pass/hash_mode_bare.rs
+++ b/firewood-macros/tests/compile_pass/hash_mode_bare.rs
@@ -1,0 +1,15 @@
+use firewood_macros::hash_mode;
+
+trait HashMode {}
+struct EthHash;
+struct MerkleDbHash;
+impl HashMode for EthHash {}
+impl HashMode for MerkleDbHash {}
+
+#[hash_mode]
+#[allow(dead_code)]
+fn runs_under_both<H: HashMode>() {
+    let _ = core::marker::PhantomData::<H>;
+}
+
+fn main() {}

--- a/firewood-macros/tests/compile_pass/hash_mode_test_case.rs
+++ b/firewood-macros/tests/compile_pass/hash_mode_test_case.rs
@@ -1,0 +1,17 @@
+use firewood_macros::hash_mode;
+use test_case::test_case;
+
+trait HashMode {}
+struct EthHash;
+struct MerkleDbHash;
+impl HashMode for EthHash {}
+impl HashMode for MerkleDbHash {}
+
+#[hash_mode]
+#[test_case(1, 2; "small")]
+#[test_case(10, 20; "large")]
+fn adds<H: HashMode>(a: u32, b: u32) {
+    assert!(a < b);
+}
+
+fn main() {}

--- a/firewood/src/api.rs
+++ b/firewood/src/api.rs
@@ -809,21 +809,20 @@ pub trait DynProposal<'db>: Debug + Send + Sync {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use firewood_storage::{EthHash, MerkleDbHash};
 
     #[test]
-    #[cfg(feature = "ethhash")]
     fn test_ethhash_compat_default_root_hash_equals_empty_rlp_hash() {
         use sha3::Digest as _;
 
         assert_eq!(
-            TrieHash::default_root_hash(),
+            EthHash::default_root_hash(),
             Some(sha3::Keccak256::digest(rlp::NULL_RLP).into()),
         );
     }
 
     #[test]
-    #[cfg(not(feature = "ethhash"))]
     fn test_firewood_default_root_hash_equals_none() {
-        assert_eq!(TrieHash::default_root_hash(), None);
+        assert_eq!(MerkleDbHash::default_root_hash(), None);
     }
 }

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -362,7 +362,10 @@ impl<H: HashMode> Db<H> {
     /// Create or open a database with the hash mode fixed by the type
     /// parameter `H`. The configured [`DbConfig::node_hash_algorithm`] must
     /// equal `H::ALGORITHM`; the open path validates it against the header.
-    fn new_with_hash_mode<P: AsRef<Path>>(db_dir: P, cfg: DbConfig) -> Result<Self, api::Error> {
+    pub(crate) fn new_with_hash_mode<P: AsRef<Path>>(
+        db_dir: P,
+        cfg: DbConfig,
+    ) -> Result<Self, api::Error> {
         // The hashing scheme is `H`, but the fresh-database header is stamped
         // from `cfg.node_hash_algorithm`. Reject a config that disagrees with
         // `H` so we never create a header that claims one mode while hashing
@@ -1012,10 +1015,13 @@ mod test {
     use std::ops::{Deref, DerefMut};
     use std::path::Path;
 
-    use firewood_storage::{CheckOpt, CheckerError, LinearAddress, MaybePersistedNode, TrieHash};
+    use firewood_storage::{
+        CheckOpt, CheckerError, DefaultHashMode, EthHash, HashMode, LinearAddress,
+        MaybePersistedNode, MerkleDbHash, TrieHash,
+    };
     use nonzero_ext::nonzero;
 
-    use crate::api::{Db as _, DbView, HashKeyExt, Proposal as _, Reconstructible};
+    use crate::api::{Db as _, DbView, Proposal as _, Reconstructible};
     use crate::db::{Db, Proposal, UseParallel};
     use crate::manager::RevisionManagerConfig;
 
@@ -1057,7 +1063,7 @@ mod test {
 
     impl<T: Iterator> IterExt for T {}
 
-    impl Db {
+    impl<H: HashMode> Db<H> {
         /// Wait until all pending commits have been persisted.
         fn wait_persisted(&self) {
             self.manager.wait_persisted();
@@ -1067,15 +1073,17 @@ mod test {
     /// Reconstruction always uses the serial path (`apply_batch_recon`), but the base
     /// revision may have been built with parallel or serial proposals. This test confirms
     /// both produce identical reconstruction results.
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     #[test]
     fn test_reconstruct_deterministic() {
-        let parallel_db = TestDb::new_with_config(
+        let parallel_db = TestDb::<DefaultHashMode>::new_with_config(
             DbConfig::builder()
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
-        let serial_db =
-            TestDb::new_with_config(DbConfig::builder().use_parallel(UseParallel::Never).build());
+        let serial_db = TestDb::<DefaultHashMode>::new_with_config(
+            DbConfig::builder().use_parallel(UseParallel::Never).build(),
+        );
 
         let initial_batch = vec![BatchOp::Put {
             key: b"base",
@@ -1125,9 +1133,9 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_update_commits_batch_and_returns_root() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_update_commits_batch_and_returns_root<H: HashMode>() {
+        let db = TestDb::<H>::new();
 
         let root = db
             .update(vec![BatchOp::Put {
@@ -1158,9 +1166,9 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_update_returns_empty_root_after_delete_all() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_update_returns_empty_root_after_delete_all<H: HashMode>() {
+        let db = TestDb::<H>::new();
 
         db.update(vec![BatchOp::Put {
             key: b"k",
@@ -1174,13 +1182,13 @@ mod test {
             }])
             .unwrap();
 
-        assert_eq!(root, TrieHash::default_root_hash());
-        assert_eq!(db.root_hash(), TrieHash::default_root_hash());
+        assert_eq!(root, H::default_root_hash());
+        assert_eq!(db.root_hash(), H::default_root_hash());
     }
 
-    #[test]
-    fn test_proposal_reads() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_proposal_reads<H: HashMode>() {
+        let db = TestDb::<H>::new();
         let batch = vec![BatchOp::Put {
             key: b"k",
             value: b"v",
@@ -1203,9 +1211,10 @@ mod test {
         assert_eq!(&*historical.val(b"k").unwrap().unwrap(), b"v");
     }
 
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     #[test]
     fn test_reconstruct_reads_and_chains() {
-        let db = TestDb::new();
+        let db = TestDb::<DefaultHashMode>::new();
 
         let initial = db
             .propose(vec![BatchOp::Put {
@@ -1241,6 +1250,7 @@ mod test {
         assert_eq!(&*reconstructed.val(b"next").unwrap().unwrap(), b"v2");
     }
 
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     #[test]
     fn test_reconstruct_from_committed_view_uses_requested_revision() {
         let db = TestDb::new();
@@ -1283,7 +1293,7 @@ mod test {
 
     #[test]
     fn test_reconstruct_clone_is_independent() {
-        let db = TestDb::new();
+        let db = TestDb::<DefaultHashMode>::new();
 
         // Build a base committed revision.
         let initial = db
@@ -1339,9 +1349,10 @@ mod test {
         assert_eq!(new_cloned.val(b"original_only").unwrap(), None);
     }
 
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     #[test]
     fn test_reconstruct_clone_of_clone() {
-        let db = TestDb::new();
+        let db = TestDb::<DefaultHashMode>::new();
 
         // Build a base committed revision.
         let initial = db
@@ -1374,9 +1385,10 @@ mod test {
         assert_eq!(original_root, second_clone.root_hash());
     }
 
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     #[test]
     fn test_reconstruct_clone_outlives_original() {
-        let db = TestDb::new();
+        let db = TestDb::<DefaultHashMode>::new();
 
         let key = b"k";
         let value = b"v";
@@ -1399,9 +1411,9 @@ mod test {
         assert_eq!(&*cloned.val(b"k").unwrap().unwrap(), b"v");
     }
 
-    #[test]
-    fn reopen_test() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn reopen_test<H: HashMode>() {
+        let db = TestDb::<H>::new();
         let initial_root = db.root_hash();
         let batch = vec![
             BatchOp::Put {
@@ -1430,13 +1442,13 @@ mod test {
         assert_eq!(final_root, initial_root);
     }
 
-    #[test]
+    #[firewood_macros::hash_mode]
     // test that dropping a proposal removes it from the list of known proposals
     //    /-> P1 - will get committed
     // R1 --> P2 - will get dropped
     //    \-> P3 - will get orphaned, but it's still known
-    fn test_proposal_scope_historic() {
-        let db = TestDb::new();
+    fn test_proposal_scope_historic<H: HashMode>() {
+        let db = TestDb::<H>::new();
         let batch1 = vec![BatchOp::Put {
             key: b"k1",
             value: b"v1",
@@ -1481,14 +1493,14 @@ mod test {
         assert!(db.manager.proposal_hashes().contains(&hash3));
     }
 
-    #[test]
+    #[firewood_macros::hash_mode]
     // test that dropping a proposal removes it from the list of known proposals
     // R1 - base revision
     //  \-> P1 - will get committed
     //   \-> P2 - will get dropped
     //    \-> P3 - will get orphaned, but it's still known
-    fn test_proposal_scope_orphan() {
-        let db = TestDb::new();
+    fn test_proposal_scope_orphan<H: HashMode>() {
+        let db = TestDb::<H>::new();
         let batch1 = vec![BatchOp::Put {
             key: b"k1",
             value: b"v1",
@@ -1537,9 +1549,9 @@ mod test {
         assert_eq!(&*proposal3.val(b"k3").unwrap().unwrap(), b"v3");
     }
 
-    #[test]
-    fn test_view_sync() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_view_sync<H: HashMode>() {
+        let db = TestDb::<H>::new();
 
         // Create and commit some data to get a historical revision
         let batch = vec![BatchOp::Put {
@@ -1569,9 +1581,9 @@ mod test {
         assert_eq!(&*value, b"proposal_value");
     }
 
-    #[test]
-    fn test_propose_parallel_reopen() {
-        fn insert_commit(db: &TestDb, kv: u8) {
+    #[firewood_macros::hash_mode]
+    fn test_propose_parallel_reopen<H: HashMode>() {
+        fn insert_commit<H: HashMode>(db: &TestDb<H>, kv: u8) {
             let keys: Vec<[u8; 1]> = vec![[kv; 1]];
             let vals: Vec<Box<[u8]>> = vec![Box::new([kv; 1])];
             let kviter = keys.iter().zip(vals.iter());
@@ -1580,7 +1592,7 @@ mod test {
         }
 
         // Create, insert, close, open, insert
-        let db = TestDb::new_with_config(
+        let db = TestDb::<H>::new_with_config(
             DbConfig::builder()
                 .use_parallel(UseParallel::Always)
                 .build(),
@@ -1599,13 +1611,13 @@ mod test {
         drop(db);
 
         // Open-db1, insert, open-db2, insert
-        let db1 = TestDb::new_with_config(
+        let db1 = TestDb::<H>::new_with_config(
             DbConfig::builder()
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
         insert_commit(&db1, 1);
-        let db2 = TestDb::new_with_config(
+        let db2 = TestDb::<H>::new_with_config(
             DbConfig::builder()
                 .use_parallel(UseParallel::Always)
                 .build(),
@@ -1622,10 +1634,10 @@ mod test {
         assert_eq!(&committed2.val(k).unwrap().unwrap(), v);
     }
 
-    #[test]
-    fn test_propose_parallel() {
+    #[firewood_macros::hash_mode]
+    fn test_propose_parallel<H: HashMode>() {
         const N: usize = 100;
-        let db = TestDb::new_with_config(
+        let db = TestDb::<H>::new_with_config(
             DbConfig::builder()
                 .use_parallel(UseParallel::Always)
                 .build(),
@@ -1743,8 +1755,8 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_propose_parallel_vs_normal_propose() {
+    #[firewood_macros::hash_mode]
+    fn test_propose_parallel_vs_normal_propose<H: HashMode>() {
         fn persisted_deleted(nodes: &[MaybePersistedNode]) -> Vec<LinearAddress> {
             let mut addresses: Vec<_> = nodes
                 .iter()
@@ -1754,13 +1766,14 @@ mod test {
             addresses
         }
 
-        let parallel_db = TestDb::new_with_config(
+        let parallel_db = TestDb::<H>::new_with_config(
             DbConfig::builder()
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
-        let single_threaded_db =
-            TestDb::new_with_config(DbConfig::builder().use_parallel(UseParallel::Never).build());
+        let single_threaded_db = TestDb::<H>::new_with_config(
+            DbConfig::builder().use_parallel(UseParallel::Never).build(),
+        );
 
         // First batch: insert two keys with different first nibbles so they are
         // handled by different workers in the parallel merkle implementation.
@@ -1814,15 +1827,16 @@ mod test {
     /// `DeleteRange { prefix: &[] }`) only sends the delete to existing workers,
     /// so children in subtries that were never touched by prior operations in the
     /// batch may survive incorrectly.
-    #[test]
-    fn test_parallel_delete_range_empty_prefix_with_existing_workers() {
-        let parallel_db = TestDb::new_with_config(
+    #[firewood_macros::hash_mode]
+    fn test_parallel_delete_range_empty_prefix_with_existing_workers<H: HashMode>() {
+        let parallel_db = TestDb::<H>::new_with_config(
             DbConfig::builder()
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
-        let single_db =
-            TestDb::new_with_config(DbConfig::builder().use_parallel(UseParallel::Never).build());
+        let single_db = TestDb::<H>::new_with_config(
+            DbConfig::builder().use_parallel(UseParallel::Never).build(),
+        );
 
         // Insert keys in different subtries (different first nibbles)
         let setup_keys: Vec<[u8; 1]> = vec![[0x00], [0x10], [0x20]];
@@ -1878,12 +1892,12 @@ mod test {
     ///
     /// Test creates two batches and proposes them, and verifies that the values are in the correct proposal.
     /// It then commits them one by one, and verifies the latest committed version is correct.
-    #[test]
-    fn test_propose_on_proposal() {
+    #[firewood_macros::hash_mode]
+    fn test_propose_on_proposal<H: HashMode>() {
         // number of keys and values to create for this test
         const N: usize = 20;
 
-        let db = TestDb::new();
+        let db = TestDb::<H>::new();
 
         // create N keys and values like (key0, value0)..(keyN, valueN)
         let (keys, vals): (Vec<_>, Vec<_>) = (0..N)
@@ -1938,11 +1952,11 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_slow_fuzz_checker() {
+    #[firewood_macros::hash_mode]
+    fn test_slow_fuzz_checker<H: HashMode>() {
         let rng = firewood_storage::SeededRng::from_env_or_random();
 
-        let db = TestDb::new();
+        let db = TestDb::<H>::new();
 
         // takes about 0.3s on a mac to run 50 times
         for _ in 0..50 {
@@ -1987,12 +2001,16 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_deep_propose() {
+    #[firewood_macros::hash_mode]
+    // The `#[hash_mode]` macro moves this body into a plain (non-`#[test]`)
+    // generic helper, so it no longer gets clippy's blanket `#[test]`
+    // exemption for `arithmetic_side_effects`.
+    #[expect(clippy::arithmetic_side_effects)]
+    fn test_deep_propose<H: HashMode>() {
         const NUM_KEYS: NonZeroUsize = const { NonZeroUsize::new(2).unwrap() };
         const NUM_PROPOSALS: usize = 100;
 
-        let db = TestDb::new();
+        let db = TestDb::<H>::new();
 
         let ops = (0..(NUM_KEYS.get() * NUM_PROPOSALS))
             .map(|i| (format!("key{i}"), format!("value{i}")))
@@ -2000,7 +2018,7 @@ mod test {
 
         let proposals = ops.iter().chunk_fold(
             NUM_KEYS,
-            Vec::<Proposal<'_>>::with_capacity(NUM_PROPOSALS),
+            Vec::<Proposal<'_, H>>::with_capacity(NUM_PROPOSALS),
             |mut proposals, ops| {
                 let proposal = if let Some(parent) = proposals.last() {
                     parent.propose(ops).unwrap()
@@ -2039,16 +2057,16 @@ mod test {
     }
 
     /// Test that reading from a proposal during commit works as expected
-    #[test]
-    fn test_slow_read_during_commit() {
+    #[firewood_macros::hash_mode]
+    fn test_slow_read_during_commit<H: HashMode>() {
         use crate::db::Proposal;
 
         const CHANNEL_CAPACITY: usize = 8;
 
-        let testdb = TestDb::new();
+        let testdb = TestDb::<H>::new();
         let db = &*testdb;
 
-        let (tx, rx) = std::sync::mpsc::sync_channel::<Proposal<'_>>(CHANNEL_CAPACITY);
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Proposal<'_, H>>(CHANNEL_CAPACITY);
         let (result_tx, result_rx) = std::sync::mpsc::sync_channel(CHANNEL_CAPACITY);
 
         // scope will block until all scope-spawned threads finish
@@ -2090,9 +2108,9 @@ mod test {
 
     /// Verifies that after reopening the database, an older revision can still
     /// be retrieved via the root store.
-    #[test]
-    fn test_resurrect_unpersisted_root() {
-        let db = TestDb::new_with_config(DbConfig::builder().root_store(true).build());
+    #[firewood_macros::hash_mode]
+    fn test_resurrect_unpersisted_root<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(DbConfig::builder().root_store(true).build());
 
         // First, create a revision to retrieve
         let key = b"key";
@@ -2129,9 +2147,9 @@ mod test {
     }
 
     /// Verifies that persisted revisions are still accessible when reopening the database.
-    #[test]
-    fn test_root_store() {
-        let db = TestDb::new_with_config(DbConfig::builder().root_store(true).build());
+    #[firewood_macros::hash_mode]
+    fn test_root_store<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(DbConfig::builder().root_store(true).build());
 
         // First, create a revision to retrieve
         let key = b"key";
@@ -2162,9 +2180,9 @@ mod test {
 
     /// Verifies that proposals skip building the future-delete log when
     /// archival mode is enabled, since it is never consumed.
-    #[test]
-    fn test_no_fdl_when_root_store_enabled() {
-        let db = TestDb::new_with_config(DbConfig::builder().root_store(true).build());
+    #[firewood_macros::hash_mode]
+    fn test_no_fdl_when_root_store_enabled<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(DbConfig::builder().root_store(true).build());
 
         let key = b"key";
         let batch = vec![BatchOp::Put {
@@ -2188,9 +2206,9 @@ mod test {
     }
 
     /// Verifies that proposals build the future-delete log if archival mode is disabled.
-    #[test]
-    fn test_fdl_tracked_when_root_store_disabled() {
-        let db = TestDb::new_with_config(DbConfig::builder().root_store(false).build());
+    #[firewood_macros::hash_mode]
+    fn test_fdl_tracked_when_root_store_disabled<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(DbConfig::builder().root_store(false).build());
 
         let key = b"key";
         let batch = vec![BatchOp::Put {
@@ -2211,23 +2229,23 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_rootstore_empty_db_reopen() {
-        let db = TestDb::new_with_config(DbConfig::builder().root_store(true).build());
+    #[firewood_macros::hash_mode]
+    fn test_rootstore_empty_db_reopen<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(DbConfig::builder().root_store(true).build());
 
         db.reopen();
     }
 
     /// Verifies that revisions exceeding the in-memory limit can still be retrieved.
-    #[test]
-    fn test_root_store_with_capped_max_revisions() {
+    #[firewood_macros::hash_mode]
+    fn test_root_store_with_capped_max_revisions<H: HashMode>() {
         const NUM_REVISIONS: usize = 10;
 
         let dbconfig = DbConfig::builder()
             .manager(RevisionManagerConfig::builder().max_revisions(5).build())
             .root_store(true)
             .build();
-        let db = TestDb::new_with_config(dbconfig);
+        let db = TestDb::<H>::new_with_config(dbconfig);
 
         // Create and commit 10 proposals
         let key = b"root_store";
@@ -2262,10 +2280,11 @@ mod test {
     }
 
     /// Verifies that `RootStore` is truncated as well if we truncate the database.
-    #[test]
-    fn test_root_store_truncation() {
-        let db =
-            TestDb::new_with_config(DbConfig::builder().root_store(true).truncate(true).build());
+    #[firewood_macros::hash_mode]
+    fn test_root_store_truncation<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(
+            DbConfig::builder().root_store(true).truncate(true).build(),
+        );
 
         // Create a revision to store
         let batch = vec![BatchOp::Put {
@@ -2281,18 +2300,20 @@ mod test {
     }
 
     /// Verifies that opening a database fails if the directory doesn't exist.
-    #[test]
-    fn test_nonexistent_directory() {
+    #[firewood_macros::hash_mode]
+    fn test_nonexistent_directory<H: HashMode>() {
         let tmpdir = tempfile::tempdir().unwrap();
 
-        assert!(Db::new(tmpdir, DbConfig::builder().create_if_missing(false).build()).is_err());
+        let mut cfg = DbConfig::builder().create_if_missing(false).build();
+        cfg.node_hash_algorithm = H::ALGORITHM;
+        assert!(Db::<H>::new_with_hash_mode(tmpdir, cfg).is_err());
     }
 
-    #[test]
-    fn test_backwards_compatible_magic_string() {
+    #[firewood_macros::hash_mode]
+    fn test_backwards_compatible_magic_string<H: HashMode>() {
         use std::os::unix::fs::FileExt;
 
-        let testdb = TestDb::new();
+        let testdb = TestDb::<H>::new();
 
         testdb
             .propose([(b"key", b"value")])
@@ -2326,8 +2347,8 @@ mod test {
         assert_eq!(rh, testdb.root_hash().unwrap());
     }
 
-    #[test]
-    fn test_deferred_persist_multiple_commits_with_commit_count_one() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persist_multiple_commits_with_commit_count_one<H: HashMode>() {
         const NUM_REVISIONS: usize = 20;
 
         let dbcfg = DbConfig::builder()
@@ -2338,7 +2359,7 @@ mod test {
             )
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         // Create and commit NUM_REVISIONS proposals, storing their root hashes
         let root_hashes: Vec<TrieHash> = (0..NUM_REVISIONS)
@@ -2371,11 +2392,11 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_deferred_persist_close_with_commit_count_one() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persist_close_with_commit_count_one<H: HashMode>() {
         let dbcfg = DbConfig::builder().build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         // Then, commit once and see what the latest revision is
         let key = b"foo";
@@ -2393,8 +2414,8 @@ mod test {
         assert_eq!(value, new_value.as_ref());
     }
 
-    #[test]
-    fn test_deferred_persist_close_with_high_commit_count() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persist_close_with_high_commit_count<H: HashMode>() {
         const HIGH_COMMIT_COUNT: NonZeroU64 = nonzero!(1_000_000u64);
         const MAX_REVISIONS: usize = HIGH_COMMIT_COUNT.get() as usize + 1;
 
@@ -2409,7 +2430,7 @@ mod test {
             )
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         // Then, commit once and see what the latest revision is
         let key = b"foo";
@@ -2427,8 +2448,8 @@ mod test {
         assert_eq!(value, new_value.as_ref());
     }
 
-    #[test]
-    fn test_deferred_persist_with_multiple_commit_count() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persist_with_multiple_commit_count<H: HashMode>() {
         const COMMIT_COUNT: NonZeroU64 = nonzero!(5u64);
         const NUM_REVISIONS: u64 = COMMIT_COUNT.get() + 1;
 
@@ -2440,7 +2461,7 @@ mod test {
             )
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         let mut root_hashes = Vec::new();
 
@@ -2470,8 +2491,8 @@ mod test {
 
     /// Verifies that an unpersisted revision which wipes the database is
     /// persisted when the database closes.
-    #[test]
-    fn test_deferred_persistence_closing_on_empty_trie() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persistence_closing_on_empty_trie<H: HashMode>() {
         const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
 
         let dbcfg = DbConfig::builder()
@@ -2482,7 +2503,7 @@ mod test {
             )
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         // Commit COMMIT_COUNT proposals to trigger the first persist
         for i in 0..COMMIT_COUNT.get() {
@@ -2503,11 +2524,11 @@ mod test {
 
         // Verify that the latest committed revision is empty.
         let last_committed_hash = db.root_hash();
-        assert_eq!(last_committed_hash, TrieHash::default_root_hash());
+        assert_eq!(last_committed_hash, H::default_root_hash());
     }
 
-    #[test]
-    fn test_deferred_persistence_root_store() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persistence_root_store<H: HashMode>() {
         const NUM_COMMITS: usize = 20;
         const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
         const MAX_REVISIONS: usize = COMMIT_COUNT.get() as usize + 1;
@@ -2522,7 +2543,7 @@ mod test {
             .root_store(true)
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         let mut root_hashes = Vec::new();
 
@@ -2570,8 +2591,8 @@ mod test {
     }
 
     /// Verifies that non-persisted revisions are lost after reopening the database.
-    #[test]
-    fn test_deferred_persistence_unpersisted_revisions() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persistence_unpersisted_revisions<H: HashMode>() {
         const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
 
         let dbcfg = DbConfig::builder()
@@ -2583,7 +2604,7 @@ mod test {
             .root_store(true)
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         let mut root_hashes = Vec::new();
 
@@ -2616,38 +2637,41 @@ mod test {
     }
 
     // Testdb is a helper struct for testing the Db. Once it's dropped, the directory and file disappear
-    pub(super) struct TestDb {
-        db: Option<Db>,
+    pub(super) struct TestDb<H: HashMode> {
+        db: Option<Db<H>>,
         tmpdir: tempfile::TempDir,
         dbconfig: DbConfig,
     }
-    impl Drop for TestDb {
+    impl<H: HashMode> Drop for TestDb<H> {
         fn drop(&mut self) {
             if let Some(db) = self.db.take() {
                 db.close().unwrap();
             }
         }
     }
-    impl Deref for TestDb {
-        type Target = Db;
+    impl<H: HashMode> Deref for TestDb<H> {
+        type Target = Db<H>;
         fn deref(&self) -> &Self::Target {
             self.db.as_ref().unwrap()
         }
     }
-    impl DerefMut for TestDb {
+    impl<H: HashMode> DerefMut for TestDb<H> {
         fn deref_mut(&mut self) -> &mut Self::Target {
             self.db.as_mut().unwrap()
         }
     }
 
-    impl TestDb {
+    impl<H: HashMode> TestDb<H> {
         pub fn new() -> Self {
             TestDb::new_with_config(DbConfig::builder().build())
         }
 
-        pub fn new_with_config(dbconfig: DbConfig) -> Self {
+        pub fn new_with_config(mut dbconfig: DbConfig) -> Self {
+            // The test's mode is `H`; make the config agree regardless of what
+            // the builder defaulted to (new_with_hash_mode rejects a mismatch).
+            dbconfig.node_hash_algorithm = H::ALGORITHM;
             let tmpdir = tempfile::tempdir().unwrap();
-            let db = Db::new(tmpdir.as_ref(), dbconfig.clone()).unwrap();
+            let db = Db::new_with_hash_mode(tmpdir.as_ref(), dbconfig.clone()).unwrap();
             TestDb {
                 db: Some(db),
                 tmpdir,
@@ -2662,7 +2686,7 @@ mod test {
         pub fn reopen(mut self) -> Self {
             self.db.take().unwrap().close().unwrap();
 
-            let db = Db::new(self.tmpdir.path(), self.dbconfig.clone()).unwrap();
+            let db = Db::new_with_hash_mode(self.tmpdir.path(), self.dbconfig.clone()).unwrap();
             self.db = Some(db);
             self
         }
@@ -2680,7 +2704,8 @@ mod test {
             self.db.take().unwrap().close().unwrap();
 
             self.dbconfig = DbConfig::builder().truncate(true).build();
-            let db = Db::new(self.tmpdir.path(), self.dbconfig.clone()).unwrap();
+            self.dbconfig.node_hash_algorithm = H::ALGORITHM;
+            let db = Db::new_with_hash_mode(self.tmpdir.path(), self.dbconfig.clone()).unwrap();
             self.db = Some(db);
             self
         }

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -21,8 +21,6 @@ use crate::verify_change_proof_structure;
 
 use crate::manager::{ConfigManager, RevisionManager, RevisionManagerConfig};
 use firewood_metrics::{firewood_counter, firewood_gauge, firewood_histogram};
-#[cfg(test)]
-use firewood_storage::DefaultHashMode;
 use firewood_storage::{
     CargoVersion, CheckOpt, CheckerReport, Committed, CommittedParentHash, EthHash, FileBacked,
     FileIoError, GitDescribe, HashMode, HashedNodeReader, ImmutableProposal, MerkleDbHash, Mutable,
@@ -111,10 +109,6 @@ pub enum UseParallel {
 #[non_exhaustive]
 pub struct DbConfig {
     /// The algorithm used for hashing nodes (required).
-    ///
-    /// In tests this defaults to the feature-selected compatibility algorithm.
-    /// Production callers must select the algorithm explicitly.
-    #[cfg_attr(test, builder(default = DefaultHashMode::ALGORITHM))]
     pub node_hash_algorithm: NodeHashAlgorithm,
     /// Whether to create the DB if it doesn't exist.
     #[builder(default = true)]
@@ -970,12 +964,12 @@ mod test {
     use std::path::Path;
 
     use firewood_storage::{
-        CheckOpt, CheckerError, DefaultHashMode, HashMode, LinearAddress, MaybePersistedNode,
-        NodeHashAlgorithm, TrieHash,
+        CheckOpt, CheckerError, DefaultHashMode, EthHash, HashMode, LinearAddress,
+        MaybePersistedNode, MerkleDbHash, NodeHashAlgorithm, TrieHash,
     };
     use nonzero_ext::nonzero;
 
-    use crate::api::{self, Db as _, DbView, HashKeyExt, Proposal as _, Reconstructible};
+    use crate::api::{self, Db as _, DbView, Proposal as _, Reconstructible};
     use crate::db::{Db, Proposal, UseParallel};
     use crate::manager::RevisionManagerConfig;
 
@@ -1017,7 +1011,7 @@ mod test {
 
     impl<T: Iterator> IterExt for T {}
 
-    impl Db<DefaultHashMode> {
+    impl<H: HashMode> Db<H> {
         /// Wait until all pending commits have been persisted.
         fn wait_persisted(&self) {
             self.manager.wait_persisted();
@@ -1196,15 +1190,20 @@ mod test {
     /// Reconstruction always uses the serial path (`apply_batch_recon`), but the base
     /// revision may have been built with parallel or serial proposals. This test confirms
     /// both produce identical reconstruction results.
-    #[test]
-    fn test_reconstruct_deterministic() {
-        let parallel_db = TestDb::new_with_config(
+    #[firewood_macros::hash_mode]
+    fn test_reconstruct_deterministic<H: HashMode>() {
+        let parallel_db = TestDb::<H>::new_with_config(
             DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
-        let serial_db =
-            TestDb::new_with_config(DbConfig::builder().use_parallel(UseParallel::Never).build());
+        let serial_db = TestDb::<H>::new_with_config(
+            DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
+                .use_parallel(UseParallel::Never)
+                .build(),
+        );
 
         let initial_batch = vec![BatchOp::Put {
             key: b"base",
@@ -1254,9 +1253,9 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_update_commits_batch_and_returns_root() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_update_commits_batch_and_returns_root<H: HashMode>() {
+        let db = TestDb::<H>::new();
 
         let root = db
             .update(vec![BatchOp::Put {
@@ -1287,9 +1286,9 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_update_returns_empty_root_after_delete_all() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_update_returns_empty_root_after_delete_all<H: HashMode>() {
+        let db = TestDb::<H>::new();
 
         db.update(vec![BatchOp::Put {
             key: b"k",
@@ -1303,13 +1302,13 @@ mod test {
             }])
             .unwrap();
 
-        assert_eq!(root, TrieHash::default_root_hash());
-        assert_eq!(db.root_hash(), TrieHash::default_root_hash());
+        assert_eq!(root, H::default_root_hash());
+        assert_eq!(db.root_hash(), H::default_root_hash());
     }
 
-    #[test]
-    fn test_proposal_reads() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_proposal_reads<H: HashMode>() {
+        let db = TestDb::<H>::new();
         let batch = vec![BatchOp::Put {
             key: b"k",
             value: b"v",
@@ -1332,9 +1331,9 @@ mod test {
         assert_eq!(&*historical.val(b"k").unwrap().unwrap(), b"v");
     }
 
-    #[test]
-    fn test_reconstruct_reads_and_chains() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_reconstruct_reads_and_chains<H: HashMode>() {
+        let db = TestDb::<H>::new();
 
         let initial = db
             .propose(vec![BatchOp::Put {
@@ -1370,9 +1369,9 @@ mod test {
         assert_eq!(&*reconstructed.val(b"next").unwrap().unwrap(), b"v2");
     }
 
-    #[test]
-    fn test_reconstruct_from_committed_view_uses_requested_revision() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_reconstruct_from_committed_view_uses_requested_revision<H: HashMode>() {
+        let db = TestDb::<H>::new();
         let key = b"k";
         let historical_value = b"historical";
         let latest_value = b"latest";
@@ -1412,7 +1411,7 @@ mod test {
 
     #[test]
     fn test_reconstruct_clone_is_independent() {
-        let db = TestDb::new();
+        let db = TestDb::<DefaultHashMode>::new();
 
         // Build a base committed revision.
         let initial = db
@@ -1468,9 +1467,9 @@ mod test {
         assert_eq!(new_cloned.val(b"original_only").unwrap(), None);
     }
 
-    #[test]
-    fn test_reconstruct_clone_of_clone() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_reconstruct_clone_of_clone<H: HashMode>() {
+        let db = TestDb::<H>::new();
 
         // Build a base committed revision.
         let initial = db
@@ -1503,9 +1502,9 @@ mod test {
         assert_eq!(original_root, second_clone.root_hash());
     }
 
-    #[test]
-    fn test_reconstruct_clone_outlives_original() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_reconstruct_clone_outlives_original<H: HashMode>() {
+        let db = TestDb::<H>::new();
 
         let key = b"k";
         let value = b"v";
@@ -1528,9 +1527,9 @@ mod test {
         assert_eq!(&*cloned.val(b"k").unwrap().unwrap(), b"v");
     }
 
-    #[test]
-    fn reopen_test() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn reopen_test<H: HashMode>() {
+        let db = TestDb::<H>::new();
         let initial_root = db.root_hash();
         let batch = vec![
             BatchOp::Put {
@@ -1559,13 +1558,13 @@ mod test {
         assert_eq!(final_root, initial_root);
     }
 
-    #[test]
+    #[firewood_macros::hash_mode]
     // test that dropping a proposal removes it from the list of known proposals
     //    /-> P1 - will get committed
     // R1 --> P2 - will get dropped
     //    \-> P3 - will get orphaned, but it's still known
-    fn test_proposal_scope_historic() {
-        let db = TestDb::new();
+    fn test_proposal_scope_historic<H: HashMode>() {
+        let db = TestDb::<H>::new();
         let batch1 = vec![BatchOp::Put {
             key: b"k1",
             value: b"v1",
@@ -1610,14 +1609,14 @@ mod test {
         assert!(db.manager.proposal_hashes().contains(&hash3));
     }
 
-    #[test]
+    #[firewood_macros::hash_mode]
     // test that dropping a proposal removes it from the list of known proposals
     // R1 - base revision
     //  \-> P1 - will get committed
     //   \-> P2 - will get dropped
     //    \-> P3 - will get orphaned, but it's still known
-    fn test_proposal_scope_orphan() {
-        let db = TestDb::new();
+    fn test_proposal_scope_orphan<H: HashMode>() {
+        let db = TestDb::<H>::new();
         let batch1 = vec![BatchOp::Put {
             key: b"k1",
             value: b"v1",
@@ -1666,9 +1665,9 @@ mod test {
         assert_eq!(&*proposal3.val(b"k3").unwrap().unwrap(), b"v3");
     }
 
-    #[test]
-    fn test_view_sync() {
-        let db = TestDb::new();
+    #[firewood_macros::hash_mode]
+    fn test_view_sync<H: HashMode>() {
+        let db = TestDb::<H>::new();
 
         // Create and commit some data to get a historical revision
         let batch = vec![BatchOp::Put {
@@ -1698,9 +1697,9 @@ mod test {
         assert_eq!(&*value, b"proposal_value");
     }
 
-    #[test]
-    fn test_propose_parallel_reopen() {
-        fn insert_commit(db: &TestDb, kv: u8) {
+    #[firewood_macros::hash_mode]
+    fn test_propose_parallel_reopen<H: HashMode>() {
+        fn insert_commit<H: HashMode>(db: &TestDb<H>, kv: u8) {
             let keys: Vec<[u8; 1]> = vec![[kv; 1]];
             let vals: Vec<Box<[u8]>> = vec![Box::new([kv; 1])];
             let kviter = keys.iter().zip(vals.iter());
@@ -1709,8 +1708,9 @@ mod test {
         }
 
         // Create, insert, close, open, insert
-        let db = TestDb::new_with_config(
+        let db = TestDb::<H>::new_with_config(
             DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
@@ -1728,14 +1728,16 @@ mod test {
         drop(db);
 
         // Open-db1, insert, open-db2, insert
-        let db1 = TestDb::new_with_config(
+        let db1 = TestDb::<H>::new_with_config(
             DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
         insert_commit(&db1, 1);
-        let db2 = TestDb::new_with_config(
+        let db2 = TestDb::<H>::new_with_config(
             DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
@@ -1751,11 +1753,12 @@ mod test {
         assert_eq!(&committed2.val(k).unwrap().unwrap(), v);
     }
 
-    #[test]
-    fn test_propose_parallel() {
+    #[firewood_macros::hash_mode]
+    fn test_propose_parallel<H: HashMode>() {
         const N: usize = 100;
-        let db = TestDb::new_with_config(
+        let db = TestDb::<H>::new_with_config(
             DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
@@ -1872,8 +1875,8 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_propose_parallel_vs_normal_propose() {
+    #[firewood_macros::hash_mode]
+    fn test_propose_parallel_vs_normal_propose<H: HashMode>() {
         fn persisted_deleted(nodes: &[MaybePersistedNode]) -> Vec<LinearAddress> {
             let mut addresses: Vec<_> = nodes
                 .iter()
@@ -1883,13 +1886,18 @@ mod test {
             addresses
         }
 
-        let parallel_db = TestDb::new_with_config(
+        let parallel_db = TestDb::<H>::new_with_config(
             DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
-        let single_threaded_db =
-            TestDb::new_with_config(DbConfig::builder().use_parallel(UseParallel::Never).build());
+        let single_threaded_db = TestDb::<H>::new_with_config(
+            DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
+                .use_parallel(UseParallel::Never)
+                .build(),
+        );
 
         // First batch: insert two keys with different first nibbles so they are
         // handled by different workers in the parallel merkle implementation.
@@ -1943,15 +1951,20 @@ mod test {
     /// `DeleteRange { prefix: &[] }`) only sends the delete to existing workers,
     /// so children in subtries that were never touched by prior operations in the
     /// batch may survive incorrectly.
-    #[test]
-    fn test_parallel_delete_range_empty_prefix_with_existing_workers() {
-        let parallel_db = TestDb::new_with_config(
+    #[firewood_macros::hash_mode]
+    fn test_parallel_delete_range_empty_prefix_with_existing_workers<H: HashMode>() {
+        let parallel_db = TestDb::<H>::new_with_config(
             DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
                 .use_parallel(UseParallel::Always)
                 .build(),
         );
-        let single_db =
-            TestDb::new_with_config(DbConfig::builder().use_parallel(UseParallel::Never).build());
+        let single_db = TestDb::<H>::new_with_config(
+            DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
+                .use_parallel(UseParallel::Never)
+                .build(),
+        );
 
         // Insert keys in different subtries (different first nibbles)
         let setup_keys: Vec<[u8; 1]> = vec![[0x00], [0x10], [0x20]];
@@ -2007,12 +2020,12 @@ mod test {
     ///
     /// Test creates two batches and proposes them, and verifies that the values are in the correct proposal.
     /// It then commits them one by one, and verifies the latest committed version is correct.
-    #[test]
-    fn test_propose_on_proposal() {
+    #[firewood_macros::hash_mode]
+    fn test_propose_on_proposal<H: HashMode>() {
         // number of keys and values to create for this test
         const N: usize = 20;
 
-        let db = TestDb::new();
+        let db = TestDb::<H>::new();
 
         // create N keys and values like (key0, value0)..(keyN, valueN)
         let (keys, vals): (Vec<_>, Vec<_>) = (0..N)
@@ -2067,11 +2080,11 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_slow_fuzz_checker() {
+    #[firewood_macros::hash_mode]
+    fn test_slow_fuzz_checker<H: HashMode>() {
         let rng = firewood_storage::SeededRng::from_env_or_random();
 
-        let db = TestDb::new();
+        let db = TestDb::<H>::new();
 
         // takes about 0.3s on a mac to run 50 times
         for _ in 0..50 {
@@ -2116,12 +2129,16 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_deep_propose() {
+    #[firewood_macros::hash_mode]
+    // The `#[hash_mode]` macro moves this body into a plain (non-`#[test]`)
+    // generic helper, so it no longer gets clippy's blanket `#[test]`
+    // exemption for `arithmetic_side_effects`.
+    #[expect(clippy::arithmetic_side_effects)]
+    fn test_deep_propose<H: HashMode>() {
         const NUM_KEYS: NonZeroUsize = const { NonZeroUsize::new(2).unwrap() };
         const NUM_PROPOSALS: usize = 100;
 
-        let db = TestDb::new();
+        let db = TestDb::<H>::new();
 
         let ops = (0..(NUM_KEYS.get() * NUM_PROPOSALS))
             .map(|i| (format!("key{i}"), format!("value{i}")))
@@ -2129,7 +2146,7 @@ mod test {
 
         let proposals = ops.iter().chunk_fold(
             NUM_KEYS,
-            Vec::<Proposal<'_, DefaultHashMode>>::with_capacity(NUM_PROPOSALS),
+            Vec::<Proposal<'_, H>>::with_capacity(NUM_PROPOSALS),
             |mut proposals, ops| {
                 let proposal = if let Some(parent) = proposals.last() {
                     parent.propose(ops).unwrap()
@@ -2168,17 +2185,16 @@ mod test {
     }
 
     /// Test that reading from a proposal during commit works as expected
-    #[test]
-    fn test_slow_read_during_commit() {
+    #[firewood_macros::hash_mode]
+    fn test_slow_read_during_commit<H: HashMode>() {
         use crate::db::Proposal;
 
         const CHANNEL_CAPACITY: usize = 8;
 
-        let testdb = TestDb::new();
+        let testdb = TestDb::<H>::new();
         let db = &*testdb;
 
-        let (tx, rx) =
-            std::sync::mpsc::sync_channel::<Proposal<'_, DefaultHashMode>>(CHANNEL_CAPACITY);
+        let (tx, rx) = std::sync::mpsc::sync_channel::<Proposal<'_, H>>(CHANNEL_CAPACITY);
         let (result_tx, result_rx) = std::sync::mpsc::sync_channel(CHANNEL_CAPACITY);
 
         // scope will block until all scope-spawned threads finish
@@ -2220,9 +2236,14 @@ mod test {
 
     /// Verifies that after reopening the database, an older revision can still
     /// be retrieved via the root store.
-    #[test]
-    fn test_resurrect_unpersisted_root() {
-        let db = TestDb::new_with_config(DbConfig::builder().root_store(true).build());
+    #[firewood_macros::hash_mode]
+    fn test_resurrect_unpersisted_root<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(
+            DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
+                .root_store(true)
+                .build(),
+        );
 
         // First, create a revision to retrieve
         let key = b"key";
@@ -2259,9 +2280,14 @@ mod test {
     }
 
     /// Verifies that persisted revisions are still accessible when reopening the database.
-    #[test]
-    fn test_root_store() {
-        let db = TestDb::new_with_config(DbConfig::builder().root_store(true).build());
+    #[firewood_macros::hash_mode]
+    fn test_root_store<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(
+            DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
+                .root_store(true)
+                .build(),
+        );
 
         // First, create a revision to retrieve
         let key = b"key";
@@ -2292,9 +2318,14 @@ mod test {
 
     /// Verifies that proposals skip building the future-delete log when
     /// archival mode is enabled, since it is never consumed.
-    #[test]
-    fn test_no_fdl_when_root_store_enabled() {
-        let db = TestDb::new_with_config(DbConfig::builder().root_store(true).build());
+    #[firewood_macros::hash_mode]
+    fn test_no_fdl_when_root_store_enabled<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(
+            DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
+                .root_store(true)
+                .build(),
+        );
 
         let key = b"key";
         let batch = vec![BatchOp::Put {
@@ -2318,9 +2349,14 @@ mod test {
     }
 
     /// Verifies that proposals build the future-delete log if archival mode is disabled.
-    #[test]
-    fn test_fdl_tracked_when_root_store_disabled() {
-        let db = TestDb::new_with_config(DbConfig::builder().root_store(false).build());
+    #[firewood_macros::hash_mode]
+    fn test_fdl_tracked_when_root_store_disabled<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(
+            DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
+                .root_store(false)
+                .build(),
+        );
 
         let key = b"key";
         let batch = vec![BatchOp::Put {
@@ -2341,23 +2377,29 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_rootstore_empty_db_reopen() {
-        let db = TestDb::new_with_config(DbConfig::builder().root_store(true).build());
+    #[firewood_macros::hash_mode]
+    fn test_rootstore_empty_db_reopen<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(
+            DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
+                .root_store(true)
+                .build(),
+        );
 
         db.reopen();
     }
 
     /// Verifies that revisions exceeding the in-memory limit can still be retrieved.
-    #[test]
-    fn test_root_store_with_capped_max_revisions() {
+    #[firewood_macros::hash_mode]
+    fn test_root_store_with_capped_max_revisions<H: HashMode>() {
         const NUM_REVISIONS: usize = 10;
 
         let dbconfig = DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
             .manager(RevisionManagerConfig::builder().max_revisions(5).build())
             .root_store(true)
             .build();
-        let db = TestDb::new_with_config(dbconfig);
+        let db = TestDb::<H>::new_with_config(dbconfig);
 
         // Create and commit 10 proposals
         let key = b"root_store";
@@ -2392,10 +2434,15 @@ mod test {
     }
 
     /// Verifies that `RootStore` is truncated as well if we truncate the database.
-    #[test]
-    fn test_root_store_truncation() {
-        let db =
-            TestDb::new_with_config(DbConfig::builder().root_store(true).truncate(true).build());
+    #[firewood_macros::hash_mode]
+    fn test_root_store_truncation<H: HashMode>() {
+        let db = TestDb::<H>::new_with_config(
+            DbConfig::builder()
+                .node_hash_algorithm(H::ALGORITHM)
+                .root_store(true)
+                .truncate(true)
+                .build(),
+        );
 
         // Create a revision to store
         let batch = vec![BatchOp::Put {
@@ -2411,26 +2458,21 @@ mod test {
     }
 
     /// Verifies that opening a database fails if the directory doesn't exist.
-    #[test]
-    fn test_nonexistent_directory() {
+    #[firewood_macros::hash_mode]
+    fn test_nonexistent_directory<H: HashMode>() {
         let tmpdir = tempfile::tempdir().unwrap();
 
-        assert!(
-            Db::<DefaultHashMode>::new_with_hash_mode(
-                tmpdir,
-                DbConfig::builder()
-                    .node_hash_algorithm(DefaultHashMode::ALGORITHM)
-                    .create_if_missing(false)
-                    .build(),
-            )
-            .is_err()
-        );
+        let cfg = DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
+            .create_if_missing(false)
+            .build();
+        assert!(Db::<H>::new_with_hash_mode(tmpdir, cfg).is_err());
     }
 
-    #[test]
-    fn test_new_rejects_hash_mode_mismatch() {
+    #[firewood_macros::hash_mode]
+    fn test_new_rejects_hash_mode_mismatch<H: HashMode>() {
         let tmpdir = tempfile::tempdir().unwrap();
-        let configured_algorithm = match DefaultHashMode::ALGORITHM {
+        let configured_algorithm = match H::ALGORITHM {
             NodeHashAlgorithm::MerkleDB => NodeHashAlgorithm::Ethereum,
             NodeHashAlgorithm::Ethereum => NodeHashAlgorithm::MerkleDB,
         };
@@ -2438,21 +2480,19 @@ mod test {
             .node_hash_algorithm(configured_algorithm)
             .build();
 
-        let error = Db::<DefaultHashMode>::new_with_hash_mode(tmpdir.path(), config).unwrap_err();
-        assert!(matches!(
-            error,
-            api::Error::HashModeMismatch {
-                expected: DefaultHashMode::ALGORITHM,
-                found,
-            } if found == configured_algorithm
-        ));
+        let error = Db::<H>::new_with_hash_mode(tmpdir.path(), config).unwrap_err();
+        let api::Error::HashModeMismatch { expected, found } = error else {
+            panic!("unexpected error: {error:?}");
+        };
+        assert_eq!(expected, H::ALGORITHM);
+        assert_eq!(found, configured_algorithm);
     }
 
-    #[test]
-    fn test_backwards_compatible_magic_string() {
+    #[firewood_macros::hash_mode]
+    fn test_backwards_compatible_magic_string<H: HashMode>() {
         use std::os::unix::fs::FileExt;
 
-        let testdb = TestDb::new();
+        let testdb = TestDb::<H>::new();
 
         testdb
             .propose([(b"key", b"value")])
@@ -2486,11 +2526,12 @@ mod test {
         assert_eq!(rh, testdb.root_hash().unwrap());
     }
 
-    #[test]
-    fn test_deferred_persist_multiple_commits_with_commit_count_one() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persist_multiple_commits_with_commit_count_one<H: HashMode>() {
         const NUM_REVISIONS: usize = 20;
 
         let dbcfg = DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(NUM_REVISIONS)
@@ -2498,7 +2539,7 @@ mod test {
             )
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         // Create and commit NUM_REVISIONS proposals, storing their root hashes
         let root_hashes: Vec<TrieHash> = (0..NUM_REVISIONS)
@@ -2531,11 +2572,13 @@ mod test {
         }
     }
 
-    #[test]
-    fn test_deferred_persist_close_with_commit_count_one() {
-        let dbcfg = DbConfig::builder().build();
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persist_close_with_commit_count_one<H: HashMode>() {
+        let dbcfg = DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
+            .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         // Then, commit once and see what the latest revision is
         let key = b"foo";
@@ -2553,14 +2596,15 @@ mod test {
         assert_eq!(value, new_value.as_ref());
     }
 
-    #[test]
-    fn test_deferred_persist_close_with_high_commit_count() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persist_close_with_high_commit_count<H: HashMode>() {
         const HIGH_COMMIT_COUNT: NonZeroU64 = nonzero!(1_000_000u64);
         const MAX_REVISIONS: usize = HIGH_COMMIT_COUNT.get() as usize + 1;
 
         // Set commit count to an arbitrarily high number so persist happens
         // only on shutdown
         let dbcfg = DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(MAX_REVISIONS)
@@ -2569,7 +2613,7 @@ mod test {
             )
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         // Then, commit once and see what the latest revision is
         let key = b"foo";
@@ -2587,12 +2631,13 @@ mod test {
         assert_eq!(value, new_value.as_ref());
     }
 
-    #[test]
-    fn test_deferred_persist_with_multiple_commit_count() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persist_with_multiple_commit_count<H: HashMode>() {
         const COMMIT_COUNT: NonZeroU64 = nonzero!(5u64);
         const NUM_REVISIONS: u64 = COMMIT_COUNT.get() + 1;
 
         let dbcfg = DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
             .manager(
                 RevisionManagerConfig::builder()
                     .deferred_persistence_commit_count(COMMIT_COUNT)
@@ -2600,7 +2645,7 @@ mod test {
             )
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         let mut root_hashes = Vec::new();
 
@@ -2630,11 +2675,12 @@ mod test {
 
     /// Verifies that an unpersisted revision which wipes the database is
     /// persisted when the database closes.
-    #[test]
-    fn test_deferred_persistence_closing_on_empty_trie() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persistence_closing_on_empty_trie<H: HashMode>() {
         const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
 
         let dbcfg = DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
             .manager(
                 RevisionManagerConfig::builder()
                     .deferred_persistence_commit_count(COMMIT_COUNT)
@@ -2642,7 +2688,7 @@ mod test {
             )
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         // Commit COMMIT_COUNT proposals to trigger the first persist
         for i in 0..COMMIT_COUNT.get() {
@@ -2663,16 +2709,17 @@ mod test {
 
         // Verify that the latest committed revision is empty.
         let last_committed_hash = db.root_hash();
-        assert_eq!(last_committed_hash, TrieHash::default_root_hash());
+        assert_eq!(last_committed_hash, H::default_root_hash());
     }
 
-    #[test]
-    fn test_deferred_persistence_root_store() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persistence_root_store<H: HashMode>() {
         const NUM_COMMITS: usize = 20;
         const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
         const MAX_REVISIONS: usize = COMMIT_COUNT.get() as usize + 1;
 
         let dbcfg = DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(MAX_REVISIONS)
@@ -2682,7 +2729,7 @@ mod test {
             .root_store(true)
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         let mut root_hashes = Vec::new();
 
@@ -2730,11 +2777,12 @@ mod test {
     }
 
     /// Verifies that non-persisted revisions are lost after reopening the database.
-    #[test]
-    fn test_deferred_persistence_unpersisted_revisions() {
+    #[firewood_macros::hash_mode]
+    fn test_deferred_persistence_unpersisted_revisions<H: HashMode>() {
         const COMMIT_COUNT: NonZeroU64 = nonzero!(10u64);
 
         let dbcfg = DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
             .manager(
                 RevisionManagerConfig::builder()
                     .deferred_persistence_commit_count(COMMIT_COUNT)
@@ -2743,7 +2791,7 @@ mod test {
             .root_store(true)
             .build();
 
-        let db = TestDb::new_with_config(dbcfg);
+        let db = TestDb::<H>::new_with_config(dbcfg);
 
         let mut root_hashes = Vec::new();
 
@@ -2776,43 +2824,42 @@ mod test {
     }
 
     // Testdb is a helper struct for testing the Db. Once it's dropped, the directory and file disappear
-    pub(super) struct TestDb {
-        db: Option<Db<DefaultHashMode>>,
+    pub(super) struct TestDb<H: HashMode> {
+        db: Option<Db<H>>,
         tmpdir: tempfile::TempDir,
         dbconfig: DbConfig,
     }
-    impl Drop for TestDb {
+    impl<H: HashMode> Drop for TestDb<H> {
         fn drop(&mut self) {
             if let Some(db) = self.db.take() {
                 db.close().unwrap();
             }
         }
     }
-    impl Deref for TestDb {
-        type Target = Db<DefaultHashMode>;
+    impl<H: HashMode> Deref for TestDb<H> {
+        type Target = Db<H>;
         fn deref(&self) -> &Self::Target {
             self.db.as_ref().unwrap()
         }
     }
-    impl DerefMut for TestDb {
+    impl<H: HashMode> DerefMut for TestDb<H> {
         fn deref_mut(&mut self) -> &mut Self::Target {
             self.db.as_mut().unwrap()
         }
     }
 
-    impl TestDb {
+    impl<H: HashMode> TestDb<H> {
         pub fn new() -> Self {
             TestDb::new_with_config(
                 DbConfig::builder()
-                    .node_hash_algorithm(DefaultHashMode::ALGORITHM)
+                    .node_hash_algorithm(H::ALGORITHM)
                     .build(),
             )
         }
 
         pub fn new_with_config(dbconfig: DbConfig) -> Self {
             let tmpdir = tempfile::tempdir().unwrap();
-            let db = Db::<DefaultHashMode>::new_with_hash_mode(tmpdir.as_ref(), dbconfig.clone())
-                .unwrap();
+            let db = Db::new_with_hash_mode(tmpdir.as_ref(), dbconfig.clone()).unwrap();
             TestDb {
                 db: Some(db),
                 tmpdir,
@@ -2827,11 +2874,7 @@ mod test {
         pub fn reopen(mut self) -> Self {
             self.db.take().unwrap().close().unwrap();
 
-            let db = Db::<DefaultHashMode>::new_with_hash_mode(
-                self.tmpdir.path(),
-                self.dbconfig.clone(),
-            )
-            .unwrap();
+            let db = Db::new_with_hash_mode(self.tmpdir.path(), self.dbconfig.clone()).unwrap();
             self.db = Some(db);
             self
         }
@@ -2849,14 +2892,10 @@ mod test {
             self.db.take().unwrap().close().unwrap();
 
             self.dbconfig = DbConfig::builder()
-                .node_hash_algorithm(DefaultHashMode::ALGORITHM)
+                .node_hash_algorithm(H::ALGORITHM)
                 .truncate(true)
                 .build();
-            let db = Db::<DefaultHashMode>::new_with_hash_mode(
-                self.tmpdir.path(),
-                self.dbconfig.clone(),
-            )
-            .unwrap();
+            let db = Db::new_with_hash_mode(self.tmpdir.path(), self.dbconfig.clone()).unwrap();
             self.db = Some(db);
             self
         }

--- a/firewood/src/db/tests/concurrent_rebase.rs
+++ b/firewood/src/db/tests/concurrent_rebase.rs
@@ -38,7 +38,7 @@
 
 use std::thread;
 
-use firewood_storage::{CheckOpt, CheckerError};
+use firewood_storage::{CheckOpt, CheckerError, EthHash, HashMode, MerkleDbHash};
 
 use crate::api::{self, Db as _, DbView as _, Proposal as _};
 use crate::db::{BatchOp, DbConfig};
@@ -88,7 +88,7 @@ fn value(thread_idx: usize, commit_idx: usize, key_idx: usize) -> Vec<u8> {
 }
 
 /// `TestDb` with a tight `max_revisions` so reaping fires during the test.
-fn test_db_with_tight_revisions() -> TestDb {
+fn test_db_with_tight_revisions<H: HashMode>() -> TestDb<H> {
     TestDb::new_with_config(
         DbConfig::builder()
             .manager(
@@ -106,7 +106,7 @@ fn test_db_with_tight_revisions() -> TestDb {
 /// behind the latest committed root — to ignore [`CheckerError::UnpersistedRoot`].
 /// After [`TestDb::reopen`], pass `false`: a reopened db must have a
 /// persisted root.
-fn assert_check_clean(db: &TestDb, label: &str, tolerate_unpersisted: bool) {
+fn assert_check_clean<H: HashMode>(db: &TestDb<H>, label: &str, tolerate_unpersisted: bool) {
     let report = db.check(CheckOpt {
         hash_check: true,
         progress_bar: None,
@@ -122,9 +122,9 @@ fn assert_check_clean(db: &TestDb, label: &str, tolerate_unpersisted: bool) {
 
 /// Verify every disjoint `(t, c, k)` key produced by [`key`]/[`value`] is
 /// present in `db`'s latest revision with the expected value.
-fn assert_disjoint_keys_present(db: &TestDb, label: &str) {
-    let latest_root = <crate::db::Db as crate::api::Db>::root_hash(db).unwrap();
-    let view = <crate::db::Db as crate::api::Db>::revision(db, latest_root).unwrap();
+fn assert_disjoint_keys_present<H: HashMode>(db: &TestDb<H>, label: &str) {
+    let latest_root = <crate::db::Db<H> as crate::api::Db>::root_hash(db).unwrap();
+    let view = <crate::db::Db<H> as crate::api::Db>::revision(db, latest_root).unwrap();
     for t in 0..THREADS {
         for c in 0..COMMITS_PER_THREAD {
             for k in 0..KEYS_PER_BATCH {
@@ -143,9 +143,13 @@ fn assert_disjoint_keys_present(db: &TestDb, label: &str) {
     }
 }
 
-#[test]
-fn test_concurrent_commit_with_rebase_no_freelist_corruption() {
-    let db = test_db_with_tight_revisions();
+#[firewood_macros::hash_mode]
+// The `#[hash_mode]` macro moves this body into a plain (non-`#[test]`)
+// generic helper, so it no longer gets clippy's blanket `#[test]` exemption
+// for `arithmetic_side_effects`.
+#[expect(clippy::arithmetic_side_effects)]
+fn test_concurrent_commit_with_rebase_no_freelist_corruption<H: HashMode>() {
+    let db = test_db_with_tight_revisions::<H>();
 
     // Seed with a small initial commit so the freelist has some starting state.
     let seed_key = vec![0xffu8; 32];
@@ -164,7 +168,7 @@ fn test_concurrent_commit_with_rebase_no_freelist_corruption() {
     thread::scope(|s| {
         let mut handles = Vec::with_capacity(THREADS);
         for t in 0..THREADS {
-            let db_ref: &crate::db::Db = &db;
+            let db_ref: &crate::db::Db<H> = &db;
             handles.push(s.spawn(move || {
                 for c in 0..COMMITS_PER_THREAD {
                     // Build the batch once and retry around it. On a slow
@@ -228,8 +232,8 @@ fn test_concurrent_commit_with_rebase_no_freelist_corruption() {
 /// random keys distributed across the entire keyspace so threads' writes
 /// share intermediate branch nodes. `max_revisions` is set low enough that
 /// reaping fires during the concurrent phase.
-#[test]
-fn test_concurrent_rebase_overlapping_paths() {
+#[firewood_macros::hash_mode]
+fn test_concurrent_rebase_overlapping_paths<H: HashMode>() {
     use std::sync::Barrier;
 
     const SHARED_THREADS: usize = 8;
@@ -250,7 +254,7 @@ fn test_concurrent_rebase_overlapping_paths() {
         k
     }
 
-    let db = test_db_with_tight_revisions();
+    let db = test_db_with_tight_revisions::<H>();
 
     // Seed with a meaningful initial trie so subsequent proposals' COWs hit
     // shared branches at upper levels.
@@ -274,7 +278,7 @@ fn test_concurrent_rebase_overlapping_paths() {
     thread::scope(|s| {
         let mut handles = Vec::with_capacity(SHARED_THREADS);
         for t in 0..SHARED_THREADS {
-            let db_ref: &crate::db::Db = &db;
+            let db_ref: &crate::db::Db<H> = &db;
             let barrier = &barrier;
             handles.push(s.spawn(move || {
                 let mut rng = 0xdead_beefu64.wrapping_add((t as u64).wrapping_mul(0x9e37_79b9));
@@ -314,9 +318,9 @@ fn test_concurrent_rebase_overlapping_paths() {
 /// trivial result (rebased batch is a no-op against current). The trivial
 /// path must succeed and not push a duplicate revision; the post-state must
 /// match the first commit and the freelist must be intact.
-#[test]
-fn test_trivial_rebase_succeeds_without_corruption() {
-    let db = TestDb::new();
+#[firewood_macros::hash_mode]
+fn test_trivial_rebase_succeeds_without_corruption<H: HashMode>() {
+    let db = TestDb::<H>::new();
 
     let key = vec![0x42u8; 32];
     let val = vec![0xaa, 0xbb, 0xcc];
@@ -335,7 +339,7 @@ fn test_trivial_rebase_succeeds_without_corruption() {
         .unwrap();
 
     p_a.commit().unwrap();
-    let after_a = <crate::db::Db as crate::api::Db>::root_hash(&db).unwrap();
+    let after_a = <crate::db::Db<H> as crate::api::Db>::root_hash(&db).unwrap();
 
     // p_b's recorded parent is stale; rebase diff applied to current is a
     // no-op. commit_with_rebase must succeed and return the same hash as
@@ -346,7 +350,7 @@ fn test_trivial_rebase_succeeds_without_corruption() {
         .expect("commit produces a hash");
     assert_eq!(returned, after_a);
 
-    let view = <crate::db::Db as crate::api::Db>::revision(&db, after_a).unwrap();
+    let view = <crate::db::Db<H> as crate::api::Db>::revision(&db, after_a).unwrap();
     assert_eq!(view.val(&key).unwrap().as_deref(), Some(val.as_slice()));
     drop(view);
 
@@ -362,9 +366,9 @@ fn test_trivial_rebase_succeeds_without_corruption() {
 /// against the third — `parent_id_is` must reject hash-equal-but-different
 /// parents and force a rebase. After rebase the proposal commits cleanly
 /// with no freelist corruption.
-#[test]
-fn test_round_trip_rejects_stale_parent() {
-    let db = TestDb::new();
+#[firewood_macros::hash_mode]
+fn test_round_trip_rejects_stale_parent<H: HashMode>() {
+    let db = TestDb::<H>::new();
 
     let key = vec![0x42u8; 32];
     let val = vec![0xaa, 0xbb, 0xcc];
@@ -377,7 +381,7 @@ fn test_round_trip_rejects_stale_parent() {
     .unwrap()
     .commit()
     .unwrap();
-    let c1_hash = <crate::db::Db as crate::api::Db>::root_hash(&db).unwrap();
+    let c1_hash = <crate::db::Db<H> as crate::api::Db>::root_hash(&db).unwrap();
 
     // P off C1 adds a separate key.
     let key2 = vec![0x43u8; 32];
@@ -403,7 +407,7 @@ fn test_round_trip_rejects_stale_parent() {
     .unwrap()
     .commit()
     .unwrap();
-    let c3_hash = <crate::db::Db as crate::api::Db>::root_hash(&db).unwrap();
+    let c3_hash = <crate::db::Db<H> as crate::api::Db>::root_hash(&db).unwrap();
     assert_eq!(
         c1_hash, c3_hash,
         "A→B→A should reach the same root hash twice"
@@ -416,8 +420,8 @@ fn test_round_trip_rejects_stale_parent() {
         .commit_with_rebase()
         .expect("commit_with_rebase must succeed via rebase");
 
-    let final_hash = <crate::db::Db as crate::api::Db>::root_hash(&db).unwrap();
-    let view = <crate::db::Db as crate::api::Db>::revision(&db, final_hash).unwrap();
+    let final_hash = <crate::db::Db<H> as crate::api::Db>::root_hash(&db).unwrap();
+    let view = <crate::db::Db<H> as crate::api::Db>::revision(&db, final_hash).unwrap();
     assert_eq!(view.val(&key).unwrap().as_deref(), Some(val.as_slice()));
     assert_eq!(view.val(&key2).unwrap().as_deref(), Some(val2.as_slice()));
     drop(view);
@@ -438,15 +442,15 @@ fn test_round_trip_rejects_stale_parent() {
 /// deletions). With the fix, an empty `Committed` view is constructed
 /// on the fly, so the diff yields exactly the proposal's puts and the
 /// rebased commit preserves all prior state.
-#[test]
-fn test_empty_parent_rebase_after_reap() {
+#[firewood_macros::hash_mode]
+fn test_empty_parent_rebase_after_reap<H: HashMode>() {
     // A tighter `max_revisions` than the concurrent tests use: those need
     // a higher cap so the persist worker can keep up, but here we just
     // need a small N so a handful of fillers reaps the initial empty
     // revision out of the queue.
     const TIGHT_MAX_REVISIONS: usize = 4;
 
-    let db = TestDb::new_with_config(
+    let db = TestDb::<H>::new_with_config(
         DbConfig::builder()
             .manager(
                 RevisionManagerConfig::builder()
@@ -490,8 +494,8 @@ fn test_empty_parent_rebase_after_reap() {
         .expect("empty-parent rebase must succeed after reap");
 
     // Final revision must contain P's key AND every filler key.
-    let final_hash = <crate::db::Db as crate::api::Db>::root_hash(&db).unwrap();
-    let view = <crate::db::Db as crate::api::Db>::revision(&db, final_hash).unwrap();
+    let final_hash = <crate::db::Db<H> as crate::api::Db>::root_hash(&db).unwrap();
+    let view = <crate::db::Db<H> as crate::api::Db>::revision(&db, final_hash).unwrap();
     assert_eq!(
         view.val(&p_key).unwrap().as_deref(),
         Some(p_val.as_slice()),

--- a/firewood/src/db/tests/concurrent_rebase.rs
+++ b/firewood/src/db/tests/concurrent_rebase.rs
@@ -38,7 +38,7 @@
 
 use std::thread;
 
-use firewood_storage::{CheckOpt, CheckerError, DefaultHashMode};
+use firewood_storage::{CheckOpt, CheckerError, EthHash, HashMode, MerkleDbHash};
 
 use crate::api::{self, Db as _, DbView as _, Proposal as _};
 use crate::db::{BatchOp, DbConfig};
@@ -88,9 +88,10 @@ fn value(thread_idx: usize, commit_idx: usize, key_idx: usize) -> Vec<u8> {
 }
 
 /// `TestDb` with a tight `max_revisions` so reaping fires during the test.
-fn test_db_with_tight_revisions() -> TestDb {
+fn test_db_with_tight_revisions<H: HashMode>() -> TestDb<H> {
     TestDb::new_with_config(
         DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(MAX_REVISIONS)
@@ -106,7 +107,7 @@ fn test_db_with_tight_revisions() -> TestDb {
 /// behind the latest committed root — to ignore [`CheckerError::UnpersistedRoot`].
 /// After [`TestDb::reopen`], pass `false`: a reopened db must have a
 /// persisted root.
-fn assert_check_clean(db: &TestDb, label: &str, tolerate_unpersisted: bool) {
+fn assert_check_clean<H: HashMode>(db: &TestDb<H>, label: &str, tolerate_unpersisted: bool) {
     let report = db.check(CheckOpt {
         hash_check: true,
         progress_bar: None,
@@ -122,10 +123,9 @@ fn assert_check_clean(db: &TestDb, label: &str, tolerate_unpersisted: bool) {
 
 /// Verify every disjoint `(t, c, k)` key produced by [`key`]/[`value`] is
 /// present in `db`'s latest revision with the expected value.
-fn assert_disjoint_keys_present(db: &TestDb, label: &str) {
-    let latest_root = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(db).unwrap();
-    let view =
-        <crate::db::Db<DefaultHashMode> as crate::api::Db>::revision(db, latest_root).unwrap();
+fn assert_disjoint_keys_present<H: HashMode>(db: &TestDb<H>, label: &str) {
+    let latest_root = <crate::db::Db<H> as crate::api::Db>::root_hash(db).unwrap();
+    let view = <crate::db::Db<H> as crate::api::Db>::revision(db, latest_root).unwrap();
     for t in 0..THREADS {
         for c in 0..COMMITS_PER_THREAD {
             for k in 0..KEYS_PER_BATCH {
@@ -144,9 +144,13 @@ fn assert_disjoint_keys_present(db: &TestDb, label: &str) {
     }
 }
 
-#[test]
-fn test_concurrent_commit_with_rebase_no_freelist_corruption() {
-    let db = test_db_with_tight_revisions();
+#[firewood_macros::hash_mode]
+// The `#[hash_mode]` macro moves this body into a plain (non-`#[test]`)
+// generic helper, so it no longer gets clippy's blanket `#[test]` exemption
+// for `arithmetic_side_effects`.
+#[expect(clippy::arithmetic_side_effects)]
+fn test_concurrent_commit_with_rebase_no_freelist_corruption<H: HashMode>() {
+    let db = test_db_with_tight_revisions::<H>();
 
     // Seed with a small initial commit so the freelist has some starting state.
     let seed_key = vec![0xffu8; 32];
@@ -165,7 +169,7 @@ fn test_concurrent_commit_with_rebase_no_freelist_corruption() {
     thread::scope(|s| {
         let mut handles = Vec::with_capacity(THREADS);
         for t in 0..THREADS {
-            let db_ref: &crate::db::Db<DefaultHashMode> = &db;
+            let db_ref: &crate::db::Db<H> = &db;
             handles.push(s.spawn(move || {
                 for c in 0..COMMITS_PER_THREAD {
                     // Build the batch once and retry around it. On a slow
@@ -229,8 +233,8 @@ fn test_concurrent_commit_with_rebase_no_freelist_corruption() {
 /// random keys distributed across the entire keyspace so threads' writes
 /// share intermediate branch nodes. `max_revisions` is set low enough that
 /// reaping fires during the concurrent phase.
-#[test]
-fn test_concurrent_rebase_overlapping_paths() {
+#[firewood_macros::hash_mode]
+fn test_concurrent_rebase_overlapping_paths<H: HashMode>() {
     use std::sync::Barrier;
 
     const SHARED_THREADS: usize = 8;
@@ -251,7 +255,7 @@ fn test_concurrent_rebase_overlapping_paths() {
         k
     }
 
-    let db = test_db_with_tight_revisions();
+    let db = test_db_with_tight_revisions::<H>();
 
     // Seed with a meaningful initial trie so subsequent proposals' COWs hit
     // shared branches at upper levels.
@@ -275,7 +279,7 @@ fn test_concurrent_rebase_overlapping_paths() {
     thread::scope(|s| {
         let mut handles = Vec::with_capacity(SHARED_THREADS);
         for t in 0..SHARED_THREADS {
-            let db_ref: &crate::db::Db<DefaultHashMode> = &db;
+            let db_ref: &crate::db::Db<H> = &db;
             let barrier = &barrier;
             handles.push(s.spawn(move || {
                 let mut rng = 0xdead_beefu64.wrapping_add((t as u64).wrapping_mul(0x9e37_79b9));
@@ -315,9 +319,9 @@ fn test_concurrent_rebase_overlapping_paths() {
 /// trivial result (rebased batch is a no-op against current). The trivial
 /// path must succeed and not push a duplicate revision; the post-state must
 /// match the first commit and the freelist must be intact.
-#[test]
-fn test_trivial_rebase_succeeds_without_corruption() {
-    let db = TestDb::new();
+#[firewood_macros::hash_mode]
+fn test_trivial_rebase_succeeds_without_corruption<H: HashMode>() {
+    let db = TestDb::<H>::new();
 
     let key = vec![0x42u8; 32];
     let val = vec![0xaa, 0xbb, 0xcc];
@@ -336,7 +340,7 @@ fn test_trivial_rebase_succeeds_without_corruption() {
         .unwrap();
 
     p_a.commit().unwrap();
-    let after_a = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(&db).unwrap();
+    let after_a = <crate::db::Db<H> as crate::api::Db>::root_hash(&db).unwrap();
 
     // p_b's recorded parent is stale; rebase diff applied to current is a
     // no-op. commit_with_rebase must succeed and return the same hash as
@@ -347,7 +351,7 @@ fn test_trivial_rebase_succeeds_without_corruption() {
         .expect("commit produces a hash");
     assert_eq!(returned, after_a);
 
-    let view = <crate::db::Db<DefaultHashMode> as crate::api::Db>::revision(&db, after_a).unwrap();
+    let view = <crate::db::Db<H> as crate::api::Db>::revision(&db, after_a).unwrap();
     assert_eq!(view.val(&key).unwrap().as_deref(), Some(val.as_slice()));
     drop(view);
 
@@ -363,9 +367,9 @@ fn test_trivial_rebase_succeeds_without_corruption() {
 /// against the third — `parent_id_is` must reject hash-equal-but-different
 /// parents and force a rebase. After rebase the proposal commits cleanly
 /// with no freelist corruption.
-#[test]
-fn test_round_trip_rejects_stale_parent() {
-    let db = TestDb::new();
+#[firewood_macros::hash_mode]
+fn test_round_trip_rejects_stale_parent<H: HashMode>() {
+    let db = TestDb::<H>::new();
 
     let key = vec![0x42u8; 32];
     let val = vec![0xaa, 0xbb, 0xcc];
@@ -378,7 +382,7 @@ fn test_round_trip_rejects_stale_parent() {
     .unwrap()
     .commit()
     .unwrap();
-    let c1_hash = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(&db).unwrap();
+    let c1_hash = <crate::db::Db<H> as crate::api::Db>::root_hash(&db).unwrap();
 
     // P off C1 adds a separate key.
     let key2 = vec![0x43u8; 32];
@@ -404,7 +408,7 @@ fn test_round_trip_rejects_stale_parent() {
     .unwrap()
     .commit()
     .unwrap();
-    let c3_hash = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(&db).unwrap();
+    let c3_hash = <crate::db::Db<H> as crate::api::Db>::root_hash(&db).unwrap();
     assert_eq!(
         c1_hash, c3_hash,
         "A→B→A should reach the same root hash twice"
@@ -417,9 +421,8 @@ fn test_round_trip_rejects_stale_parent() {
         .commit_with_rebase()
         .expect("commit_with_rebase must succeed via rebase");
 
-    let final_hash = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(&db).unwrap();
-    let view =
-        <crate::db::Db<DefaultHashMode> as crate::api::Db>::revision(&db, final_hash).unwrap();
+    let final_hash = <crate::db::Db<H> as crate::api::Db>::root_hash(&db).unwrap();
+    let view = <crate::db::Db<H> as crate::api::Db>::revision(&db, final_hash).unwrap();
     assert_eq!(view.val(&key).unwrap().as_deref(), Some(val.as_slice()));
     assert_eq!(view.val(&key2).unwrap().as_deref(), Some(val2.as_slice()));
     drop(view);
@@ -440,16 +443,17 @@ fn test_round_trip_rejects_stale_parent() {
 /// deletions). With the fix, an empty `Committed` view is constructed
 /// on the fly, so the diff yields exactly the proposal's puts and the
 /// rebased commit preserves all prior state.
-#[test]
-fn test_empty_parent_rebase_after_reap() {
+#[firewood_macros::hash_mode]
+fn test_empty_parent_rebase_after_reap<H: HashMode>() {
     // A tighter `max_revisions` than the concurrent tests use: those need
     // a higher cap so the persist worker can keep up, but here we just
     // need a small N so a handful of fillers reaps the initial empty
     // revision out of the queue.
     const TIGHT_MAX_REVISIONS: usize = 4;
 
-    let db = TestDb::new_with_config(
+    let db = TestDb::<H>::new_with_config(
         DbConfig::builder()
+            .node_hash_algorithm(H::ALGORITHM)
             .manager(
                 RevisionManagerConfig::builder()
                     .max_revisions(TIGHT_MAX_REVISIONS)
@@ -492,9 +496,8 @@ fn test_empty_parent_rebase_after_reap() {
         .expect("empty-parent rebase must succeed after reap");
 
     // Final revision must contain P's key AND every filler key.
-    let final_hash = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(&db).unwrap();
-    let view =
-        <crate::db::Db<DefaultHashMode> as crate::api::Db>::revision(&db, final_hash).unwrap();
+    let final_hash = <crate::db::Db<H> as crate::api::Db>::root_hash(&db).unwrap();
+    let view = <crate::db::Db<H> as crate::api::Db>::revision(&db, final_hash).unwrap();
     assert_eq!(
         view.val(&p_key).unwrap().as_deref(),
         Some(p_val.as_slice()),

--- a/firewood/src/db/tests/merge.rs
+++ b/firewood/src/db/tests/merge.rs
@@ -5,10 +5,12 @@ use crate::{
     api::{Db, DbView, Proposal},
     db::BatchOp,
 };
+use firewood_storage::{EthHash, HashMode, MerkleDbHash};
 
 use super::*;
 use test_case::test_case;
 
+#[firewood_macros::hash_mode]
 #[test_case(
         &[],
         None,
@@ -137,14 +139,14 @@ use test_case::test_case;
         &[(b"a", Some(b"1")), (b"b", None), (b"b2", Some(b"new")), (b"c", Some(b"updated")), (b"d", None), (b"e", Some(b"5"))];
         "boundary precision - a and e should remain unchanged"
     )]
-fn test_merge_key_value_range(
+fn test_merge_key_value_range<H: HashMode>(
     initial_kvs: &[(&[u8], &[u8])],
     first_key: Option<&[u8]>,
     last_key: Option<&[u8]>,
     merge_kvs: &[(&[u8], &[u8])],
     expected_kvs: &[(&[u8], Option<&[u8]>)],
 ) {
-    let db = TestDb::new();
+    let db = TestDb::<H>::new();
 
     if !initial_kvs.is_empty() {
         db.propose(initial_kvs).unwrap().commit().unwrap();
@@ -176,7 +178,7 @@ fn test_merge_key_value_range(
     let merge_root_hash = proposal.root_hash();
 
     // Create a fresh database with the same initial state
-    let db2 = TestDb::new();
+    let db2 = TestDb::<H>::new();
     if !initial_kvs.is_empty() {
         db2.propose(initial_kvs).unwrap().commit().unwrap();
     }

--- a/firewood/src/eth_proof.rs
+++ b/firewood/src/eth_proof.rs
@@ -432,7 +432,10 @@ mod merkledb_gate_tests {
 
     #[test]
     fn eth_get_proof_rejected_in_merkledb_mode() {
-        let merkle = init_merkle(std::iter::empty::<(&[u8], &[u8])>());
+        // Exercises the eth-only gate; runs under the compile-default mode until the flag-removal PR — the merkledb rejection path is covered by the runtime gate test above.
+        let merkle = init_merkle::<firewood_storage::DefaultHashMode, _, _, _>(
+            std::iter::empty::<(&[u8], &[u8])>(),
+        );
         let err = eth_get_proof(
             merkle.nodestore(),
             NodeHashAlgorithm::MerkleDB,
@@ -447,6 +450,7 @@ mod merkledb_gate_tests {
     }
 }
 
+// eth_getProof is an Ethereum-only surface (runtime-gated); these tests stay single-mode.
 #[cfg(all(test, feature = "ethhash"))]
 #[expect(clippy::unwrap_used, clippy::indexing_slicing)]
 mod tests {
@@ -526,7 +530,8 @@ mod tests {
     #[test]
     fn absent_account_returns_zero_fields_and_proof_bytes() {
         // Empty trie; ask for any account.
-        let merkle = init_merkle(std::iter::empty::<(&[u8], &[u8])>());
+        let merkle =
+            init_merkle::<firewood_storage::EthHash, _, _, _>(std::iter::empty::<(&[u8], &[u8])>());
         let key = [0x11u8; 32];
         let proof =
             eth_get_proof(merkle.nodestore(), NodeHashAlgorithm::Ethereum, &key, &[]).unwrap();
@@ -544,7 +549,8 @@ mod tests {
         let key = [0x22u8; 32];
         let balance = [0x12, 0x34];
         let value = account_rlp(7, &balance);
-        let merkle = init_merkle([(key.as_slice(), value.as_ref())]);
+        let merkle =
+            init_merkle::<firewood_storage::EthHash, _, _, _>([(key.as_slice(), value.as_ref())]);
         let proof =
             eth_get_proof(merkle.nodestore(), NodeHashAlgorithm::Ethereum, &key, &[]).unwrap();
         assert_eq!(proof.nonce, 7);
@@ -568,7 +574,7 @@ mod tests {
         let mut full_slot = account_key.to_vec();
         full_slot.extend_from_slice(&slot_key);
 
-        let merkle = init_merkle([
+        let merkle = init_merkle::<firewood_storage::EthHash, _, _, _>([
             (account_key.as_slice(), acc_val.as_ref()),
             (full_slot.as_slice(), slot_val.as_ref()),
         ]);
@@ -717,7 +723,7 @@ mod tests {
         let missing = [0xffu8; 32];
         let v1 = account_rlp(1, &[]);
         let v2 = account_rlp(2, &[]);
-        let merkle = init_merkle([
+        let merkle = init_merkle::<firewood_storage::EthHash, _, _, _>([
             (acc1.as_slice(), v1.as_ref()),
             (acc2.as_slice(), v2.as_ref()),
         ]);
@@ -762,7 +768,7 @@ mod tests {
         let acc2 = [0x20u8; 32];
         let v1 = account_rlp(11, &[]);
         let v2 = account_rlp(22, &[]);
-        let merkle = init_merkle([
+        let merkle = init_merkle::<firewood_storage::EthHash, _, _, _>([
             (acc1.as_slice(), v1.as_ref()),
             (acc2.as_slice(), v2.as_ref()),
         ]);
@@ -791,7 +797,7 @@ mod tests {
         let mut full_b = account_key.to_vec();
         full_b.extend_from_slice(&slot_b);
 
-        let merkle = init_merkle([
+        let merkle = init_merkle::<firewood_storage::EthHash, _, _, _>([
             (account_key.as_slice(), acc_val.as_ref()),
             (full_a.as_slice(), b"val-a".as_slice()),
             (full_b.as_slice(), b"val-b".as_slice()),
@@ -846,7 +852,7 @@ mod tests {
         let mut full_b = account_key.to_vec();
         full_b.extend_from_slice(&slot_b);
 
-        let merkle = init_merkle([
+        let merkle = init_merkle::<firewood_storage::EthHash, _, _, _>([
             (account_key.as_slice(), acc_val.as_ref()),
             (full_a.as_slice(), VAL_A),
             (full_b.as_slice(), VAL_B),

--- a/firewood/src/eth_proof.rs
+++ b/firewood/src/eth_proof.rs
@@ -415,21 +415,18 @@ fn nibbles_match_packed(nibbles: &[PathComponent], packed: &[u8]) -> bool {
 
 #[cfg(test)]
 mod merkledb_gate_tests {
-    use std::sync::Arc;
-
     use super::*;
-    use firewood_storage::{
-        Committed, DeletedNodeTracking, MemStore, MerkleDbHash, NodeHashAlgorithm, NodeStore,
-    };
+    use crate::merkle::tests::init_merkle;
 
     /// A MerkleDB view must refuse to emit eth proofs. This test runs in both
     /// feature configurations.
     #[test]
     fn eth_get_proof_rejected_in_merkledb_mode() {
-        let storage = Arc::new(MemStore::new(Vec::new(), NodeHashAlgorithm::MerkleDB));
-        let nodestore: NodeStore<Committed, _, MerkleDbHash> =
-            NodeStore::new_empty_committed(storage, DeletedNodeTracking::Enabled);
-        let err = eth_get_proof(&nodestore, &[0u8; 32], &[])
+        let merkle = init_merkle::<firewood_storage::MerkleDbHash, _, _, _>(std::iter::empty::<(
+            &[u8],
+            &[u8],
+        )>());
+        let err = eth_get_proof(merkle.nodestore(), &[0u8; 32], &[])
             .expect_err("merkledb-mode database must not emit eth proofs");
         assert!(
             matches!(err, Error::FeatureNotSupported(_)),
@@ -438,6 +435,7 @@ mod merkledb_gate_tests {
     }
 }
 
+// eth_getProof is an Ethereum-only surface (runtime-gated); these tests stay single-mode.
 #[cfg(all(test, feature = "ethhash"))]
 #[expect(clippy::unwrap_used, clippy::indexing_slicing)]
 mod tests {
@@ -510,7 +508,8 @@ mod tests {
     #[test]
     fn absent_account_returns_zero_fields_and_proof_bytes() {
         // Empty trie; ask for any account.
-        let merkle = init_merkle(std::iter::empty::<(&[u8], &[u8])>());
+        let merkle =
+            init_merkle::<firewood_storage::EthHash, _, _, _>(std::iter::empty::<(&[u8], &[u8])>());
         let key = [0x11u8; 32];
         let proof = eth_get_proof(merkle.nodestore(), &key, &[]).unwrap();
         assert_eq!(proof.nonce, 0);
@@ -527,7 +526,8 @@ mod tests {
         let key = [0x22u8; 32];
         let balance = [0x12, 0x34];
         let value = account_rlp(7, &balance);
-        let merkle = init_merkle([(key.as_slice(), value.as_ref())]);
+        let merkle =
+            init_merkle::<firewood_storage::EthHash, _, _, _>([(key.as_slice(), value.as_ref())]);
         let proof = eth_get_proof(merkle.nodestore(), &key, &[]).unwrap();
         assert_eq!(proof.nonce, 7);
         // balance is right-aligned in 32 bytes.
@@ -550,7 +550,7 @@ mod tests {
         let mut full_slot = account_key.to_vec();
         full_slot.extend_from_slice(&slot_key);
 
-        let merkle = init_merkle([
+        let merkle = init_merkle::<firewood_storage::EthHash, _, _, _>([
             (account_key.as_slice(), acc_val.as_ref()),
             (full_slot.as_slice(), slot_val.as_ref()),
         ]);
@@ -687,7 +687,7 @@ mod tests {
         let missing = [0xffu8; 32];
         let v1 = account_rlp(1, &[]);
         let v2 = account_rlp(2, &[]);
-        let merkle = init_merkle([
+        let merkle = init_merkle::<firewood_storage::EthHash, _, _, _>([
             (acc1.as_slice(), v1.as_ref()),
             (acc2.as_slice(), v2.as_ref()),
         ]);
@@ -726,7 +726,7 @@ mod tests {
         let acc2 = [0x20u8; 32];
         let v1 = account_rlp(11, &[]);
         let v2 = account_rlp(22, &[]);
-        let merkle = init_merkle([
+        let merkle = init_merkle::<firewood_storage::EthHash, _, _, _>([
             (acc1.as_slice(), v1.as_ref()),
             (acc2.as_slice(), v2.as_ref()),
         ]);
@@ -754,7 +754,7 @@ mod tests {
         let mut full_b = account_key.to_vec();
         full_b.extend_from_slice(&slot_b);
 
-        let merkle = init_merkle([
+        let merkle = init_merkle::<firewood_storage::EthHash, _, _, _>([
             (account_key.as_slice(), acc_val.as_ref()),
             (full_a.as_slice(), b"val-a".as_slice()),
             (full_b.as_slice(), b"val-b".as_slice()),
@@ -803,7 +803,7 @@ mod tests {
         let mut full_b = account_key.to_vec();
         full_b.extend_from_slice(&slot_b);
 
-        let merkle = init_merkle([
+        let merkle = init_merkle::<firewood_storage::EthHash, _, _, _>([
             (account_key.as_slice(), acc_val.as_ref()),
             (full_a.as_slice(), VAL_A),
             (full_b.as_slice(), VAL_B),

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -663,7 +663,8 @@ mod tests {
     use super::*;
     use crate::merkle::Merkle;
     use firewood_storage::{
-        DeletedNodeTracking, ImmutableProposal, MemStore, Mutable, NodeStore, Propose,
+        DeletedNodeTracking, EthHash, HashMode, ImmutableProposal, MemStore, MerkleDbHash, Mutable,
+        NodeStore, Propose,
     };
     use std::sync::Arc;
     use test_case::test_case;
@@ -678,28 +679,30 @@ mod tests {
         };
     }
 
-    pub(super) fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
-        let memstore = MemStore::default();
-        let memstore = Arc::new(memstore);
+    pub(super) fn create_test_merkle<H: HashMode>()
+    -> Merkle<NodeStore<Mutable<Propose>, MemStore, H>> {
+        let memstore = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
         let nodestore = NodeStore::new_empty_proposal(memstore, DeletedNodeTracking::Enabled);
         Merkle::from(nodestore)
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(&[]; "empty key")]
     #[test_case(&[1]; "non-empty key")]
-    fn path_iterate_empty_merkle_empty_key(key: &[u8]) {
-        let merkle = create_test_merkle();
+    fn path_iterate_empty_merkle_empty_key<H: HashMode>(key: &[u8]) {
+        let merkle = create_test_merkle::<H>();
         let mut iter = merkle.path_iter(key).unwrap();
         assert!(iter.next().is_none());
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(&[]; "empty key")]
     #[test_case(&[0xBE,0xE0]; "prefix of singleton key")]
     #[test_case(&[0xBE, 0xEF]; "match singleton key")]
     #[test_case(&[0xBE, 0xEF,0x10]; "suffix of singleton key")]
     #[test_case(&[0xF0]; "no key nibbles match singleton key")]
-    fn path_iterate_singleton_merkle(key: &[u8]) {
-        let mut merkle = create_test_merkle();
+    fn path_iterate_singleton_merkle<H: HashMode>(key: &[u8]) {
+        let mut merkle = create_test_merkle::<H>();
 
         merkle.insert(&[0xBE, 0xEF], Box::new([0x42])).unwrap();
 
@@ -713,10 +716,11 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(&[0x00, 0x00, 0x00, 0xFF]; "leaf key")]
     #[test_case(&[0x00, 0x00, 0x00, 0xFF, 0x01]; "leaf key suffix")]
-    fn path_iterate_non_singleton_merkle_seek_leaf(key: &[u8]) {
-        let merkle = created_populated_merkle();
+    fn path_iterate_non_singleton_merkle_seek_leaf<H: HashMode>(key: &[u8]) {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter = merkle.path_iter(key).unwrap();
 
@@ -761,10 +765,11 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(&[0x00, 0x00, 0x00]; "branch key")]
     #[test_case(&[0x00, 0x00, 0x00, 0x10]; "branch key suffix (but not a leaf key)")]
-    fn path_iterate_non_singleton_merkle_seek_branch(key: &[u8]) {
-        let merkle = created_populated_merkle();
+    fn path_iterate_non_singleton_merkle_seek_branch<H: HashMode>(key: &[u8]) {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter = merkle.path_iter(key).unwrap();
 
@@ -793,9 +798,9 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn path_iterate_yields_non_root_divergent_node() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn path_iterate_yields_non_root_divergent_node<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         // Key 0x00,0x01 (nibbles [0,0,0,1]) matches the root (partial_path [0,0])
         // and descends via nibble 0 into a child whose partial_path is [0,0,0].
@@ -817,23 +822,23 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn key_value_iterate_empty() {
-        let merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_iterate_empty<H: HashMode>() {
+        let merkle = create_test_merkle::<H>();
         let iter = merkle.key_value_iter_from_key(b"x");
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn node_iterate_empty() {
-        let merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterate_empty<H: HashMode>() {
+        let merkle = create_test_merkle::<H>();
         let iter = MerkleNodeIter::new(merkle.nodestore(), Box::new([]));
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn node_iterate_root_only() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterate_root_only<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         merkle.insert(&[0x00], Box::new([0x00])).unwrap();
 
@@ -863,8 +868,8 @@ mod tests {
     ///  1   F
     ///
     /// The number next to each branch is the position of the child in the branch's children array.
-    fn created_populated_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
-        let mut merkle = create_test_merkle();
+    fn created_populated_merkle<H: HashMode>() -> Merkle<NodeStore<Mutable<Propose>, MemStore, H>> {
+        let mut merkle = create_test_merkle::<H>();
 
         merkle
             .insert(&[0x00, 0x00, 0x00], Box::new([0x00, 0x00, 0x00]))
@@ -890,9 +895,9 @@ mod tests {
         merkle
     }
 
-    #[test]
-    fn node_iterator_no_start_key() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterator_no_start_key<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter = MerkleNodeIter::new(merkle.nodestore(), Box::new([]));
 
@@ -933,9 +938,9 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn node_iterator_start_key_between_nodes() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterator_start_key_between_nodes<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter = MerkleNodeIter::new(
             merkle.nodestore(),
@@ -960,9 +965,9 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn node_iterator_start_key_on_node() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterator_start_key_on_node<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter = MerkleNodeIter::new(
             merkle.nodestore(),
@@ -987,21 +992,22 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn node_iterator_start_key_after_last_key() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterator_start_key_after_last_key<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         let iter = MerkleNodeIter::new(merkle.nodestore(), vec![0xFF].into_boxed_slice());
 
         assert_iterator_is_exhausted(iter);
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(Some(&[u8::MIN]); "Starting at first key")]
     #[test_case(None; "No start specified")]
     #[test_case(Some(&[128u8]); "Starting in middle")]
     #[test_case(Some(&[u8::MAX]); "Starting at last key")]
-    fn key_value_iterate_many(start: Option<&[u8]>) {
-        let mut merkle = create_test_merkle();
+    fn key_value_iterate_many<H: HashMode>(start: Option<&[u8]>) {
+        let mut merkle = create_test_merkle::<H>();
 
         // insert all values from u8::MIN to u8::MAX, with the key and value the same
         for k in u8::MIN..=u8::MAX {
@@ -1024,15 +1030,16 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_fused_empty() {
-        let merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_fused_empty<H: HashMode>() {
+        let merkle = create_test_merkle::<H>();
         assert_iterator_is_exhausted(merkle.key_value_iter_from_key(b""));
     }
 
-    #[test]
-    fn key_value_table_test() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn key_value_table_test<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         let max: u8 = 100;
         // Insert key-values in reverse order to ensure iterator
@@ -1095,9 +1102,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn key_value_fused_full() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_fused_full<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         let last = vec![0x00, 0x00, 0x00];
 
@@ -1125,9 +1132,9 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_root_with_empty_value() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_root_with_empty_value<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         let key = vec![].into_boxed_slice();
         let value = [0x00];
@@ -1139,9 +1146,9 @@ mod tests {
         assert_eq!(iter.next().unwrap().unwrap(), (key, value.into()));
     }
 
-    #[test]
-    fn key_value_get_branch_and_leaf() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_get_branch_and_leaf<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         let first_leaf = [0x00, 0x00];
         let second_leaf = [0x00, 0x0f];
@@ -1152,7 +1159,7 @@ mod tests {
 
         merkle.insert(&branch, branch.into()).unwrap();
 
-        let immutable_merkle: Merkle<NodeStore<Arc<ImmutableProposal>, _>> =
+        let immutable_merkle: Merkle<NodeStore<Arc<ImmutableProposal>, _, H>> =
             merkle.try_into().unwrap();
         println!("{}", immutable_merkle.dump_to_string().unwrap());
         merkle = immutable_merkle.fork().unwrap();
@@ -1175,9 +1182,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn key_value_start_at_key_not_in_trie() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_not_in_trie<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         let first_key = 0x00;
         let intermediate = 0x80;
@@ -1213,13 +1220,13 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_on_branch_with_no_value() {
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_on_branch_with_no_value<H: HashMode>() {
         let sibling_path = 0x00;
         let branch_path = 0x0f;
         let children = 0..=0x0f;
 
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         children.clone().for_each(|child_path| {
             let key = vec![sibling_path, child_path];
@@ -1254,15 +1261,16 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_on_branch_with_value() {
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn key_value_start_at_key_on_branch_with_value<H: HashMode>() {
         let sibling_path = 0x00;
         let branch_path = 0x0f;
         let branch_key = vec![branch_path];
 
         let children = (0..=0xf).map(|val| (val << 4) + val); // 0x00, 0x11, ... 0xff
 
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         merkle
             .insert(&branch_key, branch_key.clone().into())
@@ -1302,11 +1310,11 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_on_extension() {
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_on_extension<H: HashMode>() {
         let missing = 0x0a;
         let children = (0..=0x0f).filter(|x| *x != missing);
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         let keys: Vec<_> = children
             .map(|child_path| {
@@ -1332,15 +1340,15 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_overlapping_with_extension_but_greater() {
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_overlapping_with_extension_but_greater<H: HashMode>() {
         let start_key = 0x0a;
         let shared_path = 0x09;
         // 0x0900, 0x0901, ... 0x0a0f
         // path extension is 0x090
         let children = (0..=0x0f).map(|val| vec![shared_path, val]);
 
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         children.for_each(|key| {
             merkle.insert(&key, key.clone().into()).unwrap();
@@ -1351,15 +1359,15 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_overlapping_with_extension_but_smaller() {
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_overlapping_with_extension_but_smaller<H: HashMode>() {
         let start_key = 0x00;
         let shared_path = 0x09;
         // 0x0900, 0x0901, ... 0x0a0f
         // path extension is 0x090
         let children = (0..=0x0f).map(|val| vec![shared_path, val]);
 
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         let keys: Vec<_> = children
             .inspect(|key| {
@@ -1379,13 +1387,14 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_between_siblings() {
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn key_value_start_at_key_between_siblings<H: HashMode>() {
         let missing = 0xaa;
         let children = (0..=0xf)
             .map(|val| (val << 4) + val) // 0x00, 0x11, ... 0xff
             .filter(|x| *x != missing);
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         let keys: Vec<_> = children
             .map(|child_path| {
@@ -1411,11 +1420,11 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_greater_than_all_others_leaf() {
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_greater_than_all_others_leaf<H: HashMode>() {
         let key = [0x00];
         let greater_key = [0xff];
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
         merkle.insert(&key, key.into()).unwrap();
 
         let iter = merkle.key_value_iter_from_key(&greater_key);
@@ -1423,13 +1432,14 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_greater_than_all_others_branch() {
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn key_value_start_at_key_greater_than_all_others_branch<H: HashMode>() {
         let greatest = 0xff;
         let children = (0..=0xf)
             .map(|val| (val << 4) + val) // 0x00, 0x11, ... 0xff
             .filter(|x| *x != greatest);
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         let keys: Vec<_> = children
             .map(|child_path| {
@@ -1459,9 +1469,9 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn iterator_skips_leaf_when_start_key_prefixed_by_leaf() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn iterator_skips_leaf_when_start_key_prefixed_by_leaf<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter =
             MerkleNodeIter::new(merkle.nodestore(), [0x00, 0x00, 0x00, 0xFF, 0x01].into());

--- a/firewood/src/iter.rs
+++ b/firewood/src/iter.rs
@@ -663,7 +663,7 @@ mod tests {
     use super::*;
     use crate::merkle::Merkle;
     use firewood_storage::{
-        DefaultHashMode, DeletedNodeTracking, HashMode, ImmutableProposal, MemStore, Mutable,
+        DeletedNodeTracking, EthHash, HashMode, ImmutableProposal, MemStore, MerkleDbHash, Mutable,
         NodeStore, Propose,
     };
     use std::sync::Arc;
@@ -679,29 +679,30 @@ mod tests {
         };
     }
 
-    pub(super) fn create_test_merkle()
-    -> Merkle<NodeStore<Mutable<Propose>, MemStore, DefaultHashMode>> {
-        let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let memstore = Arc::new(memstore);
+    pub(super) fn create_test_merkle<H: HashMode>()
+    -> Merkle<NodeStore<Mutable<Propose>, MemStore, H>> {
+        let memstore = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
         let nodestore = NodeStore::new_empty_proposal(memstore, DeletedNodeTracking::Enabled);
         Merkle::from(nodestore)
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(&[]; "empty key")]
     #[test_case(&[1]; "non-empty key")]
-    fn path_iterate_empty_merkle_empty_key(key: &[u8]) {
-        let merkle = create_test_merkle();
+    fn path_iterate_empty_merkle_empty_key<H: HashMode>(key: &[u8]) {
+        let merkle = create_test_merkle::<H>();
         let mut iter = merkle.path_iter(key).unwrap();
         assert!(iter.next().is_none());
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(&[]; "empty key")]
     #[test_case(&[0xBE,0xE0]; "prefix of singleton key")]
     #[test_case(&[0xBE, 0xEF]; "match singleton key")]
     #[test_case(&[0xBE, 0xEF,0x10]; "suffix of singleton key")]
     #[test_case(&[0xF0]; "no key nibbles match singleton key")]
-    fn path_iterate_singleton_merkle(key: &[u8]) {
-        let mut merkle = create_test_merkle();
+    fn path_iterate_singleton_merkle<H: HashMode>(key: &[u8]) {
+        let mut merkle = create_test_merkle::<H>();
 
         merkle.insert(&[0xBE, 0xEF], Box::new([0x42])).unwrap();
 
@@ -715,10 +716,11 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(&[0x00, 0x00, 0x00, 0xFF]; "leaf key")]
     #[test_case(&[0x00, 0x00, 0x00, 0xFF, 0x01]; "leaf key suffix")]
-    fn path_iterate_non_singleton_merkle_seek_leaf(key: &[u8]) {
-        let merkle = created_populated_merkle();
+    fn path_iterate_non_singleton_merkle_seek_leaf<H: HashMode>(key: &[u8]) {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter = merkle.path_iter(key).unwrap();
 
@@ -763,10 +765,11 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(&[0x00, 0x00, 0x00]; "branch key")]
     #[test_case(&[0x00, 0x00, 0x00, 0x10]; "branch key suffix (but not a leaf key)")]
-    fn path_iterate_non_singleton_merkle_seek_branch(key: &[u8]) {
-        let merkle = created_populated_merkle();
+    fn path_iterate_non_singleton_merkle_seek_branch<H: HashMode>(key: &[u8]) {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter = merkle.path_iter(key).unwrap();
 
@@ -795,9 +798,9 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn path_iterate_yields_non_root_divergent_node() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn path_iterate_yields_non_root_divergent_node<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         // Key 0x00,0x01 (nibbles [0,0,0,1]) matches the root (partial_path [0,0])
         // and descends via nibble 0 into a child whose partial_path is [0,0,0].
@@ -819,23 +822,23 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn key_value_iterate_empty() {
-        let merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_iterate_empty<H: HashMode>() {
+        let merkle = create_test_merkle::<H>();
         let iter = merkle.key_value_iter_from_key(b"x");
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn node_iterate_empty() {
-        let merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterate_empty<H: HashMode>() {
+        let merkle = create_test_merkle::<H>();
         let iter = MerkleNodeIter::new(merkle.nodestore(), Box::new([]));
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn node_iterate_root_only() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterate_root_only<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         merkle.insert(&[0x00], Box::new([0x00])).unwrap();
 
@@ -865,9 +868,8 @@ mod tests {
     ///  1   F
     ///
     /// The number next to each branch is the position of the child in the branch's children array.
-    fn created_populated_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore, DefaultHashMode>>
-    {
-        let mut merkle = create_test_merkle();
+    fn created_populated_merkle<H: HashMode>() -> Merkle<NodeStore<Mutable<Propose>, MemStore, H>> {
+        let mut merkle = create_test_merkle::<H>();
 
         merkle
             .insert(&[0x00, 0x00, 0x00], Box::new([0x00, 0x00, 0x00]))
@@ -893,9 +895,9 @@ mod tests {
         merkle
     }
 
-    #[test]
-    fn node_iterator_no_start_key() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterator_no_start_key<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter = MerkleNodeIter::new(merkle.nodestore(), Box::new([]));
 
@@ -936,9 +938,9 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn node_iterator_start_key_between_nodes() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterator_start_key_between_nodes<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter = MerkleNodeIter::new(
             merkle.nodestore(),
@@ -963,9 +965,9 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn node_iterator_start_key_on_node() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterator_start_key_on_node<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter = MerkleNodeIter::new(
             merkle.nodestore(),
@@ -990,21 +992,22 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn node_iterator_start_key_after_last_key() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn node_iterator_start_key_after_last_key<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         let iter = MerkleNodeIter::new(merkle.nodestore(), vec![0xFF].into_boxed_slice());
 
         assert_iterator_is_exhausted(iter);
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(Some(&[u8::MIN]); "Starting at first key")]
     #[test_case(None; "No start specified")]
     #[test_case(Some(&[128u8]); "Starting in middle")]
     #[test_case(Some(&[u8::MAX]); "Starting at last key")]
-    fn key_value_iterate_many(start: Option<&[u8]>) {
-        let mut merkle = create_test_merkle();
+    fn key_value_iterate_many<H: HashMode>(start: Option<&[u8]>) {
+        let mut merkle = create_test_merkle::<H>();
 
         // insert all values from u8::MIN to u8::MAX, with the key and value the same
         for k in u8::MIN..=u8::MAX {
@@ -1027,15 +1030,16 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_fused_empty() {
-        let merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_fused_empty<H: HashMode>() {
+        let merkle = create_test_merkle::<H>();
         assert_iterator_is_exhausted(merkle.key_value_iter_from_key(b""));
     }
 
-    #[test]
-    fn key_value_table_test() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn key_value_table_test<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         let max: u8 = 100;
         // Insert key-values in reverse order to ensure iterator
@@ -1098,9 +1102,9 @@ mod tests {
         }
     }
 
-    #[test]
-    fn key_value_fused_full() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_fused_full<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         let last = vec![0x00, 0x00, 0x00];
 
@@ -1128,9 +1132,9 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_root_with_empty_value() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_root_with_empty_value<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         let key = vec![].into_boxed_slice();
         let value = [0x00];
@@ -1142,9 +1146,9 @@ mod tests {
         assert_eq!(iter.next().unwrap().unwrap(), (key, value.into()));
     }
 
-    #[test]
-    fn key_value_get_branch_and_leaf() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_get_branch_and_leaf<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         let first_leaf = [0x00, 0x00];
         let second_leaf = [0x00, 0x0f];
@@ -1155,7 +1159,7 @@ mod tests {
 
         merkle.insert(&branch, branch.into()).unwrap();
 
-        let immutable_merkle: Merkle<NodeStore<Arc<ImmutableProposal>, _, DefaultHashMode>> =
+        let immutable_merkle: Merkle<NodeStore<Arc<ImmutableProposal>, _, H>> =
             merkle.try_into().unwrap();
         println!("{}", immutable_merkle.dump_to_string().unwrap());
         merkle = immutable_merkle.fork().unwrap();
@@ -1178,9 +1182,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn key_value_start_at_key_not_in_trie() {
-        let mut merkle = create_test_merkle();
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_not_in_trie<H: HashMode>() {
+        let mut merkle = create_test_merkle::<H>();
 
         let first_key = 0x00;
         let intermediate = 0x80;
@@ -1216,13 +1220,13 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_on_branch_with_no_value() {
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_on_branch_with_no_value<H: HashMode>() {
         let sibling_path = 0x00;
         let branch_path = 0x0f;
         let children = 0..=0x0f;
 
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         children.clone().for_each(|child_path| {
             let key = vec![sibling_path, child_path];
@@ -1257,15 +1261,16 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_on_branch_with_value() {
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn key_value_start_at_key_on_branch_with_value<H: HashMode>() {
         let sibling_path = 0x00;
         let branch_path = 0x0f;
         let branch_key = vec![branch_path];
 
         let children = (0..=0xf).map(|val| (val << 4) + val); // 0x00, 0x11, ... 0xff
 
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         merkle
             .insert(&branch_key, branch_key.clone().into())
@@ -1305,11 +1310,11 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_on_extension() {
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_on_extension<H: HashMode>() {
         let missing = 0x0a;
         let children = (0..=0x0f).filter(|x| *x != missing);
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         let keys: Vec<_> = children
             .map(|child_path| {
@@ -1335,15 +1340,15 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_overlapping_with_extension_but_greater() {
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_overlapping_with_extension_but_greater<H: HashMode>() {
         let start_key = 0x0a;
         let shared_path = 0x09;
         // 0x0900, 0x0901, ... 0x0a0f
         // path extension is 0x090
         let children = (0..=0x0f).map(|val| vec![shared_path, val]);
 
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         children.for_each(|key| {
             merkle.insert(&key, key.clone().into()).unwrap();
@@ -1354,15 +1359,15 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_overlapping_with_extension_but_smaller() {
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_overlapping_with_extension_but_smaller<H: HashMode>() {
         let start_key = 0x00;
         let shared_path = 0x09;
         // 0x0900, 0x0901, ... 0x0a0f
         // path extension is 0x090
         let children = (0..=0x0f).map(|val| vec![shared_path, val]);
 
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         let keys: Vec<_> = children
             .inspect(|key| {
@@ -1382,13 +1387,14 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_between_siblings() {
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn key_value_start_at_key_between_siblings<H: HashMode>() {
         let missing = 0xaa;
         let children = (0..=0xf)
             .map(|val| (val << 4) + val) // 0x00, 0x11, ... 0xff
             .filter(|x| *x != missing);
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         let keys: Vec<_> = children
             .map(|child_path| {
@@ -1414,11 +1420,11 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_greater_than_all_others_leaf() {
+    #[firewood_macros::hash_mode]
+    fn key_value_start_at_key_greater_than_all_others_leaf<H: HashMode>() {
         let key = [0x00];
         let greater_key = [0xff];
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
         merkle.insert(&key, key.into()).unwrap();
 
         let iter = merkle.key_value_iter_from_key(&greater_key);
@@ -1426,13 +1432,14 @@ mod tests {
         assert_iterator_is_exhausted(iter);
     }
 
-    #[test]
-    fn key_value_start_at_key_greater_than_all_others_branch() {
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn key_value_start_at_key_greater_than_all_others_branch<H: HashMode>() {
         let greatest = 0xff;
         let children = (0..=0xf)
             .map(|val| (val << 4) + val) // 0x00, 0x11, ... 0xff
             .filter(|x| *x != greatest);
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         let keys: Vec<_> = children
             .map(|child_path| {
@@ -1462,9 +1469,9 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn iterator_skips_leaf_when_start_key_prefixed_by_leaf() {
-        let merkle = created_populated_merkle();
+    #[firewood_macros::hash_mode]
+    fn iterator_skips_leaf_when_start_key_prefixed_by_leaf<H: HashMode>() {
+        let merkle = created_populated_merkle::<H>();
 
         let mut iter =
             MerkleNodeIter::new(merkle.nodestore(), [0x00, 0x00, 0x00, 0xFF, 0x01].into());

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -723,15 +723,14 @@ mod tests {
     use firewood_storage::RootReader;
 
     use super::*;
-    use crate::api::OptionalHashKeyExt;
 
-    impl RevisionManager {
+    impl<H: HashMode> RevisionManager<H> {
         /// Get all proposal hashes available.
         pub fn proposal_hashes(&self) -> Vec<TrieHash> {
             self.proposals
                 .lock()
                 .iter()
-                .filter_map(|p| p.root_hash().or_default_root_hash())
+                .filter_map(|p| p.root_hash().or_else(H::default_root_hash))
                 .collect()
         }
 

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -715,20 +715,17 @@ impl<H: HashMode> RevisionManager<H> {
 
 #[cfg(test)]
 mod tests {
-    use firewood_storage::{DefaultHashMode, RootReader};
+    use firewood_storage::{DefaultHashMode, EthHash, RootReader};
 
     use super::*;
-    #[cfg(feature = "ethhash")]
-    use crate::api::HashKeyExt;
-    use crate::api::OptionalHashKeyExt;
 
-    impl RevisionManager<DefaultHashMode> {
+    impl<H: HashMode> RevisionManager<H> {
         /// Get all proposal hashes available.
         pub fn proposal_hashes(&self) -> Vec<TrieHash> {
             self.proposals
                 .lock()
                 .iter()
-                .filter_map(|p| p.root_hash().or_default_root_hash())
+                .filter_map(|p| p.root_hash().or_else(H::default_root_hash))
                 .collect()
         }
 
@@ -1086,13 +1083,11 @@ mod tests {
     /// `revision()` previously fell through to `RootStore::get` and returned
     /// `RevisionNotFound`. The fix synthesizes an empty committed nodestore
     /// when the caller asks for the default empty-trie hash.
-    #[cfg(feature = "ethhash")]
     #[test]
     fn test_revision_empty_root_after_eviction() {
         use firewood_storage::{LeafNode, NibblesIterator, Node, Path};
 
-        let empty_hash =
-            HashKey::default_root_hash().expect("ethhash exposes a default empty-trie hash");
+        let empty_hash = EthHash::default_root_hash().expect("Ethereum exposes an empty-trie hash");
 
         let db_dir = tempfile::tempdir().unwrap();
         let config = ConfigManager::builder()
@@ -1107,7 +1102,7 @@ mod tests {
             )
             .build();
 
-        let manager = RevisionManager::<DefaultHashMode>::new(config).unwrap();
+        let manager = RevisionManager::<EthHash>::new(config).unwrap();
 
         // Sanity: the fresh manager indexes the empty revision under the
         // default hash.
@@ -1122,7 +1117,7 @@ mod tests {
                 partial_path: Path::from_nibbles_iterator(NibblesIterator::new(&[i])),
                 value: Box::new([i]),
             }));
-            let proposal: Arc<NodeStore<Arc<ImmutableProposal>, _, DefaultHashMode>> =
+            let proposal: Arc<NodeStore<Arc<ImmutableProposal>, _, EthHash>> =
                 Arc::new(proposal.try_into().unwrap());
             manager.add_proposal(proposal.clone());
             manager.commit(proposal).unwrap();

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -580,36 +580,39 @@ mod tests {
     };
 
     use firewood_storage::{
-        Committed, DeletedNodeTracking, FileBacked, FileIoError, HashedNodeReader,
-        ImmutableProposal, MemStore, Mutable, NodeStore, Propose, SeededRng, TestRecorder,
-        TrieReader,
+        Committed, DeletedNodeTracking, EthHash, FileBacked, FileIoError, HashMode,
+        HashedNodeReader, ImmutableProposal, MemStore, MerkleDbHash, Mutable, NodeStore, Propose,
+        SeededRng, TestRecorder, TrieReader,
     };
     use lender::Lender;
     use std::{collections::HashSet, ops::Deref, path::PathBuf, sync::Arc};
     use test_case::test_case;
 
     type BatchOpVec = Vec<BatchOp<Box<[u8]>, Box<[u8]>>>;
-    type ImmutableMemstore = Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>>;
+    type ImmutableMemstore<H> = Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>>;
 
-    struct TestDb {
-        db: Db,
+    struct TestDb<H: HashMode> {
+        db: Db<H>,
     }
 
-    impl Deref for TestDb {
-        type Target = Db;
+    impl<H: HashMode> Deref for TestDb<H> {
+        type Target = Db<H>;
         fn deref(&self) -> &Self::Target {
             &self.db
         }
     }
 
-    impl TestDb {
+    impl<H: HashMode> TestDb<H> {
         pub fn new() -> Self {
             let tmpdir = tempfile::tempdir().unwrap();
-            let dbconfig = DbConfig::builder().truncate(true).build();
+            let dbconfig = DbConfig::builder()
+                .truncate(true)
+                .node_hash_algorithm(H::ALGORITHM)
+                .build();
             let dbpath: PathBuf = [tmpdir.path().to_path_buf(), PathBuf::from("testdb")]
                 .iter()
                 .collect();
-            let db = Db::new(dbpath, dbconfig.clone()).unwrap();
+            let db = Db::<H>::new_with_hash_mode(dbpath, dbconfig).unwrap();
             TestDb { db }
         }
     }
@@ -626,17 +629,16 @@ mod tests {
         DiffMerkleNodeStream::new(tree_left.nodestore(), tree_right.nodestore(), start_key)
     }
 
-    fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
-        let memstore = MemStore::default();
-        let nodestore =
-            NodeStore::new_empty_proposal(Arc::new(memstore), DeletedNodeTracking::Enabled);
+    fn create_test_merkle<H: HashMode>() -> Merkle<NodeStore<Mutable<Propose>, MemStore, H>> {
+        let memstore = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let nodestore = NodeStore::new_empty_proposal(memstore, DeletedNodeTracking::Enabled);
         Merkle::from(nodestore)
     }
 
-    fn populate_merkle(
-        mut merkle: Merkle<NodeStore<Mutable<Propose>, MemStore>>,
+    fn populate_merkle<H: HashMode>(
+        mut merkle: Merkle<NodeStore<Mutable<Propose>, MemStore, H>>,
         items: &[(&[u8], &[u8])],
-    ) -> Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>> {
+    ) -> Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> {
         for (key, value) in items {
             merkle
                 .insert(key, value.to_vec().into_boxed_slice())
@@ -645,10 +647,10 @@ mod tests {
         merkle.try_into().unwrap()
     }
 
-    fn apply_ops_and_freeze(
-        base: &Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>>,
+    fn apply_ops_and_freeze<H: HashMode>(
+        base: &Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>>,
         ops: &[BatchOp<Key, Value>],
-    ) -> Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>> {
+    ) -> Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> {
         let mut fork = base.fork().unwrap();
         for op in ops {
             match op {
@@ -798,8 +800,8 @@ mod tests {
         (batch, next_val)
     }
 
-    #[test]
-    fn test_preorder_iterator() {
+    #[firewood_macros::hash_mode]
+    fn test_preorder_iterator<H: HashMode>() {
         let rng = SeededRng::from_env_or_random();
         let (batch, _) = gen_random_test_batchops(&rng, &HashSet::new(), 1000, 0);
 
@@ -808,7 +810,7 @@ mod tests {
         batch_sorted.sort_by(|op1, op2| op1.key().cmp(op2.key()));
 
         // Insert batch into a merkle trie.
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
         for item in &batch {
             // All of the ops should be Puts
             merkle
@@ -819,7 +821,7 @@ mod tests {
                 .unwrap();
         }
         // freeze and compute the hash
-        let merkle: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>> =
+        let merkle: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
             merkle.try_into().unwrap();
         assert!(HashedNodeReader::root_hash(merkle.nodestore()).is_some());
 
@@ -871,42 +873,42 @@ mod tests {
         assert!(preorder_it.count() > 0);
     }
 
-    #[test]
-    fn test_diff_empty_trees() {
-        let m1: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>> =
-            create_test_merkle().try_into().unwrap();
-        let m2: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>> =
-            create_test_merkle().try_into().unwrap();
+    #[firewood_macros::hash_mode]
+    fn test_diff_empty_trees<H: HashMode>() {
+        let m1: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
+            create_test_merkle::<H>().try_into().unwrap();
+        let m2: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
+            create_test_merkle::<H>().try_into().unwrap();
 
         let mut diff_iter = diff_merkle_iterator(&m1, &m2, Box::new([])).unwrap();
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_identical_trees() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_identical_trees<H: HashMode>() {
         let items = [
             (b"key1".as_slice(), b"value1".as_slice()),
             (b"key2".as_slice(), b"value2".as_slice()),
             (b"key3".as_slice(), b"value3".as_slice()),
         ];
 
-        let m1 = populate_merkle(create_test_merkle(), &items);
-        let m2 = populate_merkle(create_test_merkle(), &items);
+        let m1 = populate_merkle(create_test_merkle::<H>(), &items);
+        let m2 = populate_merkle(create_test_merkle::<H>(), &items);
 
         let mut diff_iter = diff_merkle_iterator(&m1, &m2, Box::new([])).unwrap();
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_additions_only() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_additions_only<H: HashMode>() {
         let items = [
             (b"key1".as_slice(), b"value1".as_slice()),
             (b"key2".as_slice(), b"value2".as_slice()),
         ];
 
-        let m1: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>> =
-            create_test_merkle().try_into().unwrap();
-        let m2 = populate_merkle(create_test_merkle(), &items);
+        let m1: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
+            create_test_merkle::<H>().try_into().unwrap();
+        let m2 = populate_merkle(create_test_merkle::<H>(), &items);
 
         let mut diff_iter = diff_merkle_iterator(&m1, &m2, Box::new([])).unwrap();
 
@@ -923,16 +925,16 @@ mod tests {
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_deletions_only() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_deletions_only<H: HashMode>() {
         let items = [
             (b"key1".as_slice(), b"value1".as_slice()),
             (b"key2".as_slice(), b"value2".as_slice()),
         ];
 
-        let m1 = populate_merkle(create_test_merkle(), &items);
-        let m2: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>> =
-            create_test_merkle().try_into().unwrap();
+        let m1 = populate_merkle(create_test_merkle::<H>(), &items);
+        let m2: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
+            create_test_merkle::<H>().try_into().unwrap();
 
         let mut diff_iter = diff_merkle_iterator(&m1, &m2, Box::new([])).unwrap();
 
@@ -945,10 +947,10 @@ mod tests {
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_modifications() {
-        let m1 = populate_merkle(create_test_merkle(), &[(b"key1", b"old_value")]);
-        let m2 = populate_merkle(create_test_merkle(), &[(b"key1", b"new_value")]);
+    #[firewood_macros::hash_mode]
+    fn test_diff_modifications<H: HashMode>() {
+        let m1 = populate_merkle(create_test_merkle::<H>(), &[(b"key1", b"old_value")]);
+        let m2 = populate_merkle(create_test_merkle::<H>(), &[(b"key1", b"new_value")]);
 
         let mut diff_iter = diff_merkle_iterator(&m1, &m2, Box::new([])).unwrap();
 
@@ -960,14 +962,14 @@ mod tests {
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_mixed_operations() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_mixed_operations<H: HashMode>() {
         // m1 has: key1=value1, key2=old_value, key3=value3
         // m2 has: key2=new_value, key4=value4
         // Expected: Delete key1, Put key2=new_value, Delete key3, Put key4=value4
 
         let m1 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"key1", b"value1"), // [6b, 65, 79, 31]
                 (b"key2", b"old_value"),
@@ -976,7 +978,7 @@ mod tests {
         );
 
         let m2 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[(b"key2", b"new_value"), (b"key4", b"value4")],
         );
 
@@ -1001,19 +1003,19 @@ mod tests {
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_interleaved_keys() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_interleaved_keys<H: HashMode>() {
         // m1: a, c, e
         // m2: b, c, d, f
         // Expected: Delete a, Put b, Put d, Delete e, Put f
 
         let m1 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[(b"a", b"value_a"), (b"c", b"value_c"), (b"e", b"value_e")],
         );
 
         let m2 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"b", b"value_b"),
                 (b"c", b"value_c"),
@@ -1089,11 +1091,12 @@ mod tests {
         assert_eq!(ops.len(), 0);
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(true, false, 0, 1)] // same value, m1->m2: no put needed, delete prefix/b
     #[test_case(false, false, 1, 1)] // diff value, m1->m2: put prefix/a, delete prefix/b
     #[test_case(true, true, 1, 0)] // same value, m2->m1: no change to prefix/a, add prefix/b
     #[test_case(false, true, 2, 0)] // diff value, m2->m1: update prefix/a, add prefix/b
-    fn test_branch_vs_leaf_empty_partial_path_bug(
+    fn test_branch_vs_leaf_empty_partial_path_bug<H: HashMode>(
         same_value: bool,
         backwards: bool,
         expected_puts: usize,
@@ -1111,7 +1114,7 @@ mod tests {
         // Tree1: Create children under "prefix" but no value at "prefix" itself
         // This creates a branch node at "prefix" with value=None
         let m1 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"prefix/a".as_slice(), b"value_a".as_slice()),
                 (b"prefix/b".as_slice(), b"value_b".as_slice()),
@@ -1125,7 +1128,10 @@ mod tests {
         } else {
             b"prefix_a_value"
         };
-        let m2 = populate_merkle(create_test_merkle(), &[(b"prefix/a".as_slice(), m2_value)]);
+        let m2 = populate_merkle(
+            create_test_merkle::<H>(),
+            &[(b"prefix/a".as_slice(), m2_value)],
+        );
 
         // Choose direction based on backwards parameter
         let (tree_left, tree_right, direction_desc) = if backwards {
@@ -1168,11 +1174,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_diff_processes_all_branch_children() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_processes_all_branch_children<H: HashMode>() {
         // This test verifies the bug fix: ensure that after finding different children
         // at the same position in a branch, the algorithm continues to process remaining children
-        let m1 = create_test_merkle();
+        let m1 = create_test_merkle::<H>();
         let m1 = populate_merkle(
             m1,
             &[
@@ -1182,7 +1188,7 @@ mod tests {
             ],
         );
 
-        let m2 = create_test_merkle();
+        let m2 = create_test_merkle::<H>();
         let m2 = populate_merkle(
             m2,
             &[
@@ -1234,8 +1240,8 @@ mod tests {
         assert_eq!(additions, 1, "Should have 1 addition");
     }
 
-    #[test]
-    fn test_diff_states_coverage() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_states_coverage<H: HashMode>() {
         // Create trees with carefully designed structure to trigger the following:
         // 1. Deep branching structure to ensure branch nodes exist
         // 2. Mix of shared, modified, left-only, and right-only content
@@ -1312,8 +1318,8 @@ mod tests {
             ),
         ];
 
-        let m1 = populate_merkle(create_test_merkle(), &tree1_data);
-        let m2 = populate_merkle(create_test_merkle(), &tree2_data);
+        let m1 = populate_merkle(create_test_merkle::<H>(), &tree1_data);
+        let m2 = populate_merkle(create_test_merkle::<H>(), &tree2_data);
 
         let diff_iter = diff_merkle_iterator(&m1, &m2, Key::default()).unwrap();
         let results: Vec<_> = diff_iter.collect::<Result<Vec<_>, _>>().unwrap();
@@ -1345,14 +1351,14 @@ mod tests {
         println!("All 6 diff coverage tests passed:");
     }
 
-    #[test]
-    fn test_branch_vs_leaf_state_transitions() {
+    #[firewood_macros::hash_mode]
+    fn test_branch_vs_leaf_state_transitions<H: HashMode>() {
         // This test specifically covers the branch-vs-leaf scenarios in UnvisitedNodePairState
         // which can trigger different state transitions
 
         // Tree1: Has a branch structure at "path"
         let m1 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"path/file1".as_slice(), b"value1".as_slice()),
                 (b"path/file2".as_slice(), b"value2".as_slice()),
@@ -1361,7 +1367,7 @@ mod tests {
 
         // Tree2: Has a leaf at "path"
         let m2 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[(b"path".as_slice(), b"leaf_value".as_slice())],
         );
 
@@ -1384,10 +1390,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_diff_with_start_key() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_with_start_key<H: HashMode>() {
         let m1 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"aaa", b"value1"),
                 (b"bbb", b"value2"),
@@ -1396,7 +1402,7 @@ mod tests {
         );
 
         let m2 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"aaa", b"value2"),   // Same
                 (b"bbb", b"modified"), // Modified
@@ -1424,10 +1430,11 @@ mod tests {
         assert!(diff_iter.next().is_none());
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(500)]
     #[test_case(10)]
     #[test_case(3)]
-    fn test_diff_random_with_deletions(num_items: usize) {
+    fn test_diff_random_with_deletions<H: HashMode>(num_items: usize) {
         let rng = SeededRng::from_env_or_random();
 
         // Generate random key-value pairs, ensuring uniqueness
@@ -1448,8 +1455,8 @@ mod tests {
         }
 
         // Create two identical merkles
-        let mut m1 = create_test_merkle();
-        let mut m2 = create_test_merkle();
+        let mut m1 = create_test_merkle::<H>();
+        let mut m2 = create_test_merkle::<H>();
 
         for (key, value) in &items {
             m1.insert(key, value.clone().into_boxed_slice()).unwrap();
@@ -1472,10 +1479,10 @@ mod tests {
         }
 
         // Compute ops and immutable views according to mutability flags
-        let (ops, m1_immut, m2_immut): (BatchOpVec, ImmutableMemstore, ImmutableMemstore) = {
-            let m1_immut: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>> =
+        let (ops, m1_immut, m2_immut): (BatchOpVec, ImmutableMemstore<H>, ImmutableMemstore<H>) = {
+            let m1_immut: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
                 m1.try_into().unwrap();
-            let m2_immut: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>> =
+            let m2_immut: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
                 m2.try_into().unwrap();
             let ops = diff_merkle_iterator(&m1_immut, &m2_immut, Box::new([]))
                 .unwrap()
@@ -1489,16 +1496,17 @@ mod tests {
         assert_merkle_eq(&left_after, &m2_immut);
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(20, 500)]
-    fn test_db_fuzz(num_iterations: usize, num_items: usize) {
-        fn one_iteration(
+    fn test_db_fuzz<H: HashMode>(num_iterations: usize, num_items: usize) {
+        fn one_iteration<H: HashMode>(
             rng: &SeededRng,
-            db: &Db,
-            committed: Arc<NodeStore<Committed, FileBacked>>,
+            db: &Db<H>,
+            committed: Arc<NodeStore<Committed, FileBacked, H>>,
             committed_keys: &mut HashSet<Vec<u8>>,
             num_items: usize,
             start_val: usize,
-        ) -> (Arc<NodeStore<Committed, FileBacked>>, usize) {
+        ) -> (Arc<NodeStore<Committed, FileBacked, H>>, usize) {
             const CHANCE_COMMIT_PERCENT: usize = 25;
             let proposal = NodeStore::new(&committed).unwrap();
             let mut merkle = Merkle::from(proposal);
@@ -1522,7 +1530,7 @@ mod tests {
             // Randomly choose between comparing the committed nodestore against a
             // mutable proposal or an immutable proposal.
             let ops = {
-                let immutable: NodeStore<Arc<ImmutableProposal>, FileBacked> =
+                let immutable: NodeStore<Arc<ImmutableProposal>, FileBacked, H> =
                     nodestore.try_into().unwrap();
                 diff_merkle_iterator(&committed.clone().into(), &immutable.into(), Box::new([]))
                     .unwrap()
@@ -1575,7 +1583,7 @@ mod tests {
             }
         }
 
-        let db = TestDb::new();
+        let db = TestDb::<H>::new();
         let rng = SeededRng::from_env_or_random();
         let mut committed_keys = HashSet::new();
         let start_val = 0;
@@ -1611,12 +1619,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_two_round_diff_with_start_keys() {
+    #[firewood_macros::hash_mode]
+    fn test_two_round_diff_with_start_keys<H: HashMode>() {
         let rng = SeededRng::from_env_or_random();
         // Run this test several times.
         for _ in 0..4 {
-            let db = TestDb::new();
+            let db = TestDb::<H>::new();
             let mut committed_keys = HashSet::new();
             let start_val = 0;
 
@@ -1655,7 +1663,7 @@ mod tests {
                 }
             }
             let nodestore = merkle.into_inner();
-            let target_immutable: NodeStore<Arc<ImmutableProposal>, FileBacked> =
+            let target_immutable: NodeStore<Arc<ImmutableProposal>, FileBacked, H> =
                 nodestore.try_into().unwrap();
 
             // Now generate a diff iterator, but only create a vector from the first
@@ -1705,8 +1713,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_hash_optimization_reduces_next_calls() {
+    #[firewood_macros::hash_mode]
+    fn test_hash_optimization_reduces_next_calls<H: HashMode>() {
         let recorder = TestRecorder::default();
         recorder.with_local_recorder(|| {
             // Create test data with substantial shared content and unique content
@@ -1764,8 +1772,8 @@ mod tests {
                 (b"tree2_unique/r".as_slice(), b"r_value".as_slice()),
             ];
 
-            let m1 = populate_merkle(create_test_merkle(), &tree1_items);
-            let m2 = populate_merkle(create_test_merkle(), &tree2_items);
+            let m1 = populate_merkle(create_test_merkle::<H>(), &tree1_items);
+            let m2 = populate_merkle(create_test_merkle::<H>(), &tree2_items);
 
             // Check the number of next calls on two full tree traversals.
             let diff_nexts_before =

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -580,39 +580,39 @@ mod tests {
     };
 
     use firewood_storage::{
-        Committed, DefaultHashMode, DeletedNodeTracking, FileBacked, FileIoError, HashMode,
-        HashedNodeReader, ImmutableProposal, MemStore, Mutable, NodeStore, Propose, SeededRng,
-        TestRecorder, TrieReader,
+        Committed, DeletedNodeTracking, EthHash, FileBacked, FileIoError, HashMode,
+        HashedNodeReader, ImmutableProposal, MemStore, MerkleDbHash, Mutable, NodeStore, Propose,
+        SeededRng, TestRecorder, TrieReader,
     };
     use lender::Lender;
     use std::{collections::HashSet, ops::Deref, path::PathBuf, sync::Arc};
     use test_case::test_case;
 
     type BatchOpVec = Vec<BatchOp<Box<[u8]>, Box<[u8]>>>;
-    type ImmutableMemstore = Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>>;
+    type ImmutableMemstore<H> = Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>>;
 
-    struct TestDb {
-        db: Db<DefaultHashMode>,
+    struct TestDb<H: HashMode> {
+        db: Db<H>,
     }
 
-    impl Deref for TestDb {
-        type Target = Db<DefaultHashMode>;
+    impl<H: HashMode> Deref for TestDb<H> {
+        type Target = Db<H>;
         fn deref(&self) -> &Self::Target {
             &self.db
         }
     }
 
-    impl TestDb {
+    impl<H: HashMode> TestDb<H> {
         pub fn new() -> Self {
             let tmpdir = tempfile::tempdir().unwrap();
             let dbconfig = DbConfig::builder()
-                .node_hash_algorithm(DefaultHashMode::ALGORITHM)
                 .truncate(true)
+                .node_hash_algorithm(H::ALGORITHM)
                 .build();
             let dbpath: PathBuf = [tmpdir.path().to_path_buf(), PathBuf::from("testdb")]
                 .iter()
                 .collect();
-            let db = Db::<DefaultHashMode>::new_with_hash_mode(dbpath, dbconfig).unwrap();
+            let db = Db::<H>::new_with_hash_mode(dbpath, dbconfig).unwrap();
             TestDb { db }
         }
     }
@@ -629,17 +629,16 @@ mod tests {
         DiffMerkleNodeStream::new(tree_left.nodestore(), tree_right.nodestore(), start_key)
     }
 
-    fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore, DefaultHashMode>> {
-        let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
-            NodeStore::new_empty_proposal(Arc::new(memstore), DeletedNodeTracking::Enabled);
+    fn create_test_merkle<H: HashMode>() -> Merkle<NodeStore<Mutable<Propose>, MemStore, H>> {
+        let memstore = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let nodestore = NodeStore::new_empty_proposal(memstore, DeletedNodeTracking::Enabled);
         Merkle::from(nodestore)
     }
 
-    fn populate_merkle(
-        mut merkle: Merkle<NodeStore<Mutable<Propose>, MemStore, DefaultHashMode>>,
+    fn populate_merkle<H: HashMode>(
+        mut merkle: Merkle<NodeStore<Mutable<Propose>, MemStore, H>>,
         items: &[(&[u8], &[u8])],
-    ) -> Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>> {
+    ) -> Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> {
         for (key, value) in items {
             merkle
                 .insert(key, value.to_vec().into_boxed_slice())
@@ -648,10 +647,10 @@ mod tests {
         merkle.try_into().unwrap()
     }
 
-    fn apply_ops_and_freeze(
-        base: &Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>>,
+    fn apply_ops_and_freeze<H: HashMode>(
+        base: &Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>>,
         ops: &[BatchOp<Key, Value>],
-    ) -> Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>> {
+    ) -> Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> {
         let mut fork = base.fork().unwrap();
         for op in ops {
             match op {
@@ -801,8 +800,8 @@ mod tests {
         (batch, next_val)
     }
 
-    #[test]
-    fn test_preorder_iterator() {
+    #[firewood_macros::hash_mode]
+    fn test_preorder_iterator<H: HashMode>() {
         let rng = SeededRng::from_env_or_random();
         let (batch, _) = gen_random_test_batchops(&rng, &HashSet::new(), 1000, 0);
 
@@ -811,7 +810,7 @@ mod tests {
         batch_sorted.sort_by(|op1, op2| op1.key().cmp(op2.key()));
 
         // Insert batch into a merkle trie.
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
         for item in &batch {
             // All of the ops should be Puts
             merkle
@@ -822,7 +821,7 @@ mod tests {
                 .unwrap();
         }
         // freeze and compute the hash
-        let merkle: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>> =
+        let merkle: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
             merkle.try_into().unwrap();
         assert!(HashedNodeReader::root_hash(merkle.nodestore()).is_some());
 
@@ -874,42 +873,42 @@ mod tests {
         assert!(preorder_it.count() > 0);
     }
 
-    #[test]
-    fn test_diff_empty_trees() {
-        let m1: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>> =
-            create_test_merkle().try_into().unwrap();
-        let m2: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>> =
-            create_test_merkle().try_into().unwrap();
+    #[firewood_macros::hash_mode]
+    fn test_diff_empty_trees<H: HashMode>() {
+        let m1: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
+            create_test_merkle::<H>().try_into().unwrap();
+        let m2: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
+            create_test_merkle::<H>().try_into().unwrap();
 
         let mut diff_iter = diff_merkle_iterator(&m1, &m2, Box::new([])).unwrap();
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_identical_trees() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_identical_trees<H: HashMode>() {
         let items = [
             (b"key1".as_slice(), b"value1".as_slice()),
             (b"key2".as_slice(), b"value2".as_slice()),
             (b"key3".as_slice(), b"value3".as_slice()),
         ];
 
-        let m1 = populate_merkle(create_test_merkle(), &items);
-        let m2 = populate_merkle(create_test_merkle(), &items);
+        let m1 = populate_merkle(create_test_merkle::<H>(), &items);
+        let m2 = populate_merkle(create_test_merkle::<H>(), &items);
 
         let mut diff_iter = diff_merkle_iterator(&m1, &m2, Box::new([])).unwrap();
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_additions_only() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_additions_only<H: HashMode>() {
         let items = [
             (b"key1".as_slice(), b"value1".as_slice()),
             (b"key2".as_slice(), b"value2".as_slice()),
         ];
 
-        let m1: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>> =
-            create_test_merkle().try_into().unwrap();
-        let m2 = populate_merkle(create_test_merkle(), &items);
+        let m1: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
+            create_test_merkle::<H>().try_into().unwrap();
+        let m2 = populate_merkle(create_test_merkle::<H>(), &items);
 
         let mut diff_iter = diff_merkle_iterator(&m1, &m2, Box::new([])).unwrap();
 
@@ -926,16 +925,16 @@ mod tests {
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_deletions_only() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_deletions_only<H: HashMode>() {
         let items = [
             (b"key1".as_slice(), b"value1".as_slice()),
             (b"key2".as_slice(), b"value2".as_slice()),
         ];
 
-        let m1 = populate_merkle(create_test_merkle(), &items);
-        let m2: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>> =
-            create_test_merkle().try_into().unwrap();
+        let m1 = populate_merkle(create_test_merkle::<H>(), &items);
+        let m2: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
+            create_test_merkle::<H>().try_into().unwrap();
 
         let mut diff_iter = diff_merkle_iterator(&m1, &m2, Box::new([])).unwrap();
 
@@ -948,10 +947,10 @@ mod tests {
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_modifications() {
-        let m1 = populate_merkle(create_test_merkle(), &[(b"key1", b"old_value")]);
-        let m2 = populate_merkle(create_test_merkle(), &[(b"key1", b"new_value")]);
+    #[firewood_macros::hash_mode]
+    fn test_diff_modifications<H: HashMode>() {
+        let m1 = populate_merkle(create_test_merkle::<H>(), &[(b"key1", b"old_value")]);
+        let m2 = populate_merkle(create_test_merkle::<H>(), &[(b"key1", b"new_value")]);
 
         let mut diff_iter = diff_merkle_iterator(&m1, &m2, Box::new([])).unwrap();
 
@@ -963,14 +962,14 @@ mod tests {
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_mixed_operations() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_mixed_operations<H: HashMode>() {
         // m1 has: key1=value1, key2=old_value, key3=value3
         // m2 has: key2=new_value, key4=value4
         // Expected: Delete key1, Put key2=new_value, Delete key3, Put key4=value4
 
         let m1 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"key1", b"value1"), // [6b, 65, 79, 31]
                 (b"key2", b"old_value"),
@@ -979,7 +978,7 @@ mod tests {
         );
 
         let m2 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[(b"key2", b"new_value"), (b"key4", b"value4")],
         );
 
@@ -1004,19 +1003,19 @@ mod tests {
         assert!(diff_iter.next().is_none());
     }
 
-    #[test]
-    fn test_diff_interleaved_keys() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_interleaved_keys<H: HashMode>() {
         // m1: a, c, e
         // m2: b, c, d, f
         // Expected: Delete a, Put b, Put d, Delete e, Put f
 
         let m1 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[(b"a", b"value_a"), (b"c", b"value_c"), (b"e", b"value_e")],
         );
 
         let m2 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"b", b"value_b"),
                 (b"c", b"value_c"),
@@ -1092,11 +1091,12 @@ mod tests {
         assert_eq!(ops.len(), 0);
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(true, false, 0, 1)] // same value, m1->m2: no put needed, delete prefix/b
     #[test_case(false, false, 1, 1)] // diff value, m1->m2: put prefix/a, delete prefix/b
     #[test_case(true, true, 1, 0)] // same value, m2->m1: no change to prefix/a, add prefix/b
     #[test_case(false, true, 2, 0)] // diff value, m2->m1: update prefix/a, add prefix/b
-    fn test_branch_vs_leaf_empty_partial_path_bug(
+    fn test_branch_vs_leaf_empty_partial_path_bug<H: HashMode>(
         same_value: bool,
         backwards: bool,
         expected_puts: usize,
@@ -1114,7 +1114,7 @@ mod tests {
         // Tree1: Create children under "prefix" but no value at "prefix" itself
         // This creates a branch node at "prefix" with value=None
         let m1 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"prefix/a".as_slice(), b"value_a".as_slice()),
                 (b"prefix/b".as_slice(), b"value_b".as_slice()),
@@ -1128,7 +1128,10 @@ mod tests {
         } else {
             b"prefix_a_value"
         };
-        let m2 = populate_merkle(create_test_merkle(), &[(b"prefix/a".as_slice(), m2_value)]);
+        let m2 = populate_merkle(
+            create_test_merkle::<H>(),
+            &[(b"prefix/a".as_slice(), m2_value)],
+        );
 
         // Choose direction based on backwards parameter
         let (tree_left, tree_right, direction_desc) = if backwards {
@@ -1171,11 +1174,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_diff_processes_all_branch_children() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_processes_all_branch_children<H: HashMode>() {
         // This test verifies the bug fix: ensure that after finding different children
         // at the same position in a branch, the algorithm continues to process remaining children
-        let m1 = create_test_merkle();
+        let m1 = create_test_merkle::<H>();
         let m1 = populate_merkle(
             m1,
             &[
@@ -1185,7 +1188,7 @@ mod tests {
             ],
         );
 
-        let m2 = create_test_merkle();
+        let m2 = create_test_merkle::<H>();
         let m2 = populate_merkle(
             m2,
             &[
@@ -1237,8 +1240,8 @@ mod tests {
         assert_eq!(additions, 1, "Should have 1 addition");
     }
 
-    #[test]
-    fn test_diff_states_coverage() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_states_coverage<H: HashMode>() {
         // Create trees with carefully designed structure to trigger the following:
         // 1. Deep branching structure to ensure branch nodes exist
         // 2. Mix of shared, modified, left-only, and right-only content
@@ -1315,8 +1318,8 @@ mod tests {
             ),
         ];
 
-        let m1 = populate_merkle(create_test_merkle(), &tree1_data);
-        let m2 = populate_merkle(create_test_merkle(), &tree2_data);
+        let m1 = populate_merkle(create_test_merkle::<H>(), &tree1_data);
+        let m2 = populate_merkle(create_test_merkle::<H>(), &tree2_data);
 
         let diff_iter = diff_merkle_iterator(&m1, &m2, Key::default()).unwrap();
         let results: Vec<_> = diff_iter.collect::<Result<Vec<_>, _>>().unwrap();
@@ -1348,14 +1351,14 @@ mod tests {
         println!("All 6 diff coverage tests passed:");
     }
 
-    #[test]
-    fn test_branch_vs_leaf_state_transitions() {
+    #[firewood_macros::hash_mode]
+    fn test_branch_vs_leaf_state_transitions<H: HashMode>() {
         // This test specifically covers the branch-vs-leaf scenarios in UnvisitedNodePairState
         // which can trigger different state transitions
 
         // Tree1: Has a branch structure at "path"
         let m1 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"path/file1".as_slice(), b"value1".as_slice()),
                 (b"path/file2".as_slice(), b"value2".as_slice()),
@@ -1364,7 +1367,7 @@ mod tests {
 
         // Tree2: Has a leaf at "path"
         let m2 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[(b"path".as_slice(), b"leaf_value".as_slice())],
         );
 
@@ -1387,10 +1390,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_diff_with_start_key() {
+    #[firewood_macros::hash_mode]
+    fn test_diff_with_start_key<H: HashMode>() {
         let m1 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"aaa", b"value1"),
                 (b"bbb", b"value2"),
@@ -1399,7 +1402,7 @@ mod tests {
         );
 
         let m2 = populate_merkle(
-            create_test_merkle(),
+            create_test_merkle::<H>(),
             &[
                 (b"aaa", b"value2"),   // Same
                 (b"bbb", b"modified"), // Modified
@@ -1427,10 +1430,11 @@ mod tests {
         assert!(diff_iter.next().is_none());
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(500)]
     #[test_case(10)]
     #[test_case(3)]
-    fn test_diff_random_with_deletions(num_items: usize) {
+    fn test_diff_random_with_deletions<H: HashMode>(num_items: usize) {
         let rng = SeededRng::from_env_or_random();
 
         // Generate random key-value pairs, ensuring uniqueness
@@ -1451,8 +1455,8 @@ mod tests {
         }
 
         // Create two identical merkles
-        let mut m1 = create_test_merkle();
-        let mut m2 = create_test_merkle();
+        let mut m1 = create_test_merkle::<H>();
+        let mut m2 = create_test_merkle::<H>();
 
         for (key, value) in &items {
             m1.insert(key, value.clone().into_boxed_slice()).unwrap();
@@ -1475,10 +1479,10 @@ mod tests {
         }
 
         // Compute ops and immutable views according to mutability flags
-        let (ops, m1_immut, m2_immut): (BatchOpVec, ImmutableMemstore, ImmutableMemstore) = {
-            let m1_immut: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>> =
+        let (ops, m1_immut, m2_immut): (BatchOpVec, ImmutableMemstore<H>, ImmutableMemstore<H>) = {
+            let m1_immut: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
                 m1.try_into().unwrap();
-            let m2_immut: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, DefaultHashMode>> =
+            let m2_immut: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>> =
                 m2.try_into().unwrap();
             let ops = diff_merkle_iterator(&m1_immut, &m2_immut, Box::new([]))
                 .unwrap()
@@ -1492,19 +1496,17 @@ mod tests {
         assert_merkle_eq(&left_after, &m2_immut);
     }
 
+    #[firewood_macros::hash_mode]
     #[test_case(20, 500)]
-    fn test_db_fuzz(num_iterations: usize, num_items: usize) {
-        fn one_iteration(
+    fn test_db_fuzz<H: HashMode>(num_iterations: usize, num_items: usize) {
+        fn one_iteration<H: HashMode>(
             rng: &SeededRng,
-            db: &Db<DefaultHashMode>,
-            committed: Arc<NodeStore<Committed, FileBacked, DefaultHashMode>>,
+            db: &Db<H>,
+            committed: Arc<NodeStore<Committed, FileBacked, H>>,
             committed_keys: &mut HashSet<Vec<u8>>,
             num_items: usize,
             start_val: usize,
-        ) -> (
-            Arc<NodeStore<Committed, FileBacked, DefaultHashMode>>,
-            usize,
-        ) {
+        ) -> (Arc<NodeStore<Committed, FileBacked, H>>, usize) {
             const CHANCE_COMMIT_PERCENT: usize = 25;
             let proposal = NodeStore::new(&committed).unwrap();
             let mut merkle = Merkle::from(proposal);
@@ -1528,7 +1530,7 @@ mod tests {
             // Randomly choose between comparing the committed nodestore against a
             // mutable proposal or an immutable proposal.
             let ops = {
-                let immutable: NodeStore<Arc<ImmutableProposal>, FileBacked, DefaultHashMode> =
+                let immutable: NodeStore<Arc<ImmutableProposal>, FileBacked, H> =
                     nodestore.try_into().unwrap();
                 diff_merkle_iterator(&committed.clone().into(), &immutable.into(), Box::new([]))
                     .unwrap()
@@ -1581,7 +1583,7 @@ mod tests {
             }
         }
 
-        let db = TestDb::new();
+        let db = TestDb::<H>::new();
         let rng = SeededRng::from_env_or_random();
         let mut committed_keys = HashSet::new();
         let start_val = 0;
@@ -1617,12 +1619,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_two_round_diff_with_start_keys() {
+    #[firewood_macros::hash_mode]
+    fn test_two_round_diff_with_start_keys<H: HashMode>() {
         let rng = SeededRng::from_env_or_random();
         // Run this test several times.
         for _ in 0..4 {
-            let db = TestDb::new();
+            let db = TestDb::<H>::new();
             let mut committed_keys = HashSet::new();
             let start_val = 0;
 
@@ -1661,7 +1663,7 @@ mod tests {
                 }
             }
             let nodestore = merkle.into_inner();
-            let target_immutable: NodeStore<Arc<ImmutableProposal>, FileBacked, DefaultHashMode> =
+            let target_immutable: NodeStore<Arc<ImmutableProposal>, FileBacked, H> =
                 nodestore.try_into().unwrap();
 
             // Now generate a diff iterator, but only create a vector from the first
@@ -1711,8 +1713,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_hash_optimization_reduces_next_calls() {
+    #[firewood_macros::hash_mode]
+    fn test_hash_optimization_reduces_next_calls<H: HashMode>() {
         let recorder = TestRecorder::default();
         recorder.with_local_recorder(|| {
             // Create test data with substantial shared content and unique content
@@ -1770,8 +1772,8 @@ mod tests {
                 (b"tree2_unique/r".as_slice(), b"r_value".as_slice()),
             ];
 
-            let m1 = populate_merkle(create_test_merkle(), &tree1_items);
-            let m2 = populate_merkle(create_test_merkle(), &tree2_items);
+            let m1 = populate_merkle(create_test_merkle::<H>(), &tree1_items);
+            let m2 = populate_merkle(create_test_merkle::<H>(), &tree2_items);
 
             // Check the number of next calls on two full tree traversals.
             let diff_nexts_before =

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -407,20 +407,21 @@ impl<S: ReadableStorage, H: HashMode> Merkle<NodeStore<Mutable<Propose>, S, H>> 
 
 #[cfg(test)]
 mod tests {
-    use firewood_storage::{DeletedNodeTracking, MemStore};
+    use std::sync::Arc;
+
+    use firewood_storage::{DeletedNodeTracking, EthHash, MemStore, MerkleDbHash};
 
     use super::*;
 
-    fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
-        let memstore = MemStore::default();
-        let nodestore =
-            NodeStore::new_empty_proposal(memstore.into(), DeletedNodeTracking::Enabled);
+    fn create_test_merkle<H: HashMode>() -> Merkle<NodeStore<Mutable<Propose>, MemStore, H>> {
+        let memstore = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let nodestore = NodeStore::new_empty_proposal(memstore, DeletedNodeTracking::Enabled);
         Merkle { nodestore }
     }
 
-    type TestMerkle = Merkle<NodeStore<Mutable<Propose>, MemStore>>;
+    type TestMerkle<H> = Merkle<NodeStore<Mutable<Propose>, MemStore, H>>;
 
-    fn branch_child(m: &mut TestMerkle, keys: &[&[u8]], nibble: u8) -> Child {
+    fn branch_child<H: HashMode>(m: &mut TestMerkle<H>, keys: &[&[u8]], nibble: u8) -> Child {
         for key in keys {
             m.insert(key, Box::from(b"v".as_slice())).unwrap();
         }
@@ -432,15 +433,15 @@ mod tests {
             .unwrap()
     }
 
-    fn check_child_in_range(
-        setup: impl FnOnce(&mut TestMerkle) -> Child,
+    fn check_child_in_range<H: HashMode>(
+        setup: impl FnOnce(&mut TestMerkle<H>) -> Child,
         acc_prefix: &[u8],
         nibble: u8,
         start_nib: &[u8],
         end_nib: &[u8],
         expected: bool,
     ) {
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
         let child = setup(&mut merkle);
         let pc = PathComponent::try_new(nibble).unwrap();
         let result = merkle
@@ -452,10 +453,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_child_in_range() {
+    #[firewood_macros::hash_mode]
+    fn test_child_in_range<H: HashMode>() {
         // nibble clearly out of range — returns false without reading
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x50", b"\x60"], 0x5),
             &[],
             0x5,
@@ -465,7 +466,7 @@ mod tests {
         );
 
         // leaf: nibble straddles start, full key [0,0] < start [0,1]
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x00", b"\x10"], 0x0),
             &[],
             0x0,
@@ -475,7 +476,7 @@ mod tests {
         );
 
         // leaf: nibble straddles start, full key [0,5] >= start [0,1]
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x05", b"\x10"], 0x0),
             &[],
             0x0,
@@ -485,7 +486,7 @@ mod tests {
         );
 
         // leaf: nibble straddles end, full key [3,f] > end [3,0]
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x3f", b"\x10"], 0x3),
             &[],
             0x3,
@@ -495,7 +496,7 @@ mod tests {
         );
 
         // branch: all children out of range ([0,0,0,0] and [0,0,5,0] both < [0,1])
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x00\x00", b"\x00\x50", b"\x10"], 0x0),
             &[],
             0x0,
@@ -505,7 +506,7 @@ mod tests {
         );
 
         // branch: one child in range ([0,1,0,0] >= [0,1])
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x00\x00", b"\x01\x00", b"\x10"], 0x0),
             &[],
             0x0,
@@ -515,7 +516,7 @@ mod tests {
         );
 
         // branch with value: key [0,0] in range [0,0]..[0,f], has value
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x00", b"\x00\x50", b"\x10"], 0x0),
             &[],
             0x0,
@@ -562,10 +563,10 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_collapse_navigate_exact_match() {
+    #[firewood_macros::hash_mode]
+    fn test_collapse_navigate_exact_match<H: HashMode>() {
         let pc = |n: u8| PathComponent::try_new(n).unwrap();
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         // Under \x10, branch with children at 2 and 3.
         // Under \x10\x2, branch with children at 1 and 2.
@@ -607,10 +608,10 @@ mod tests {
         assert!(merkle.get_value(b"\x10\x30").unwrap().is_some());
     }
 
-    #[test]
-    fn test_collapse_navigate_recurse() {
+    #[firewood_macros::hash_mode]
+    fn test_collapse_navigate_recurse<H: HashMode>() {
         let pc = |n: u8| PathComponent::try_new(n).unwrap();
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         // Under \x1, branch with children at nibbles 0 and 1.
         // Under \x10\x2, branch with children at nibbles 1 and 3.
@@ -645,10 +646,10 @@ mod tests {
         assert!(merkle.get_value(b"\x10\x23").unwrap().is_none());
     }
 
-    #[test]
-    fn test_collapse_navigate_errors() {
+    #[firewood_macros::hash_mode]
+    fn test_collapse_navigate_errors<H: HashMode>() {
         let pc = |n: u8| PathComponent::try_new(n).unwrap();
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         // Single key \x10 → root has partial_path [1, 0]
         merkle.insert(b"\x10", Box::from(b"a".as_slice())).unwrap();
@@ -685,7 +686,7 @@ mod tests {
 
         // Range covers \x10\x22 in this test. An in-range off-path child
         // should result in an `EndRootMismatch`.
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
         merkle
             .insert(b"\x10\x21", Box::from(b"a".as_slice()))
             .unwrap();
@@ -715,10 +716,10 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_collapse_navigate_mismatched_partial_path() {
+    #[firewood_macros::hash_mode]
+    fn test_collapse_navigate_mismatched_partial_path<H: HashMode>() {
         let pc = |n: u8| PathComponent::try_new(n).unwrap();
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         // Under [1, 0, 2]: leaf with partial_path [1] for \x10\x21
         merkle

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -503,20 +503,21 @@ impl<S: ReadableStorage, H: HashMode> Merkle<NodeStore<Mutable<Propose>, S, H>> 
 
 #[cfg(test)]
 mod tests {
-    use firewood_storage::{DefaultHashMode, DeletedNodeTracking, HashMode, MemStore};
+    use std::sync::Arc;
+
+    use firewood_storage::{DeletedNodeTracking, EthHash, MemStore, MerkleDbHash};
 
     use super::*;
 
-    fn create_test_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore, DefaultHashMode>> {
-        let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
-            NodeStore::new_empty_proposal(memstore.into(), DeletedNodeTracking::Enabled);
+    fn create_test_merkle<H: HashMode>() -> Merkle<NodeStore<Mutable<Propose>, MemStore, H>> {
+        let memstore = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let nodestore = NodeStore::new_empty_proposal(memstore, DeletedNodeTracking::Enabled);
         Merkle { nodestore }
     }
 
-    type TestMerkle = Merkle<NodeStore<Mutable<Propose>, MemStore, DefaultHashMode>>;
+    type TestMerkle<H> = Merkle<NodeStore<Mutable<Propose>, MemStore, H>>;
 
-    fn branch_child(m: &mut TestMerkle, keys: &[&[u8]], nibble: u8) -> Child {
+    fn branch_child<H: HashMode>(m: &mut TestMerkle<H>, keys: &[&[u8]], nibble: u8) -> Child {
         for key in keys {
             m.insert(key, Box::from(b"v".as_slice())).unwrap();
         }
@@ -528,15 +529,15 @@ mod tests {
             .unwrap()
     }
 
-    fn check_child_in_range(
-        setup: impl FnOnce(&mut TestMerkle) -> Child,
+    fn check_child_in_range<H: HashMode>(
+        setup: impl FnOnce(&mut TestMerkle<H>) -> Child,
         acc_prefix: &[u8],
         nibble: u8,
         start_nib: &[u8],
         end_nib: Option<&[u8]>,
         expected: bool,
     ) {
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
         let child = setup(&mut merkle);
         let pc = PathComponent::try_new(nibble).unwrap();
         let result = merkle
@@ -556,10 +557,10 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_child_in_range() {
+    #[firewood_macros::hash_mode]
+    fn test_child_in_range<H: HashMode>() {
         // nibble clearly out of range — returns false without reading
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x50", b"\x60"], 0x5),
             &[],
             0x5,
@@ -569,7 +570,7 @@ mod tests {
         );
 
         // leaf: nibble straddles start, full key [0,0] < start [0,1]
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x00", b"\x10"], 0x0),
             &[],
             0x0,
@@ -579,7 +580,7 @@ mod tests {
         );
 
         // leaf: nibble straddles start, full key [0,5] >= start [0,1]
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x05", b"\x10"], 0x0),
             &[],
             0x0,
@@ -589,7 +590,7 @@ mod tests {
         );
 
         // leaf: nibble straddles end, full key [3,f] > end [3,0]
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x3f", b"\x10"], 0x3),
             &[],
             0x3,
@@ -599,7 +600,7 @@ mod tests {
         );
 
         // branch: all children out of range ([0,0,0,0] and [0,0,5,0] both < [0,1])
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x00\x00", b"\x00\x50", b"\x10"], 0x0),
             &[],
             0x0,
@@ -609,7 +610,7 @@ mod tests {
         );
 
         // branch: one child in range ([0,1,0,0] >= [0,1])
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x00\x00", b"\x01\x00", b"\x10"], 0x0),
             &[],
             0x0,
@@ -619,7 +620,7 @@ mod tests {
         );
 
         // branch with value: key [0,0] in range [0,0]..[0,f], has value
-        check_child_in_range(
+        check_child_in_range::<H>(
             |m| branch_child(m, &[b"\x00", b"\x00\x50", b"\x10"], 0x0),
             &[],
             0x0,
@@ -630,8 +631,8 @@ mod tests {
 
         // unbounded end (None = +∞): a key above start is in range. An empty
         // end slice sorts as the minimum key and would wrongly reject this.
-        check_child_in_range(
-            |m| branch_child(m, &[b"\x50", b"\x10"], 0x5),
+        check_child_in_range::<H>(
+            |m| branch_child::<H>(m, &[b"\x50", b"\x10"], 0x5),
             &[],
             0x5,
             &[0x0],
@@ -694,10 +695,10 @@ mod tests {
         assert!(!nir_open(&[0xa], pc(0x2), &[0xa, 0x5]));
     }
 
-    #[test]
-    fn test_collapse_navigate_exact_match() {
+    #[firewood_macros::hash_mode]
+    fn test_collapse_navigate_exact_match<H: HashMode>() {
         let pc = |n: u8| PathComponent::try_new(n).unwrap();
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         // Under \x10, branch with children at 2 and 3.
         // Under \x10\x2, branch with children at 1 and 2.
@@ -739,10 +740,10 @@ mod tests {
         assert!(merkle.get_value(b"\x10\x30").unwrap().is_some());
     }
 
-    #[test]
-    fn test_collapse_navigate_recurse() {
+    #[firewood_macros::hash_mode]
+    fn test_collapse_navigate_recurse<H: HashMode>() {
         let pc = |n: u8| PathComponent::try_new(n).unwrap();
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         // Under \x1, branch with children at nibbles 0 and 1.
         // Under \x10\x2, branch with children at nibbles 1 and 3.
@@ -777,10 +778,10 @@ mod tests {
         assert!(merkle.get_value(b"\x10\x23").unwrap().is_none());
     }
 
-    #[test]
-    fn test_collapse_navigate_errors() {
+    #[firewood_macros::hash_mode]
+    fn test_collapse_navigate_errors<H: HashMode>() {
         let pc = |n: u8| PathComponent::try_new(n).unwrap();
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         // Single key \x10 → root has partial_path [1, 0]
         merkle.insert(b"\x10", Box::from(b"a".as_slice())).unwrap();
@@ -817,7 +818,7 @@ mod tests {
 
         // Range covers \x10\x22 in this test. An in-range off-path child
         // should result in an `EndRootMismatch`.
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
         merkle
             .insert(b"\x10\x21", Box::from(b"a".as_slice()))
             .unwrap();
@@ -850,10 +851,10 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_collapse_navigate_mismatched_partial_path() {
+    #[firewood_macros::hash_mode]
+    fn test_collapse_navigate_mismatched_partial_path<H: HashMode>() {
         let pc = |n: u8| PathComponent::try_new(n).unwrap();
-        let mut merkle = create_test_merkle();
+        let mut merkle = create_test_merkle::<H>();
 
         // Under [1, 0, 2]: leaf with partial_path [1] for \x10\x21
         merkle

--- a/firewood/src/merkle/tests/change/account.rs
+++ b/firewood/src/merkle/tests/change/account.rs
@@ -11,6 +11,11 @@
 //! `account_values_equal_except_storage_root` relaxation in
 //! `reconcile_branch_proof_node`, that mismatch is rejected as
 //! `UnexpectedValue`.
+//!
+//! Pinned to `EthHash`: account-depth semantics (RLP-encoded values,
+//! `storageRoot` splicing) and most fixtures below start from an empty trie
+//! (whose root hash only exists under ethhash) only apply under Ethereum
+//! hashing.
 
 use super::*;
 use test_case::test_case;
@@ -35,7 +40,8 @@ fn key_under_account(account_key: &[u8; 32], byte_32: u8) -> [u8; 64] {
 /// (`ACCOUNT_KEY`) with four storage children at suffixes 0x10/0x30/0x60/0xC0.
 /// Returns the DB and its tempdir guard (which the caller must keep alive),
 /// plus the empty and populated roots.
-fn source_with_four_storage_children() -> (Db, tempfile::TempDir, api::HashKey, api::HashKey) {
+fn source_with_four_storage_children()
+-> (Db<EthHash>, tempfile::TempDir, api::HashKey, api::HashKey) {
     let storage_keys: Vec<[u8; 64]> = [0x10u8, 0x30, 0x60, 0xC0]
         .iter()
         .map(|&p| key_under_account(&ACCOUNT_KEY, p))
@@ -45,7 +51,7 @@ fn source_with_four_storage_children() -> (Db, tempfile::TempDir, api::HashKey, 
         .collect();
     let account_value = rlp_encode_account(1, 100, &[0u8; 32], &empty_code_hash());
 
-    let (source, dir) = setup_db![];
+    let (source, dir) = setup_db![mode = EthHash];
     let (empty_root, root2) = setup_2nd_commit!(
         source,
         [
@@ -110,10 +116,17 @@ fn test_change_proof_partial_storage_children_against_empty(start_bound: Bound, 
     let proof = source
         .change_proof(empty_root.clone(), root2.clone(), start_key, end_key, None)
         .unwrap();
-    let ctx =
-        verify_change_proof_structure(&proof, root2.clone(), start_key, end_key, None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        start_key,
+        end_key,
+        EthHash::ALGORITHM,
+        None,
+    )
+    .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
 }
@@ -155,6 +168,7 @@ fn test_change_proof_arbitrary_order_right_then_left_converges() {
         full_root.clone(),
         None,
         Some(mid_key.as_ref()),
+        EthHash::ALGORITHM,
         None,
     )
     .unwrap();
@@ -173,12 +187,13 @@ fn test_change_proof_arbitrary_order_right_then_left_converges() {
         full_root.clone(),
         Some(mid_key.as_ref()),
         None,
+        EthHash::ALGORITHM,
         None,
     )
     .unwrap();
 
     // Apply RIGHT first, then LEFT, to an empty target.
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let target_empty_root = target.root_hash().unwrap();
 
     // Step 1: apply RIGHT half. Verifies, then commits.
@@ -254,11 +269,12 @@ fn test_change_proof_both_bounds_inside_account_storage() {
         root2.clone(),
         Some(start.as_ref()),
         Some(end.as_ref()),
+        EthHash::ALGORITHM,
         None,
     )
     .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
 }
@@ -288,10 +304,17 @@ fn test_change_proof_account_in_range_no_storage_in_range() {
             None,
         )
         .unwrap();
-    let ctx = verify_change_proof_structure(&proof, root2.clone(), None, Some(end.as_ref()), None)
-        .unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        None,
+        Some(end.as_ref()),
+        EthHash::ALGORITHM,
+        None,
+    )
+    .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
 }
@@ -309,7 +332,7 @@ fn test_change_proof_single_storage_child_truncated() {
     let storage_value = rlp_encode_storage(&[1u8; 32]);
     let account_value = rlp_encode_account(1, 100, &[0u8; 32], &empty_code_hash());
 
-    let (source, _dir_source) = setup_db![];
+    let (source, _dir_source) = setup_db![mode = EthHash];
     let (empty_root, root2) = setup_2nd_commit!(
         source,
         [
@@ -331,10 +354,17 @@ fn test_change_proof_single_storage_child_truncated() {
             None,
         )
         .unwrap();
-    let ctx = verify_change_proof_structure(&proof, root2.clone(), None, Some(end.as_ref()), None)
-        .unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        None,
+        Some(end.as_ref()),
+        EthHash::ALGORITHM,
+        None,
+    )
+    .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
 }

--- a/firewood/src/merkle/tests/change/account.rs
+++ b/firewood/src/merkle/tests/change/account.rs
@@ -11,6 +11,11 @@
 //! `account_values_equal_except_storage_root` relaxation in
 //! `reconcile_branch_proof_node`, that mismatch is rejected as
 //! `UnexpectedValue`.
+//!
+//! Pinned to `EthHash`: account-depth semantics (RLP-encoded values,
+//! `storageRoot` splicing) and most fixtures below start from an empty trie
+//! (whose root hash only exists under ethhash) only apply under Ethereum
+//! hashing.
 
 use super::*;
 use test_case::test_case;
@@ -35,12 +40,8 @@ fn key_under_account(account_key: &[u8; 32], byte_32: u8) -> [u8; 64] {
 /// (`ACCOUNT_KEY`) with four storage children at suffixes 0x10/0x30/0x60/0xC0.
 /// Returns the DB and its tempdir guard (which the caller must keep alive),
 /// plus the empty and populated roots.
-fn source_with_four_storage_children() -> (
-    Db<DefaultHashMode>,
-    tempfile::TempDir,
-    api::HashKey,
-    api::HashKey,
-) {
+fn source_with_four_storage_children()
+-> (Db<EthHash>, tempfile::TempDir, api::HashKey, api::HashKey) {
     let storage_keys: Vec<[u8; 64]> = [0x10u8, 0x30, 0x60, 0xC0]
         .iter()
         .map(|&p| key_under_account(&ACCOUNT_KEY, p))
@@ -50,7 +51,7 @@ fn source_with_four_storage_children() -> (
         .collect();
     let account_value = rlp_encode_account(1, 100, &[0u8; 32], &empty_code_hash());
 
-    let (source, dir) = setup_db![];
+    let (source, dir) = setup_db![mode = EthHash];
     let (empty_root, root2) = setup_2nd_commit!(
         source,
         [
@@ -115,10 +116,17 @@ fn test_change_proof_partial_storage_children_against_empty(start_bound: Bound, 
     let proof = source
         .change_proof(empty_root.clone(), root2.clone(), start_key, end_key, None)
         .unwrap();
-    let ctx =
-        verify_change_proof_structure(&proof, root2.clone(), start_key, end_key, None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        start_key,
+        end_key,
+        EthHash::ALGORITHM,
+        None,
+    )
+    .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
 }
@@ -160,6 +168,7 @@ fn test_change_proof_arbitrary_order_right_then_left_converges() {
         full_root.clone(),
         None,
         Some(mid_key.as_ref()),
+        EthHash::ALGORITHM,
         None,
     )
     .unwrap();
@@ -178,12 +187,13 @@ fn test_change_proof_arbitrary_order_right_then_left_converges() {
         full_root.clone(),
         Some(mid_key.as_ref()),
         None,
+        EthHash::ALGORITHM,
         None,
     )
     .unwrap();
 
     // Apply RIGHT first, then LEFT, to an empty target.
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let target_empty_root = target.root_hash().unwrap();
 
     // Step 1: apply RIGHT half. Verifies, then commits.
@@ -248,11 +258,12 @@ fn test_change_proof_both_bounds_inside_account_storage() {
         root2.clone(),
         Some(start.as_ref()),
         Some(end.as_ref()),
+        EthHash::ALGORITHM,
         None,
     )
     .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
 }
@@ -282,10 +293,17 @@ fn test_change_proof_account_in_range_no_storage_in_range() {
             None,
         )
         .unwrap();
-    let ctx = verify_change_proof_structure(&proof, root2.clone(), None, Some(end.as_ref()), None)
-        .unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        None,
+        Some(end.as_ref()),
+        EthHash::ALGORITHM,
+        None,
+    )
+    .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
 }
@@ -303,7 +321,7 @@ fn test_change_proof_single_storage_child_truncated() {
     let storage_value = rlp_encode_storage(&[1u8; 32]);
     let account_value = rlp_encode_account(1, 100, &[0u8; 32], &empty_code_hash());
 
-    let (source, _dir_source) = setup_db![];
+    let (source, _dir_source) = setup_db![mode = EthHash];
     let (empty_root, root2) = setup_2nd_commit!(
         source,
         [
@@ -325,10 +343,17 @@ fn test_change_proof_single_storage_child_truncated() {
             None,
         )
         .unwrap();
-    let ctx = verify_change_proof_structure(&proof, root2.clone(), None, Some(end.as_ref()), None)
-        .unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        None,
+        Some(end.as_ref()),
+        EthHash::ALGORITHM,
+        None,
+    )
+    .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
 }
@@ -383,7 +408,7 @@ fn test_change_proof_boundary_child_folds_single_storage_child() {
     let slot_b = rlp_encode_storage(&[2u8; 32]);
     let slot_a_new = rlp_encode_storage(&[3u8; 32]);
 
-    let (source, target, root1_target, _ds, _dt) = setup_source_target![
+    let (source, target, root1_target, _ds, _dt) = setup_source_target![mode = EthHash;
         (ACCOUNT_KEY.as_ref(), account_value.as_ref()),
         (in_range.as_ref(), slot_a.as_ref()),
         (out_of_range.as_ref(), slot_b.as_ref())
@@ -426,7 +451,7 @@ fn test_change_proof_added_out_of_range_slot_unfolds_in_range_slot() {
     let slot_a = rlp_encode_storage(&[1u8; 32]);
     let slot_b = rlp_encode_storage(&[2u8; 32]);
 
-    let (source, target, root1_target, _ds, _dt) = setup_source_target![
+    let (source, target, root1_target, _ds, _dt) = setup_source_target![mode = EthHash;
         (ACCOUNT_KEY.as_ref(), account_value.as_ref()),
         (in_range.as_ref(), slot_a.as_ref())
     ];

--- a/firewood/src/merkle/tests/change/attack.rs
+++ b/firewood/src/merkle/tests/change/attack.rs
@@ -9,23 +9,24 @@ type OwnedBatchOps = Vec<BatchOp<Box<[u8]>, Box<[u8]>>>;
 
 /// Helper: returns true if the (possibly corrupted) proof is rejected by
 /// either the structural check or the root hash check.
-fn is_rejected(
-    db: &Db,
+fn is_rejected<H: HashMode>(
+    db: &Db<H>,
     proof: &FrozenChangeProof,
     end_root: api::HashKey,
     start_key: Option<&[u8]>,
     end_key: Option<&[u8]>,
     start_root: api::HashKey,
 ) -> bool {
-    match verify_change_proof_structure(proof, end_root, start_key, end_key, None) {
+    match verify_change_proof_structure(proof, end_root, start_key, end_key, H::ALGORITHM, None) {
         Err(_) => true,
         Ok(ctx) => verify_and_check(db, proof, &ctx, start_root).is_err(),
     }
 }
 
-#[test]
-fn test_crafted_omitted_change_detected() {
+#[firewood_macros::hash_mode]
+fn test_crafted_omitted_change_detected<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10", b"v0"),
         (b"\x20", b"v1"),
         (b"\x30", b"v2"),
@@ -47,14 +48,22 @@ fn test_crafted_omitted_change_detected() {
 
     let mut shortened: Vec<BatchOp<Key, Value>> = valid.batch_ops().to_vec();
     shortened.remove(0);
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         shortened.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let ctx =
-        verify_change_proof_structure(&crafted, root2, Some(b"\x10"), Some(b"\x40"), None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &crafted,
+        root2,
+        Some(b"\x10"),
+        Some(b"\x40"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     let err = verify_and_check(&target, &crafted, &ctx, root1_target)
         .expect_err("omitted change must be detected");
     assert!(matches!(
@@ -63,10 +72,10 @@ fn test_crafted_omitted_change_detected() {
     ));
 }
 
-#[test]
-fn test_crafted_forged_value_detected() {
+#[firewood_macros::hash_mode]
+fn test_crafted_forged_value_detected<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+        setup_source_target![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x10", b"real")]);
 
@@ -79,13 +88,15 @@ fn test_crafted_forged_value_detected() {
         key: b"\x10".to_vec().into(),
         value: b"FORGED".to_vec().into(),
     };
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         forged_ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let ctx = verify_change_proof_structure(&crafted, root2, None, None, None).unwrap();
+    let ctx =
+        verify_change_proof_structure(&crafted, root2, None, None, H::ALGORITHM, None).unwrap();
     let err = verify_and_check(&target, &crafted, &ctx, root1_target)
         .expect_err("forged value must be detected");
     assert!(matches!(
@@ -94,9 +105,9 @@ fn test_crafted_forged_value_detected() {
     ));
 }
 
-#[test]
-fn test_crafted_spurious_batch_op_detected() {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_crafted_spurious_batch_op_detected<H: HashMode>() {
+    let (source, _dir_source) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\xa0", b"changed")]);
 
@@ -111,13 +122,14 @@ fn test_crafted_spurious_batch_op_detected() {
     });
     ops.sort_by(|a, b| a.key().cmp(b.key()));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let err = verify_change_proof_structure(&crafted, root2, None, None, None)
+    let err = verify_change_proof_structure(&crafted, root2, None, None, H::ALGORITHM, None)
         .expect_err("structural check should reject spurious batch op");
     assert!(matches!(
         err,
@@ -129,10 +141,10 @@ fn test_crafted_spurious_batch_op_detected() {
 /// exist in `end_root`. The start proof is an exclusion proof. The
 /// `StartProofOperationMismatch` check catches this: Put expects inclusion
 /// but the proof is exclusion.
-#[test]
-fn test_crafted_spurious_put_at_start_key_boundary() {
+#[firewood_macros::hash_mode]
+fn test_crafted_spurious_put_at_start_key_boundary<H: HashMode>() {
     // Keys \x20 and \x90 exist. \x10 (start_key) does NOT exist.
-    let (source, _dir_source) = setup_db![(b"\x20", b"v2"), (b"\x90", b"v9")];
+    let (source, _dir_source) = setup_db![mode = H; (b"\x20", b"v2"), (b"\x90", b"v9")];
 
     // Change \x20 on source
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x20", b"changed")]);
@@ -157,14 +169,22 @@ fn test_crafted_spurious_put_at_start_key_boundary() {
     });
     ops.sort_by(|a, b| a.key().cmp(b.key()));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let err = verify_change_proof_structure(&crafted, root2, Some(b"\x10"), Some(b"\x90"), None)
-        .expect_err("structural check should reject spurious Put at start_key");
+    let err = verify_change_proof_structure(
+        &crafted,
+        root2,
+        Some(b"\x10"),
+        Some(b"\x90"),
+        H::ALGORITHM,
+        None,
+    )
+    .expect_err("structural check should reject spurious Put at start_key");
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::StartProofOperationMismatch)
@@ -174,10 +194,10 @@ fn test_crafted_spurious_put_at_start_key_boundary() {
 /// Attacker adds a spurious Delete at `start_key` when `start_key` EXISTS
 /// in `end_root`. The start proof is an inclusion proof, but the Delete
 /// claims the key was removed — `StartProofOperationMismatch`.
-#[test]
-fn test_crafted_spurious_delete_at_start_key_boundary() {
+#[firewood_macros::hash_mode]
+fn test_crafted_spurious_delete_at_start_key_boundary<H: HashMode>() {
     // Keys \x20 and \x90 exist. start_key \x20 EXISTS in end_root.
-    let (source, _dir_source) = setup_db![(b"\x20", b"v2"), (b"\x90", b"v9")];
+    let (source, _dir_source) = setup_db![mode = H; (b"\x20", b"v2"), (b"\x90", b"v9")];
 
     // Change \x90 on source (not \x20 — \x20 stays in end_root).
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x90", b"changed")]);
@@ -203,14 +223,22 @@ fn test_crafted_spurious_delete_at_start_key_boundary() {
     });
     ops.sort_by(|a, b| a.key().cmp(b.key()));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let err = verify_change_proof_structure(&crafted, root2, Some(b"\x20"), Some(b"\x90"), None)
-        .expect_err("structural check should reject spurious Delete at start_key");
+    let err = verify_change_proof_structure(
+        &crafted,
+        root2,
+        Some(b"\x20"),
+        Some(b"\x90"),
+        H::ALGORITHM,
+        None,
+    )
+    .expect_err("structural check should reject spurious Delete at start_key");
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::StartProofOperationMismatch)
@@ -221,9 +249,9 @@ fn test_crafted_spurious_delete_at_start_key_boundary() {
 /// The end proof is exclusion but Put expects inclusion — mismatch.
 ///
 /// Exercises: `EndProofOperationMismatch`
-#[test]
-fn test_crafted_spurious_put_at_end_key_boundary() {
-    let (source, _dir_source) = setup_db![(b"\x20", b"v2"), (b"\x90", b"v9")];
+#[firewood_macros::hash_mode]
+fn test_crafted_spurious_put_at_end_key_boundary<H: HashMode>() {
+    let (source, _dir_source) = setup_db![mode = H; (b"\x20", b"v2"), (b"\x90", b"v9")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x20", b"changed")]);
 
@@ -246,15 +274,22 @@ fn test_crafted_spurious_put_at_end_key_boundary() {
     });
     ops.sort_by(|a, b| a.key().cmp(b.key()));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let err =
-        verify_change_proof_structure(&crafted, root2.clone(), Some(b"\x20"), Some(b"\xb0"), None)
-            .expect_err("structural check should reject spurious Put at end_key");
+    let err = verify_change_proof_structure(
+        &crafted,
+        root2.clone(),
+        Some(b"\x20"),
+        Some(b"\xb0"),
+        H::ALGORITHM,
+        None,
+    )
+    .expect_err("structural check should reject spurious Put at end_key");
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::EndProofOperationMismatch)
@@ -265,9 +300,9 @@ fn test_crafted_spurious_put_at_end_key_boundary() {
 /// The end proof is inclusion but Delete expects exclusion — mismatch.
 ///
 /// Exercises: `EndProofOperationMismatch`
-#[test]
-fn test_crafted_spurious_delete_at_end_key_boundary() {
-    let (source, _dir_source) = setup_db![(b"\x20", b"v2"), (b"\x90", b"v9")];
+#[firewood_macros::hash_mode]
+fn test_crafted_spurious_delete_at_end_key_boundary<H: HashMode>() {
+    let (source, _dir_source) = setup_db![mode = H; (b"\x20", b"v2"), (b"\x90", b"v9")];
 
     // Change \x20, leave \x90 unchanged.
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x20", b"changed")]);
@@ -290,15 +325,22 @@ fn test_crafted_spurious_delete_at_end_key_boundary() {
     });
     ops.sort_by(|a, b| a.key().cmp(b.key()));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let err =
-        verify_change_proof_structure(&crafted, root2.clone(), Some(b"\x20"), Some(b"\x90"), None)
-            .expect_err("structural check should reject spurious Delete at end_key");
+    let err = verify_change_proof_structure(
+        &crafted,
+        root2.clone(),
+        Some(b"\x20"),
+        Some(b"\x90"),
+        H::ALGORITHM,
+        None,
+    )
+    .expect_err("structural check should reject spurious Delete at end_key");
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::EndProofOperationMismatch)
@@ -308,10 +350,10 @@ fn test_crafted_spurious_delete_at_end_key_boundary() {
 /// The `start_key` value MUST be checked for inclusion proofs. If the
 /// proposal has a different value at `start_key` than `end_root`, the
 /// reconciliation or root hash comparison should detect the mismatch.
-#[test]
-fn test_crafted_tampered_start_key_value_detected() {
+#[firewood_macros::hash_mode]
+fn test_crafted_tampered_start_key_value_detected<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10", b"v0"), (b"\x30", b"v1")];
+        setup_source_target![mode = H; (b"\x10", b"v0"), (b"\x30", b"v1")];
 
     let (root1_source, root2) =
         setup_2nd_commit!(source, [(b"\x10", b"changed"), (b"\x30", b"changed")]);
@@ -321,8 +363,15 @@ fn test_crafted_tampered_start_key_value_detected() {
         .unwrap();
 
     // Verify the honest proof works.
-    let ctx =
-        verify_change_proof_structure(&honest, root2.clone(), Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &honest,
+        root2.clone(),
+        Some(b"\x10"),
+        None,
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &honest, &ctx, root1_target.clone()).unwrap();
 
     // Tamper: replace Put(\x10, "changed") with Put(\x10, "WRONG").
@@ -336,15 +385,18 @@ fn test_crafted_tampered_start_key_value_detected() {
         value: b"WRONG".to_vec().into(),
     };
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         tampered_ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     // Structural checks pass (hash chain is valid), but root hash
     // verification catches the tampered value.
-    let ctx2 = verify_change_proof_structure(&crafted, root2, Some(b"\x10"), None, None).unwrap();
+    let ctx2 =
+        verify_change_proof_structure(&crafted, root2, Some(b"\x10"), None, H::ALGORITHM, None)
+            .unwrap();
     let err = verify_and_check(&target, &crafted, &ctx2, root1_target)
         .expect_err("tampered start_key value must be detected");
     assert!(
@@ -365,9 +417,9 @@ fn test_crafted_tampered_start_key_value_detected() {
 /// This breaks the structural hash chain, so we skip structural validation
 /// and call `verify_change_proof_root_hash` directly. The start and end
 /// proofs both contain the root node, but now they disagree.
-#[test]
-fn test_crafted_conflicting_proof_nodes_rejected() {
-    let (db, _dir) = setup_db![(b"\x10", b"a"), (b"\x20", b"b")];
+#[firewood_macros::hash_mode]
+fn test_crafted_conflicting_proof_nodes_rejected<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"a"), (b"\x20", b"b")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x10", b"A"), (b"\x20", b"B")]);
 
     let valid = db
@@ -396,10 +448,11 @@ fn test_crafted_conflicting_proof_nodes_rejected() {
     new_bytes[0] ^= 1;
     *child_hash = firewood_storage::TrieHash::from(new_bytes).into();
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(end_nodes.into_boxed_slice()),
         valid.batch_ops().into(),
+        H::ALGORITHM,
     );
 
     // Skip structural validation (the modified hash chain won't pass).
@@ -429,9 +482,9 @@ fn test_crafted_conflicting_proof_nodes_rejected() {
 /// Keys `\x10` and `\x15` share nibble 1 at depth 0, then fork at depth 1
 /// (nibbles 0 vs 5). The branch at depth 1 is at odd nibble length. We
 /// inject a spurious value into that odd-depth proof node.
-#[test]
-fn test_crafted_value_at_odd_nibble_length_rejected() {
-    let (db, _dir) = setup_db![(b"\x10", b"a"), (b"\x15", b"b"), (b"\x30", b"c")];
+#[firewood_macros::hash_mode]
+fn test_crafted_value_at_odd_nibble_length_rejected<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"a"), (b"\x15", b"b"), (b"\x30", b"c")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x30", b"changed")]);
 
     let valid = db
@@ -449,10 +502,11 @@ fn test_crafted_value_at_odd_nibble_length_rejected() {
         b"injected".to_vec().into(),
     ));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(start_nodes.into_boxed_slice()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         valid.batch_ops().into(),
+        H::ALGORITHM,
     );
 
     // Skip structural validation (injected value breaks the hash chain).
@@ -479,9 +533,10 @@ fn test_crafted_value_at_odd_nibble_length_rejected() {
 /// Craft start/end proofs from two disjoint bounded proofs, skipping the
 /// shared root node. The proofs diverge at depth zero — reconciliation
 /// should detect the inconsistency.
-#[test]
-fn test_crafted_divergence_at_depth_zero() {
+#[firewood_macros::hash_mode]
+fn test_crafted_divergence_at_depth_zero<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10", b"v0"),
         (b"\x11", b"v1"),
         (b"\xa0", b"v2"),
@@ -526,13 +581,14 @@ fn test_crafted_divergence_at_depth_zero() {
     let e = right.end_proof().as_ref();
     assert!(s.len() >= 2 && e.len() >= 2);
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(s[1..].into()),
         crate::Proof::new(e[1..].into()),
         Box::new([BatchOp::Put {
             key: b"\x50".to_vec().into(),
             value: b"mid".to_vec().into(),
         }]),
+        H::ALGORITHM,
     );
 
     let parent = target.revision(root1_target).unwrap();
@@ -566,9 +622,10 @@ fn test_crafted_divergence_at_depth_zero() {
 /// divergent siblings at nibbles 8 and f. The branch survives deletion
 /// because two children remain. Stripping nibble 8's child hash from
 /// the proof node at [1, 0, 5] should cause rejection.
-#[test]
-fn test_crafted_stripped_divergent_child_rejected() {
+#[firewood_macros::hash_mode]
+fn test_crafted_stripped_divergent_child_rejected<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10\x50", b"a"),
         (b"\x10\x58", b"b"),
         (b"\x10\x5f", b"d"),
@@ -607,6 +664,7 @@ fn test_crafted_stripped_divergent_child_rejected() {
         root2.clone(),
         Some(b"\x10\x50"),
         Some(b"\x30\x00"),
+        H::ALGORITHM,
         None,
     )
     .unwrap();
@@ -623,10 +681,11 @@ fn test_crafted_stripped_divergent_child_rejected() {
     let nibble_8 = firewood_storage::PathComponent::try_new(8).unwrap();
     start_nodes[branch_idx].child_hashes[nibble_8] = None;
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(start_nodes.into_boxed_slice()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         valid.batch_ops().into(),
+        H::ALGORITHM,
     );
 
     assert!(
@@ -651,10 +710,10 @@ fn test_crafted_stripped_divergent_child_rejected() {
 ///
 /// The verifier would then commit the incomplete `batch_ops`, leaving `\x05`
 /// in their state when `end_root` says it shouldn't exist.
-#[test]
-fn test_crafted_omitted_delete_at_straddling_nibble() {
+#[firewood_macros::hash_mode]
+fn test_crafted_omitted_delete_at_straddling_nibble<H: HashMode>() {
     // start_root: \x00, \x05, \x10
-    let (db, _dir) = setup_db![(b"\x00", b"a"), (b"\x05", b"e"), (b"\x10", b"b")];
+    let (db, _dir) = setup_db![mode = H; (b"\x00", b"a"), (b"\x05", b"e"), (b"\x10", b"b")];
     let root1 = db.root_hash().unwrap();
 
     // end_root: only \x10 (both \x00 and \x05 deleted)
@@ -682,13 +741,14 @@ fn test_crafted_omitted_delete_at_straddling_nibble() {
     assert_eq!(honest.batch_ops().len(), 2);
 
     // Craft a tampered proof: remove Delete(\x05), keep only Put(\x10)
-    let tampered = FrozenChangeProof::new(
+    let tampered = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         Box::new([BatchOp::Put {
             key: b"\x10".to_vec().into(),
             value: b"changed".to_vec().into(),
         }]),
+        H::ALGORITHM,
     );
 
     assert!(
@@ -704,9 +764,9 @@ fn test_crafted_omitted_delete_at_straddling_nibble() {
 /// "non-on-path"), so the hash computation never sees it.
 /// The range-safety check in `collapse_strip` detects the in-range child
 /// before stripping and rejects with `EndRootMismatch`.
-#[test]
-fn test_collapse_root_hides_spurious_key() {
-    let (db, _dir) = setup_db![(b"\x90", b"orig")];
+#[firewood_macros::hash_mode]
+fn test_collapse_root_hides_spurious_key<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x90", b"orig")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x90", b"new!")]);
 
     let valid_proof = db
@@ -724,10 +784,11 @@ fn test_collapse_root_hides_spurious_key() {
         },
     );
 
-    let attack_proof = crate::ChangeProof::new(
+    let attack_proof = crate::ChangeProof::with_hash_mode(
         crate::Proof::new(valid_proof.start_proof().as_ref().into()),
         crate::Proof::new(valid_proof.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     assert!(
@@ -764,8 +825,8 @@ fn gap_boundaries() -> ([u8; 32], [u8; 32]) {
 /// Helper for the common adversarial pattern: generate a valid bounded proof
 /// for the 5-key setup, inject a spurious operation, and assert rejection.
 #[allow(clippy::too_many_arguments)]
-fn inject_and_assert_rejected(
-    db: &Db,
+fn inject_and_assert_rejected<H: HashMode>(
+    db: &Db<H>,
     root1: api::HashKey,
     root2: api::HashKey,
     valid_proof: &FrozenChangeProof,
@@ -780,10 +841,11 @@ fn inject_and_assert_rejected(
         .unwrap_or_else(|i| i);
     ops.insert(pos, spurious_op);
 
-    let attack_proof = crate::ChangeProof::new(
+    let attack_proof = crate::ChangeProof::with_hash_mode(
         crate::Proof::new(valid_proof.start_proof().as_ref().into()),
         crate::Proof::new(valid_proof.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     assert!(
@@ -808,10 +870,11 @@ fn inject_and_assert_rejected(
 ///   - The change proof is bounded by non-existent gap keys around B..D.
 ///   - Key C is unchanged between revisions and is NOT in `batch_ops`.
 ///   - An attacker adds `Delete { key: C }` to `batch_ops`.
-#[test]
-fn test_spurious_delete_in_range_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_spurious_delete_in_range_is_rejected<H: HashMode>() {
     let keys = five_keys();
     let (db, _dir) = setup_db![
+        mode = H;
         (&keys[0], &[0xAAu8; 20]),
         (&keys[1], &[0xBBu8; 20]),
         (&keys[2], &[0xCCu8; 20]),
@@ -861,12 +924,13 @@ fn test_spurious_delete_in_range_is_rejected() {
 /// IS in `batch_ops`, forcing them into the same top-level subtree. The subtree
 /// must be recomputed because it contains a changed key, so the delete of the
 /// unchanged sibling should be visible.
-#[test]
-fn test_spurious_delete_same_subtree_as_changed_key() {
+#[firewood_macros::hash_mode]
+fn test_spurious_delete_same_subtree_as_changed_key<H: HashMode>() {
     let mut keys = five_keys();
     keys[2][0] = 0x38; // C — target, same first nibble as B (0x30)
 
     let (db, _dir) = setup_db![
+        mode = H;
         (&keys[0], &[0xAAu8; 20]),
         (&keys[1], &[0xBBu8; 20]),
         (&keys[2], &[0xCCu8; 20]),
@@ -901,10 +965,11 @@ fn test_spurious_delete_same_subtree_as_changed_key() {
 }
 
 /// Same attack with EXISTING boundary keys (inclusion proofs).
-#[test]
-fn test_spurious_delete_with_existing_boundaries() {
+#[firewood_macros::hash_mode]
+fn test_spurious_delete_with_existing_boundaries<H: HashMode>() {
     let keys = five_keys();
     let (db, _dir) = setup_db![
+        mode = H;
         (&keys[0], &[0xAAu8; 20]),
         (&keys[1], &[0xBBu8; 20]),
         (&keys[2], &[0xCCu8; 20]),
@@ -953,10 +1018,11 @@ fn test_spurious_delete_with_existing_boundaries() {
 /// rejected. This confirms the hybrid hash works for keys that were changed
 /// between revisions (their subtree is computed from the proposal, not borrowed
 /// from proof nodes).
-#[test]
-fn test_swapped_value_in_range_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_swapped_value_in_range_is_rejected<H: HashMode>() {
     let keys = five_keys();
     let (db, _dir) = setup_db![
+        mode = H;
         (&keys[0], &[0xAAu8; 20]),
         (&keys[1], &[0xBBu8; 20]),
         (&keys[2], &[0xCCu8; 20]),
@@ -993,10 +1059,11 @@ fn test_swapped_value_in_range_is_rejected() {
         value: [0xFFu8; 20].to_vec().into_boxed_slice(),
     };
 
-    let attack_proof = crate::ChangeProof::new(
+    let attack_proof = crate::ChangeProof::with_hash_mode(
         crate::Proof::new(valid_proof.start_proof().as_ref().into()),
         crate::Proof::new(valid_proof.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     assert!(
@@ -1023,13 +1090,19 @@ fn test_swapped_value_in_range_is_rejected() {
 /// silently accepted it (`None == None`). The second op (`\x90`) keeps the
 /// batch non-empty so the tamper reaches reconcile instead of the structural
 /// check.
-#[cfg(not(feature = "ethhash"))]
-#[test]
-fn test_crafted_dropped_hashed_put_behind_left_exclusion_rejected() {
+///
+/// Pinned to `MerkleDbHash`: `ValueDigest::Hash` (the >= 32 byte cap this
+/// test relies on to give the boundary node a hash digest) is only ever
+/// produced by the merkledb wire-serialization rule — the Ethereum scheme
+/// never emits a `Hash` digest (see `ValueDigest::write_item`), so the
+/// scenario this test exercises doesn't exist under `ethhash`.
+#[firewood_macros::hash_mode(merkledb)]
+fn test_crafted_dropped_hashed_put_behind_left_exclusion_rejected<H: HashMode>() {
     let big = [0xabu8; 40]; // >= 32 bytes => Hash after serialization
     // start: 0x90 only. end: add NEW key 0x1234 (large value) AND change 0x90
     // (a second in-range op so the batch isn't empty after dropping 0x1234).
-    let (source, target, root1_target, _ds, _dt) = setup_source_target![(b"\x90", b"anchor")];
+    let (source, target, root1_target, _ds, _dt) =
+        setup_source_target![mode = H; (b"\x90", b"anchor")];
     let (root1_source, root2) = setup_2nd_commit!(
         source,
         [
@@ -1050,16 +1123,18 @@ fn test_crafted_dropped_hashed_put_behind_left_exclusion_rejected() {
     // Tamper: drop the in-range Put of 0x1234, keeping the 0x90 change.
     let mut ops: Vec<BatchOp<Key, Value>> = valid.batch_ops().to_vec();
     ops.retain(|op| !matches!(op, BatchOp::Put { key, .. } if key.as_ref() == b"\x12\x34"));
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     // The structural checks pass (the hash chain is intact); the reconcile
     // in-range guard rejects the empty-branch-vs-Hash conflict.
     let ctx =
-        verify_change_proof_structure(&crafted, root2, Some(b"\x12\x30"), None, None).unwrap();
+        verify_change_proof_structure(&crafted, root2, Some(b"\x12\x30"), None, H::ALGORITHM, None)
+            .unwrap();
     let err = verify_and_check(&target, &crafted, &ctx, root1_target)
         .expect_err("dropped in-range Put (hashed) behind a left exclusion must be rejected");
     assert!(
@@ -1079,11 +1154,15 @@ fn test_crafted_dropped_hashed_put_behind_left_exclusion_rejected() {
 /// hash; the empty-branch-vs-`Hash` conflict must route to the end-proof
 /// in-range guard (`\x12\x34` <= `end_key`) and be rejected. The second op
 /// (`\x10`, below the dropped key) keeps the batch non-empty.
-#[cfg(not(feature = "ethhash"))]
-#[test]
-fn test_crafted_dropped_hashed_put_behind_right_exclusion_rejected() {
+///
+/// Pinned to `MerkleDbHash` for the same reason as the left-edge sibling
+/// test above: the >= 32 byte raw value driving the `Hash` digest is a
+/// merkledb-specific serialization threshold.
+#[firewood_macros::hash_mode(merkledb)]
+fn test_crafted_dropped_hashed_put_behind_right_exclusion_rejected<H: HashMode>() {
     let big = [0xabu8; 40]; // >= 32 bytes => Hash after serialization
-    let (source, target, root1_target, _ds, _dt) = setup_source_target![(b"\x10", b"anchor")];
+    let (source, target, root1_target, _ds, _dt) =
+        setup_source_target![mode = H; (b"\x10", b"anchor")];
     let (root1_source, root2) = setup_2nd_commit!(
         source,
         [
@@ -1104,16 +1183,18 @@ fn test_crafted_dropped_hashed_put_behind_right_exclusion_rejected() {
     // Tamper: drop the in-range Put of 0x1234, keeping the 0x10 change.
     let mut ops: Vec<BatchOp<Key, Value>> = valid.batch_ops().to_vec();
     ops.retain(|op| !matches!(op, BatchOp::Put { key, .. } if key.as_ref() == b"\x12\x34"));
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     // The structural checks pass (the hash chain is intact); the reconcile
     // in-range guard rejects the empty-branch-vs-Hash conflict.
     let ctx =
-        verify_change_proof_structure(&crafted, root2, None, Some(b"\x12\x38"), None).unwrap();
+        verify_change_proof_structure(&crafted, root2, None, Some(b"\x12\x38"), H::ALGORITHM, None)
+            .unwrap();
     let err = verify_and_check(&target, &crafted, &ctx, root1_target)
         .expect_err("dropped in-range Put (hashed) behind a right exclusion must be rejected");
     assert!(
@@ -1127,10 +1208,11 @@ fn test_crafted_dropped_hashed_put_behind_right_exclusion_rejected() {
 
 /// Control test: a spurious Put for a non-existent in-range key is correctly
 /// rejected when the key falls in a subtree that is recomputed (not borrowed).
-#[test]
-fn test_spurious_put_in_range_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_spurious_put_in_range_is_rejected<H: HashMode>() {
     let keys = five_keys();
     let (db, _dir) = setup_db![
+        mode = H;
         (&keys[0], &[0xAAu8; 20]),
         (&keys[1], &[0xBBu8; 20]),
         (&keys[2], &[0xCCu8; 20]),

--- a/firewood/src/merkle/tests/change/attack.rs
+++ b/firewood/src/merkle/tests/change/attack.rs
@@ -9,23 +9,24 @@ type OwnedBatchOps = Vec<BatchOp<Box<[u8]>, Box<[u8]>>>;
 
 /// Helper: returns true if the (possibly corrupted) proof is rejected by
 /// either the structural check or the root hash check.
-fn is_rejected(
-    db: &Db<DefaultHashMode>,
+fn is_rejected<H: HashMode>(
+    db: &Db<H>,
     proof: &FrozenChangeProof,
     end_root: api::HashKey,
     start_key: Option<&[u8]>,
     end_key: Option<&[u8]>,
     start_root: api::HashKey,
 ) -> bool {
-    match verify_change_proof_structure(proof, end_root, start_key, end_key, None) {
+    match verify_change_proof_structure(proof, end_root, start_key, end_key, H::ALGORITHM, None) {
         Err(_) => true,
         Ok(ctx) => verify_and_check(db, proof, &ctx, start_root).is_err(),
     }
 }
 
-#[test]
-fn test_crafted_omitted_change_detected() {
+#[firewood_macros::hash_mode]
+fn test_crafted_omitted_change_detected<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10", b"v0"),
         (b"\x20", b"v1"),
         (b"\x30", b"v2"),
@@ -47,14 +48,22 @@ fn test_crafted_omitted_change_detected() {
 
     let mut shortened: Vec<BatchOp<Key, Value>> = valid.batch_ops().to_vec();
     shortened.remove(0);
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         shortened.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let ctx =
-        verify_change_proof_structure(&crafted, root2, Some(b"\x10"), Some(b"\x40"), None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &crafted,
+        root2,
+        Some(b"\x10"),
+        Some(b"\x40"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     let err = verify_and_check(&target, &crafted, &ctx, root1_target)
         .expect_err("omitted change must be detected");
     assert!(matches!(
@@ -63,10 +72,10 @@ fn test_crafted_omitted_change_detected() {
     ));
 }
 
-#[test]
-fn test_crafted_forged_value_detected() {
+#[firewood_macros::hash_mode]
+fn test_crafted_forged_value_detected<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+        setup_source_target![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x10", b"real")]);
 
@@ -79,13 +88,15 @@ fn test_crafted_forged_value_detected() {
         key: b"\x10".to_vec().into(),
         value: b"FORGED".to_vec().into(),
     };
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         forged_ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let ctx = verify_change_proof_structure(&crafted, root2, None, None, None).unwrap();
+    let ctx =
+        verify_change_proof_structure(&crafted, root2, None, None, H::ALGORITHM, None).unwrap();
     let err = verify_and_check(&target, &crafted, &ctx, root1_target)
         .expect_err("forged value must be detected");
     assert!(matches!(
@@ -94,9 +105,9 @@ fn test_crafted_forged_value_detected() {
     ));
 }
 
-#[test]
-fn test_crafted_spurious_batch_op_detected() {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_crafted_spurious_batch_op_detected<H: HashMode>() {
+    let (source, _dir_source) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\xa0", b"changed")]);
 
@@ -111,13 +122,14 @@ fn test_crafted_spurious_batch_op_detected() {
     });
     ops.sort_by(|a, b| a.key().cmp(b.key()));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let err = verify_change_proof_structure(&crafted, root2, None, None, None)
+    let err = verify_change_proof_structure(&crafted, root2, None, None, H::ALGORITHM, None)
         .expect_err("structural check should reject spurious batch op");
     assert!(matches!(
         err,
@@ -129,10 +141,10 @@ fn test_crafted_spurious_batch_op_detected() {
 /// exist in `end_root`. The start proof is an exclusion proof. The
 /// `StartProofOperationMismatch` check catches this: Put expects inclusion
 /// but the proof is exclusion.
-#[test]
-fn test_crafted_spurious_put_at_start_key_boundary() {
+#[firewood_macros::hash_mode]
+fn test_crafted_spurious_put_at_start_key_boundary<H: HashMode>() {
     // Keys \x20 and \x90 exist. \x10 (start_key) does NOT exist.
-    let (source, _dir_source) = setup_db![(b"\x20", b"v2"), (b"\x90", b"v9")];
+    let (source, _dir_source) = setup_db![mode = H; (b"\x20", b"v2"), (b"\x90", b"v9")];
 
     // Change \x20 on source
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x20", b"changed")]);
@@ -157,14 +169,22 @@ fn test_crafted_spurious_put_at_start_key_boundary() {
     });
     ops.sort_by(|a, b| a.key().cmp(b.key()));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let err = verify_change_proof_structure(&crafted, root2, Some(b"\x10"), Some(b"\x90"), None)
-        .expect_err("structural check should reject spurious Put at start_key");
+    let err = verify_change_proof_structure(
+        &crafted,
+        root2,
+        Some(b"\x10"),
+        Some(b"\x90"),
+        H::ALGORITHM,
+        None,
+    )
+    .expect_err("structural check should reject spurious Put at start_key");
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::StartProofOperationMismatch)
@@ -174,10 +194,10 @@ fn test_crafted_spurious_put_at_start_key_boundary() {
 /// Attacker adds a spurious Delete at `start_key` when `start_key` EXISTS
 /// in `end_root`. The start proof is an inclusion proof, but the Delete
 /// claims the key was removed — `StartProofOperationMismatch`.
-#[test]
-fn test_crafted_spurious_delete_at_start_key_boundary() {
+#[firewood_macros::hash_mode]
+fn test_crafted_spurious_delete_at_start_key_boundary<H: HashMode>() {
     // Keys \x20 and \x90 exist. start_key \x20 EXISTS in end_root.
-    let (source, _dir_source) = setup_db![(b"\x20", b"v2"), (b"\x90", b"v9")];
+    let (source, _dir_source) = setup_db![mode = H; (b"\x20", b"v2"), (b"\x90", b"v9")];
 
     // Change \x90 on source (not \x20 — \x20 stays in end_root).
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x90", b"changed")]);
@@ -203,14 +223,22 @@ fn test_crafted_spurious_delete_at_start_key_boundary() {
     });
     ops.sort_by(|a, b| a.key().cmp(b.key()));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let err = verify_change_proof_structure(&crafted, root2, Some(b"\x20"), Some(b"\x90"), None)
-        .expect_err("structural check should reject spurious Delete at start_key");
+    let err = verify_change_proof_structure(
+        &crafted,
+        root2,
+        Some(b"\x20"),
+        Some(b"\x90"),
+        H::ALGORITHM,
+        None,
+    )
+    .expect_err("structural check should reject spurious Delete at start_key");
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::StartProofOperationMismatch)
@@ -221,9 +249,9 @@ fn test_crafted_spurious_delete_at_start_key_boundary() {
 /// The end proof is exclusion but Put expects inclusion — mismatch.
 ///
 /// Exercises: `EndProofOperationMismatch`
-#[test]
-fn test_crafted_spurious_put_at_end_key_boundary() {
-    let (source, _dir_source) = setup_db![(b"\x20", b"v2"), (b"\x90", b"v9")];
+#[firewood_macros::hash_mode]
+fn test_crafted_spurious_put_at_end_key_boundary<H: HashMode>() {
+    let (source, _dir_source) = setup_db![mode = H; (b"\x20", b"v2"), (b"\x90", b"v9")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x20", b"changed")]);
 
@@ -246,15 +274,22 @@ fn test_crafted_spurious_put_at_end_key_boundary() {
     });
     ops.sort_by(|a, b| a.key().cmp(b.key()));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let err =
-        verify_change_proof_structure(&crafted, root2.clone(), Some(b"\x20"), Some(b"\xb0"), None)
-            .expect_err("structural check should reject spurious Put at end_key");
+    let err = verify_change_proof_structure(
+        &crafted,
+        root2.clone(),
+        Some(b"\x20"),
+        Some(b"\xb0"),
+        H::ALGORITHM,
+        None,
+    )
+    .expect_err("structural check should reject spurious Put at end_key");
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::EndProofOperationMismatch)
@@ -265,9 +300,9 @@ fn test_crafted_spurious_put_at_end_key_boundary() {
 /// The end proof is inclusion but Delete expects exclusion — mismatch.
 ///
 /// Exercises: `EndProofOperationMismatch`
-#[test]
-fn test_crafted_spurious_delete_at_end_key_boundary() {
-    let (source, _dir_source) = setup_db![(b"\x20", b"v2"), (b"\x90", b"v9")];
+#[firewood_macros::hash_mode]
+fn test_crafted_spurious_delete_at_end_key_boundary<H: HashMode>() {
+    let (source, _dir_source) = setup_db![mode = H; (b"\x20", b"v2"), (b"\x90", b"v9")];
 
     // Change \x20, leave \x90 unchanged.
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x20", b"changed")]);
@@ -290,15 +325,22 @@ fn test_crafted_spurious_delete_at_end_key_boundary() {
     });
     ops.sort_by(|a, b| a.key().cmp(b.key()));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let err =
-        verify_change_proof_structure(&crafted, root2.clone(), Some(b"\x20"), Some(b"\x90"), None)
-            .expect_err("structural check should reject spurious Delete at end_key");
+    let err = verify_change_proof_structure(
+        &crafted,
+        root2.clone(),
+        Some(b"\x20"),
+        Some(b"\x90"),
+        H::ALGORITHM,
+        None,
+    )
+    .expect_err("structural check should reject spurious Delete at end_key");
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::EndProofOperationMismatch)
@@ -308,10 +350,10 @@ fn test_crafted_spurious_delete_at_end_key_boundary() {
 /// The `start_key` value MUST be checked for inclusion proofs. If the
 /// proposal has a different value at `start_key` than `end_root`, the
 /// reconciliation or root hash comparison should detect the mismatch.
-#[test]
-fn test_crafted_tampered_start_key_value_detected() {
+#[firewood_macros::hash_mode]
+fn test_crafted_tampered_start_key_value_detected<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10", b"v0"), (b"\x30", b"v1")];
+        setup_source_target![mode = H; (b"\x10", b"v0"), (b"\x30", b"v1")];
 
     let (root1_source, root2) =
         setup_2nd_commit!(source, [(b"\x10", b"changed"), (b"\x30", b"changed")]);
@@ -321,8 +363,15 @@ fn test_crafted_tampered_start_key_value_detected() {
         .unwrap();
 
     // Verify the honest proof works.
-    let ctx =
-        verify_change_proof_structure(&honest, root2.clone(), Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &honest,
+        root2.clone(),
+        Some(b"\x10"),
+        None,
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &honest, &ctx, root1_target.clone()).unwrap();
 
     // Tamper: replace Put(\x10, "changed") with Put(\x10, "WRONG").
@@ -336,15 +385,18 @@ fn test_crafted_tampered_start_key_value_detected() {
         value: b"WRONG".to_vec().into(),
     };
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         tampered_ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     // Structural checks pass (hash chain is valid), but root hash
     // verification catches the tampered value.
-    let ctx2 = verify_change_proof_structure(&crafted, root2, Some(b"\x10"), None, None).unwrap();
+    let ctx2 =
+        verify_change_proof_structure(&crafted, root2, Some(b"\x10"), None, H::ALGORITHM, None)
+            .unwrap();
     let err = verify_and_check(&target, &crafted, &ctx2, root1_target)
         .expect_err("tampered start_key value must be detected");
     assert!(
@@ -365,9 +417,9 @@ fn test_crafted_tampered_start_key_value_detected() {
 /// This breaks the structural hash chain, so we skip structural validation
 /// and call `verify_change_proof_root_hash` directly. The start and end
 /// proofs both contain the root node, but now they disagree.
-#[test]
-fn test_crafted_conflicting_proof_nodes_rejected() {
-    let (db, _dir) = setup_db![(b"\x10", b"a"), (b"\x20", b"b")];
+#[firewood_macros::hash_mode]
+fn test_crafted_conflicting_proof_nodes_rejected<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"a"), (b"\x20", b"b")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x10", b"A"), (b"\x20", b"B")]);
 
     let valid = db
@@ -397,10 +449,11 @@ fn test_crafted_conflicting_proof_nodes_rejected() {
     new_bytes[0] ^= 1;
     *child_hash = firewood_storage::TrieHash::from(new_bytes).into();
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(end_nodes.into_boxed_slice()),
         valid.batch_ops().into(),
+        H::ALGORITHM,
     );
 
     // Skip structural validation (the modified hash chain won't pass).
@@ -429,9 +482,9 @@ fn test_crafted_conflicting_proof_nodes_rejected() {
 /// Keys `\x10` and `\x15` share nibble 1 at depth 0, then fork at depth 1
 /// (nibbles 0 vs 5). The branch at depth 1 is at odd nibble length. We
 /// inject a spurious value into that odd-depth proof node.
-#[test]
-fn test_crafted_value_at_odd_nibble_length_rejected() {
-    let (db, _dir) = setup_db![(b"\x10", b"a"), (b"\x15", b"b"), (b"\x30", b"c")];
+#[firewood_macros::hash_mode]
+fn test_crafted_value_at_odd_nibble_length_rejected<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"a"), (b"\x15", b"b"), (b"\x30", b"c")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x30", b"changed")]);
 
     let valid = db
@@ -449,10 +502,11 @@ fn test_crafted_value_at_odd_nibble_length_rejected() {
         b"injected".to_vec().into(),
     ));
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(start_nodes.into_boxed_slice()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         valid.batch_ops().into(),
+        H::ALGORITHM,
     );
 
     // Skip structural validation (injected value breaks the hash chain).
@@ -474,9 +528,10 @@ fn test_crafted_value_at_odd_nibble_length_rejected() {
 /// Craft start/end proofs from two disjoint bounded proofs, skipping the
 /// shared root node. The proofs diverge at depth zero — reconciliation
 /// should detect the inconsistency.
-#[test]
-fn test_crafted_divergence_at_depth_zero() {
+#[firewood_macros::hash_mode]
+fn test_crafted_divergence_at_depth_zero<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10", b"v0"),
         (b"\x11", b"v1"),
         (b"\xa0", b"v2"),
@@ -521,13 +576,14 @@ fn test_crafted_divergence_at_depth_zero() {
     let e = right.end_proof().as_ref();
     assert!(s.len() >= 2 && e.len() >= 2);
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(s[1..].into()),
         crate::Proof::new(e[1..].into()),
         Box::new([BatchOp::Put {
             key: b"\x50".to_vec().into(),
             value: b"mid".to_vec().into(),
         }]),
+        H::ALGORITHM,
     );
 
     let parent = target.revision(root1_target).unwrap();
@@ -559,9 +615,10 @@ fn test_crafted_divergence_at_depth_zero() {
 /// divergent siblings at nibbles 8 and f. The branch survives deletion
 /// because two children remain. Stripping nibble 8's child hash from
 /// the proof node at [1, 0, 5] should cause rejection.
-#[test]
-fn test_crafted_stripped_divergent_child_rejected() {
+#[firewood_macros::hash_mode]
+fn test_crafted_stripped_divergent_child_rejected<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10\x50", b"a"),
         (b"\x10\x58", b"b"),
         (b"\x10\x5f", b"d"),
@@ -600,6 +657,7 @@ fn test_crafted_stripped_divergent_child_rejected() {
         root2.clone(),
         Some(b"\x10\x50"),
         Some(b"\x30\x00"),
+        H::ALGORITHM,
         None,
     )
     .unwrap();
@@ -616,10 +674,11 @@ fn test_crafted_stripped_divergent_child_rejected() {
     let nibble_8 = firewood_storage::PathComponent::try_new(8).unwrap();
     start_nodes[branch_idx].child_hashes.remove(nibble_8.0);
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(start_nodes.into_boxed_slice()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         valid.batch_ops().into(),
+        H::ALGORITHM,
     );
 
     assert!(
@@ -644,10 +703,10 @@ fn test_crafted_stripped_divergent_child_rejected() {
 ///
 /// The verifier would then commit the incomplete `batch_ops`, leaving `\x05`
 /// in their state when `end_root` says it shouldn't exist.
-#[test]
-fn test_crafted_omitted_delete_at_straddling_nibble() {
+#[firewood_macros::hash_mode]
+fn test_crafted_omitted_delete_at_straddling_nibble<H: HashMode>() {
     // start_root: \x00, \x05, \x10
-    let (db, _dir) = setup_db![(b"\x00", b"a"), (b"\x05", b"e"), (b"\x10", b"b")];
+    let (db, _dir) = setup_db![mode = H; (b"\x00", b"a"), (b"\x05", b"e"), (b"\x10", b"b")];
     let root1 = db.root_hash().unwrap();
 
     // end_root: only \x10 (both \x00 and \x05 deleted)
@@ -675,13 +734,14 @@ fn test_crafted_omitted_delete_at_straddling_nibble() {
     assert_eq!(honest.batch_ops().len(), 2);
 
     // Craft a tampered proof: remove Delete(\x05), keep only Put(\x10)
-    let tampered = FrozenChangeProof::new(
+    let tampered = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().as_ref().into()),
         crate::Proof::new(honest.end_proof().as_ref().into()),
         Box::new([BatchOp::Put {
             key: b"\x10".to_vec().into(),
             value: b"changed".to_vec().into(),
         }]),
+        H::ALGORITHM,
     );
 
     assert!(
@@ -697,9 +757,9 @@ fn test_crafted_omitted_delete_at_straddling_nibble() {
 /// "non-on-path"), so the hash computation never sees it.
 /// The range-safety check in `collapse_strip` detects the in-range child
 /// before stripping and rejects with `EndRootMismatch`.
-#[test]
-fn test_collapse_root_hides_spurious_key() {
-    let (db, _dir) = setup_db![(b"\x90", b"orig")];
+#[firewood_macros::hash_mode]
+fn test_collapse_root_hides_spurious_key<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x90", b"orig")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x90", b"new!")]);
 
     let valid_proof = db
@@ -717,10 +777,11 @@ fn test_collapse_root_hides_spurious_key() {
         },
     );
 
-    let attack_proof = crate::ChangeProof::new(
+    let attack_proof = crate::ChangeProof::with_hash_mode(
         crate::Proof::new(valid_proof.start_proof().as_ref().into()),
         crate::Proof::new(valid_proof.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     assert!(
@@ -757,8 +818,8 @@ fn gap_boundaries() -> ([u8; 32], [u8; 32]) {
 /// Helper for the common adversarial pattern: generate a valid bounded proof
 /// for the 5-key setup, inject a spurious operation, and assert rejection.
 #[expect(clippy::too_many_arguments)]
-fn inject_and_assert_rejected(
-    db: &Db<DefaultHashMode>,
+fn inject_and_assert_rejected<H: HashMode>(
+    db: &Db<H>,
     root1: api::HashKey,
     root2: api::HashKey,
     valid_proof: &FrozenChangeProof,
@@ -773,10 +834,11 @@ fn inject_and_assert_rejected(
         .unwrap_or_else(|i| i);
     ops.insert(pos, spurious_op);
 
-    let attack_proof = crate::ChangeProof::new(
+    let attack_proof = crate::ChangeProof::with_hash_mode(
         crate::Proof::new(valid_proof.start_proof().as_ref().into()),
         crate::Proof::new(valid_proof.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     assert!(
@@ -801,10 +863,11 @@ fn inject_and_assert_rejected(
 ///   - The change proof is bounded by non-existent gap keys around B..D.
 ///   - Key C is unchanged between revisions and is NOT in `batch_ops`.
 ///   - An attacker adds `Delete { key: C }` to `batch_ops`.
-#[test]
-fn test_spurious_delete_in_range_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_spurious_delete_in_range_is_rejected<H: HashMode>() {
     let keys = five_keys();
     let (db, _dir) = setup_db![
+        mode = H;
         (&keys[0], &[0xAAu8; 20]),
         (&keys[1], &[0xBBu8; 20]),
         (&keys[2], &[0xCCu8; 20]),
@@ -854,12 +917,13 @@ fn test_spurious_delete_in_range_is_rejected() {
 /// IS in `batch_ops`, forcing them into the same top-level subtree. The subtree
 /// must be recomputed because it contains a changed key, so the delete of the
 /// unchanged sibling should be visible.
-#[test]
-fn test_spurious_delete_same_subtree_as_changed_key() {
+#[firewood_macros::hash_mode]
+fn test_spurious_delete_same_subtree_as_changed_key<H: HashMode>() {
     let mut keys = five_keys();
     keys[2][0] = 0x38; // C — target, same first nibble as B (0x30)
 
     let (db, _dir) = setup_db![
+        mode = H;
         (&keys[0], &[0xAAu8; 20]),
         (&keys[1], &[0xBBu8; 20]),
         (&keys[2], &[0xCCu8; 20]),
@@ -894,10 +958,11 @@ fn test_spurious_delete_same_subtree_as_changed_key() {
 }
 
 /// Same attack with EXISTING boundary keys (inclusion proofs).
-#[test]
-fn test_spurious_delete_with_existing_boundaries() {
+#[firewood_macros::hash_mode]
+fn test_spurious_delete_with_existing_boundaries<H: HashMode>() {
     let keys = five_keys();
     let (db, _dir) = setup_db![
+        mode = H;
         (&keys[0], &[0xAAu8; 20]),
         (&keys[1], &[0xBBu8; 20]),
         (&keys[2], &[0xCCu8; 20]),
@@ -946,10 +1011,11 @@ fn test_spurious_delete_with_existing_boundaries() {
 /// rejected. This confirms the hybrid hash works for keys that were changed
 /// between revisions (their subtree is computed from the proposal, not borrowed
 /// from proof nodes).
-#[test]
-fn test_swapped_value_in_range_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_swapped_value_in_range_is_rejected<H: HashMode>() {
     let keys = five_keys();
     let (db, _dir) = setup_db![
+        mode = H;
         (&keys[0], &[0xAAu8; 20]),
         (&keys[1], &[0xBBu8; 20]),
         (&keys[2], &[0xCCu8; 20]),
@@ -986,10 +1052,11 @@ fn test_swapped_value_in_range_is_rejected() {
         value: [0xFFu8; 20].to_vec().into_boxed_slice(),
     };
 
-    let attack_proof = crate::ChangeProof::new(
+    let attack_proof = crate::ChangeProof::with_hash_mode(
         crate::Proof::new(valid_proof.start_proof().as_ref().into()),
         crate::Proof::new(valid_proof.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     assert!(
@@ -1016,13 +1083,23 @@ fn test_swapped_value_in_range_is_rejected() {
 /// silently accepted it (`None == None`). The second op (`\x90`) keeps the
 /// batch non-empty so the tamper reaches reconcile instead of the structural
 /// check.
-#[cfg(not(feature = "ethhash"))]
+///
+/// Pinned to `MerkleDbHash`: `ValueDigest::Hash` (the >= 32 byte cap this
+/// test relies on to give the boundary node a hash digest) is only ever
+/// produced by the merkledb wire-serialization rule — the Ethereum scheme
+/// never emits a `Hash` digest (see `ValueDigest::write_item`), so the
+/// scenario this test exercises doesn't exist under `ethhash`.
 #[test]
-fn test_crafted_dropped_hashed_put_behind_left_exclusion_rejected() {
+fn test_crafted_dropped_hashed_put_behind_left_exclusion_rejected_merkledb() {
+    test_crafted_dropped_hashed_put_behind_left_exclusion_rejected::<MerkleDbHash>();
+}
+
+fn test_crafted_dropped_hashed_put_behind_left_exclusion_rejected<H: HashMode>() {
     let big = [0xabu8; 40]; // >= 32 bytes => Hash after serialization
     // start: 0x90 only. end: add NEW key 0x1234 (large value) AND change 0x90
     // (a second in-range op so the batch isn't empty after dropping 0x1234).
-    let (source, target, root1_target, _ds, _dt) = setup_source_target![(b"\x90", b"anchor")];
+    let (source, target, root1_target, _ds, _dt) =
+        setup_source_target![mode = H; (b"\x90", b"anchor")];
     let (root1_source, root2) = setup_2nd_commit!(
         source,
         [
@@ -1043,16 +1120,18 @@ fn test_crafted_dropped_hashed_put_behind_left_exclusion_rejected() {
     // Tamper: drop the in-range Put of 0x1234, keeping the 0x90 change.
     let mut ops: Vec<BatchOp<Key, Value>> = valid.batch_ops().to_vec();
     ops.retain(|op| !matches!(op, BatchOp::Put { key, .. } if key.as_ref() == b"\x12\x34"));
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     // The structural checks pass (the hash chain is intact); the reconcile
     // in-range guard rejects the empty-branch-vs-Hash conflict.
     let ctx =
-        verify_change_proof_structure(&crafted, root2, Some(b"\x12\x30"), None, None).unwrap();
+        verify_change_proof_structure(&crafted, root2, Some(b"\x12\x30"), None, H::ALGORITHM, None)
+            .unwrap();
     let err = verify_and_check(&target, &crafted, &ctx, root1_target)
         .expect_err("dropped in-range Put (hashed) behind a left exclusion must be rejected");
     assert!(
@@ -1072,11 +1151,19 @@ fn test_crafted_dropped_hashed_put_behind_left_exclusion_rejected() {
 /// hash; the empty-branch-vs-`Hash` conflict must route to the end-proof
 /// in-range guard (`\x12\x34` <= `end_key`) and be rejected. The second op
 /// (`\x10`, below the dropped key) keeps the batch non-empty.
-#[cfg(not(feature = "ethhash"))]
+///
+/// Pinned to `MerkleDbHash` for the same reason as the left-edge sibling
+/// test above: the >= 32 byte raw value driving the `Hash` digest is a
+/// merkledb-specific serialization threshold.
 #[test]
-fn test_crafted_dropped_hashed_put_behind_right_exclusion_rejected() {
+fn test_crafted_dropped_hashed_put_behind_right_exclusion_rejected_merkledb() {
+    test_crafted_dropped_hashed_put_behind_right_exclusion_rejected::<MerkleDbHash>();
+}
+
+fn test_crafted_dropped_hashed_put_behind_right_exclusion_rejected<H: HashMode>() {
     let big = [0xabu8; 40]; // >= 32 bytes => Hash after serialization
-    let (source, target, root1_target, _ds, _dt) = setup_source_target![(b"\x10", b"anchor")];
+    let (source, target, root1_target, _ds, _dt) =
+        setup_source_target![mode = H; (b"\x10", b"anchor")];
     let (root1_source, root2) = setup_2nd_commit!(
         source,
         [
@@ -1097,16 +1184,18 @@ fn test_crafted_dropped_hashed_put_behind_right_exclusion_rejected() {
     // Tamper: drop the in-range Put of 0x1234, keeping the 0x10 change.
     let mut ops: Vec<BatchOp<Key, Value>> = valid.batch_ops().to_vec();
     ops.retain(|op| !matches!(op, BatchOp::Put { key, .. } if key.as_ref() == b"\x12\x34"));
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     // The structural checks pass (the hash chain is intact); the reconcile
     // in-range guard rejects the empty-branch-vs-Hash conflict.
     let ctx =
-        verify_change_proof_structure(&crafted, root2, None, Some(b"\x12\x38"), None).unwrap();
+        verify_change_proof_structure(&crafted, root2, None, Some(b"\x12\x38"), H::ALGORITHM, None)
+            .unwrap();
     let err = verify_and_check(&target, &crafted, &ctx, root1_target)
         .expect_err("dropped in-range Put (hashed) behind a right exclusion must be rejected");
     assert!(
@@ -1120,10 +1209,11 @@ fn test_crafted_dropped_hashed_put_behind_right_exclusion_rejected() {
 
 /// Control test: a spurious Put for a non-existent in-range key is correctly
 /// rejected when the key falls in a subtree that is recomputed (not borrowed).
-#[test]
-fn test_spurious_put_in_range_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_spurious_put_in_range_is_rejected<H: HashMode>() {
     let keys = five_keys();
     let (db, _dir) = setup_db![
+        mode = H;
         (&keys[0], &[0xAAu8; 20]),
         (&keys[1], &[0xBBu8; 20]),
         (&keys[2], &[0xCCu8; 20]),

--- a/firewood/src/merkle/tests/change/bounds.rs
+++ b/firewood/src/merkle/tests/change/bounds.rs
@@ -9,14 +9,17 @@ use test_case::test_case;
 
 /// Left edge proof is present iff `requested_start_key` is set. Right edge
 /// proof is always present (generator produces one for non-empty batch ops).
+#[firewood_macros::hash_mode]
 #[test_case(None,          None,          b"\x20" ; "full keyrange")]
 #[test_case(None,          Some(b"\x30"), b"\x10" ; "provided right edge")]
 #[test_case(Some(b"\x10"), None,          b"\x30" ; "provided left edge")]
 #[test_case(Some(b"\x10"), Some(b"\x30"), b"\x20" ; "provided both edges")]
 #[test_case(Some(b"\x15"), Some(b"\x25"), b"\x20" ; "both edges with gap keys")]
-fn test_verify(start_key: Option<&[u8]>, end_key: Option<&[u8]>, change_key: &[u8]) {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
-    let (target, _dir_target) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+fn test_verify<H: HashMode>(start_key: Option<&[u8]>, end_key: Option<&[u8]>, change_key: &[u8]) {
+    let (source, _dir_source) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+    let (target, _dir_target) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_target = target.root_hash().unwrap();
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(change_key, b"changed")]);
@@ -28,8 +31,15 @@ fn test_verify(start_key: Option<&[u8]>, end_key: Option<&[u8]>, change_key: &[u
     assert_eq!(proof.start_proof().is_empty(), start_key.is_none());
     assert!(!proof.end_proof().is_empty());
 
-    let ctx =
-        verify_change_proof_structure(&proof, root2.clone(), start_key, end_key, None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        start_key,
+        end_key,
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target.clone()).unwrap();
 
     // Apply the proof to target and verify roots converge.
@@ -45,9 +55,9 @@ fn test_verify(start_key: Option<&[u8]>, end_key: Option<&[u8]>, change_key: &[u
 /// The start boundary (`b"\x01"`) falls between the deleted key (`b"\x00"`)
 /// and the changed key (`b"\x10"`), so the delete is out-of-range and the
 /// proof must still verify.
-#[test]
-fn test_inherited_key_at_start_boundary_accepted() {
-    let (db, _dir) = setup_db![(b"\x00", b"a"), (b"\x10", b"b")];
+#[firewood_macros::hash_mode]
+fn test_inherited_key_at_start_boundary_accepted<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x00", b"a"), (b"\x10", b"b")];
     let root1 = db.root_hash().unwrap();
     db.propose(vec![
         BatchOp::Delete {
@@ -73,15 +83,16 @@ fn test_inherited_key_at_start_boundary_accepted() {
         )
         .unwrap();
 
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x01"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x01"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&db, &proof, &ctx, root1).unwrap();
 }
 
 /// When `requested_end_key` is set and the proof is complete (not truncated),
 /// the right edge proof anchors at `requested_end_key`, not the last batch key.
-#[test]
-fn test_generator_uses_end_key_for_complete_proof() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_generator_uses_end_key_for_complete_proof<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x10", b"changed")]);
 
     // end_key far beyond last change, no limit — complete proof
@@ -92,10 +103,6 @@ fn test_generator_uses_end_key_for_complete_proof() {
     // End proof validates against end_key for complete proofs
     proof
         .end_proof()
-        .value_digest(
-            b"\xff",
-            &root2,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .value_digest(b"\xff", &root2, H::ALGORITHM)
         .unwrap();
 }

--- a/firewood/src/merkle/tests/change/bounds.rs
+++ b/firewood/src/merkle/tests/change/bounds.rs
@@ -5,19 +5,22 @@
 //! no edges, left only, right only, and both edges.
 
 use super::*;
-use firewood_storage::{DefaultHashMode, HashMode};
+use firewood_storage::HashMode;
 use test_case::test_case;
 
 /// Left edge proof is present iff `requested_start_key` is set. Right edge
 /// proof is always present (generator produces one for non-empty batch ops).
+#[firewood_macros::hash_mode]
 #[test_case(None,          None,          b"\x20" ; "full keyrange")]
 #[test_case(None,          Some(b"\x30"), b"\x10" ; "provided right edge")]
 #[test_case(Some(b"\x10"), None,          b"\x30" ; "provided left edge")]
 #[test_case(Some(b"\x10"), Some(b"\x30"), b"\x20" ; "provided both edges")]
 #[test_case(Some(b"\x15"), Some(b"\x25"), b"\x20" ; "both edges with gap keys")]
-fn test_verify(start_key: Option<&[u8]>, end_key: Option<&[u8]>, change_key: &[u8]) {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
-    let (target, _dir_target) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+fn test_verify<H: HashMode>(start_key: Option<&[u8]>, end_key: Option<&[u8]>, change_key: &[u8]) {
+    let (source, _dir_source) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+    let (target, _dir_target) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_target = target.root_hash().unwrap();
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(change_key, b"changed")]);
@@ -29,8 +32,15 @@ fn test_verify(start_key: Option<&[u8]>, end_key: Option<&[u8]>, change_key: &[u
     assert_eq!(proof.start_proof().is_empty(), start_key.is_none());
     assert!(!proof.end_proof().is_empty());
 
-    let ctx =
-        verify_change_proof_structure(&proof, root2.clone(), start_key, end_key, None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        start_key,
+        end_key,
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target.clone()).unwrap();
 
     // Apply the proof to target and verify roots converge.
@@ -46,9 +56,9 @@ fn test_verify(start_key: Option<&[u8]>, end_key: Option<&[u8]>, change_key: &[u
 /// The start boundary (`b"\x01"`) falls between the deleted key (`b"\x00"`)
 /// and the changed key (`b"\x10"`), so the delete is out-of-range and the
 /// proof must still verify.
-#[test]
-fn test_inherited_key_at_start_boundary_accepted() {
-    let (db, _dir) = setup_db![(b"\x00", b"a"), (b"\x10", b"b")];
+#[firewood_macros::hash_mode]
+fn test_inherited_key_at_start_boundary_accepted<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x00", b"a"), (b"\x10", b"b")];
     let root1 = db.root_hash().unwrap();
     db.propose(vec![
         BatchOp::Delete {
@@ -74,15 +84,16 @@ fn test_inherited_key_at_start_boundary_accepted() {
         )
         .unwrap();
 
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x01"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x01"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&db, &proof, &ctx, root1).unwrap();
 }
 
 /// When `requested_end_key` is set and the proof is complete (not truncated),
 /// the right edge proof anchors at `requested_end_key`, not the last batch key.
-#[test]
-fn test_generator_uses_end_key_for_complete_proof() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_generator_uses_end_key_for_complete_proof<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x10", b"changed")]);
 
     // end_key far beyond last change, no limit — complete proof
@@ -93,6 +104,6 @@ fn test_generator_uses_end_key_for_complete_proof() {
     // End proof validates against end_key for complete proofs
     proof
         .end_proof()
-        .value_digest(b"\xff", &root2, DefaultHashMode::ALGORITHM)
+        .value_digest(b"\xff", &root2, H::ALGORITHM)
         .unwrap();
 }

--- a/firewood/src/merkle/tests/change/edge_cases.rs
+++ b/firewood/src/merkle/tests/change/edge_cases.rs
@@ -5,10 +5,10 @@
 
 use super::*;
 
-#[test]
-fn test_empty_batch_ops_with_nonempty_proofs() {
+#[firewood_macros::hash_mode]
+fn test_empty_batch_ops_with_nonempty_proofs<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+        setup_source_target![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
 
     // Change only \x30 (outside range [\x10, \x20])
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x30", b"changed")]);
@@ -26,15 +26,22 @@ fn test_empty_batch_ops_with_nonempty_proofs() {
     assert!(!proof.start_proof().is_empty());
     assert!(!proof.end_proof().is_empty());
 
-    let ctx =
-        verify_change_proof_structure(&proof, root2, Some(b"\x10"), Some(b"\x20"), None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        Some(b"\x10"),
+        Some(b"\x20"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
-#[test]
-fn test_odd_depth_proof_node_accepted() {
+#[firewood_macros::hash_mode]
+fn test_odd_depth_proof_node_accepted<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x12", b"v0"), (b"\x13", b"v1"), (b"\x50", b"v2")];
+        setup_source_target![mode = H; (b"\x12", b"v0"), (b"\x13", b"v1"), (b"\x50", b"v2")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x50", b"changed")]);
 
@@ -49,22 +56,19 @@ fn test_odd_depth_proof_node_accepted() {
     assert!(
         proof
             .start_proof()
-            .value_digest(
-                b"\x14",
-                &root2,
-                firewood_storage::DefaultHashMode::ALGORITHM
-            )
+            .value_digest(b"\x14", &root2, H::ALGORITHM)
             .unwrap()
             .is_none()
     );
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x14"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x14"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
-#[test]
-fn test_start_proof_inclusion_with_children_below() {
+#[firewood_macros::hash_mode]
+fn test_start_proof_inclusion_with_children_below<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\xab", b"v0"), (b"\xab\xcd", b"v1"), (b"\xf0", b"v2")];
+        setup_source_target![mode = H; (b"\xab", b"v0"), (b"\xab\xcd", b"v1"), (b"\xf0", b"v2")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\xf0", b"changed")]);
 
@@ -75,23 +79,20 @@ fn test_start_proof_inclusion_with_children_below() {
     assert!(
         proof
             .start_proof()
-            .value_digest(
-                b"\xab",
-                &root2,
-                firewood_storage::DefaultHashMode::ALGORITHM
-            )
+            .value_digest(b"\xab", &root2, H::ALGORITHM)
             .unwrap()
             .is_some(),
         "start proof should be an inclusion proof for \\xab"
     );
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\xab"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\xab"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
-#[test]
-fn test_end_proof_inclusion_with_children_below() {
+#[firewood_macros::hash_mode]
+fn test_end_proof_inclusion_with_children_below<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\xab", b"v0"), (b"\xab\xcd", b"v1"), (b"\xf0", b"v2")];
+        setup_source_target![mode = H; (b"\xab", b"v0"), (b"\xab\xcd", b"v1"), (b"\xf0", b"v2")];
 
     let (root1_source, root2) = setup_2nd_commit!(
         source,
@@ -110,15 +111,26 @@ fn test_end_proof_inclusion_with_children_below() {
         .unwrap();
     assert_eq!(proof.batch_ops().len(), 1);
     assert!(proof.start_proof().is_empty());
-    let ctx =
-        verify_change_proof_structure(&proof, root2, None, None, NonZeroUsize::new(1)).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        None,
+        None,
+        H::ALGORITHM,
+        NonZeroUsize::new(1),
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
-#[test]
-fn test_divergence_parent_start_key_exhausted() {
-    let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x12\x01", b"v0"), (b"\x12\x02", b"v1"), (b"\xf0", b"v2")];
+#[firewood_macros::hash_mode]
+fn test_divergence_parent_start_key_exhausted<H: HashMode>() {
+    let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
+        (b"\x12\x01", b"v0"),
+        (b"\x12\x02", b"v1"),
+        (b"\xf0", b"v2")
+    ];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\xf0", b"changed")]);
 
@@ -136,17 +148,20 @@ fn test_divergence_parent_start_key_exhausted() {
     assert!(
         proof
             .start_proof()
-            .value_digest(
-                b"\x12",
-                &root2,
-                firewood_storage::DefaultHashMode::ALGORITHM
-            )
+            .value_digest(b"\x12", &root2, H::ALGORITHM)
             .unwrap()
             .is_none(),
         "start proof should be an exclusion proof for \\x12"
     );
-    let ctx =
-        verify_change_proof_structure(&proof, root2, Some(b"\x12"), Some(b"\xf0"), None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        Some(b"\x12"),
+        Some(b"\xf0"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -168,10 +183,10 @@ fn test_divergence_parent_start_key_exhausted() {
 // The change proof query uses start=\x10 (the branch node), end=None.
 // Only \x30 changes ("c" -> "changed"), but the verifier must still
 // validate that \x10's children are intact.
-#[test]
-fn test_start_tail_last_node_children_checked() {
+#[firewood_macros::hash_mode]
+fn test_start_tail_last_node_children_checked<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10\x01", b"a"), (b"\x10\x02", b"b"), (b"\x30", b"c")];
+        setup_source_target![mode = H; (b"\x10\x01", b"a"), (b"\x10\x02", b"b"), (b"\x30", b"c")];
 
     // Only modify \x30 on the source; \x10's children are untouched
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x30", b"changed")]);
@@ -184,24 +199,23 @@ fn test_start_tail_last_node_children_checked() {
     assert!(
         proof
             .start_proof()
-            .value_digest(
-                b"\x10",
-                &root2,
-                firewood_storage::DefaultHashMode::ALGORITHM
-            )
+            .value_digest(b"\x10", &root2, H::ALGORITHM)
             .unwrap()
             .is_none(),
         "start proof should be an exclusion proof for \\x10"
     );
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
-#[test]
-fn test_start_proof_exclusion_for_deleted_key() {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+#[firewood_macros::hash_mode]
+fn test_start_proof_exclusion_for_deleted_key<H: HashMode>() {
+    let (source, _dir_source) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_source = source.root_hash().unwrap();
-    let (target, _dir_target) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+    let (target, _dir_target) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_target = target.root_hash().unwrap();
 
     source
@@ -224,16 +238,13 @@ fn test_start_proof_exclusion_for_deleted_key() {
     assert!(
         proof
             .start_proof()
-            .value_digest(
-                b"\x10",
-                &root2,
-                firewood_storage::DefaultHashMode::ALGORITHM
-            )
+            .value_digest(b"\x10", &root2, H::ALGORITHM)
             .unwrap()
             .is_none(),
         "start proof should be an exclusion proof for deleted \\x10"
     );
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -247,10 +258,10 @@ fn test_start_proof_exclusion_for_deleted_key() {
 /// between the proposal (R1 + empty ops) and the end trie (R2), but
 /// because `\x00\x10` < `\x00\x10\x20` the value check should be
 /// skipped.
-#[test]
-fn test_disjoint_proof() {
+#[firewood_macros::hash_mode]
+fn test_disjoint_proof<H: HashMode>() {
     // R1: trie with a single key \x00
-    let (db, _dir) = setup_db![(b"\x00", b"v0")];
+    let (db, _dir) = setup_db![mode = H; (b"\x00", b"v0")];
 
     // R2: add \x00\x10 (outside query range [\x00\x10\x20, \x00\x10\x30])
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x00\x10", b"v1")]);
@@ -274,6 +285,7 @@ fn test_disjoint_proof() {
         root2,
         Some(first.as_slice()),
         Some(last.as_slice()),
+        H::ALGORITHM,
         None,
     )
     .unwrap();
@@ -285,16 +297,18 @@ fn test_disjoint_proof() {
 /// exercises the fixed path — a Delete near `start_key` under a shared
 /// branch produces a valid proof. Before the fix, the proof generator
 /// omitted the divergent child, leaving a verification gap.
-#[test]
-fn test_boundary_child_gap_closed_for_start_key() {
+#[firewood_macros::hash_mode]
+fn test_boundary_child_gap_closed_for_start_key<H: HashMode>() {
     // \x10\x50 and \x10\x58 share a branch at nibble path [1,0].
     let (source, _dir_source) = setup_db![
+        mode = H;
         (b"\x10\x50", b"a"),
         (b"\x10\x58", b"b"),
         (b"\x30\x00", b"c")
     ];
     let root1_source = source.root_hash().unwrap();
     let (target, _dir_target) = setup_db![
+        mode = H;
         (b"\x10\x50", b"a"),
         (b"\x10\x58", b"b"),
         (b"\x30\x00", b"c")
@@ -328,9 +342,15 @@ fn test_boundary_child_gap_closed_for_start_key() {
         .unwrap();
     assert_eq!(honest.batch_ops().len(), 2); // Delete(\x10\x50) + Put(\x30\x00)
 
-    let ctx =
-        verify_change_proof_structure(&honest, root2, Some(b"\x10\x50"), Some(b"\x30\x00"), None)
-            .unwrap();
+    let ctx = verify_change_proof_structure(
+        &honest,
+        root2,
+        Some(b"\x10\x50"),
+        Some(b"\x30\x00"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &honest, &ctx, root1_target).unwrap();
 }
 
@@ -340,10 +360,10 @@ fn test_boundary_child_gap_closed_for_start_key() {
 /// Keys `\x10\x50` and `\x10\x58` share a branch with partial path containing
 /// nibble 5. `start_key` `\x10\x40` diverges at nibble 4 < 5, so the start
 /// boundary is "before" the terminal — no children are marked outside.
-#[test]
-fn test_terminal_divergence_within_partial_path() {
+#[firewood_macros::hash_mode]
+fn test_terminal_divergence_within_partial_path<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10\x50", b"a"), (b"\x10\x58", b"b"), (b"\x30", b"c")];
+        setup_source_target![mode = H; (b"\x10\x50", b"a"), (b"\x10\x58", b"b"), (b"\x30", b"c")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x30", b"changed")]);
 
@@ -351,7 +371,9 @@ fn test_terminal_divergence_within_partial_path() {
         .change_proof(root1_source, root2.clone(), Some(b"\x10\x40"), None, None)
         .unwrap();
     assert_eq!(proof.batch_ops().len(), 1);
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10\x40"), None, None).unwrap();
+    let ctx =
+        verify_change_proof_structure(&proof, root2, Some(b"\x10\x40"), None, H::ALGORITHM, None)
+            .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -363,9 +385,10 @@ fn test_terminal_divergence_within_partial_path() {
 /// with children at nibbles 1, 2, and 3. `start_key` `\x10\x05` has
 /// on-path nibble 5 at the terminal, so nibbles 1, 2, and 3 are all
 /// below 5 and marked outside.
-#[test]
-fn test_terminal_ancestor_all_children_outside() {
+#[firewood_macros::hash_mode]
+fn test_terminal_ancestor_all_children_outside<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10\x01", b"a"),
         (b"\x10\x02", b"b"),
         (b"\x10\x03", b"c"),
@@ -384,7 +407,9 @@ fn test_terminal_ancestor_all_children_outside() {
     let terminal = proof.start_proof().as_ref().last().unwrap();
     assert_eq!(terminal.key.len(), 3);
 
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10\x05"), None, None).unwrap();
+    let ctx =
+        verify_change_proof_structure(&proof, root2, Some(b"\x10\x05"), None, H::ALGORITHM, None)
+            .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -395,9 +420,10 @@ fn test_terminal_ancestor_all_children_outside() {
 /// key is exhausted before the node's partial path is fully consumed.
 /// All children of this terminal are in-range (>= `\x10`), so none are
 /// marked outside by `compute_outside_children`.
-#[test]
-fn test_terminal_divergent_node_all_children_in_range() {
+#[firewood_macros::hash_mode]
+fn test_terminal_divergent_node_all_children_in_range<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10\x01", b"a"),
         (b"\x10\x02", b"b"),
         (b"\x10\x03", b"c"),
@@ -418,7 +444,8 @@ fn test_terminal_divergent_node_all_children_in_range() {
     let terminal = proof.start_proof().as_ref().last().unwrap();
     assert_eq!(terminal.key.len(), 3);
 
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -428,10 +455,10 @@ fn test_terminal_divergent_node_all_children_in_range() {
 ///
 /// Key `\x20` is a prefix of `\x20\xab`. `end_key` = `\x20` — children of
 /// the `\x20` node extend beyond `end_key` and must use proof hashes.
-#[test]
-fn test_right_edge_boundary_prefix_of_terminal() {
+#[firewood_macros::hash_mode]
+fn test_right_edge_boundary_prefix_of_terminal<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10", b"a"), (b"\x20", b"b"), (b"\x20\xab", b"c")];
+        setup_source_target![mode = H; (b"\x10", b"a"), (b"\x20", b"b"), (b"\x20\xab", b"c")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x10", b"changed")]);
 
@@ -439,7 +466,8 @@ fn test_right_edge_boundary_prefix_of_terminal() {
         .change_proof(root1_source, root2.clone(), None, Some(b"\x20"), None)
         .unwrap();
     assert_eq!(proof.batch_ops().len(), 1);
-    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x20"), None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x20"), H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -451,9 +479,10 @@ fn test_right_edge_boundary_prefix_of_terminal() {
 /// range `[\x10\x50, \x30]` excludes `\x10` (it's a proper prefix of `start_key`),
 /// so `\x10` is out-of-range. The start proof path passes through `\x10`, and
 /// reconciliation must adopt the proof's value (`"new_pfx"`) to match `end_root`.
-#[test]
-fn test_out_of_range_value_change_adopted() {
+#[firewood_macros::hash_mode]
+fn test_out_of_range_value_change_adopted<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10", b"old_pfx"),
         (b"\x10\x50", b"val0000"),
         (b"\x30", b"val1000")
@@ -473,8 +502,15 @@ fn test_out_of_range_value_change_adopted() {
         .unwrap();
     // Only \x30 is in range [\x10\x50, \x30]; \x10's change is out of range.
     assert_eq!(proof.batch_ops().len(), 1);
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10\x50"), Some(b"\x30"), None)
-        .unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        Some(b"\x10\x50"),
+        Some(b"\x30"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -488,9 +524,10 @@ fn test_out_of_range_value_change_adopted() {
 /// caused `EndRootMismatch` during root hash verification. Now, the
 /// out-of-range callback clears the stale value so the hash matches
 /// `end_root`.
-#[test]
-fn test_change_proof_prefix_key_deleted_in_end_root() {
+#[firewood_macros::hash_mode]
+fn test_change_proof_prefix_key_deleted_in_end_root<H: HashMode>() {
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\xab", b"prefix_value"),
         (b"\xab\xcd", b"full_key"),
         (b"\xab\xef", b"sibling"),
@@ -532,6 +569,7 @@ fn test_change_proof_prefix_key_deleted_in_end_root() {
         root2.clone(),
         Some(b"\xab\x00".as_slice()),
         Some(b"\xff".as_slice()),
+        H::ALGORITHM,
         None,
     )
     .unwrap();
@@ -544,11 +582,13 @@ fn test_change_proof_prefix_key_deleted_in_end_root() {
 /// is an exclusion proof. Start and end proofs take different code paths
 /// (`compute_right_edge_key`, `verify_boundary_proof` with different
 /// `boundary_op`), so both sides need coverage.
-#[test]
-fn test_end_proof_exclusion_for_deleted_key() {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+#[firewood_macros::hash_mode]
+fn test_end_proof_exclusion_for_deleted_key<H: HashMode>() {
+    let (source, _dir_source) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_source = source.root_hash().unwrap();
-    let (target, _dir_target) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+    let (target, _dir_target) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_target = target.root_hash().unwrap();
 
     source
@@ -571,25 +611,22 @@ fn test_end_proof_exclusion_for_deleted_key() {
     assert!(
         proof
             .end_proof()
-            .value_digest(
-                b"\x30",
-                &root2,
-                firewood_storage::DefaultHashMode::ALGORITHM
-            )
+            .value_digest(b"\x30", &root2, H::ALGORITHM)
             .unwrap()
             .is_none(),
         "end proof should be an exclusion proof for deleted \\x30"
     );
-    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x30"), None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x30"), H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
 /// Single-point range: `start_key == end_key`. Both boundary proofs anchor
 /// at the same key. If that key was changed, `batch_ops` has exactly 1 entry.
-#[test]
-fn test_single_point_range() {
+#[firewood_macros::hash_mode]
+fn test_single_point_range<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+        setup_source_target![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x20", b"changed")]);
 
@@ -607,27 +644,26 @@ fn test_single_point_range() {
     assert!(
         proof
             .start_proof()
-            .value_digest(
-                b"\x20",
-                &root2,
-                firewood_storage::DefaultHashMode::ALGORITHM
-            )
+            .value_digest(b"\x20", &root2, H::ALGORITHM)
             .unwrap()
             .is_some()
     );
     assert!(
         proof
             .end_proof()
-            .value_digest(
-                b"\x20",
-                &root2,
-                firewood_storage::DefaultHashMode::ALGORITHM
-            )
+            .value_digest(b"\x20", &root2, H::ALGORITHM)
             .unwrap()
             .is_some()
     );
-    let ctx =
-        verify_change_proof_structure(&proof, root2, Some(b"\x20"), Some(b"\x20"), None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        Some(b"\x20"),
+        Some(b"\x20"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -640,9 +676,10 @@ fn test_single_point_range() {
 /// Bounded proof `[\x10, None]` excludes the deleted key.
 ///
 /// Found by `ChangeProofVerification.tla` `HonestProofAccepted` invariant.
-#[test]
-fn test_out_of_range_root_compression() {
+#[firewood_macros::hash_mode]
+fn test_out_of_range_root_compression<H: HashMode>() {
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\x01", b"alpha"),
         (b"\x10", b"betax"),
         (b"\x11", b"gamma")
@@ -685,18 +722,25 @@ fn test_out_of_range_root_compression() {
         "root should compress to [1] after deletion"
     );
 
-    let ctx =
-        verify_change_proof_structure(&proof, root2.clone(), Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        Some(b"\x10"),
+        None,
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&db, &proof, &ctx, root1).unwrap();
 }
 
 /// Reverse of root compression: out-of-range insert adds a key at a new
 /// first nibble, expanding root's `partial_path` from `[1]` to `[]`.
-#[test]
-fn test_out_of_range_root_expansion() {
-    let (source, _dir_source) = setup_db![(b"\x10", b"a"), (b"\x11", b"b")];
+#[firewood_macros::hash_mode]
+fn test_out_of_range_root_expansion<H: HashMode>() {
+    let (source, _dir_source) = setup_db![mode = H; (b"\x10", b"a"), (b"\x11", b"b")];
     let root1_source = source.root_hash().unwrap();
-    let (target, _dir_target) = setup_db![(b"\x10", b"a"), (b"\x11", b"b")];
+    let (target, _dir_target) = setup_db![mode = H; (b"\x10", b"a"), (b"\x11", b"b")];
     let root1_target = target.root_hash().unwrap();
 
     // Insert \x01 (nibble 0, out of range) and change \x10 (in range).
@@ -727,16 +771,17 @@ fn test_out_of_range_root_expansion() {
         "root should expand to [] after insertion"
     );
 
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
 /// The root node itself has a value (key `b""`) that changes between
 /// revisions. Tests that root-level value deltas are handled correctly.
-#[test]
-fn test_root_value_change() {
+#[firewood_macros::hash_mode]
+fn test_root_value_change<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"", b"root_old"), (b"\x10", b"v0")];
+        setup_source_target![mode = H; (b"", b"root_old"), (b"\x10", b"v0")];
 
     let (root1_source, root2) =
         setup_2nd_commit!(source, [(b"", b"root_new"), (b"\x10", b"changed")]);
@@ -746,7 +791,7 @@ fn test_root_value_change() {
         .unwrap();
     assert_eq!(proof.batch_ops().len(), 2);
 
-    let ctx = verify_change_proof_structure(&proof, root2, None, None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, None, None, H::ALGORITHM, None).unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -755,10 +800,15 @@ fn test_root_value_change() {
 /// proving trie may not have the value at these out-of-range positions,
 /// so `compute_root_hash_with_proofs` must fall back to the proof node's
 /// Hash digest.
-#[cfg(not(feature = "ethhash"))]
-#[test]
-fn test_change_proof_with_hashed_out_of_range_value() {
+///
+/// In ethhash mode this out-of-range key is a would-be account node at
+/// depth 32, whose live-hashing account semantics (RLP-encoded value,
+/// storageRoot splicing) don't apply to a raw 64-byte blob — the test is
+/// pinned to `MerkleDbHash`, which hashes the raw value directly.
+#[firewood_macros::hash_mode(merkledb)]
+fn test_change_proof_with_hashed_out_of_range_value<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10", [0u8; 64].as_slice()),
         (b"\x10\x50", b"child"),
         (b"\x30", b"other")
@@ -797,8 +847,14 @@ fn test_change_proof_with_hashed_out_of_range_value() {
     proof.write_to_vec(&mut serialized);
     let deserialized = crate::api::FrozenChangeProof::from_slice(&serialized).unwrap();
 
-    let ctx =
-        verify_change_proof_structure(&deserialized, root2, Some(b"\x10\x50"), Some(b"\x30"), None)
-            .unwrap();
+    let ctx = verify_change_proof_structure(
+        &deserialized,
+        root2,
+        Some(b"\x10\x50"),
+        Some(b"\x30"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &deserialized, &ctx, root1_target).unwrap();
 }

--- a/firewood/src/merkle/tests/change/edge_cases.rs
+++ b/firewood/src/merkle/tests/change/edge_cases.rs
@@ -8,12 +8,12 @@ use std::num::NonZeroUsize;
 use tempfile::TempDir;
 use test_case::test_case;
 
-use firewood_storage::{DefaultHashMode, HashMode};
+use firewood_storage::HashMode;
 
-#[test]
-fn test_empty_batch_ops_with_nonempty_proofs() {
+#[firewood_macros::hash_mode]
+fn test_empty_batch_ops_with_nonempty_proofs<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+        setup_source_target![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
 
     // Change only \x30 (outside range [\x10, \x20])
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x30", b"changed")]);
@@ -31,15 +31,22 @@ fn test_empty_batch_ops_with_nonempty_proofs() {
     assert!(!proof.start_proof().is_empty());
     assert!(!proof.end_proof().is_empty());
 
-    let ctx =
-        verify_change_proof_structure(&proof, root2, Some(b"\x10"), Some(b"\x20"), None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        Some(b"\x10"),
+        Some(b"\x20"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
-#[test]
-fn test_odd_depth_proof_node_accepted() {
+#[firewood_macros::hash_mode]
+fn test_odd_depth_proof_node_accepted<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x12", b"v0"), (b"\x13", b"v1"), (b"\x50", b"v2")];
+        setup_source_target![mode = H; (b"\x12", b"v0"), (b"\x13", b"v1"), (b"\x50", b"v2")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x50", b"changed")]);
 
@@ -54,18 +61,19 @@ fn test_odd_depth_proof_node_accepted() {
     assert!(
         proof
             .start_proof()
-            .value_digest(b"\x14", &root2, DefaultHashMode::ALGORITHM)
+            .value_digest(b"\x14", &root2, H::ALGORITHM)
             .unwrap()
             .is_none()
     );
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x14"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x14"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
-#[test]
-fn test_start_proof_inclusion_with_children_below() {
+#[firewood_macros::hash_mode]
+fn test_start_proof_inclusion_with_children_below<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\xab", b"v0"), (b"\xab\xcd", b"v1"), (b"\xf0", b"v2")];
+        setup_source_target![mode = H; (b"\xab", b"v0"), (b"\xab\xcd", b"v1"), (b"\xf0", b"v2")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\xf0", b"changed")]);
 
@@ -76,19 +84,20 @@ fn test_start_proof_inclusion_with_children_below() {
     assert!(
         proof
             .start_proof()
-            .value_digest(b"\xab", &root2, DefaultHashMode::ALGORITHM)
+            .value_digest(b"\xab", &root2, H::ALGORITHM)
             .unwrap()
             .is_some(),
         "start proof should be an inclusion proof for \\xab"
     );
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\xab"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\xab"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
-#[test]
-fn test_end_proof_inclusion_with_children_below() {
+#[firewood_macros::hash_mode]
+fn test_end_proof_inclusion_with_children_below<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\xab", b"v0"), (b"\xab\xcd", b"v1"), (b"\xf0", b"v2")];
+        setup_source_target![mode = H; (b"\xab", b"v0"), (b"\xab\xcd", b"v1"), (b"\xf0", b"v2")];
 
     let (root1_source, root2) = setup_2nd_commit!(
         source,
@@ -107,15 +116,26 @@ fn test_end_proof_inclusion_with_children_below() {
         .unwrap();
     assert_eq!(proof.batch_ops().len(), 1);
     assert!(proof.start_proof().is_empty());
-    let ctx =
-        verify_change_proof_structure(&proof, root2, None, None, NonZeroUsize::new(1)).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        None,
+        None,
+        H::ALGORITHM,
+        NonZeroUsize::new(1),
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
-#[test]
-fn test_divergence_parent_start_key_exhausted() {
-    let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x12\x01", b"v0"), (b"\x12\x02", b"v1"), (b"\xf0", b"v2")];
+#[firewood_macros::hash_mode]
+fn test_divergence_parent_start_key_exhausted<H: HashMode>() {
+    let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
+        (b"\x12\x01", b"v0"),
+        (b"\x12\x02", b"v1"),
+        (b"\xf0", b"v2")
+    ];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\xf0", b"changed")]);
 
@@ -133,13 +153,20 @@ fn test_divergence_parent_start_key_exhausted() {
     assert!(
         proof
             .start_proof()
-            .value_digest(b"\x12", &root2, DefaultHashMode::ALGORITHM)
+            .value_digest(b"\x12", &root2, H::ALGORITHM)
             .unwrap()
             .is_none(),
         "start proof should be an exclusion proof for \\x12"
     );
-    let ctx =
-        verify_change_proof_structure(&proof, root2, Some(b"\x12"), Some(b"\xf0"), None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        Some(b"\x12"),
+        Some(b"\xf0"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -161,10 +188,10 @@ fn test_divergence_parent_start_key_exhausted() {
 // The change proof query uses start=\x10 (the branch node), end=None.
 // Only \x30 changes ("c" -> "changed"), but the verifier must still
 // validate that \x10's children are intact.
-#[test]
-fn test_start_tail_last_node_children_checked() {
+#[firewood_macros::hash_mode]
+fn test_start_tail_last_node_children_checked<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10\x01", b"a"), (b"\x10\x02", b"b"), (b"\x30", b"c")];
+        setup_source_target![mode = H; (b"\x10\x01", b"a"), (b"\x10\x02", b"b"), (b"\x30", b"c")];
 
     // Only modify \x30 on the source; \x10's children are untouched
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x30", b"changed")]);
@@ -177,20 +204,23 @@ fn test_start_tail_last_node_children_checked() {
     assert!(
         proof
             .start_proof()
-            .value_digest(b"\x10", &root2, DefaultHashMode::ALGORITHM)
+            .value_digest(b"\x10", &root2, H::ALGORITHM)
             .unwrap()
             .is_none(),
         "start proof should be an exclusion proof for \\x10"
     );
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
-#[test]
-fn test_start_proof_exclusion_for_deleted_key() {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+#[firewood_macros::hash_mode]
+fn test_start_proof_exclusion_for_deleted_key<H: HashMode>() {
+    let (source, _dir_source) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_source = source.root_hash().unwrap();
-    let (target, _dir_target) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+    let (target, _dir_target) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_target = target.root_hash().unwrap();
 
     source
@@ -213,12 +243,13 @@ fn test_start_proof_exclusion_for_deleted_key() {
     assert!(
         proof
             .start_proof()
-            .value_digest(b"\x10", &root2, DefaultHashMode::ALGORITHM)
+            .value_digest(b"\x10", &root2, H::ALGORITHM)
             .unwrap()
             .is_none(),
         "start proof should be an exclusion proof for deleted \\x10"
     );
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -232,10 +263,10 @@ fn test_start_proof_exclusion_for_deleted_key() {
 /// between the proposal (R1 + empty ops) and the end trie (R2), but
 /// because `\x00\x10` < `\x00\x10\x20` the value check should be
 /// skipped.
-#[test]
-fn test_disjoint_proof() {
+#[firewood_macros::hash_mode]
+fn test_disjoint_proof<H: HashMode>() {
     // R1: trie with a single key \x00
-    let (db, _dir) = setup_db![(b"\x00", b"v0")];
+    let (db, _dir) = setup_db![mode = H; (b"\x00", b"v0")];
 
     // R2: add \x00\x10 (outside query range [\x00\x10\x20, \x00\x10\x30])
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x00\x10", b"v1")]);
@@ -259,6 +290,7 @@ fn test_disjoint_proof() {
         root2,
         Some(first.as_slice()),
         Some(last.as_slice()),
+        H::ALGORITHM,
         None,
     )
     .unwrap();
@@ -270,16 +302,18 @@ fn test_disjoint_proof() {
 /// exercises the fixed path — a Delete near `start_key` under a shared
 /// branch produces a valid proof. Before the fix, the proof generator
 /// omitted the divergent child, leaving a verification gap.
-#[test]
-fn test_boundary_child_gap_closed_for_start_key() {
+#[firewood_macros::hash_mode]
+fn test_boundary_child_gap_closed_for_start_key<H: HashMode>() {
     // \x10\x50 and \x10\x58 share a branch at nibble path [1,0].
     let (source, _dir_source) = setup_db![
+        mode = H;
         (b"\x10\x50", b"a"),
         (b"\x10\x58", b"b"),
         (b"\x30\x00", b"c")
     ];
     let root1_source = source.root_hash().unwrap();
     let (target, _dir_target) = setup_db![
+        mode = H;
         (b"\x10\x50", b"a"),
         (b"\x10\x58", b"b"),
         (b"\x30\x00", b"c")
@@ -313,9 +347,15 @@ fn test_boundary_child_gap_closed_for_start_key() {
         .unwrap();
     assert_eq!(honest.batch_ops().len(), 2); // Delete(\x10\x50) + Put(\x30\x00)
 
-    let ctx =
-        verify_change_proof_structure(&honest, root2, Some(b"\x10\x50"), Some(b"\x30\x00"), None)
-            .unwrap();
+    let ctx = verify_change_proof_structure(
+        &honest,
+        root2,
+        Some(b"\x10\x50"),
+        Some(b"\x30\x00"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &honest, &ctx, root1_target).unwrap();
 }
 
@@ -325,10 +365,10 @@ fn test_boundary_child_gap_closed_for_start_key() {
 /// Keys `\x10\x50` and `\x10\x58` share a branch with partial path containing
 /// nibble 5. `start_key` `\x10\x40` diverges at nibble 4 < 5, so the start
 /// boundary is "before" the terminal — no children are marked outside.
-#[test]
-fn test_terminal_divergence_within_partial_path() {
+#[firewood_macros::hash_mode]
+fn test_terminal_divergence_within_partial_path<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10\x50", b"a"), (b"\x10\x58", b"b"), (b"\x30", b"c")];
+        setup_source_target![mode = H; (b"\x10\x50", b"a"), (b"\x10\x58", b"b"), (b"\x30", b"c")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x30", b"changed")]);
 
@@ -336,7 +376,9 @@ fn test_terminal_divergence_within_partial_path() {
         .change_proof(root1_source, root2.clone(), Some(b"\x10\x40"), None, None)
         .unwrap();
     assert_eq!(proof.batch_ops().len(), 1);
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10\x40"), None, None).unwrap();
+    let ctx =
+        verify_change_proof_structure(&proof, root2, Some(b"\x10\x40"), None, H::ALGORITHM, None)
+            .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -348,9 +390,10 @@ fn test_terminal_divergence_within_partial_path() {
 /// with children at nibbles 1, 2, and 3. `start_key` `\x10\x05` has
 /// on-path nibble 5 at the terminal, so nibbles 1, 2, and 3 are all
 /// below 5 and marked outside.
-#[test]
-fn test_terminal_ancestor_all_children_outside() {
+#[firewood_macros::hash_mode]
+fn test_terminal_ancestor_all_children_outside<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10\x01", b"a"),
         (b"\x10\x02", b"b"),
         (b"\x10\x03", b"c"),
@@ -369,7 +412,9 @@ fn test_terminal_ancestor_all_children_outside() {
     let terminal = proof.start_proof().as_ref().last().unwrap();
     assert_eq!(terminal.key.len(), 3);
 
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10\x05"), None, None).unwrap();
+    let ctx =
+        verify_change_proof_structure(&proof, root2, Some(b"\x10\x05"), None, H::ALGORITHM, None)
+            .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -380,9 +425,10 @@ fn test_terminal_ancestor_all_children_outside() {
 /// key is exhausted before the node's partial path is fully consumed.
 /// All children of this terminal are in-range (>= `\x10`), so none are
 /// marked outside by `compute_outside_children`.
-#[test]
-fn test_terminal_divergent_node_all_children_in_range() {
+#[firewood_macros::hash_mode]
+fn test_terminal_divergent_node_all_children_in_range<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10\x01", b"a"),
         (b"\x10\x02", b"b"),
         (b"\x10\x03", b"c"),
@@ -403,7 +449,8 @@ fn test_terminal_divergent_node_all_children_in_range() {
     let terminal = proof.start_proof().as_ref().last().unwrap();
     assert_eq!(terminal.key.len(), 3);
 
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -413,10 +460,10 @@ fn test_terminal_divergent_node_all_children_in_range() {
 ///
 /// Key `\x20` is a prefix of `\x20\xab`. `end_key` = `\x20` — children of
 /// the `\x20` node extend beyond `end_key` and must use proof hashes.
-#[test]
-fn test_right_edge_boundary_prefix_of_terminal() {
+#[firewood_macros::hash_mode]
+fn test_right_edge_boundary_prefix_of_terminal<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10", b"a"), (b"\x20", b"b"), (b"\x20\xab", b"c")];
+        setup_source_target![mode = H; (b"\x10", b"a"), (b"\x20", b"b"), (b"\x20\xab", b"c")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x10", b"changed")]);
 
@@ -424,7 +471,8 @@ fn test_right_edge_boundary_prefix_of_terminal() {
         .change_proof(root1_source, root2.clone(), None, Some(b"\x20"), None)
         .unwrap();
     assert_eq!(proof.batch_ops().len(), 1);
-    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x20"), None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x20"), H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -436,9 +484,10 @@ fn test_right_edge_boundary_prefix_of_terminal() {
 /// range `[\x10\x50, \x30]` excludes `\x10` (it's a proper prefix of `start_key`),
 /// so `\x10` is out-of-range. The start proof path passes through `\x10`, and
 /// reconciliation must adopt the proof's value (`"new_pfx"`) to match `end_root`.
-#[test]
-fn test_out_of_range_value_change_adopted() {
+#[firewood_macros::hash_mode]
+fn test_out_of_range_value_change_adopted<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10", b"old_pfx"),
         (b"\x10\x50", b"val0000"),
         (b"\x30", b"val1000")
@@ -458,8 +507,15 @@ fn test_out_of_range_value_change_adopted() {
         .unwrap();
     // Only \x30 is in range [\x10\x50, \x30]; \x10's change is out of range.
     assert_eq!(proof.batch_ops().len(), 1);
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10\x50"), Some(b"\x30"), None)
-        .unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        Some(b"\x10\x50"),
+        Some(b"\x30"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -473,9 +529,10 @@ fn test_out_of_range_value_change_adopted() {
 /// caused `EndRootMismatch` during root hash verification. Now, the
 /// out-of-range callback clears the stale value so the hash matches
 /// `end_root`.
-#[test]
-fn test_change_proof_prefix_key_deleted_in_end_root() {
+#[firewood_macros::hash_mode]
+fn test_change_proof_prefix_key_deleted_in_end_root<H: HashMode>() {
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\xab", b"prefix_value"),
         (b"\xab\xcd", b"full_key"),
         (b"\xab\xef", b"sibling"),
@@ -517,6 +574,7 @@ fn test_change_proof_prefix_key_deleted_in_end_root() {
         root2.clone(),
         Some(b"\xab\x00".as_slice()),
         Some(b"\xff".as_slice()),
+        H::ALGORITHM,
         None,
     )
     .unwrap();
@@ -529,11 +587,13 @@ fn test_change_proof_prefix_key_deleted_in_end_root() {
 /// is an exclusion proof. Start and end proofs take different code paths
 /// (`compute_right_edge_key`, `verify_boundary_proof` with different
 /// `boundary_op`), so both sides need coverage.
-#[test]
-fn test_end_proof_exclusion_for_deleted_key() {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+#[firewood_macros::hash_mode]
+fn test_end_proof_exclusion_for_deleted_key<H: HashMode>() {
+    let (source, _dir_source) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_source = source.root_hash().unwrap();
-    let (target, _dir_target) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+    let (target, _dir_target) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_target = target.root_hash().unwrap();
 
     source
@@ -556,21 +616,22 @@ fn test_end_proof_exclusion_for_deleted_key() {
     assert!(
         proof
             .end_proof()
-            .value_digest(b"\x30", &root2, DefaultHashMode::ALGORITHM)
+            .value_digest(b"\x30", &root2, H::ALGORITHM)
             .unwrap()
             .is_none(),
         "end proof should be an exclusion proof for deleted \\x30"
     );
-    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x30"), None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x30"), H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
 /// Single-point range: `start_key == end_key`. Both boundary proofs anchor
 /// at the same key. If that key was changed, `batch_ops` has exactly 1 entry.
-#[test]
-fn test_single_point_range() {
+#[firewood_macros::hash_mode]
+fn test_single_point_range<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+        setup_source_target![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
 
     let (root1_source, root2) = setup_2nd_commit!(source, [(b"\x20", b"changed")]);
 
@@ -588,19 +649,26 @@ fn test_single_point_range() {
     assert!(
         proof
             .start_proof()
-            .value_digest(b"\x20", &root2, DefaultHashMode::ALGORITHM)
+            .value_digest(b"\x20", &root2, H::ALGORITHM)
             .unwrap()
             .is_some()
     );
     assert!(
         proof
             .end_proof()
-            .value_digest(b"\x20", &root2, DefaultHashMode::ALGORITHM)
+            .value_digest(b"\x20", &root2, H::ALGORITHM)
             .unwrap()
             .is_some()
     );
-    let ctx =
-        verify_change_proof_structure(&proof, root2, Some(b"\x20"), Some(b"\x20"), None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        Some(b"\x20"),
+        Some(b"\x20"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -613,9 +681,10 @@ fn test_single_point_range() {
 /// Bounded proof `[\x10, None]` excludes the deleted key.
 ///
 /// Found by `ChangeProofVerification.tla` `HonestProofAccepted` invariant.
-#[test]
-fn test_out_of_range_root_compression() {
+#[firewood_macros::hash_mode]
+fn test_out_of_range_root_compression<H: HashMode>() {
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\x01", b"alpha"),
         (b"\x10", b"betax"),
         (b"\x11", b"gamma")
@@ -658,18 +727,25 @@ fn test_out_of_range_root_compression() {
         "root should compress to [1] after deletion"
     );
 
-    let ctx =
-        verify_change_proof_structure(&proof, root2.clone(), Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        Some(b"\x10"),
+        None,
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&db, &proof, &ctx, root1).unwrap();
 }
 
 /// Reverse of root compression: out-of-range insert adds a key at a new
 /// first nibble, expanding root's `partial_path` from `[1]` to `[]`.
-#[test]
-fn test_out_of_range_root_expansion() {
-    let (source, _dir_source) = setup_db![(b"\x10", b"a"), (b"\x11", b"b")];
+#[firewood_macros::hash_mode]
+fn test_out_of_range_root_expansion<H: HashMode>() {
+    let (source, _dir_source) = setup_db![mode = H; (b"\x10", b"a"), (b"\x11", b"b")];
     let root1_source = source.root_hash().unwrap();
-    let (target, _dir_target) = setup_db![(b"\x10", b"a"), (b"\x11", b"b")];
+    let (target, _dir_target) = setup_db![mode = H; (b"\x10", b"a"), (b"\x11", b"b")];
     let root1_target = target.root_hash().unwrap();
 
     // Insert \x01 (nibble 0, out of range) and change \x10 (in range).
@@ -700,16 +776,17 @@ fn test_out_of_range_root_expansion() {
         "root should expand to [] after insertion"
     );
 
-    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, Some(b"\x10"), None, H::ALGORITHM, None)
+        .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
 /// The root node itself has a value (key `b""`) that changes between
 /// revisions. Tests that root-level value deltas are handled correctly.
-#[test]
-fn test_root_value_change() {
+#[firewood_macros::hash_mode]
+fn test_root_value_change<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) =
-        setup_source_target![(b"", b"root_old"), (b"\x10", b"v0")];
+        setup_source_target![mode = H; (b"", b"root_old"), (b"\x10", b"v0")];
 
     let (root1_source, root2) =
         setup_2nd_commit!(source, [(b"", b"root_new"), (b"\x10", b"changed")]);
@@ -719,7 +796,7 @@ fn test_root_value_change() {
         .unwrap();
     assert_eq!(proof.batch_ops().len(), 2);
 
-    let ctx = verify_change_proof_structure(&proof, root2, None, None, None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, None, None, H::ALGORITHM, None).unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
@@ -728,10 +805,19 @@ fn test_root_value_change() {
 /// proving trie may not have the value at these out-of-range positions,
 /// so `compute_root_hash_with_proofs` must fall back to the proof node's
 /// Hash digest.
-#[cfg(not(feature = "ethhash"))]
+///
+/// In ethhash mode this out-of-range key is a would-be account node at
+/// depth 32, whose live-hashing account semantics (RLP-encoded value,
+/// storageRoot splicing) don't apply to a raw 64-byte blob — the test is
+/// pinned to `MerkleDbHash`, which hashes the raw value directly.
 #[test]
-fn test_change_proof_with_hashed_out_of_range_value() {
+fn test_change_proof_with_hashed_out_of_range_value_merkledb() {
+    test_change_proof_with_hashed_out_of_range_value::<MerkleDbHash>();
+}
+
+fn test_change_proof_with_hashed_out_of_range_value<H: HashMode>() {
     let (source, target, root1_target, _ds, _dt) = setup_source_target![
+        mode = H;
         (b"\x10", [0u8; 64].as_slice()),
         (b"\x10\x50", b"child"),
         (b"\x30", b"other")
@@ -772,9 +858,15 @@ fn test_change_proof_with_hashed_out_of_range_value() {
         .expect("serialize proof");
     let deserialized = crate::api::FrozenChangeProof::from_slice(&serialized).unwrap();
 
-    let ctx =
-        verify_change_proof_structure(&deserialized, root2, Some(b"\x10\x50"), Some(b"\x30"), None)
-            .unwrap();
+    let ctx = verify_change_proof_structure(
+        &deserialized,
+        root2,
+        Some(b"\x10\x50"),
+        Some(b"\x30"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap();
     verify_and_check(&target, &deserialized, &ctx, root1_target).unwrap();
 }
 
@@ -790,18 +882,19 @@ fn test_change_proof_with_hashed_out_of_range_value() {
 /// out. Either way verification asserts the range the reply provably covers,
 /// which is what makes a trailing `Delete` the only shape where a stop-short can
 /// go unrecognised.
+#[firewood_macros::hash_mode]
 #[test_case(true, NonZeroUsize::new(1), b"\x10" ; "put, one op")]
 #[test_case(true, NonZeroUsize::new(2), b"\x20" ; "put, two ops")]
 #[test_case(true, NonZeroUsize::new(3), b"\x30" ; "put, three ops")]
 #[test_case(false, NonZeroUsize::new(1), b"\x10" ; "delete, one op")]
 #[test_case(false, NonZeroUsize::new(2), b"\x20" ; "delete, two ops")]
 #[test_case(false, NonZeroUsize::new(3), b"\x30" ; "delete, three ops")]
-fn test_truncation_narrows_to_the_last_op(
+fn test_truncation_narrows_to_the_last_op<H: HashMode>(
     trailing_put: bool,
     limit: Option<NonZeroUsize>,
     expected_edge: &[u8],
 ) {
-    let (db, _dir) = setup_db![
+    let (db, _dir) = setup_db![mode = H;
         (b"\x10", b"v0"),
         (b"\x20", b"v1"),
         (b"\x30", b"v2"),
@@ -831,7 +924,9 @@ fn test_truncation_narrows_to_the_last_op(
     let proof = db
         .change_proof(root1, root2.clone(), None, Some(b"\x50"), limit)
         .unwrap();
-    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x50"), limit).unwrap();
+    let ctx =
+        verify_change_proof_structure(&proof, root2, None, Some(b"\x50"), H::ALGORITHM, limit)
+            .unwrap();
 
     let last_is_put = matches!(proof.batch_ops().last(), Some(BatchOp::Put { .. }));
     assert_eq!(
@@ -853,13 +948,14 @@ fn test_truncation_narrows_to_the_last_op(
 /// since its node carries a value. The `Delete` narrows because the surviving
 /// branch on that path holds no value, so its absence is validly stated and
 /// stopping short cannot be ruled out.
+#[firewood_macros::hash_mode]
 #[test_case(true, Some(&b"\x10"[..]) ; "put is recognised")]
 #[test_case(false, Some(&b"\x10"[..]) ; "delete narrows to its own key")]
-fn test_truncation_classification_under_a_prefix_key(
+fn test_truncation_classification_under_a_prefix_key<H: HashMode>(
     trailing_put: bool,
     expected_edge: Option<&[u8]>,
 ) {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\x10\x00", b"v1"), (b"\x20", b"v2")];
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\x10\x00", b"v1"), (b"\x20", b"v2")];
     let root1 = db.root_hash().unwrap();
 
     // Two changes so a limit of one truncates, with \x10 first either way.
@@ -887,7 +983,9 @@ fn test_truncation_classification_under_a_prefix_key(
     let proof = db
         .change_proof(root1, root2.clone(), None, Some(b"\x20"), limit)
         .unwrap();
-    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x20"), limit).unwrap();
+    let ctx =
+        verify_change_proof_structure(&proof, root2, None, Some(b"\x20"), H::ALGORITHM, limit)
+            .unwrap();
 
     assert_eq!(ctx.right_edge_key(), expected_edge);
 }
@@ -903,10 +1001,10 @@ fn test_truncation_classification_under_a_prefix_key(
 /// Compare [`test_a_terminal_at_the_last_operation_narrows_the_range`], where the
 /// last operation's node is the proof's terminal, the lookup answers, and the
 /// range narrows.
-#[test]
-fn test_prefix_bound_does_not_narrow_a_complete_proof() {
-    let (source, _ds) = setup_db![(b"\x10", b"v0"), (b"\x10\x20", b"v1")];
-    let (target, _dt) = setup_db![(b"\x10", b"v0"), (b"\x10\x20", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_prefix_bound_does_not_narrow_a_complete_proof<H: HashMode>() {
+    let (source, _ds) = setup_db![mode = H; (b"\x10", b"v0"), (b"\x10\x20", b"v1")];
+    let (target, _dt) = setup_db![mode = H; (b"\x10", b"v0"), (b"\x10\x20", b"v1")];
     let root1_target = target.root_hash().unwrap();
 
     // One change, no limit: nothing is left out.
@@ -932,12 +1030,14 @@ fn test_prefix_bound_does_not_narrow_a_complete_proof() {
     assert!(
         proof
             .end_proof()
-            .value_digest(b"\x10", &root2, DefaultHashMode::ALGORITHM)
+            .value_digest(b"\x10", &root2, H::ALGORITHM)
             .is_err(),
         "a proof anchored at the bound must refuse to answer about a shorter key"
     );
 
-    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x10\x20"), None).unwrap();
+    let ctx =
+        verify_change_proof_structure(&proof, root2, None, Some(b"\x10\x20"), H::ALGORITHM, None)
+            .unwrap();
     assert_eq!(
         ctx.right_edge_key(),
         ctx.end_key(),
@@ -957,10 +1057,10 @@ fn test_prefix_bound_does_not_narrow_a_complete_proof() {
 /// of the requested range empty on its next request. Compare
 /// [`test_prefix_bound_does_not_narrow_a_complete_proof`], where the last
 /// operation's node is interior and the lookup refuses.
-#[test]
-fn test_a_terminal_at_the_last_operation_narrows_the_range() {
-    let (source, _ds) = setup_db![(b"\x10", b"v0")];
-    let (target, _dt) = setup_db![(b"\x10", b"v0")];
+#[firewood_macros::hash_mode]
+fn test_a_terminal_at_the_last_operation_narrows_the_range<H: HashMode>() {
+    let (source, _ds) = setup_db![mode = H; (b"\x10", b"v0")];
+    let (target, _dt) = setup_db![mode = H; (b"\x10", b"v0")];
     let root1_target = target.root_hash().unwrap();
 
     // One change, no cap, bound well above the only key: nothing stops short.
@@ -974,13 +1074,14 @@ fn test_a_terminal_at_the_last_operation_narrows_the_range() {
     assert!(
         proof
             .end_proof()
-            .value_digest(b"\x10", &root2, DefaultHashMode::ALGORITHM)
+            .value_digest(b"\x10", &root2, H::ALGORITHM)
             .unwrap()
             .is_some(),
         "the terminal is the last op's own node and carries its value"
     );
 
-    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\xff"), None).unwrap();
+    let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\xff"), H::ALGORITHM, None)
+        .unwrap();
     assert_eq!(
         ctx.right_edge_key(),
         Some(&b"\x10"[..]),
@@ -999,9 +1100,9 @@ type FrozenBatchOp = BatchOp<Box<[u8]>, Box<[u8]>>;
 
 /// A proof that stops short on a `Delete`, with the databases and roots it was
 /// built from.
-struct StoppedShort {
-    source: Db<DefaultHashMode>,
-    target: Db<DefaultHashMode>,
+struct StoppedShort<H: HashMode> {
+    source: Db<H>,
+    target: Db<H>,
     start_root: api::HashKey,
     end_root: api::HashKey,
     proof: FrozenChangeProof,
@@ -1011,14 +1112,14 @@ struct StoppedShort {
 /// Build the fixture where a proof stops short on a `Delete`: four keys, three
 /// changes, and a limit of two so the reply ends on the removal of `\x20` while
 /// the requested bound is still `\xff`.
-fn stopped_short_on_a_delete() -> StoppedShort {
-    let (source, ds) = setup_db![
+fn stopped_short_on_a_delete<H: HashMode>() -> StoppedShort<H> {
+    let (source, ds) = setup_db![mode = H;
         (b"\x10", b"v0"),
         (b"\x20", b"v1"),
         (b"\x30", b"v2"),
         (b"\x40", b"v3")
     ];
-    let (target, dt) = setup_db![
+    let (target, dt) = setup_db![mode = H;
         (b"\x10", b"v0"),
         (b"\x20", b"v1"),
         (b"\x30", b"v2"),
@@ -1067,9 +1168,9 @@ fn stopped_short_on_a_delete() -> StoppedShort {
 /// requested bound. Here the walk toward the bound needs the surviving key's
 /// node, which the proof does not carry — so the two shapes reach the narrowing
 /// decision from different directions.
-fn stopped_short_below_a_surviving_key() -> StoppedShort {
-    let (source, ds) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\xf0", b"v2")];
-    let (target, dt) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\xf0", b"v2")];
+fn stopped_short_below_a_surviving_key<H: HashMode>() -> StoppedShort<H> {
+    let (source, ds) = setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\xf0", b"v2")];
+    let (target, dt) = setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\xf0", b"v2")];
     let root1 = source.root_hash().unwrap();
     let ops: Vec<BatchOp<&[u8], &[u8]>> = vec![
         BatchOp::Put {
@@ -1114,15 +1215,16 @@ fn stopped_short_below_a_surviving_key() -> StoppedShort {
 /// Verification narrows the proven range to the trailing removal's key and checks
 /// the reply on that basis. Judging it against the requested bound would demand
 /// operations the reply never claimed to carry, and reject an honest reply.
-#[test]
-fn test_stopping_short_on_a_delete_is_accepted_over_the_narrowed_range() {
-    let f = stopped_short_on_a_delete();
+#[firewood_macros::hash_mode]
+fn test_stopping_short_on_a_delete_is_accepted_over_the_narrowed_range<H: HashMode>() {
+    let f = stopped_short_on_a_delete::<H>();
 
     let ctx = verify_change_proof_structure(
         &f.proof,
         f.end_root.clone(),
         None,
         Some(b"\xff"),
+        H::ALGORITHM,
         NonZeroUsize::new(2),
     )
     .unwrap();
@@ -1144,15 +1246,16 @@ fn test_stopping_short_on_a_delete_is_accepted_over_the_narrowed_range() {
 /// surviving key's node, which the proof does not carry, so this shape reaches
 /// the narrowing decision through structural validation rather than the root
 /// hash. Narrowing happens in the same place, so the reply is accepted here too.
-#[test]
-fn test_stopping_short_below_a_surviving_key_is_accepted() {
-    let f = stopped_short_below_a_surviving_key();
+#[firewood_macros::hash_mode]
+fn test_stopping_short_below_a_surviving_key_is_accepted<H: HashMode>() {
+    let f = stopped_short_below_a_surviving_key::<H>();
 
     let ctx = verify_change_proof_structure(
         &f.proof,
         f.end_root.clone(),
         None,
         Some(b"\xff"),
+        H::ALGORITHM,
         NonZeroUsize::new(2),
     )
     .unwrap();
@@ -1168,10 +1271,10 @@ fn test_stopping_short_below_a_surviving_key_is_accepted() {
 /// operation is a `Put` still rejects: stopping short on a `Put` is recognised
 /// outright, so a `Put` the end proof reports absent is inconsistent rather than
 /// truncated, and the requested range stands for the root hash to judge.
-#[test]
-fn test_mismatch_ending_in_a_put_is_still_rejected() {
-    let (source, _ds) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
-    let (target, _dt) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+#[firewood_macros::hash_mode]
+fn test_mismatch_ending_in_a_put_is_still_rejected<H: HashMode>() {
+    let (source, _ds) = setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+    let (target, _dt) = setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_target = target.root_hash().unwrap();
     let (root1, root2) = setup_2nd_commit!(source, [(b"\x10", b"c0"), (b"\x20", b"c1")]);
 
@@ -1189,13 +1292,16 @@ fn test_mismatch_ending_in_a_put_is_still_rejected() {
         panic!("the last operation must be a Put");
     };
     *value = Box::from(&b"forged"[..]);
-    let tampered = crate::ChangeProof::new(
+    let tampered = crate::ChangeProof::with_hash_mode(
         crate::Proof::new(honest.start_proof().to_vec().into_boxed_slice()),
         crate::Proof::new(honest.end_proof().to_vec().into_boxed_slice()),
         ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
-    let ctx = verify_change_proof_structure(&tampered, root2, None, Some(b"\xff"), None).unwrap();
+    let ctx =
+        verify_change_proof_structure(&tampered, root2, None, Some(b"\xff"), H::ALGORITHM, None)
+            .unwrap();
     let err = verify_and_check(&target, &tampered, &ctx, root1_target).unwrap_err();
     assert!(
         matches!(
@@ -1210,9 +1316,9 @@ fn test_mismatch_ending_in_a_put_is_still_rejected() {
 /// removal's key is absent. Splicing in an end proof about an unrelated key
 /// leaves a proof that cannot be anchored at the last operation, so the range
 /// stays wide and the failure stands.
-#[test]
-fn test_an_unrelated_end_proof_does_not_narrow() {
-    let f = stopped_short_below_a_surviving_key();
+#[firewood_macros::hash_mode]
+fn test_an_unrelated_end_proof_does_not_narrow<H: HashMode>() {
+    let f = stopped_short_below_a_surviving_key::<H>();
 
     // An end proof anchored at \x10: a complete proof over [None, \x10].
     let donor = f
@@ -1225,10 +1331,11 @@ fn test_an_unrelated_end_proof_does_not_narrow() {
             None,
         )
         .unwrap();
-    let spliced = crate::ChangeProof::new(
+    let spliced = crate::ChangeProof::with_hash_mode(
         crate::Proof::new(f.proof.start_proof().to_vec().into_boxed_slice()),
         crate::Proof::new(donor.end_proof().to_vec().into_boxed_slice()),
         f.proof.batch_ops().to_vec().into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     match verify_change_proof_structure(
@@ -1236,6 +1343,7 @@ fn test_an_unrelated_end_proof_does_not_narrow() {
         f.end_root.clone(),
         None,
         Some(b"\xff"),
+        H::ALGORITHM,
         NonZeroUsize::new(2),
     ) {
         // Structural validation rejects this shape outright, before a right edge
@@ -1273,7 +1381,7 @@ fn test_an_unrelated_end_proof_does_not_narrow() {
 /// rather than `start_root`, and it must still hash to `end_root`.
 #[test]
 fn test_same_change_proof_applied_twice_succeeds() {
-    let (source, target, root1, _ds, _dt) = setup_source_target![
+    let (source, target, root1, _ds, _dt) = setup_source_target![mode = MerkleDbHash;
         (b"\x10", b"v0"),
         (b"\x20", b"v1"),
         (b"\x30", b"v2"),

--- a/firewood/src/merkle/tests/change/empty.rs
+++ b/firewood/src/merkle/tests/change/empty.rs
@@ -6,21 +6,28 @@
 //! When the start revision is empty, every key in the end revision is a new
 //! insertion. These tests exercise the interaction between empty start tries
 //! and the divergent child / value skip logic.
+//!
+//! Pinned to `EthHash`: an empty trie has no root hash under `MerkleDbHash`
+//! (there is nothing to hash), so a change proof from an empty database
+//! can't be generated in that mode. Only `ethhash` gives an empty trie a
+//! well-defined root hash.
 
 use super::*;
 
 /// Empty start trie, single key inserted. Complete proof (no bounds).
 #[test]
 fn test_empty_start_trie_single_key_no_bounds() {
-    let (db, _dir) = setup_db![];
+    let (db, _dir) = setup_db![mode = EthHash];
     let (empty_root, root2) = setup_2nd_commit!(db, [(b"\x50", b"hello")]);
 
     let proof = db
         .change_proof(empty_root, root2.clone(), None, None, None)
         .unwrap();
-    let ctx = verify_change_proof_structure(&proof, root2.clone(), None, None, None).unwrap();
+    let ctx =
+        verify_change_proof_structure(&proof, root2.clone(), None, None, EthHash::ALGORITHM, None)
+            .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
 
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
@@ -30,7 +37,7 @@ fn test_empty_start_trie_single_key_no_bounds() {
 /// start proof (`start_key` exists in end trie).
 #[test]
 fn test_empty_start_trie_bounded_inclusion() {
-    let (db, _dir) = setup_db![];
+    let (db, _dir) = setup_db![mode = EthHash];
     let (empty_root, root2) = setup_2nd_commit!(
         db,
         [
@@ -50,11 +57,17 @@ fn test_empty_start_trie_bounded_inclusion() {
             None,
         )
         .unwrap();
-    let ctx =
-        verify_change_proof_structure(&proof, root2.clone(), Some(b"\x10"), Some(b"\x30"), None)
-            .unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        Some(b"\x10"),
+        Some(b"\x30"),
+        EthHash::ALGORITHM,
+        None,
+    )
+    .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
 
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
@@ -64,7 +77,7 @@ fn test_empty_start_trie_bounded_inclusion() {
 /// (`start_key` does NOT exist in end trie).
 #[test]
 fn test_empty_start_trie_bounded_exclusion() {
-    let (db, _dir) = setup_db![];
+    let (db, _dir) = setup_db![mode = EthHash];
     let (empty_root, root2) =
         setup_2nd_commit!(db, [(b"\x10", b"a"), (b"\x20", b"b"), (b"\x30", b"c")]);
 
@@ -77,11 +90,17 @@ fn test_empty_start_trie_bounded_exclusion() {
             None,
         )
         .unwrap();
-    let ctx =
-        verify_change_proof_structure(&proof, root2.clone(), Some(b"\x05"), Some(b"\x30"), None)
-            .unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2.clone(),
+        Some(b"\x05"),
+        Some(b"\x30"),
+        EthHash::ALGORITHM,
+        None,
+    )
+    .unwrap();
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
 
     verify_and_check(&target, &proof, &ctx, empty_root_target).unwrap();
@@ -93,7 +112,7 @@ fn test_empty_start_trie_bounded_exclusion() {
 /// which places a value on the root node itself.
 #[test]
 fn test_empty_start_trie_prefix_keys() {
-    let (db, _dir) = setup_db![];
+    let (db, _dir) = setup_db![mode = EthHash];
     let (empty_root, root2) = setup_2nd_commit!(
         db,
         [
@@ -105,7 +124,7 @@ fn test_empty_start_trie_prefix_keys() {
         ]
     );
 
-    let (target, _dir_target) = setup_db![];
+    let (target, _dir_target) = setup_db![mode = EthHash];
     let empty_root_target = target.root_hash().unwrap();
 
     // Range [\x10\x50, \x20]: start_key \x10\x50 exists (inclusion).
@@ -125,6 +144,7 @@ fn test_empty_start_trie_prefix_keys() {
         root2.clone(),
         Some(b"\x10\x50"),
         Some(b"\x20"),
+        EthHash::ALGORITHM,
         None,
     )
     .unwrap();
@@ -146,6 +166,7 @@ fn test_empty_start_trie_prefix_keys() {
         root2.clone(),
         Some(b"\x10\x50\x00"),
         Some(b"\x20"),
+        EthHash::ALGORITHM,
         None,
     )
     .unwrap();

--- a/firewood/src/merkle/tests/change/mod.rs
+++ b/firewood/src/merkle/tests/change/mod.rs
@@ -3,63 +3,40 @@
 
 use super::*;
 use crate::ChangeProofVerificationContext;
-use crate::api::{self, BatchOp, Db as DbTrait, DbView, FrozenChangeProof, HashKey, Proposal as _};
+use crate::api::{self, BatchOp, Db as DbTrait, DbView, FrozenChangeProof, Proposal as _};
 use crate::db::{Db, DbConfig};
 use crate::merkle::verify_change_proof_root_hash;
-use firewood_storage::{DefaultHashMode, HashMode, PathComponentSliceExt};
-
-/// Test wrapper around [`crate::verify_change_proof_structure`] that supplies
-/// the compile-default hash mode as the expected `algorithm` (the mode every
-/// proof built in the test binary carries). Defined here so the many existing
-/// call sites in the change-proof test submodules (which `use super::*`) need
-/// not pass the mode explicitly.
-fn verify_change_proof_structure(
-    proof: &FrozenChangeProof,
-    end_root: HashKey,
-    start_key: Option<&[u8]>,
-    end_key: Option<&[u8]>,
-    max_length: Option<std::num::NonZeroUsize>,
-) -> Result<ChangeProofVerificationContext, api::Error> {
-    crate::verify_change_proof_structure(
-        proof,
-        end_root,
-        start_key,
-        end_key,
-        DefaultHashMode::ALGORITHM,
-        max_length,
-    )
-}
+use crate::verify_change_proof_structure;
+use firewood_storage::{EthHash, HashMode, MerkleDbHash, PathComponentSliceExt};
 
 // ── Test infrastructure ────────────────────────────────────────────────────
 
-pub(super) fn new_db() -> (Db<DefaultHashMode>, tempfile::TempDir) {
+pub(super) fn new_db<H: HashMode>() -> (Db<H>, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
-    let db = Db::<DefaultHashMode>::new_with_hash_mode(
-        dir.path(),
-        DbConfig::builder()
-            .node_hash_algorithm(DefaultHashMode::ALGORITHM)
-            .build(),
-    )
-    .unwrap();
+    let cfg = DbConfig::builder()
+        .node_hash_algorithm(H::ALGORITHM)
+        .build();
+    let db = Db::new_with_hash_mode(dir.path(), cfg).unwrap();
     (db, dir)
 }
 
-/// Create a new database pre-populated with key/value pairs.
+/// Create a new database pre-populated with key/value pairs, hashed under
+/// the mode `$H`.
 ///
 /// ```rust,no_run
-/// let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1")];
+/// let (db, _dir) = setup_db![mode = EthHash; (b"\x10", b"v0"), (b"\x20", b"v1")];
 /// ```
 macro_rules! setup_db {
-    [] => {{
-        let (db, dir) = new_db();
+    [mode = $H:ty $(;)?] => {{
+        let (db, dir) = new_db::<$H>();
         db.propose(vec![] as Vec<BatchOp<&[u8], &[u8]>>)
             .unwrap()
             .commit()
             .unwrap();
         (db, dir)
     }};
-    [$(($key:expr, $val:expr)),+ $(,)?] => {{
-        let (db, dir) = new_db();
+    [mode = $H:ty; $(($key:expr, $val:expr)),+ $(,)?] => {{
+        let (db, dir) = new_db::<$H>();
         db.propose(vec![$(BatchOp::Put { key: $key as &[u8], value: $val as &[u8] }),+])
             .unwrap()
             .commit()
@@ -85,17 +62,17 @@ macro_rules! setup_2nd_commit {
     }};
 }
 
-/// Create two databases with the same initial key/value pairs, returning
-/// both databases and the target's root hash.
+/// Create two databases with the same initial key/value pairs, both hashed
+/// under the mode `$H`, returning both databases and the target's root hash.
 ///
 /// ```rust,no_run
 /// let (source, target, root1_target, _ds, _dt) =
-///     setup_source_target![(b"\x10", b"v0"), (b"\x20", b"v1")];
+///     setup_source_target![mode = EthHash; (b"\x10", b"v0"), (b"\x20", b"v1")];
 /// ```
 macro_rules! setup_source_target {
-    [$(($key:expr, $val:expr)),+ $(,)?] => {{
-        let (source, dir_s) = setup_db![$(($key, $val)),+];
-        let (target, dir_t) = setup_db![$(($key, $val)),+];
+    [mode = $H:ty; $(($key:expr, $val:expr)),+ $(,)?] => {{
+        let (source, dir_s) = setup_db![mode = $H; $(($key, $val)),+];
+        let (target, dir_t) = setup_db![mode = $H; $(($key, $val)),+];
         let root1 = target.root_hash().unwrap();
         (source, target, root1, dir_s, dir_t)
     }};
@@ -107,8 +84,8 @@ macro_rules! setup_source_target {
 /// state matches `end_root` using the restructure approach: an in-memory
 /// proving trie is built from the proposal's in-range keys, boundary
 /// proof nodes are reconciled into it, and a hybrid root hash is computed.
-pub(super) fn verify_and_check(
-    db: &Db<DefaultHashMode>,
+pub(super) fn verify_and_check<H: HashMode>(
+    db: &Db<H>,
     proof: &FrozenChangeProof,
     verification: &ChangeProofVerificationContext,
     start_root: api::HashKey,
@@ -120,17 +97,16 @@ pub(super) fn verify_and_check(
 
 // ── Test modules ──────────────────────────────────────────────────────────
 
-// Account partial-storage reconcile tests require ethhash: they rely on
-// Ethereum account semantics at depth 64, and most start from an empty trie
-// (whose root hash only exists under ethhash).
-#[cfg(feature = "ethhash")]
+// Account partial-storage reconcile tests are pinned to `EthHash`: they rely
+// on Ethereum account semantics at depth 64, and most start from an empty
+// trie (whose root hash only exists under Ethereum hashing).
 mod account;
 mod attack;
 mod bounds;
 mod edge_cases;
-// Empty start trie tests require ethhash: without it, the empty trie has no
-// root hash, so change proofs from an empty database can't be generated.
-#[cfg(feature = "ethhash")]
+// Empty start trie tests are pinned to `EthHash`: under `MerkleDbHash` the
+// empty trie has no root hash, so change proofs from an empty database can't
+// be generated.
 mod empty;
 // Helpers shared by fuzz tests. Gated to the only current consumer.
 #[cfg(feature = "ethhash")]

--- a/firewood/src/merkle/tests/change/mod.rs
+++ b/firewood/src/merkle/tests/change/mod.rs
@@ -3,57 +3,40 @@
 
 use super::*;
 use crate::ChangeProofVerificationContext;
-use crate::api::{self, BatchOp, Db as DbTrait, DbView, FrozenChangeProof, HashKey, Proposal as _};
+use crate::api::{self, BatchOp, Db as DbTrait, DbView, FrozenChangeProof, Proposal as _};
 use crate::db::{Db, DbConfig};
 use crate::merkle::verify_change_proof_root_hash;
-use firewood_storage::PathComponentSliceExt;
-
-/// Test wrapper around [`crate::verify_change_proof_structure`] that supplies
-/// the compile-default hash mode as the expected `algorithm` (the mode every
-/// proof built in the test binary carries). Defined here so the many existing
-/// call sites in the change-proof test submodules (which `use super::*`) need
-/// not pass the mode explicitly.
-fn verify_change_proof_structure(
-    proof: &FrozenChangeProof,
-    end_root: HashKey,
-    start_key: Option<&[u8]>,
-    end_key: Option<&[u8]>,
-    max_length: Option<std::num::NonZeroUsize>,
-) -> Result<ChangeProofVerificationContext, api::Error> {
-    crate::verify_change_proof_structure(
-        proof,
-        end_root,
-        start_key,
-        end_key,
-        <firewood_storage::DefaultHashMode as firewood_storage::HashMode>::ALGORITHM,
-        max_length,
-    )
-}
+use crate::verify_change_proof_structure;
+use firewood_storage::{EthHash, HashMode, MerkleDbHash, PathComponentSliceExt};
 
 // ── Test infrastructure ────────────────────────────────────────────────────
 
-pub(super) fn new_db() -> (Db, tempfile::TempDir) {
+pub(super) fn new_db<H: HashMode>() -> (Db<H>, tempfile::TempDir) {
     let dir = tempfile::tempdir().unwrap();
-    let db = Db::new(dir.path(), DbConfig::builder().build()).unwrap();
+    let cfg = DbConfig::builder()
+        .node_hash_algorithm(H::ALGORITHM)
+        .build();
+    let db = Db::new_with_hash_mode(dir.path(), cfg).unwrap();
     (db, dir)
 }
 
-/// Create a new database pre-populated with key/value pairs.
+/// Create a new database pre-populated with key/value pairs, hashed under
+/// the mode `$H`.
 ///
 /// ```rust,no_run
-/// let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1")];
+/// let (db, _dir) = setup_db![mode = EthHash; (b"\x10", b"v0"), (b"\x20", b"v1")];
 /// ```
 macro_rules! setup_db {
-    [] => {{
-        let (db, dir) = new_db();
+    [mode = $H:ty $(;)?] => {{
+        let (db, dir) = new_db::<$H>();
         db.propose(vec![] as Vec<BatchOp<&[u8], &[u8]>>)
             .unwrap()
             .commit()
             .unwrap();
         (db, dir)
     }};
-    [$(($key:expr, $val:expr)),+ $(,)?] => {{
-        let (db, dir) = new_db();
+    [mode = $H:ty; $(($key:expr, $val:expr)),+ $(,)?] => {{
+        let (db, dir) = new_db::<$H>();
         db.propose(vec![$(BatchOp::Put { key: $key as &[u8], value: $val as &[u8] }),+])
             .unwrap()
             .commit()
@@ -79,17 +62,17 @@ macro_rules! setup_2nd_commit {
     }};
 }
 
-/// Create two databases with the same initial key/value pairs, returning
-/// both databases and the target's root hash.
+/// Create two databases with the same initial key/value pairs, both hashed
+/// under the mode `$H`, returning both databases and the target's root hash.
 ///
 /// ```rust,no_run
 /// let (source, target, root1_target, _ds, _dt) =
-///     setup_source_target![(b"\x10", b"v0"), (b"\x20", b"v1")];
+///     setup_source_target![mode = EthHash; (b"\x10", b"v0"), (b"\x20", b"v1")];
 /// ```
 macro_rules! setup_source_target {
-    [$(($key:expr, $val:expr)),+ $(,)?] => {{
-        let (source, dir_s) = setup_db![$(($key, $val)),+];
-        let (target, dir_t) = setup_db![$(($key, $val)),+];
+    [mode = $H:ty; $(($key:expr, $val:expr)),+ $(,)?] => {{
+        let (source, dir_s) = setup_db![mode = $H; $(($key, $val)),+];
+        let (target, dir_t) = setup_db![mode = $H; $(($key, $val)),+];
         let root1 = target.root_hash().unwrap();
         (source, target, root1, dir_s, dir_t)
     }};
@@ -101,8 +84,8 @@ macro_rules! setup_source_target {
 /// state matches `end_root` using the restructure approach: an in-memory
 /// proving trie is built from the proposal's in-range keys, boundary
 /// proof nodes are reconciled into it, and a hybrid root hash is computed.
-pub(super) fn verify_and_check(
-    db: &Db,
+pub(super) fn verify_and_check<H: HashMode>(
+    db: &Db<H>,
     proof: &FrozenChangeProof,
     verification: &ChangeProofVerificationContext,
     start_root: api::HashKey,
@@ -114,17 +97,16 @@ pub(super) fn verify_and_check(
 
 // ── Test modules ──────────────────────────────────────────────────────────
 
-// Account partial-storage reconcile tests require ethhash: they rely on
-// Ethereum account semantics at depth 64, and most start from an empty trie
-// (whose root hash only exists under ethhash).
-#[cfg(feature = "ethhash")]
+// Account partial-storage reconcile tests are pinned to `EthHash`: they rely
+// on Ethereum account semantics at depth 64, and most start from an empty
+// trie (whose root hash only exists under Ethereum hashing).
 mod account;
 mod attack;
 mod bounds;
 mod edge_cases;
-// Empty start trie tests require ethhash: without it, the empty trie has no
-// root hash, so change proofs from an empty database can't be generated.
-#[cfg(feature = "ethhash")]
+// Empty start trie tests are pinned to `EthHash`: under `MerkleDbHash` the
+// empty trie has no root hash, so change proofs from an empty database can't
+// be generated.
 mod empty;
 // Helpers shared by fuzz tests. Gated to the only current consumer.
 #[cfg(feature = "ethhash")]

--- a/firewood/src/merkle/tests/change/partial.rs
+++ b/firewood/src/merkle/tests/change/partial.rs
@@ -16,6 +16,7 @@ use test_case::test_case;
 /// Verify that partial proofs return the expected number of batch ops
 /// and pass both structural and root hash verification, across
 /// combinations of `start_key`, `end_key`, and `limit`.
+#[firewood_macros::hash_mode]
 #[test_case(None,          None,          Some(1),  1 ; "limit 1 of 3 truncates")]
 #[test_case(None,          None,          Some(2),  2 ; "limit 2 of 3 truncates")]
 #[test_case(None,          None,          Some(3),  3 ; "limit equals change count not truncated")]
@@ -24,14 +25,16 @@ use test_case::test_case;
 #[test_case(None,          Some(b"\x05"), Some(1),  0 ; "end before first change gives empty proof")]
 #[test_case(Some(b"\x20"), Some(b"\x40"), Some(1),  1 ; "bounded and limited")]
 #[test_case(Some(b"\x20"), Some(b"\x40"), None,     1 ; "bounded all fit")]
-fn test_partial_proof_verified(
+fn test_partial_proof_verified<H: HashMode>(
     start_key: Option<&[u8]>,
     end_key: Option<&[u8]>,
     limit: Option<usize>,
     expected_ops: usize,
 ) {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\x30", b"v1"), (b"\x50", b"v2")];
-    let (target, _dir_target) = setup_db![(b"\x10", b"v0"), (b"\x30", b"v1"), (b"\x50", b"v2")];
+    let (source, _dir_source) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x30", b"v1"), (b"\x50", b"v2")];
+    let (target, _dir_target) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x30", b"v1"), (b"\x50", b"v2")];
     let root1_target = target.root_hash().unwrap();
     let (root1_source, root2) = setup_2nd_commit!(
         source,
@@ -44,16 +47,20 @@ fn test_partial_proof_verified(
         .unwrap();
     assert_eq!(proof.batch_ops().len(), expected_ops);
 
-    let ctx = verify_change_proof_structure(&proof, root2, start_key, end_key, limit_nz).unwrap();
+    let ctx =
+        verify_change_proof_structure(&proof, root2, start_key, end_key, H::ALGORITHM, limit_nz)
+            .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }
 
 /// Sync source→target using a partial proof of 1 key (limit=1), commit,
 /// then a proof of the remaining keys (2 passes).
-#[test]
-fn test_partial_proof_round_trip() {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
-    let (target, _dir_target) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+#[firewood_macros::hash_mode]
+fn test_partial_proof_round_trip<H: HashMode>() {
+    let (source, _dir_source) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+    let (target, _dir_target) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_target = target.root_hash().unwrap();
 
     let (root1_source, root2) = setup_2nd_commit!(
@@ -72,9 +79,15 @@ fn test_partial_proof_round_trip() {
             NonZeroUsize::new(1),
         )
         .unwrap();
-    let ctx1 =
-        verify_change_proof_structure(&proof1, root2.clone(), None, None, NonZeroUsize::new(1))
-            .unwrap();
+    let ctx1 = verify_change_proof_structure(
+        &proof1,
+        root2.clone(),
+        None,
+        None,
+        H::ALGORITHM,
+        NonZeroUsize::new(1),
+    )
+    .unwrap();
     verify_and_check(&target, &proof1, &ctx1, root1_target.clone()).unwrap();
 
     // Commit round 1
@@ -91,7 +104,8 @@ fn test_partial_proof_round_trip() {
         .change_proof(root1_source, root2.clone(), Some(&next_start), None, None)
         .unwrap();
     let ctx2 =
-        verify_change_proof_structure(&proof2, root2, Some(&next_start), None, None).unwrap();
+        verify_change_proof_structure(&proof2, root2, Some(&next_start), None, H::ALGORITHM, None)
+            .unwrap();
     verify_and_check(&target, &proof2, &ctx2, root_target_after_1).unwrap();
 }
 
@@ -100,10 +114,12 @@ fn test_partial_proof_round_trip() {
 /// proof validates against the last returned key — a Put produces an
 /// inclusion proof, but a Delete produces an exclusion proof, exercising
 /// a different verification path.
-#[test]
-fn test_partial_proof_with_delete_last_op() {
-    let (source, _dir_source) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
-    let (target, _dir_target) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+#[firewood_macros::hash_mode]
+fn test_partial_proof_with_delete_last_op<H: HashMode>() {
+    let (source, _dir_source) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
+    let (target, _dir_target) =
+        setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1"), (b"\x30", b"v2")];
     let root1_target = target.root_hash().unwrap();
 
     let changes: Vec<BatchOp<&[u8], &[u8]>> = vec![
@@ -129,7 +145,14 @@ fn test_partial_proof_with_delete_last_op() {
             NonZeroUsize::new(2),
         )
         .unwrap();
-    let ctx =
-        verify_change_proof_structure(&proof, root2, None, None, NonZeroUsize::new(2)).unwrap();
+    let ctx = verify_change_proof_structure(
+        &proof,
+        root2,
+        None,
+        None,
+        H::ALGORITHM,
+        NonZeroUsize::new(2),
+    )
+    .unwrap();
     verify_and_check(&target, &proof, &ctx, root1_target).unwrap();
 }

--- a/firewood/src/merkle/tests/change/regression.rs
+++ b/firewood/src/merkle/tests/change/regression.rs
@@ -11,20 +11,20 @@
 use super::*;
 use crate::{ChangeProof, Proof};
 
-fn is_rejected(
-    db: &Db,
+fn is_rejected<H: HashMode>(
+    db: &Db<H>,
     proof: &FrozenChangeProof,
     start_root: api::HashKey,
     end_root: api::HashKey,
 ) -> bool {
-    match verify_change_proof_structure(proof, end_root, None, None, None) {
+    match verify_change_proof_structure(proof, end_root, None, None, H::ALGORITHM, None) {
         Err(_) => true,
         Ok(ctx) => verify_and_check(db, proof, &ctx, start_root).is_err(),
     }
 }
 
-#[test]
-fn test_tampered_right_edge_delete_to_put_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_tampered_right_edge_delete_to_put_is_rejected<H: HashMode>() {
     // `0xf0` and `0xfa` keep the `f` branch (nibble path `[f]`) real in the END
     // trie. `0xf51c` (victim) and `0xf5cd` (the max changed key) both live under
     // that branch's child `5`, and both are deleted — so in the end trie child
@@ -33,6 +33,7 @@ fn test_tampered_right_edge_delete_to_put_is_rejected() {
     // victim `0xf51c` sorts below the anchor `0xf5cd` but in that same on-path
     // child.
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\x10".as_slice(), b"low".as_slice()),
         (b"\xf0".as_slice(), b"fz".as_slice()),
         (b"\xfa".as_slice(), b"fa".as_slice()),
@@ -68,10 +69,11 @@ fn test_tampered_right_edge_delete_to_put_is_rejected() {
             other => other.clone(),
         })
         .collect::<Vec<_>>();
-    let mutated = ChangeProof::new(
+    let mutated = ChangeProof::with_hash_mode(
         Proof::new(proof.start_proof().as_ref().into()),
         Proof::new(proof.end_proof().as_ref().into()),
         mutated_ops.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     assert!(

--- a/firewood/src/merkle/tests/change/regression.rs
+++ b/firewood/src/merkle/tests/change/regression.rs
@@ -46,22 +46,29 @@ type OwnedOps = Box<[BatchOp<Box<[u8]>, Box<[u8]>>]>;
 
 /// Verifies `proof` against the given inclusive bounds, returning the rejection
 /// reason on failure.
-fn verify(
-    db: &Db<DefaultHashMode>,
+fn verify<H: HashMode>(
+    db: &Db<H>,
     proof: &FrozenChangeProof,
     start_root: &api::HashKey,
     end_root: &api::HashKey,
     start_key: Option<&[u8]>,
     end_key: Option<&[u8]>,
 ) -> Result<(), api::Error> {
-    let ctx = verify_change_proof_structure(proof, end_root.clone(), start_key, end_key, None)?;
+    let ctx = verify_change_proof_structure(
+        proof,
+        end_root.clone(),
+        start_key,
+        end_key,
+        H::ALGORITHM,
+        None,
+    )?;
     verify_and_check(db, proof, &ctx, start_root.clone())
 }
 
 /// Commit `end_batch` onto `db`, returning the roots before and after. Unlike
 /// `setup_2nd_commit!` this takes arbitrary ops, so it can apply deletes.
-fn commit_batch(
-    db: &Db<DefaultHashMode>,
+fn commit_batch<H: HashMode>(
+    db: &Db<H>,
     end_batch: Vec<BatchOp<&[u8], &[u8]>>,
 ) -> (api::HashKey, api::HashKey) {
     let start_root = db.root_hash().unwrap();
@@ -70,16 +77,17 @@ fn commit_batch(
 }
 
 /// Rebuild `proof` with different `batch_ops`, keeping both boundary proofs.
-fn replace_ops(proof: &FrozenChangeProof, batch_ops: OwnedOps) -> FrozenChangeProof {
-    ChangeProof::new(
+fn replace_ops<H: HashMode>(proof: &FrozenChangeProof, batch_ops: OwnedOps) -> FrozenChangeProof {
+    ChangeProof::with_hash_mode(
         Proof::new(proof.start_proof().as_ref().into()),
         Proof::new(proof.end_proof().as_ref().into()),
         batch_ops,
+        H::ALGORITHM,
     )
 }
 
 /// Rebuild `proof` with the `Delete` at `victim` flipped to a `Put`.
-fn forge_delete_to_put(proof: &FrozenChangeProof, victim: &[u8]) -> FrozenChangeProof {
+fn forge_delete_to_put<H: HashMode>(proof: &FrozenChangeProof, victim: &[u8]) -> FrozenChangeProof {
     let ops: Vec<_> = proof
         .batch_ops()
         .iter()
@@ -91,16 +99,16 @@ fn forge_delete_to_put(proof: &FrozenChangeProof, victim: &[u8]) -> FrozenChange
             other => other.clone(),
         })
         .collect();
-    replace_ops(proof, ops.into_boxed_slice())
+    replace_ops::<H>(proof, ops.into_boxed_slice())
 }
 
 /// Rebuild `proof` claiming nothing changed, keeping both boundary proofs.
-fn omit_all_ops(proof: &FrozenChangeProof) -> FrozenChangeProof {
-    replace_ops(proof, Vec::new().into_boxed_slice())
+fn omit_all_ops<H: HashMode>(proof: &FrozenChangeProof) -> FrozenChangeProof {
+    replace_ops::<H>(proof, Vec::new().into_boxed_slice())
 }
 
-#[test]
-fn test_tampered_right_edge_delete_to_put_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_tampered_right_edge_delete_to_put_is_rejected<H: HashMode>() {
     // `0xf0` and `0xfa` keep the `f` branch (nibble path `[f]`) real in the END
     // trie. `0xf51c` (victim) and `0xf5cd` (the max changed key) both live under
     // that branch's child `5`, and both are deleted — so in the end trie child
@@ -109,6 +117,7 @@ fn test_tampered_right_edge_delete_to_put_is_rejected() {
     // victim `0xf51c` sorts below the anchor `0xf5cd` but in that same on-path
     // child.
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\x10".as_slice(), b"low".as_slice()),
         (b"\xf0".as_slice(), b"fz".as_slice()),
         (b"\xfa".as_slice(), b"fa".as_slice()),
@@ -130,7 +139,7 @@ fn test_tampered_right_edge_delete_to_put_is_rejected() {
     verify(&db, &proof, &start_root, &end_root, None, None).expect("honest proof must verify");
 
     // Tamper: Delete{0xf51c} -> Put{0xf51c, "forged"}.
-    let mutated = forge_delete_to_put(&proof, b"\xf5\x1c");
+    let mutated = forge_delete_to_put::<H>(&proof, b"\xf5\x1c");
     assert!(
         matches!(
             verify(&db, &mutated, &start_root, &end_root, None, None),
@@ -150,9 +159,12 @@ fn test_tampered_right_edge_delete_to_put_is_rejected() {
 /// under the `f` branch's `b` child, so that child must be taken from the proof
 /// rather than recomputed — recomputing it would surface the retained key and
 /// mismatch `end_root`, rejecting the proof with `EndRootMismatch`.
-#[test]
-fn test_out_of_range_delete_past_end_bound_verifies() {
-    let (db, _dir) = setup_db![(b"\xfb\x00".as_slice(), b"\x00".as_slice())];
+#[firewood_macros::hash_mode]
+fn test_out_of_range_delete_past_end_bound_verifies<H: HashMode>() {
+    let (db, _dir) = setup_db![
+        mode = H;
+        (b"\xfb\x00".as_slice(), b"\x00".as_slice())
+    ];
     let (start_root, end_root) = commit_batch(
         &db,
         vec![
@@ -193,9 +205,10 @@ fn test_out_of_range_delete_past_end_bound_verifies() {
 /// keeps that value from being cleared: it is hashed from the proposal, which
 /// surfaces the forged value. Clearing it would let the proof supply the digest
 /// instead and the forgery would go unchecked.
-#[test]
-fn test_forged_in_range_delete_to_put_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_forged_in_range_delete_to_put_is_rejected<H: HashMode>() {
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\x56".as_slice(), b"\x01".as_slice()),
         (b"\x56\x01".as_slice(), b"\x01".as_slice())
     ];
@@ -214,7 +227,7 @@ fn test_forged_in_range_delete_to_put_is_rejected() {
     verify(&db, &proof, &start_root, &end_root, Some(sk), Some(ek))
         .expect("honest proof must verify");
 
-    let forged = forge_delete_to_put(&proof, b"\x56");
+    let forged = forge_delete_to_put::<H>(&proof, b"\x56");
     assert!(
         matches!(
             verify(&db, &forged, &start_root, &end_root, Some(sk), Some(ek)),
@@ -243,9 +256,10 @@ fn test_forged_in_range_delete_to_put_is_rejected() {
 /// `end_root`, rejecting the proof with `EndRootMismatch`. `0xd5` and `0xdb` are
 /// in range (`0xdb` keeps the `d` branch non-trivial). Minimized from
 /// change-proof fuzz seed 8534711138888643184 (`start_nonexistent` scenario).
-#[test]
-fn test_out_of_range_delete_below_start_bound_verifies() {
+#[firewood_macros::hash_mode]
+fn test_out_of_range_delete_below_start_bound_verifies<H: HashMode>() {
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\xd4".as_slice(), b"\x00".as_slice()),
         (b"\xdb".as_slice(), b"\x00".as_slice())
     ];
@@ -287,9 +301,10 @@ fn test_out_of_range_delete_below_start_bound_verifies() {
 /// start trie `{ 0x10, 0x53, 0x60 }`, end trie deletes in-range `0x53`, range
 /// `[0x52, +∞)`. The forge drops both the `Delete` and the end proof, so an
 /// empty batch with `end_key == None` makes `right_edge_key` `None`.
-#[test]
-fn test_unbounded_end_omitted_in_range_delete_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_unbounded_end_omitted_in_range_delete_is_rejected<H: HashMode>() {
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\x10".as_slice(), b"low".as_slice()),
         (b"\x53".as_slice(), b"victim".as_slice()),
         (b"\x60".as_slice(), b"hi".as_slice())
@@ -305,10 +320,11 @@ fn test_unbounded_end_omitted_in_range_delete_is_rejected() {
     // Forge: drop the in-range Delete and the end proof, so `right_edge_key`
     // resolves to None (unbounded end). Dropping the end proof is essential —
     // reusing the honest one leaves `right_edge_key` non-empty.
-    let forged = ChangeProof::new(
+    let forged = ChangeProof::with_hash_mode(
         Proof::new(proof.start_proof().as_ref().into()),
         Proof::new(Vec::new().into_boxed_slice()),
         Vec::new().into_boxed_slice(),
+        H::ALGORITHM,
     );
     assert!(
         matches!(
@@ -335,9 +351,10 @@ fn test_unbounded_end_omitted_in_range_delete_is_rejected() {
 /// is recomputed from the proposal — surfacing the un-deleted `0xfb10` — and
 /// the root-hash check fails. The out-of-range `0xfb90` sharing the child must
 /// not let it be taken wholesale from the proof.
-#[test]
-fn test_split_boundary_child_omitted_in_range_delete_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_split_boundary_child_omitted_in_range_delete_is_rejected<H: HashMode>() {
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\x10".as_slice(), b"a".as_slice()),
         (b"\xf1".as_slice(), b"a".as_slice()),
         (b"\xf7".as_slice(), b"a".as_slice()),
@@ -368,7 +385,7 @@ fn test_split_boundary_child_omitted_in_range_delete_is_rejected() {
 
     // Forge: drop the in-range Delete{0xfb10}, keeping the honest boundary
     // proofs. The proposal keeps 0xfb10, so boundary child b is split.
-    let forged = omit_all_ops(&proof);
+    let forged = omit_all_ops::<H>(&proof);
     assert!(
         matches!(
             verify(&db, &forged, &start_root, &end_root, Some(sk), Some(ek)),
@@ -394,9 +411,10 @@ fn test_split_boundary_child_omitted_in_range_delete_is_rejected() {
 ///
 /// `0xd1` and `0xdb` keep the `[d]` branch non-trivial in the end trie, and
 /// `0x10` keeps the root a branch.
-#[test]
-fn test_split_start_boundary_child_omitted_in_range_delete_is_rejected() {
+#[firewood_macros::hash_mode]
+fn test_split_start_boundary_child_omitted_in_range_delete_is_rejected<H: HashMode>() {
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\x10".as_slice(), b"a".as_slice()),
         (b"\xd1".as_slice(), b"a".as_slice()),
         (b"\xd4\x10".as_slice(), b"out".as_slice()),
@@ -427,7 +445,7 @@ fn test_split_start_boundary_child_omitted_in_range_delete_is_rejected() {
 
     // Forge: drop the in-range Delete{0xd490}, keeping the honest boundary
     // proofs. The proposal keeps 0xd490, so boundary child 4 is split.
-    let forged = omit_all_ops(&proof);
+    let forged = omit_all_ops::<H>(&proof);
     assert!(
         matches!(
             verify(&db, &forged, &start_root, &end_root, Some(sk), Some(ek)),
@@ -457,9 +475,10 @@ fn test_split_start_boundary_child_omitted_in_range_delete_is_rejected() {
 /// short-circuits when the proof node's value already equals the branch's, so
 /// without a value change the guard is never reached and this test passes even
 /// with the defect present.
-#[test]
-fn test_all_deleted_range_with_survivor_above_end_bound_verifies() {
+#[firewood_macros::hash_mode]
+fn test_all_deleted_range_with_survivor_above_end_bound_verifies<H: HashMode>() {
     let (db, _dir) = setup_db![
+        mode = H;
         (b"\x10".as_slice(), b"a".as_slice()),
         (b"\x56".as_slice(), b"b".as_slice()),
         (b"\x56\x01".as_slice(), b"c".as_slice()),
@@ -506,9 +525,9 @@ fn test_all_deleted_range_with_survivor_above_end_bound_verifies() {
 /// `0x60` — that is `0xe0`, which sorts after the end bound. A guard testing
 /// only `>= start_key` treats that terminal as in-range and reports its value as
 /// `UnexpectedValue`, rejecting an honest proof.
-#[test]
-fn test_key_empty_range_verifies() {
-    let (db, _dir) = setup_db![(b"\x20".as_slice(), b"\x01".as_slice())];
+#[firewood_macros::hash_mode]
+fn test_key_empty_range_verifies<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x20".as_slice(), b"\x01".as_slice())];
     let (start_root, end_root) = commit_batch(
         &db,
         vec![

--- a/firewood/src/merkle/tests/change/structural.rs
+++ b/firewood/src/merkle/tests/change/structural.rs
@@ -14,17 +14,24 @@
 use super::*;
 use test_case::test_case;
 
-#[test]
-fn test_inverted_range_rejected() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_inverted_range_rejected<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x50", b"mid")]);
 
     let proof = db
         .change_proof(root1, root2.clone(), Some(b"\x10"), Some(b"\xa0"), None)
         .unwrap();
 
-    let err = verify_change_proof_structure(&proof, root2, Some(b"\xa0"), Some(b"\x10"), None)
-        .unwrap_err();
+    let err = verify_change_proof_structure(
+        &proof,
+        root2,
+        Some(b"\xa0"),
+        Some(b"\x10"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap_err();
     assert!(matches!(
         err,
         api::Error::InvalidRange { start_key, end_key }
@@ -34,16 +41,17 @@ fn test_inverted_range_rejected() {
 
 /// Start proof present but `requested_start_key` is None — the proof
 /// is unverifiable so the structural check rejects it.
-#[test]
-fn test_unexpected_start_proof() {
-    let (db, _dir) = setup_db![(b"\x00", b"v0"), (b"\x10", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_unexpected_start_proof<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x00", b"v0"), (b"\x10", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x05", b"v2")]);
 
     let proof = db
         .change_proof(root1, root2.clone(), Some(b"\x00"), Some(b"\x10"), None)
         .unwrap();
 
-    let err = verify_change_proof_structure(&proof, root2, None, Some(b"\x10"), None).unwrap_err();
+    let err = verify_change_proof_structure(&proof, root2, None, Some(b"\x10"), H::ALGORITHM, None)
+        .unwrap_err();
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::UnexpectedStartProof)
@@ -51,18 +59,19 @@ fn test_unexpected_start_proof() {
 }
 
 /// The `key <= prev.key()` check rejects both duplicate and reverse-ordered keys.
+#[firewood_macros::hash_mode]
 #[test_case(b"\x50", b"\x50" ; "duplicate keys rejected")]
 #[test_case(b"\xa0", b"\x50" ; "reverse order rejected")]
 #[test_case(b"\x50", b"" ; "empty key after non-empty rejected")]
-fn test_crafted_out_of_order_or_dup_keys(key_a: &[u8], key_b: &[u8]) {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+fn test_crafted_out_of_order_or_dup_keys<H: HashMode>(key_a: &[u8], key_b: &[u8]) {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x50", b"mid")]);
 
     let valid = db
         .change_proof(root1, root2.clone(), None, None, None)
         .unwrap();
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         Box::new([
@@ -75,39 +84,43 @@ fn test_crafted_out_of_order_or_dup_keys(key_a: &[u8], key_b: &[u8]) {
                 value: b"b".to_vec().into(),
             },
         ]),
+        H::ALGORITHM,
     );
 
-    let err = verify_change_proof_structure(&crafted, root2, None, None, None).unwrap_err();
+    let err =
+        verify_change_proof_structure(&crafted, root2, None, None, H::ALGORITHM, None).unwrap_err();
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::ChangeProofKeysNotSorted)
     ));
 }
 
-#[test]
-fn test_start_key_larger_than_first_key() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_start_key_larger_than_first_key<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x50", b"mid")]);
 
     let proof = db
         .change_proof(root1, root2.clone(), None, None, None)
         .unwrap();
-    let err = verify_change_proof_structure(&proof, root2, Some(b"\xff"), None, None).unwrap_err();
+    let err = verify_change_proof_structure(&proof, root2, Some(b"\xff"), None, H::ALGORITHM, None)
+        .unwrap_err();
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::StartKeyLargerThanFirstKey)
     ));
 }
 
-#[test]
-fn test_end_key_less_than_last_key() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_end_key_less_than_last_key<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x50", b"mid")]);
 
     let proof = db
         .change_proof(root1, root2.clone(), None, None, None)
         .unwrap();
-    let err = verify_change_proof_structure(&proof, root2, None, Some(b"\x01"), None).unwrap_err();
+    let err = verify_change_proof_structure(&proof, root2, None, Some(b"\x01"), H::ALGORITHM, None)
+        .unwrap_err();
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::EndKeyLessThanLastKey)
@@ -115,16 +128,23 @@ fn test_end_key_less_than_last_key() {
 }
 
 /// Proof has 2 batch ops but `max_length` is 1.
-#[test]
-fn test_proof_larger_than_max_length() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_proof_larger_than_max_length<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x50", b"mid_"), (b"\x60", b"mid2")]);
 
     let proof = db
         .change_proof(root1, root2.clone(), None, None, None)
         .unwrap();
-    let err =
-        verify_change_proof_structure(&proof, root2, None, None, NonZeroUsize::new(1)).unwrap_err();
+    let err = verify_change_proof_structure(
+        &proof,
+        root2,
+        None,
+        None,
+        H::ALGORITHM,
+        NonZeroUsize::new(1),
+    )
+    .unwrap_err();
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::ProofIsLargerThanMaxLength)
@@ -133,21 +153,23 @@ fn test_proof_larger_than_max_length() {
 
 /// Non-empty `batch_ops` with `requested_start_key` and `requested_end_key`
 /// but both boundary proofs empty.
-#[test]
-fn test_crafted_missing_boundary_proof() {
-    let proof = FrozenChangeProof::new(
+#[firewood_macros::hash_mode]
+fn test_crafted_missing_boundary_proof<H: HashMode>() {
+    let proof = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(Box::new([])),
         crate::Proof::new(Box::new([])),
         Box::new([BatchOp::Put {
             key: b"\x50".to_vec().into(),
             value: b"value".to_vec().into(),
         }]),
+        H::ALGORITHM,
     );
     let err = verify_change_proof_structure(
         &proof,
         api::HashKey::empty(),
         Some(b"\x10"),
         Some(b"\xa0"),
+        H::ALGORITHM,
         None,
     )
     .unwrap_err();
@@ -158,9 +180,9 @@ fn test_crafted_missing_boundary_proof() {
 }
 
 /// Non-empty `batch_ops` with start proof present but end proof stripped.
-#[test]
-fn test_crafted_missing_end_proof() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_crafted_missing_end_proof<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x50", b"mid")]);
 
     let valid = db
@@ -171,12 +193,14 @@ fn test_crafted_missing_end_proof() {
         "generator must produce end proof for non-empty ops"
     );
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(Box::new([])),
         valid.batch_ops().into(),
+        H::ALGORITHM,
     );
-    let err = verify_change_proof_structure(&crafted, root2, None, None, None).unwrap_err();
+    let err =
+        verify_change_proof_structure(&crafted, root2, None, None, H::ALGORITHM, None).unwrap_err();
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::MissingEndProof)
@@ -184,9 +208,9 @@ fn test_crafted_missing_end_proof() {
 }
 
 /// Non-empty end proof with empty `batch_ops` and no `requested_end_key`.
-#[test]
-fn test_crafted_unexpected_end_proof() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\x20", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_crafted_unexpected_end_proof<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\x20", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x20", b"changed")]);
 
     let valid = db
@@ -194,13 +218,15 @@ fn test_crafted_unexpected_end_proof() {
         .unwrap();
     assert!(!valid.end_proof().is_empty());
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(Box::new([])),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         Box::new([]),
+        H::ALGORITHM,
     );
 
-    let err = verify_change_proof_structure(&crafted, root2, None, None, None).unwrap_err();
+    let err =
+        verify_change_proof_structure(&crafted, root2, None, None, H::ALGORITHM, None).unwrap_err();
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::UnexpectedEndProof)
@@ -210,9 +236,9 @@ fn test_crafted_unexpected_end_proof() {
 /// Boundary proof hash chain was built for `root2` but verified against
 /// `HashKey::empty()` — the root hash in the proof nodes won't match,
 /// producing `UnexpectedHash`.
-#[test]
-fn test_boundary_proof_rejects_wrong_root() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_boundary_proof_rejects_wrong_root<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x50", b"mid")]);
 
     let proof = db
@@ -223,6 +249,7 @@ fn test_boundary_proof_rejects_wrong_root() {
         api::HashKey::empty(),
         Some(b"\x10"),
         Some(b"\xa0"),
+        H::ALGORITHM,
         None,
     )
     .unwrap_err();
@@ -238,18 +265,24 @@ fn test_boundary_proof_rejects_wrong_root() {
 /// Right-edge companion to `test_boundary_proof_rejects_wrong_root`: with no
 /// `start_key` the start proof is empty and skipped, so the wrong-root failure
 /// surfaces on the *end* boundary and must be annotated `ProofEdge::Right`.
-#[test]
-fn test_boundary_proof_rejects_wrong_root_right_edge() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_boundary_proof_rejects_wrong_root_right_edge<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x50", b"mid")]);
 
     let proof = db
         .change_proof(root1, root2, None, Some(b"\xa0"), None)
         .unwrap();
     assert!(proof.start_proof().is_empty());
-    let err =
-        verify_change_proof_structure(&proof, api::HashKey::empty(), None, Some(b"\xa0"), None)
-            .unwrap_err();
+    let err = verify_change_proof_structure(
+        &proof,
+        api::HashKey::empty(),
+        None,
+        Some(b"\xa0"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap_err();
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::EdgeProofHashMismatch {
@@ -259,40 +292,49 @@ fn test_boundary_proof_rejects_wrong_root_right_edge() {
     ));
 }
 
-#[test]
-fn test_crafted_delete_range_rejected() {
-    let (db, _dir) = setup_db![(b"\x10", b"v0"), (b"\xa0", b"v1")];
+#[firewood_macros::hash_mode]
+fn test_crafted_delete_range_rejected<H: HashMode>() {
+    let (db, _dir) = setup_db![mode = H; (b"\x10", b"v0"), (b"\xa0", b"v1")];
     let (root1, root2) = setup_2nd_commit!(db, [(b"\x50", b"mid")]);
 
     let valid = db
         .change_proof(root1, root2.clone(), None, None, None)
         .unwrap();
 
-    let crafted = FrozenChangeProof::new(
+    let crafted = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(valid.start_proof().as_ref().into()),
         crate::Proof::new(valid.end_proof().as_ref().into()),
         Box::new([BatchOp::DeleteRange {
             prefix: b"\x50".to_vec().into(),
         }]),
+        H::ALGORITHM,
     );
 
-    let err = verify_change_proof_structure(&crafted, root2, None, None, None).unwrap_err();
+    let err =
+        verify_change_proof_structure(&crafted, root2, None, None, H::ALGORITHM, None).unwrap_err();
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::DeleteRangeFoundInChangeProof)
     ));
 }
 
-#[test]
-fn test_crafted_missing_end_proof_empty_batch_ops() {
-    let proof = FrozenChangeProof::new(
+#[firewood_macros::hash_mode]
+fn test_crafted_missing_end_proof_empty_batch_ops<H: HashMode>() {
+    let proof = FrozenChangeProof::with_hash_mode(
         crate::Proof::new(Box::new([])),
         crate::Proof::new(Box::new([])),
         Box::new([]),
+        H::ALGORITHM,
     );
-    let err =
-        verify_change_proof_structure(&proof, api::HashKey::empty(), None, Some(b"\x50"), None)
-            .unwrap_err();
+    let err = verify_change_proof_structure(
+        &proof,
+        api::HashKey::empty(),
+        None,
+        Some(b"\x50"),
+        H::ALGORITHM,
+        None,
+    )
+    .unwrap_err();
     assert!(matches!(
         err,
         api::Error::ProofError(crate::ProofError::MissingEndProof)

--- a/firewood/src/merkle/tests/change/walk.rs
+++ b/firewood/src/merkle/tests/change/walk.rs
@@ -58,9 +58,9 @@ fn ranges(trace: &[(String, String)]) -> String {
 ///
 /// Returns `Err` if the walk exceeds `max_rounds`, which is how a non-advancing
 /// continuation surfaces.
-fn sync_walk(
-    source: &Db<DefaultHashMode>,
-    target: &Db<DefaultHashMode>,
+fn sync_walk<H: HashMode>(
+    source: &Db<H>,
+    target: &Db<H>,
     start_root: &api::HashKey,
     end_root: &api::HashKey,
     end_key: Option<&[u8]>,
@@ -180,9 +180,9 @@ fn deletes(
 
 /// Two databases that start in sync, and the roots either side of one batch of
 /// changes applied only to `source`.
-struct Fixture {
-    source: Db<DefaultHashMode>,
-    target: Db<DefaultHashMode>,
+struct Fixture<H: HashMode> {
+    source: Db<H>,
+    target: Db<H>,
     keys: Vec<Vec<u8>>,
     start_root: api::HashKey,
     end_root: api::HashKey,
@@ -198,49 +198,49 @@ struct Fixture {
 /// The removals matter because a walk resumes from the key just above the last
 /// op, so a removed last op means resuming above a key the end revision no longer
 /// holds.
-fn go_shaped_fixture(has_deletes: bool) -> Fixture {
+fn go_shaped_fixture<H: HashMode>(has_deletes: bool) -> Fixture<H> {
     let keys = hundred_keys();
     let mut changes = puts(&keys, 50..100, b"v0");
     if has_deletes {
         changes.extend(deletes(&keys, (0..40).step_by(2)));
     }
-    fixture_from(keys, 0..50, changes)
+    fixture_from::<H>(keys, 0..50, changes)
 }
 
 /// 100 shared keys with two clusters of changes: `key50..key59` and
 /// `key80..key89`. A bounded walk between the clusters must leave the upper one
 /// alone, which is what makes this shape useful.
-fn clustered_fixture() -> Fixture {
+fn clustered_fixture<H: HashMode>() -> Fixture<H> {
     let keys = hundred_keys();
     let mut changes = puts(&keys, 50..60, b"v1");
     changes.extend(puts(&keys, 80..90, b"v1"));
-    fixture_from(keys, 0..100, changes)
+    fixture_from::<H>(keys, 0..100, changes)
 }
 
 /// 100 shared keys where `key50..key59` are removed and `key80` is changed. A
 /// bounded walk below `key80` must apply the removals and leave that change
 /// alone, and its closing round starts just above a removed key.
-fn removed_cluster_fixture() -> Fixture {
+fn removed_cluster_fixture<H: HashMode>() -> Fixture<H> {
     let keys = hundred_keys();
     let mut changes = deletes(&keys, 50..60);
     changes.extend(puts(&keys, 80..81, b"v1"));
-    fixture_from(keys, 0..100, changes)
+    fixture_from::<H>(keys, 0..100, changes)
 }
 
 /// Four keys `10/20/30/40`, with `10` changed and `20`/`30` removed. A cap of two
 /// makes the first reply stop on the removal of `20`.
-fn small_removal_fixture() -> Fixture {
+fn small_removal_fixture<H: HashMode>() -> Fixture<H> {
     let keys: Vec<Vec<u8>> = [0x10, 0x20, 0x30, 0x40].map(|b| vec![b]).into();
     let mut changes = puts(&keys, 0..1, b"A");
     changes.extend(deletes(&keys, 1..3));
     let shared = 0..keys.len();
-    fixture_from(keys, shared, changes)
+    fixture_from::<H>(keys, shared, changes)
 }
 
 /// The root a client should hold after applying exactly `ops` to the shared
 /// starting state, which is every key in `keys` at `v0`.
-fn root_after(keys: &[Vec<u8>], ops: Vec<BatchOp<Vec<u8>, Vec<u8>>>) -> api::HashKey {
-    let (db, _dir) = new_db();
+fn root_after<H: HashMode>(keys: &[Vec<u8>], ops: Vec<BatchOp<Vec<u8>, Vec<u8>>>) -> api::HashKey {
+    let (db, _dir) = new_db::<H>();
     db.propose(puts(keys, 0..keys.len(), b"v0"))
         .unwrap()
         .commit()
@@ -252,13 +252,13 @@ fn root_after(keys: &[Vec<u8>], ops: Vec<BatchOp<Vec<u8>, Vec<u8>>>) -> api::Has
 /// Two synced databases holding `keys[shared]` at `v0`, with `changes` applied to
 /// `source` only. Keys outside `shared` exist in neither database until `changes`
 /// introduces them.
-fn fixture_from(
+fn fixture_from<H: HashMode>(
     keys: Vec<Vec<u8>>,
     shared: std::ops::Range<usize>,
     changes: Vec<BatchOp<Vec<u8>, Vec<u8>>>,
-) -> Fixture {
-    let (source, ds) = new_db();
-    let (target, dt) = new_db();
+) -> Fixture<H> {
+    let (source, ds) = new_db::<H>();
+    let (target, dt) = new_db::<H>();
     let shared = puts(&keys, shared, b"v0");
     source.propose(shared.clone()).unwrap().commit().unwrap();
     target.propose(shared).unwrap().commit().unwrap();
@@ -296,11 +296,12 @@ fn assert_keys_strictly_increase(walk: &Walk) {
 /// An unbounded walk must reach `end_root`, and must do it in one round per batch
 /// of changes plus the round that ends the walk. Anything more means the
 /// continuation repeated a range.
+#[firewood_macros::hash_mode]
 #[test_case(false, 10 ; "no deletes")]
 #[test_case(true, 10 ; "with deletes")]
 #[test_case(false, 1 ; "one op per round")]
-fn test_unbounded_walk_reaches_end_root(has_deletes: bool, limit: usize) {
-    let f = go_shaped_fixture(has_deletes);
+fn test_unbounded_walk_reaches_end_root<H: HashMode>(has_deletes: bool, limit: usize) {
+    let f = go_shaped_fixture::<H>(has_deletes);
     let walk = sync_walk(
         &f.source,
         &f.target,
@@ -338,15 +339,16 @@ fn test_unbounded_walk_reaches_end_root(has_deletes: bool, limit: usize) {
 /// In every case the client must end holding exactly the changes at or below the
 /// bound, which is what `root_with_only(keys, applied)` checks; a key fetched
 /// above the bound would make that root disagree.
+#[firewood_macros::hash_mode]
 #[test_case(b"key40", 1, 50..50 ; "below both clusters")]
 #[test_case(b"key65", 2, 50..60 ; "between the clusters")]
 #[test_case(b"key59", 1, 50..60 ; "on the last changed key")]
-fn test_bounded_walk_stops_at_its_bound(
+fn test_bounded_walk_stops_at_its_bound<H: HashMode>(
     bound: &[u8],
     expected_rounds: usize,
     applied: std::ops::Range<usize>,
 ) {
-    let f = clustered_fixture();
+    let f = clustered_fixture::<H>();
     let walk = sync_walk(
         &f.source,
         &f.target,
@@ -362,7 +364,7 @@ fn test_bounded_walk_stops_at_its_bound(
     assert_keys_strictly_increase(&walk);
     assert_eq!(
         f.target.root_hash().unwrap(),
-        root_after(&f.keys, puts(&f.keys, applied, b"v1")),
+        root_after::<H>(&f.keys, puts(&f.keys, applied, b"v1")),
         "the client must hold exactly the changes at or below the bound: {}",
         ranges(&walk.trace)
     );
@@ -376,9 +378,9 @@ fn test_bounded_walk_stops_at_its_bound(
 /// last removal while the requested bound is still higher. The closing round
 /// therefore begins just above a removed key, finds nothing, and ends the walk.
 /// The change at `key80` sits above the bound and must be left untouched.
-#[test]
-fn test_bounded_walk_closing_round_starts_above_a_removed_key() {
-    let f = removed_cluster_fixture();
+#[firewood_macros::hash_mode]
+fn test_bounded_walk_closing_round_starts_above_a_removed_key<H: HashMode>() {
+    let f = removed_cluster_fixture::<H>();
     let end = b"key65";
     let walk = sync_walk(
         &f.source,
@@ -402,7 +404,7 @@ fn test_bounded_walk_closing_round_starts_above_a_removed_key() {
     assert_keys_strictly_increase(&walk);
     assert_eq!(
         f.target.root_hash().unwrap(),
-        root_after(&f.keys, deletes(&f.keys, 50..60)),
+        root_after::<H>(&f.keys, deletes(&f.keys, 50..60)),
         "the removals are applied and the change above the bound is not: {}",
         ranges(&walk.trace)
     );
@@ -419,9 +421,9 @@ fn test_bounded_walk_closing_round_starts_above_a_removed_key() {
 /// This is the walk-level counterpart to the narrowing tests in `edge_cases.rs`:
 /// those pin the right edge for a single reply, this pins that a client following
 /// the ordinary loop reaches the end revision.
-#[test]
-fn test_walk_stopping_short_on_a_removal_converges() {
-    let f = small_removal_fixture();
+#[firewood_macros::hash_mode]
+fn test_walk_stopping_short_on_a_removal_converges<H: HashMode>() {
+    let f = small_removal_fixture::<H>();
     let walk = sync_walk(
         &f.source,
         &f.target,

--- a/firewood/src/merkle/tests/collapse.rs
+++ b/firewood/src/merkle/tests/collapse.rs
@@ -8,9 +8,9 @@ use super::*;
 /// with a target of \x10. Since \x01 is not on the path from the root
 /// to the target, nibble 0 is stripped from the root. Path compression
 /// changes the root's partial path from a length of 0 to a length of 2.
-#[test]
-fn test_collapse_root_to_path() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_collapse_root_to_path<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     let pc = |n: u8| PathComponent::try_new(n).unwrap();
 
     // \x01 → nibbles [0, 1], \x10 → nibbles [1, 0]
@@ -37,9 +37,9 @@ fn test_collapse_root_to_path() {
 /// of the remaining nodes. In this example, the target is \x10, the range is
 /// [0x0], [0xf], and the root (which is on-path) has a child in the range.
 /// Therefore we expect to receive an `EndRootMismatch` error.
-#[test]
-fn test_collapse_root_to_path_rejects() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_collapse_root_to_path_rejects<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     let pc = |n: u8| PathComponent::try_new(n).unwrap();
 
     // \x01 → nibbles [0, 1], \x10 → nibbles [1, 0]
@@ -61,10 +61,10 @@ fn test_collapse_root_to_path_rejects() {
     ));
 }
 
-#[test]
-fn test_collapse_branch_to_path() {
+#[firewood_macros::hash_mode]
+fn test_collapse_branch_to_path<H: HashMode>() {
     let pc = |n: u8| PathComponent::try_new(n).unwrap();
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle
         .insert(b"\x10\x21", Box::from(b"a".as_slice()))
@@ -90,10 +90,10 @@ fn test_collapse_branch_to_path() {
     assert!(merkle.get_value(b"\x10\x30").unwrap().is_some());
 }
 
-#[test]
-fn test_collapse_branch_to_path_rejects() {
+#[firewood_macros::hash_mode]
+fn test_collapse_branch_to_path_rejects<H: HashMode>() {
     let pc = |n: u8| PathComponent::try_new(n).unwrap();
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle
         .insert(b"\x10\x21", Box::from(b"a".as_slice()))

--- a/firewood/src/merkle/tests/collapse.rs
+++ b/firewood/src/merkle/tests/collapse.rs
@@ -8,9 +8,9 @@ use super::*;
 /// with a target of \x10. Since \x01 is not on the path from the root
 /// to the target, nibble 0 is stripped from the root. Path compression
 /// changes the root's partial path from a length of 0 to a length of 2.
-#[test]
-fn test_collapse_root_to_path() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_collapse_root_to_path<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     let pc = |n: u8| PathComponent::try_new(n).unwrap();
 
     // \x01 → nibbles [0, 1], \x10 → nibbles [1, 0]
@@ -37,9 +37,9 @@ fn test_collapse_root_to_path() {
 /// of the remaining nodes. In this example, the target is \x10, the range is
 /// [0x0], [0xf], and the root (which is on-path) has a child in the range.
 /// Therefore we expect to receive an `EndRootMismatch` error.
-#[test]
-fn test_collapse_root_to_path_rejects() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_collapse_root_to_path_rejects<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     let pc = |n: u8| PathComponent::try_new(n).unwrap();
 
     // \x01 → nibbles [0, 1], \x10 → nibbles [1, 0]
@@ -67,10 +67,10 @@ fn test_collapse_root_to_path_rejects() {
     ));
 }
 
-#[test]
-fn test_collapse_branch_to_path() {
+#[firewood_macros::hash_mode]
+fn test_collapse_branch_to_path<H: HashMode>() {
     let pc = |n: u8| PathComponent::try_new(n).unwrap();
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle
         .insert(b"\x10\x21", Box::from(b"a".as_slice()))
@@ -96,10 +96,10 @@ fn test_collapse_branch_to_path() {
     assert!(merkle.get_value(b"\x10\x30").unwrap().is_some());
 }
 
-#[test]
-fn test_collapse_branch_to_path_rejects() {
+#[firewood_macros::hash_mode]
+fn test_collapse_branch_to_path_rejects<H: HashMode>() {
     let pc = |n: u8| PathComponent::try_new(n).unwrap();
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle
         .insert(b"\x10\x21", Box::from(b"a".as_slice()))

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -1,7 +1,8 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use crate::api::OptionalHashKeyExt;
+//! Ethereum-only: keccak/RLP golden vectors.
+
 use crate::merkle::Merkle;
 use firewood_storage::{Committed, DeletedNodeTracking, MemStore, NodeStore};
 
@@ -50,7 +51,7 @@ where
     K: AsRef<[u8]> + Ord,
     V: AsRef<[u8]>,
 {
-    let merkle = init_merkle(kvs.clone());
+    let merkle = init_merkle::<EthHash, I, K, V>(kvs.clone());
     let firewood_hash = merkle.nodestore.root_hash().unwrap_or_else(TrieHash::empty);
     let eth_hash: TrieHash = KeccakHasher::trie_root(kvs).to_fixed_bytes().into();
     assert_eq!(firewood_hash, eth_hash);
@@ -106,7 +107,7 @@ fn test_eth_compatible_accounts(
     }))
     .collect::<Vec<(Box<_>, Box<_>)>>();
 
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<EthHash, _, _, _>(items);
     let firewood_hash = merkle.nodestore.root_hash();
 
     assert_eq!(
@@ -120,6 +121,11 @@ fn make_key(hex_str: &str) -> Key {
     hex::decode(hex_str).unwrap().into_boxed_slice()
 }
 
+/// Ethereum's empty-trie root (`keccak256(0x80)`) is a property of the
+/// `EthHash` scheme, not of the binary's compile-time `ethhash` feature — so
+/// this reaches for `EthHash::default_root_hash()` directly rather than the
+/// `OptionalHashKeyExt` convenience (which resolves via the compile-selected
+/// `DefaultHashMode` and would silently go stale in a non-`ethhash` build).
 #[test]
 fn test_root_hash_random_deletions() {
     use rand::seq::SliceRandom;
@@ -151,7 +157,8 @@ fn test_root_hash_random_deletions() {
         items_ordered.sort_unstable();
         items_ordered.shuffle(&mut &rng);
 
-        let (mut committed_merkle, mut header) = init_merkle_with_header(&items);
+        let (mut committed_merkle, mut header) =
+            init_merkle_with_header::<EthHash, _, _, _>(&items);
 
         for (k, v) in items_ordered {
             let mut merkle = committed_merkle.fork().unwrap();
@@ -175,7 +182,7 @@ fn test_root_hash_random_deletions() {
             let h0 = committed_merkle
                 .nodestore()
                 .root_hash()
-                .or_default_root_hash()
+                .or_else(EthHash::default_root_hash)
                 .unwrap();
 
             assert_eq!(h, h0);
@@ -239,17 +246,22 @@ fn assert_range_proof_roundtrips(
     root_hash: &TrieHash,
     range_proof: &crate::api::FrozenRangeProof,
 ) {
-    verify_range_proof(first, last, root_hash, range_proof).unwrap();
+    verify_range_proof(first, last, root_hash, EthHash::ALGORITHM, range_proof).unwrap();
 
     let mut serialized = Vec::new();
     range_proof.write_to_vec(&mut serialized);
     let deserialized = crate::api::FrozenRangeProof::from_slice(&serialized).unwrap();
-    verify_range_proof(first, last, root_hash, &deserialized).unwrap();
+    verify_range_proof(first, last, root_hash, EthHash::ALGORITHM, &deserialized).unwrap();
 }
 
 /// The pieces a fold test needs from [`build_account_trie`].
 struct AccountTrie {
-    merkle: Merkle<NodeStore<Committed, MemStore>>,
+    // Explicit `EthHash`: `NodeStore`'s default `H` tracks the compile-time
+    // `ethhash` feature, but this module now compiles under both configs, so
+    // relying on the default would silently swap in `MerkleDbHash` in a
+    // non-`ethhash` build even though `build_account_trie` always hashes
+    // with `EthHash`.
+    merkle: Merkle<NodeStore<Committed, MemStore, EthHash>>,
     root_hash: TrieHash,
     account_key: Box<[u8]>,
     storage_keys: Box<[Box<[u8]>]>,
@@ -286,7 +298,7 @@ fn build_account_trie(storage_child_nibbles: &[u8]) -> AccountTrie {
     }
     items.push((following_key.as_ref(), following_value.as_ref()));
 
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<EthHash, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
     AccountTrie {
         merkle,
@@ -318,7 +330,7 @@ fn commit_and_read_storage_root(
         items.push((key, Box::from(*value)));
     }
 
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<EthHash, _, _, _>(items);
 
     let stored = merkle
         .get_value(account_key_hash.as_slice())
@@ -389,10 +401,11 @@ fn test_persisted_storage_root_one_storage_entry() {
     // just (storage_key, storage_value). Building it the same way the
     // ethhash hasher would lets us assert against a concrete hash rather
     // than just "not empty".
-    let expected = init_merkle([(storage_key.as_slice(), storage_value.as_slice())])
-        .nodestore()
-        .root_hash()
-        .expect("standalone storage trie should have a root");
+    let expected =
+        init_merkle::<EthHash, _, _, _>([(storage_key.as_slice(), storage_value.as_slice())])
+            .nodestore()
+            .root_hash()
+            .expect("standalone storage trie should have a root");
 
     assert_eq!(
         storage_root.as_slice(),
@@ -424,7 +437,7 @@ fn test_persisted_storage_root_two_storage_entries() {
         ],
     );
 
-    let expected = init_merkle([
+    let expected = init_merkle::<EthHash, _, _, _>([
         (storage_key_a.as_slice(), storage_value_a.as_slice()),
         (storage_key_b.as_slice(), storage_value_b.as_slice()),
     ])
@@ -485,7 +498,7 @@ fn test_range_proof_accounts_have_computed_storage_root() {
         .map(|(k, v)| (k.clone(), v.clone()))
         .chain(once((storage_key, storage_value)))
         .collect();
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<EthHash, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     // Build a range proof over [left_key, right_key]. The storage entry
@@ -499,6 +512,7 @@ fn test_range_proof_accounts_have_computed_storage_root() {
         Some(left_key.as_ref()),
         Some(right_key.as_ref()),
         &root_hash,
+        EthHash::ALGORITHM,
         &range_proof,
     )
     .unwrap();
@@ -641,7 +655,7 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
         .map(|(k, v)| (k.clone(), v.clone()))
         .chain(once((storage_key, storage_value)))
         .collect();
-    let (merkle, _header) = init_merkle_with_header(items);
+    let (merkle, _header) = init_merkle_with_header::<EthHash, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     // ── Phase 1: generate a correct range proof to learn the real storageRoot values ──
@@ -658,11 +672,17 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
         })
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values);
+    // `RangeProof::new` stamps the compile-time `DefaultHashMode`, which would
+    // silently mismatch this test's pinned `EthHash` in a non-`ethhash` build.
+    // `new_with_hash_mode` records the actual mode explicitly instead, exactly
+    // as `Merkle::range_proof` does for a proof built from a live trie.
+    let range_proof =
+        RangeProof::with_hash_mode(start_proof, end_proof, key_values, EthHash::ALGORITHM);
     verify_range_proof(
         Some(left_key.as_ref()),
         Some(right_key.as_ref()),
         &root_hash,
+        EthHash::ALGORITHM,
         &range_proof,
     )
     .unwrap();
@@ -694,8 +714,12 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
     // Re-read the header from the clobbered storage so the version matches.
     let header = NodeStoreHeader::read_from_storage(&*storage).unwrap();
 
-    // Re-open from the clobbered MemStore so all reads come from disk.
-    let reopened: NodeStore<Committed, _> =
+    // Re-open from the clobbered MemStore so all reads come from disk. Explicit
+    // `EthHash`: the data on disk was written under `EthHash` (see `merkle`
+    // above), and `NodeStore`'s default `H` would otherwise silently follow
+    // the compile-time `ethhash` feature instead of the mode this test is
+    // pinned to.
+    let reopened: NodeStore<Committed, _, EthHash> =
         NodeStore::open(&header, storage, DeletedNodeTracking::Enabled).unwrap();
     let merkle = Merkle::from(reopened);
 
@@ -723,6 +747,7 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
         Some(left_key.as_ref()),
         Some(right_key.as_ref()),
         &root_hash,
+        EthHash::ALGORITHM,
         &range_proof,
     )
     .unwrap();

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -3,7 +3,6 @@
 
 mod change;
 mod collapse;
-#[cfg(feature = "ethhash")]
 mod ethhash;
 #[cfg(feature = "ethhash")]
 mod ethhash_fuzz;
@@ -11,42 +10,17 @@ mod ethhash_fuzz;
 mod proof;
 mod range;
 mod reconcile;
-#[cfg(not(feature = "ethhash"))]
 mod triehash;
 
 use std::collections::HashMap;
 use std::fmt::Write;
 
 use super::*;
-use crate::proofs::range::RangeProof;
-use crate::{
-    ProofCollection,
-    api::{Error, KeyType, ValueType},
-};
 use crate::{ProofError, ProofNode};
 use firewood_storage::{
-    Children, Committed, DeletedNodeTracking, MemStore, Mutable, NodeStore, NodeStoreHeader,
-    PathComponent, Propose, RootReader, TrieHash, ValueDigest,
+    Children, Committed, DeletedNodeTracking, EthHash, HashMode, MemStore, MerkleDbHash, Mutable,
+    NodeStore, NodeStoreHeader, PathComponent, Propose, RootReader, TrieHash, ValueDigest,
 };
-
-/// Test wrapper around [`crate::merkle::verify_range_proof`] that supplies the
-/// compile-default hash mode as the expected `algorithm` (the mode every proof
-/// built in the test binary carries). Shadows the glob-imported real function
-/// so the many existing call sites need not pass the mode explicitly.
-fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
-    first_key: Option<impl KeyType>,
-    last_key: Option<impl KeyType>,
-    root_hash: &TrieHash,
-    proof: &RangeProof<impl KeyType, impl ValueType, H>,
-) -> Result<(), Error> {
-    crate::merkle::verify_range_proof(
-        first_key,
-        last_key,
-        root_hash,
-        <firewood_storage::DefaultHashMode as firewood_storage::HashMode>::ALGORITHM,
-        proof,
-    )
-}
 
 // Returns n random key-value pairs.
 fn generate_random_kvs(rng: &firewood_storage::SeededRng, n: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
@@ -64,17 +38,23 @@ fn generate_random_kvs(rng: &firewood_storage::SeededRng, n: usize) -> Vec<(Vec<
     kvs
 }
 
-fn into_committed(
-    merkle: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore>>,
+fn into_committed<H: HashMode>(
+    merkle: Merkle<NodeStore<Arc<ImmutableProposal>, MemStore, H>>,
     header: &mut NodeStoreHeader,
-) -> Merkle<NodeStore<Committed, MemStore>> {
+) -> Merkle<NodeStore<Committed, MemStore, H>> {
     let ns = merkle.into_inner().as_committed();
     ns.persist(header).unwrap();
     ns.into()
 }
 
-pub(crate) fn init_merkle<I, K, V>(iter: I) -> Merkle<NodeStore<Committed, MemStore>>
+/// Builds a committed in-memory merkle with the given key-value pairs, hashed
+/// under the mode `H`. Callers choose `H` explicitly (there is no default) so
+/// that mode-agnostic tests can be instantiated under both `EthHash` and
+/// `MerkleDbHash` via `#[firewood_macros::hash_mode]`, and mode-specific tests
+/// can pin a concrete mode regardless of the binary's `ethhash` feature.
+pub(crate) fn init_merkle<H, I, K, V>(iter: I) -> Merkle<NodeStore<Committed, MemStore, H>>
 where
+    H: HashMode,
     I: Clone + IntoIterator<Item = (K, V)>,
     K: AsRef<[u8]>,
     V: AsRef<[u8]>,
@@ -83,15 +63,12 @@ where
     merkle
 }
 
-/// Builds a committed in-memory merkle pinned to the hash mode `H`, regardless
-/// of the binary's `ethhash` feature. Used by the `ValueDigest::Hash` tests,
-/// which depend on MerkleDB's ≥32-byte value capping and must run under
-/// `MerkleDbHash` in either binary.
-#[cfg(not(feature = "ethhash"))]
-pub(crate) fn init_merkle_in_mode<H, I, K, V>(iter: I) -> Merkle<NodeStore<Committed, MemStore, H>>
+pub(crate) fn init_merkle_with_header<H, I, K, V>(
+    iter: I,
+) -> (Merkle<NodeStore<Committed, MemStore, H>>, NodeStoreHeader)
 where
-    H: firewood_storage::HashMode,
-    I: IntoIterator<Item = (K, V)>,
+    H: HashMode,
+    I: Clone + IntoIterator<Item = (K, V)>,
     K: AsRef<[u8]>,
     V: AsRef<[u8]>,
 {
@@ -100,49 +77,6 @@ where
     let base: Merkle<NodeStore<Committed, MemStore, H>> = Merkle::from(
         NodeStore::new_empty_committed(memstore, DeletedNodeTracking::Enabled),
     );
-    let mut merkle = base.fork().unwrap();
-    for (k, v) in iter {
-        merkle.insert(k.as_ref(), v.as_ref().into()).unwrap();
-    }
-    let merkle = merkle.hash();
-    let ns = merkle.into_inner().as_committed();
-    ns.persist(&mut header).unwrap();
-    ns.into()
-}
-
-/// `verify_range_proof` variant that supplies an explicit `algorithm` rather
-/// than the compile default, so mode-specific tests can verify under the mode
-/// their proof was built in regardless of the binary.
-#[cfg(not(feature = "ethhash"))]
-fn verify_range_proof_in_mode<H: crate::ProofCollection<Node = ProofNode>>(
-    first_key: Option<impl crate::api::KeyType>,
-    last_key: Option<impl crate::api::KeyType>,
-    root_hash: &TrieHash,
-    algorithm: firewood_storage::NodeHashAlgorithm,
-    proof: &RangeProof<impl crate::api::KeyType, impl crate::api::ValueType, H>,
-) -> Result<(), crate::api::Error> {
-    crate::merkle::verify_range_proof(first_key, last_key, root_hash, algorithm, proof)
-}
-
-pub(crate) fn init_merkle_with_header<I, K, V>(
-    iter: I,
-) -> (Merkle<NodeStore<Committed, MemStore>>, NodeStoreHeader)
-where
-    I: Clone + IntoIterator<Item = (K, V)>,
-    K: AsRef<[u8]>,
-    V: AsRef<[u8]>,
-{
-    let memstore = Arc::new(MemStore::new(
-        Vec::with_capacity(64 * 1024),
-        <firewood_storage::DefaultHashMode as firewood_storage::HashMode>::ALGORITHM,
-    ));
-    let mut header = NodeStoreHeader::new(
-        <firewood_storage::DefaultHashMode as firewood_storage::HashMode>::ALGORITHM,
-    );
-    let base = Merkle::from(NodeStore::new_empty_committed(
-        memstore.clone(),
-        DeletedNodeTracking::Enabled,
-    ));
     let mut merkle = base.fork().unwrap();
 
     for (k, v) in iter.clone() {
@@ -161,10 +95,10 @@ where
         let value = v.as_ref();
 
         let stored = merkle.get_value(key).unwrap();
-        // In ethhash mode, account keys (32 bytes) have their storageRoot field
-        // updated during hashing, so the stored value will differ from the original.
-        #[cfg(feature = "ethhash")]
-        if key.len() == 32 {
+        // Under Ethereum hashing, account keys (32 bytes) have their storageRoot
+        // field updated during hashing, so the stored value will differ from the
+        // original.
+        if H::ALGORITHM.is_ethereum() && key.len() == 32 {
             assert!(
                 stored.is_some(),
                 "Failed to get account key after committing: {key:?}"
@@ -237,9 +171,9 @@ fn decrease_key(key: &[u8; 32]) -> [u8; 32] {
     new_key
 }
 
-#[test]
-fn test_get_regression() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_get_regression<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle.insert(&[0], Box::new([0])).unwrap();
     assert_eq!(merkle.get_value(&[0]).unwrap(), Some(Box::from([0])));
@@ -261,14 +195,14 @@ fn test_get_regression() {
     }
 }
 
-#[test]
-fn insert_one() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn insert_one<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     merkle.insert(b"abc", Box::new([])).unwrap();
 }
 
-fn create_in_memory_merkle() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
-    let memstore = MemStore::default();
+fn create_in_memory_merkle<H: HashMode>() -> Merkle<NodeStore<Mutable<Propose>, MemStore, H>> {
+    let memstore = MemStore::new(Vec::new(), H::ALGORITHM);
 
     let nodestore = NodeStore::new_empty_proposal(memstore.into(), DeletedNodeTracking::Enabled);
 
@@ -293,9 +227,9 @@ fn test_branch_proof_node(
     }
 }
 
-#[test]
-fn test_get_node_from_nibbles_matches_byte_lookup() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_get_node_from_nibbles_matches_byte_lookup<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     merkle.insert(&[0xab, 0xcd], Box::from([1u8])).unwrap();
 
     let from_bytes = merkle.get_node(&[0xab, 0xcd]).unwrap();
@@ -304,9 +238,9 @@ fn test_get_node_from_nibbles_matches_byte_lookup() {
     assert_eq!(from_bytes, from_nibbles);
 }
 
-#[test]
-fn test_insert_branch_from_nibbles_into_empty_trie() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_insert_branch_from_nibbles_into_empty_trie<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle.insert_branch_from_nibbles(&[0xa, 0xb, 0xc]).unwrap();
 
@@ -318,9 +252,9 @@ fn test_insert_branch_from_nibbles_into_empty_trie() {
     assert!(branch.value.is_none());
 }
 
-#[test]
-fn test_insert_branch_from_nibbles_converts_leaf_to_branch() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_insert_branch_from_nibbles_converts_leaf_to_branch<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     merkle.insert(&[0xab], Box::from([9u8])).unwrap();
 
     merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
@@ -334,9 +268,9 @@ fn test_insert_branch_from_nibbles_converts_leaf_to_branch() {
     );
 }
 
-#[test]
-fn test_insert_branch_from_nibbles_inserts_missing_ancestor() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_insert_branch_from_nibbles_inserts_missing_ancestor<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     merkle.insert(&[0xab, 0xcd], Box::from([7u8])).unwrap();
 
     merkle.insert_branch_from_nibbles(&[0xa]).unwrap();
@@ -350,9 +284,9 @@ fn test_insert_branch_from_nibbles_inserts_missing_ancestor() {
     );
 }
 
-#[test]
-fn test_insert_branch_from_nibbles_inserts_missing_descendant() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_insert_branch_from_nibbles_inserts_missing_descendant<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     merkle.insert(&[0xab], Box::from([5u8])).unwrap();
 
     merkle.insert_branch_from_nibbles(&[0xa, 0xb, 0xc]).unwrap();
@@ -369,9 +303,9 @@ fn test_insert_branch_from_nibbles_inserts_missing_descendant() {
     );
 }
 
-#[test]
-fn test_insert_branch_from_nibbles_splits_divergent_paths() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_insert_branch_from_nibbles_splits_divergent_paths<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     // Leaf at [0xab] has nibble path [a, b]
     merkle.insert(&[0xab], Box::from([3u8])).unwrap();
 
@@ -388,9 +322,9 @@ fn test_insert_branch_from_nibbles_splits_divergent_paths() {
     );
 }
 
-#[test]
-fn test_insert_and_get() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_insert_and_get<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
 
     // insert values
     for key_val in u8::MIN..=u8::MAX {
@@ -416,13 +350,13 @@ fn test_insert_and_get() {
     }
 }
 
-#[test]
-fn overwrite_leaf() {
+#[firewood_macros::hash_mode]
+fn overwrite_leaf<H: HashMode>() {
     let key = &[0x00];
     let val = &[1];
     let overwrite = &[2];
 
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle.insert(key, val[..].into()).unwrap();
 
@@ -439,8 +373,8 @@ fn overwrite_leaf() {
     );
 }
 
-#[test]
-fn remove_root() {
+#[firewood_macros::hash_mode]
+fn remove_root<H: HashMode>() {
     let key0 = vec![0];
     let val0 = [0];
     let key1 = vec![0, 1];
@@ -450,7 +384,7 @@ fn remove_root() {
     let key3 = vec![0, 1, 15];
     let val3 = [0, 1, 15];
 
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle.insert(&key0, Box::from(val0)).unwrap();
     merkle.insert(&key1, Box::from(val1)).unwrap();
@@ -498,9 +432,9 @@ fn remove_root() {
     assert!(merkle.nodestore.root_node().is_none());
 }
 
-#[test]
-fn remove_prefix_exact() {
-    let mut merkle = two_byte_all_keys();
+#[firewood_macros::hash_mode]
+fn remove_prefix_exact<H: HashMode>() {
+    let mut merkle = two_byte_all_keys::<H>();
     for key_val in u8::MIN..=u8::MAX {
         let key = [key_val];
         let got = merkle.remove_prefix(&key).unwrap();
@@ -510,8 +444,8 @@ fn remove_prefix_exact() {
     }
 }
 
-fn two_byte_all_keys() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
-    let mut merkle = create_in_memory_merkle();
+fn two_byte_all_keys<H: HashMode>() -> Merkle<NodeStore<Mutable<Propose>, MemStore, H>> {
+    let mut merkle = create_in_memory_merkle::<H>();
     for key_val in u8::MIN..=u8::MAX {
         let key = [key_val, key_val];
         let val = [key_val];
@@ -523,16 +457,16 @@ fn two_byte_all_keys() -> Merkle<NodeStore<Mutable<Propose>, MemStore>> {
     merkle
 }
 
-#[test]
-fn remove_prefix_all() {
-    let mut merkle = two_byte_all_keys();
+#[firewood_macros::hash_mode]
+fn remove_prefix_all<H: HashMode>() {
+    let mut merkle = two_byte_all_keys::<H>();
     let got = merkle.remove_prefix(&[]).unwrap();
     assert_eq!(got, 256);
 }
 
-#[test]
-fn remove_prefix_partial() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn remove_prefix_partial<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     merkle
         .insert(b"abc", Box::from(b"value".as_slice()))
         .unwrap();
@@ -543,9 +477,9 @@ fn remove_prefix_partial() {
     assert_eq!(got, 2);
 }
 
-#[test]
-fn remove_many() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn remove_many<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
 
     // insert key-value pairs
     for key_val in u8::MIN..=u8::MAX {
@@ -574,9 +508,9 @@ fn remove_many() {
     assert!(merkle.nodestore.root_node().is_none());
 }
 
-#[test]
-fn remove_prefix() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn remove_prefix<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
 
     // insert key-value pairs
     for key_val in u8::MIN..=u8::MAX {
@@ -604,18 +538,18 @@ fn remove_prefix() {
     }
 }
 
-#[test]
-fn get_empty_proof() {
-    let merkle = create_in_memory_merkle().hash();
+#[firewood_macros::hash_mode]
+fn get_empty_proof<H: HashMode>() {
+    let merkle = create_in_memory_merkle::<H>().hash();
     let proof = merkle.prove(b"any-key");
     assert!(matches!(proof.unwrap_err(), ProofError::Empty));
 }
 
-#[test]
-fn single_key_proof() {
+#[firewood_macros::hash_mode]
+fn single_key_proof<H: HashMode>() {
     const TEST_SIZE: usize = 1;
 
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
@@ -633,12 +567,7 @@ fn single_key_proof() {
         let proof = merkle.prove(&key).unwrap();
 
         proof
-            .verify(
-                key.clone(),
-                Some(value.clone()),
-                &root_hash,
-                <firewood_storage::DefaultHashMode as firewood_storage::HashMode>::ALGORITHM,
-            )
+            .verify(key.clone(), Some(value.clone()), &root_hash, H::ALGORITHM)
             .unwrap();
 
         {
@@ -647,12 +576,7 @@ fn single_key_proof() {
             value[0] = value[0].wrapping_add(1);
             assert!(
                 proof
-                    .verify(
-                        key.clone(),
-                        Some(value),
-                        &root_hash,
-                        <firewood_storage::DefaultHashMode as firewood_storage::HashMode>::ALGORITHM
-                    )
+                    .verify(key.clone(), Some(value), &root_hash, H::ALGORITHM)
                     .is_err()
             );
         }
@@ -661,21 +585,16 @@ fn single_key_proof() {
             // Test that the proof is invalid when the hash is different
             assert!(
                 proof
-                    .verify(
-                        key,
-                        Some(value),
-                        &TrieHash::empty(),
-                        <firewood_storage::DefaultHashMode as firewood_storage::HashMode>::ALGORITHM
-                    )
+                    .verify(key, Some(value), &TrieHash::empty(), H::ALGORITHM)
                     .is_err()
             );
         }
     }
 }
 
-#[test]
-fn empty_range_proof() {
-    let merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn empty_range_proof<H: HashMode>() {
+    let merkle = create_in_memory_merkle::<H>();
 
     assert!(matches!(
         merkle.range_proof(None, None, None).unwrap_err(),
@@ -683,15 +602,15 @@ fn empty_range_proof() {
     ));
 }
 
-#[test]
-fn test_insert_leaf_suffix() {
+#[firewood_macros::hash_mode]
+fn test_insert_leaf_suffix<H: HashMode>() {
     // key_2 is a suffix of key, which is a leaf
     let key = vec![0xff];
     let val = [1];
     let key_2 = vec![0xff, 0x00];
     let val_2 = [2];
 
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle.insert(&key, Box::new(val)).unwrap();
     merkle.insert(&key_2, Box::new(val_2)).unwrap();
@@ -704,15 +623,15 @@ fn test_insert_leaf_suffix() {
     assert_eq!(*got, val_2);
 }
 
-#[test]
-fn test_insert_leaf_prefix() {
+#[firewood_macros::hash_mode]
+fn test_insert_leaf_prefix<H: HashMode>() {
     // key_2 is a prefix of key, which is a leaf
     let key = vec![0xff, 0x00];
     let val = [1];
     let key_2 = vec![0xff];
     let val_2 = [2];
 
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle.insert(&key, Box::new(val)).unwrap();
     merkle.insert(&key_2, Box::new(val_2)).unwrap();
@@ -724,8 +643,8 @@ fn test_insert_leaf_prefix() {
     assert_eq!(*got, val_2);
 }
 
-#[test]
-fn test_insert_sibling_leaf() {
+#[firewood_macros::hash_mode]
+fn test_insert_sibling_leaf<H: HashMode>() {
     // The node at key is a branch node with children key_2 and key_3.
     // TODO(rkuris) assert in this test that key is the parent of key_2 and key_3.
     // i.e. the node types are branch, leaf, leaf respectively.
@@ -736,7 +655,7 @@ fn test_insert_sibling_leaf() {
     let key_3 = vec![0xff, 0x0f];
     let val_3 = [3];
 
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle.insert(&key, Box::new(val)).unwrap();
     merkle.insert(&key_2, Box::new(val_2)).unwrap();
@@ -752,8 +671,8 @@ fn test_insert_sibling_leaf() {
     assert_eq!(*got, val_3);
 }
 
-#[test]
-fn test_insert_branch_as_branch_parent() {
+#[firewood_macros::hash_mode]
+fn test_insert_branch_as_branch_parent<H: HashMode>() {
     let key = vec![0xff, 0xf0];
     let val = [1];
     let key_2 = vec![0xff, 0xf0, 0x00];
@@ -761,7 +680,7 @@ fn test_insert_branch_as_branch_parent() {
     let key_3 = vec![0xff];
     let val_3 = [3];
 
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle.insert(&key, Box::new(val)).unwrap();
     // key is a leaf
@@ -783,15 +702,15 @@ fn test_insert_branch_as_branch_parent() {
     assert_eq!(&*got, val_3);
 }
 
-#[test]
-fn test_insert_overwrite_branch_value() {
+#[firewood_macros::hash_mode]
+fn test_insert_overwrite_branch_value<H: HashMode>() {
     let key = vec![0xff];
     let val = [1];
     let key_2 = vec![0xff, 0x00];
     let val_2 = [2];
     let overwrite = [3];
 
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<H>();
 
     merkle.insert(&key, Box::new(val)).unwrap();
     merkle.insert(&key_2, Box::new(val_2)).unwrap();
@@ -811,9 +730,9 @@ fn test_insert_overwrite_branch_value() {
     assert_eq!(*got, val_2);
 }
 
-#[test]
-fn test_delete_one_child_with_branch_value() {
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_delete_one_child_with_branch_value<H: HashMode>() {
+    let mut merkle = create_in_memory_merkle::<H>();
     // insert a parent with a value
     merkle.insert(&[0], Box::new([42u8])).unwrap();
     // insert child1 with a value
@@ -834,9 +753,9 @@ fn test_delete_one_child_with_branch_value() {
     assert_eq!(*other_child, [44u8]);
 }
 
-#[test]
-fn test_root_hash_simple_insertions() -> Result<(), Error> {
-    init_merkle([
+#[firewood_macros::hash_mode]
+fn test_root_hash_simple_insertions<H: HashMode>() -> Result<(), Error> {
+    init_merkle::<H, _, _, _>([
         ("do", "verb"),
         ("doe", "reindeer"),
         ("dog", "puppy"),
@@ -849,8 +768,8 @@ fn test_root_hash_simple_insertions() -> Result<(), Error> {
     Ok(())
 }
 
-#[test]
-fn test_root_hash_fuzz_insertions() -> Result<(), FileIoError> {
+#[firewood_macros::hash_mode]
+fn test_root_hash_fuzz_insertions<H: HashMode>() -> Result<(), FileIoError> {
     let rng = firewood_storage::SeededRng::from_option(Some(42));
     let max_len0 = 8;
     let max_len1 = 4;
@@ -876,24 +795,24 @@ fn test_root_hash_fuzz_insertions() -> Result<(), FileIoError> {
             items.push((keygen(), val));
         }
 
-        init_merkle(items);
+        init_merkle::<H, _, _, _>(items);
     }
 
     Ok(())
 }
 
-#[test]
-fn test_delete_child() {
+#[firewood_macros::hash_mode]
+fn test_delete_child<H: HashMode>() {
     let items = vec![("do", "verb")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let mut merkle = merkle.fork().unwrap();
 
     assert_eq!(merkle.remove(b"does_not_exist").unwrap(), None);
     assert_eq!(&*merkle.get_value(b"do").unwrap().unwrap(), b"verb");
 }
 
-#[test]
-fn test_delete_some() {
+#[firewood_macros::hash_mode]
+fn test_delete_some<H: HashMode>() {
     let items = (0..100)
         .map(|n| {
             let key = format!("key{n}");
@@ -901,7 +820,7 @@ fn test_delete_some() {
             (key.as_bytes().to_vec(), val.as_bytes().to_vec())
         })
         .collect::<Vec<(Vec<u8>, Vec<u8>)>>();
-    let mut merkle = init_merkle(items.clone()).fork().unwrap();
+    let mut merkle = init_merkle::<H, _, _, _>(items.clone()).fork().unwrap();
     merkle.remove_prefix(b"key1").unwrap();
     for item in items {
         let (key, val) = item;
@@ -913,8 +832,8 @@ fn test_delete_some() {
     }
 }
 
-#[test]
-fn test_root_hash_reversed_deletions() -> Result<(), FileIoError> {
+#[firewood_macros::hash_mode]
+fn test_root_hash_reversed_deletions<H: HashMode>() -> Result<(), FileIoError> {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let max_len0 = 8;
@@ -944,7 +863,7 @@ fn test_root_hash_reversed_deletions() -> Result<(), FileIoError> {
         items.sort_unstable();
         items.dedup_by_key(|(k, _)| k.clone());
 
-        let init_merkle = create_in_memory_merkle();
+        let init_merkle = create_in_memory_merkle::<H>();
         let init_immutable_merkle = init_merkle.hash();
 
         let (hashes, complete_immutable_merkle) = items.iter().fold(
@@ -966,8 +885,9 @@ fn test_root_hash_reversed_deletions() -> Result<(), FileIoError> {
                     NodeStore::new(immutable_merkle_before_removal.nodestore()).unwrap(),
                 );
                 merkle.remove(k).unwrap();
-                let immutable_merkle_after_removal: Merkle<NodeStore<Arc<ImmutableProposal>, _>> =
-                    merkle.try_into().unwrap();
+                let immutable_merkle_after_removal: Merkle<
+                    NodeStore<Arc<ImmutableProposal>, _, H>,
+                > = merkle.try_into().unwrap();
                 new_hashes.push((
                     immutable_merkle_after_removal.nodestore.root_hash(),
                     k,
@@ -995,38 +915,38 @@ fn test_root_hash_reversed_deletions() -> Result<(), FileIoError> {
     Ok(())
 }
 
-#[test]
-fn remove_nonexistent_with_one() {
+#[firewood_macros::hash_mode]
+fn remove_nonexistent_with_one<H: HashMode>() {
     let items = [("do", "verb")];
-    let mut merkle = init_merkle(items).fork().unwrap();
+    let mut merkle = init_merkle::<H, _, _, _>(items).fork().unwrap();
 
     assert_eq!(merkle.remove(b"does_not_exist").unwrap(), None);
     assert_eq!(&*merkle.get_value(b"do").unwrap().unwrap(), b"verb");
 }
 
-#[test]
-fn test_get_branch_from_nibbles_mut() {
-    type TestMerkle = Merkle<NodeStore<Mutable<Propose>, MemStore>>;
-    let mut merkle = create_in_memory_merkle();
+#[firewood_macros::hash_mode]
+fn test_get_branch_from_nibbles_mut<H: HashMode>() {
+    type TestMerkle<H> = Merkle<NodeStore<Mutable<Propose>, MemStore, H>>;
+    let mut merkle = create_in_memory_merkle::<H>();
     merkle.insert(b"\xab", Box::from([1])).unwrap();
     merkle.insert(b"\xac", Box::from([2])).unwrap();
 
     // Branch exists at [a] — has children at b and c
-    let branch = TestMerkle::get_branch_from_nibbles_mut(
+    let branch = TestMerkle::<H>::get_branch_from_nibbles_mut(
         merkle.nodestore.root_mut(),
         &[PathComponent::try_new(0xa).unwrap()],
     );
     assert!(branch.is_some());
 
     // Nothing at [f]
-    let missing = TestMerkle::get_branch_from_nibbles_mut(
+    let missing = TestMerkle::<H>::get_branch_from_nibbles_mut(
         merkle.nodestore.root_mut(),
         &[PathComponent::try_new(0xf).unwrap()],
     );
     assert!(missing.is_none());
 
     // [a, b] is a leaf, not a branch
-    let leaf = TestMerkle::get_branch_from_nibbles_mut(
+    let leaf = TestMerkle::<H>::get_branch_from_nibbles_mut(
         merkle.nodestore.root_mut(),
         &[
             PathComponent::try_new(0xa).unwrap(),

--- a/firewood/src/merkle/tests/proof.rs
+++ b/firewood/src/merkle/tests/proof.rs
@@ -1,14 +1,13 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use firewood_storage::Preimage;
 use firewood_storage::logger::debug;
 
 use super::*;
 
-#[test]
-fn range_proof_invalid_bounds() {
-    let merkle = create_in_memory_merkle().hash();
+#[firewood_macros::hash_mode]
+fn range_proof_invalid_bounds<H: HashMode>() {
+    let merkle = create_in_memory_merkle::<H>().hash();
 
     let start_key = &[0x01];
     let end_key = &[0x00];
@@ -23,26 +22,28 @@ fn range_proof_invalid_bounds() {
     }
 }
 
-#[test]
-fn full_range_proof() {
-    let merkle = init_merkle((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
+#[firewood_macros::hash_mode]
+fn full_range_proof<H: HashMode>() {
+    const FULL_KEY_RANGE_LEN: usize = 256; // u8::MAX + 1 keys
+
+    let merkle = init_merkle::<H, _, _, _>((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
 
     let rangeproof = merkle.range_proof(None, None, None).unwrap();
-    assert_eq!(rangeproof.key_values().len(), u8::MAX as usize + 1);
+    assert_eq!(rangeproof.key_values().len(), FULL_KEY_RANGE_LEN);
     assert_eq!(rangeproof.start_proof(), &FrozenProof::default());
     assert_eq!(rangeproof.end_proof(), &FrozenProof::default());
 
     let rangeproof = roundtrip_range_proof(&rangeproof);
-    assert_eq!(rangeproof.key_values().len(), u8::MAX as usize + 1);
+    assert_eq!(rangeproof.key_values().len(), FULL_KEY_RANGE_LEN);
     assert_eq!(rangeproof.start_proof(), &FrozenProof::default());
     assert_eq!(rangeproof.end_proof(), &FrozenProof::default());
 }
 
-#[test]
-fn single_value_range_proof() {
+#[firewood_macros::hash_mode]
+fn single_value_range_proof<H: HashMode>() {
     const RANDOM_KEY: u8 = 42;
 
-    let merkle = init_merkle((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
+    let merkle = init_merkle::<H, _, _, _>((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
 
     let rangeproof = merkle
         .range_proof(Some(&[RANDOM_KEY]), None, NonZeroUsize::new(1))
@@ -55,108 +56,83 @@ fn single_value_range_proof() {
     assert_eq!(rangeproof.key_values().len(), 1);
 }
 
-#[test]
-fn shared_path_proof() {
+#[firewood_macros::hash_mode]
+fn shared_path_proof<H: HashMode>() {
     let key1 = b"key1";
     let value1 = b"1";
 
     let key2 = b"key2";
     let value2 = b"2";
 
-    let merkle = init_merkle([(key1, value1), (key2, value2)]);
+    let merkle = init_merkle::<H, _, _, _>([(key1, value1), (key2, value2)]);
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let key = key1;
     let proof = merkle.prove(key).unwrap();
     proof
-        .verify(
-            key,
-            Some(value1),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(value1), &root_hash, H::ALGORITHM)
         .unwrap();
 
     let key = key2;
     let proof = merkle.prove(key).unwrap();
     proof
-        .verify(
-            key,
-            Some(value2),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(value2), &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn single_key_proof_with_one_node() {
+#[firewood_macros::hash_mode]
+fn single_key_proof_with_one_node<H: HashMode>() {
     let key = b"key";
     let value = b"value";
 
-    let merkle = init_merkle([(key, value)]);
+    let merkle = init_merkle::<H, _, _, _>([(key, value)]);
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let proof = merkle.prove(key).unwrap();
     proof
-        .verify(
-            key,
-            Some(value),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(value), &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn two_key_proof_without_shared_path() {
+#[firewood_macros::hash_mode]
+fn two_key_proof_without_shared_path<H: HashMode>() {
     let key1 = &[0x00];
     let key2 = &[0xff];
 
-    let merkle = init_merkle([(key1, key1), (key2, key2)]);
+    let merkle = init_merkle::<H, _, _, _>([(key1, key1), (key2, key2)]);
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let proof = merkle.prove(key1).unwrap();
     proof
-        .verify(
-            key1,
-            Some(key1),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key1, Some(key1), &root_hash, H::ALGORITHM)
         .unwrap();
 
     let proof = merkle.prove(key2).unwrap();
     proof
-        .verify(
-            key2,
-            Some(key2),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key2, Some(key2), &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn test_empty_tree_proof() {
+#[firewood_macros::hash_mode]
+fn test_empty_tree_proof<H: HashMode>() {
     let items: Vec<(&str, &str)> = Vec::new();
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let key = "x".as_ref();
 
     let proof_err = merkle.prove(key).unwrap_err();
     assert!(matches!(proof_err, ProofError::Empty), "{proof_err:?}");
 }
 
-#[test]
-fn test_proof() {
+#[firewood_macros::hash_mode]
+fn test_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
     let set = fixed_and_pseudorandom_data(&rng, 500);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
@@ -169,19 +145,14 @@ fn test_proof() {
         // committed, not what was originally inserted.
         let stored_val = merkle.get_value(key).unwrap().expect("key should exist");
         proof
-            .verify(
-                key,
-                Some(&stored_val),
-                &root_hash,
-                firewood_storage::DefaultHashMode::ALGORITHM,
-            )
+            .verify(key, Some(&stored_val), &root_hash, H::ALGORITHM)
             .unwrap();
     }
 }
 
-#[test]
-fn test_proof_end_with_leaf() {
-    let merkle = init_merkle([
+#[firewood_macros::hash_mode]
+fn test_proof_end_with_leaf<H: HashMode>() {
+    let merkle = init_merkle::<H, _, _, _>([
         ("do", "verb"),
         ("doe", "reindeer"),
         ("dog", "puppy"),
@@ -197,24 +168,19 @@ fn test_proof_end_with_leaf() {
     assert!(!proof.is_empty());
 
     proof
-        .verify(
-            key,
-            Some(b"reindeer"),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(b"reindeer"), &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn test_proof_end_with_branch() {
+#[firewood_macros::hash_mode]
+fn test_proof_end_with_branch<H: HashMode>() {
     let items = [
         ("d", "verb"),
         ("do", "verb"),
         ("doe", "reindeer"),
         ("e", "coin"),
     ];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let key = b"d";
@@ -223,22 +189,17 @@ fn test_proof_end_with_branch() {
     assert!(!proof.is_empty());
 
     proof
-        .verify(
-            key,
-            Some(b"verb"),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(b"verb"), &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn test_bad_proof() {
+#[firewood_macros::hash_mode]
+fn test_bad_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
     let set = fixed_and_pseudorandom_data(&rng, 800);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     for (key, value) in items {
@@ -252,21 +213,16 @@ fn test_bad_proof() {
         // TODO(demosdemon): verify error result matches expected error
         assert!(
             new_proof
-                .verify(
-                    key,
-                    Some(value),
-                    &root_hash,
-                    firewood_storage::DefaultHashMode::ALGORITHM
-                )
+                .verify(key, Some(value), &root_hash, H::ALGORITHM)
                 .is_err()
         );
     }
 }
 
-#[test]
-fn exclusion_with_proof_value_present() {
+#[firewood_macros::hash_mode]
+fn exclusion_with_proof_value_present<H: HashMode>() {
     // Build a trie where an ancestor on the path has a value
-    let mut merkle = crate::merkle::tests::create_in_memory_merkle();
+    let mut merkle = crate::merkle::tests::create_in_memory_merkle::<H>();
     // Parent has a value
     merkle.insert(&[0u8], Box::from([0u8])).unwrap();
     // Child under the same branch
@@ -282,8 +238,14 @@ fn exclusion_with_proof_value_present() {
     let proof = merkle.prove(&missing).unwrap();
 
     debug!("{proof:#?}");
+    // `Preimage::to_hash` (the inherent `.to_hash()` method) always hashes
+    // under the compile-time `DefaultHashMode`, not the mode this trie was
+    // actually built with — it hasn't been threaded over `H` yet (see the
+    // `Preimage` doc comment in `firewood-storage::hashednode`). Call the
+    // mode-aware `HashMode::to_hash` directly so this assertion holds under
+    // both wrappers regardless of which mode the binary defaults to.
     assert_eq!(
-        proof.as_ref().first().unwrap().to_hash(),
+        H::to_hash(proof.as_ref().first().unwrap()),
         HashType::from(root_hash.clone())
     );
 
@@ -292,21 +254,16 @@ fn exclusion_with_proof_value_present() {
 
     // Exclusion should verify with expected None even if proof includes node values
     proof
-        .verify(
-            missing,
-            Option::<&[u8]>::None,
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(missing, Option::<&[u8]>::None, &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn proof_path_construction_and_corruption() {
+#[firewood_macros::hash_mode]
+fn proof_path_construction_and_corruption<H: HashMode>() {
     use crate::{Proof, ProofNode};
 
     // Build a trie with several entries
-    let mut merkle = crate::merkle::tests::create_in_memory_merkle();
+    let mut merkle = crate::merkle::tests::create_in_memory_merkle::<H>();
     merkle.insert(b"a", Box::from(b"1".as_slice())).unwrap();
     merkle.insert(b"ab", Box::from(b"2".as_slice())).unwrap();
     merkle.insert(b"abc", Box::from(b"3".as_slice())).unwrap();
@@ -334,12 +291,7 @@ fn proof_path_construction_and_corruption() {
 
     // Sanity: proof verifies
     proof
-        .verify(
-            key,
-            Some(val.as_slice()),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(val.as_slice()), &root_hash, H::ALGORITHM)
         .unwrap();
 
     // Negative: corrupt the path by clearing children of the first node
@@ -350,12 +302,7 @@ fn proof_path_construction_and_corruption() {
     }
     let corrupt = corrupt.into_immutable();
     let err = corrupt
-        .verify(
-            key,
-            Some(val.as_slice()),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(val.as_slice()), &root_hash, H::ALGORITHM)
         .unwrap_err();
     // Node traversal should fail
     assert!(matches!(
@@ -364,9 +311,9 @@ fn proof_path_construction_and_corruption() {
     ));
 }
 
-#[test]
-fn range_proof_serialization_roundtrip() {
-    let merkle = init_merkle((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
+#[firewood_macros::hash_mode]
+fn range_proof_serialization_roundtrip<H: HashMode>() {
+    let merkle = init_merkle::<H, _, _, _>((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
 
     let start_key = &[42u8];
     let end_key = &[84u8];
@@ -390,21 +337,17 @@ fn roundtrip_range_proof(proof: &FrozenRangeProof) -> FrozenRangeProof {
 /// is an ancestor of the proven key and has a child at the next nibble,
 /// the proof is incomplete — it must include that child to demonstrate
 /// the key's absence.
-#[test]
-fn truncated_exclusion_proof_rejected() {
+#[firewood_macros::hash_mode]
+fn truncated_exclusion_proof_rejected<H: HashMode>() {
     // \x10 and \x20 exist. \x15 does not.
-    let merkle = init_merkle([(b"\x10" as &[u8], b"a"), (b"\x20", b"b")]);
+    let merkle = init_merkle::<H, _, _, _>([(b"\x10" as &[u8], b"a"), (b"\x20", b"b")]);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     // Full exclusion proof for \x15 — proves it doesn't exist.
     let full_proof = merkle.prove(b"\x15").unwrap();
     assert!(
         full_proof
-            .value_digest(
-                b"\x15",
-                &root_hash,
-                firewood_storage::DefaultHashMode::ALGORITHM
-            )
+            .value_digest(b"\x15", &root_hash, H::ALGORITHM)
             .unwrap()
             .is_none(),
         "full proof should be a valid exclusion proof"
@@ -421,11 +364,7 @@ fn truncated_exclusion_proof_rejected() {
 
     // The truncated proof must be rejected — the remaining terminal node
     // has a child toward \x15 but the proof doesn't include it.
-    let result = truncated.value_digest(
-        b"\x15",
-        &root_hash,
-        firewood_storage::DefaultHashMode::ALGORITHM,
-    );
+    let result = truncated.value_digest(b"\x15", &root_hash, H::ALGORITHM);
     assert!(
         matches!(result, Err(crate::ProofError::ExclusionProofMissingChild)),
         "truncated exclusion proof should be rejected with ExclusionProofMissingChild, got {result:?}"

--- a/firewood/src/merkle/tests/proof.rs
+++ b/firewood/src/merkle/tests/proof.rs
@@ -1,14 +1,13 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use firewood_storage::Preimage;
 use firewood_storage::logger::debug;
 
 use super::*;
 
-#[test]
-fn range_proof_invalid_bounds() {
-    let merkle = create_in_memory_merkle().hash();
+#[firewood_macros::hash_mode]
+fn range_proof_invalid_bounds<H: HashMode>() {
+    let merkle = create_in_memory_merkle::<H>().hash();
 
     let start_key = &[0x01];
     let end_key = &[0x00];
@@ -23,26 +22,28 @@ fn range_proof_invalid_bounds() {
     }
 }
 
-#[test]
-fn full_range_proof() {
-    let merkle = init_merkle((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
+#[firewood_macros::hash_mode]
+fn full_range_proof<H: HashMode>() {
+    const FULL_KEY_RANGE_LEN: usize = 256; // u8::MAX + 1 keys
+
+    let merkle = init_merkle::<H, _, _, _>((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
 
     let rangeproof = merkle.range_proof(None, None, None).unwrap();
-    assert_eq!(rangeproof.key_values().len(), u8::MAX as usize + 1);
+    assert_eq!(rangeproof.key_values().len(), FULL_KEY_RANGE_LEN);
     assert_eq!(rangeproof.start_proof(), &FrozenProof::default());
     assert_eq!(rangeproof.end_proof(), &FrozenProof::default());
 
     let rangeproof = roundtrip_range_proof(&rangeproof);
-    assert_eq!(rangeproof.key_values().len(), u8::MAX as usize + 1);
+    assert_eq!(rangeproof.key_values().len(), FULL_KEY_RANGE_LEN);
     assert_eq!(rangeproof.start_proof(), &FrozenProof::default());
     assert_eq!(rangeproof.end_proof(), &FrozenProof::default());
 }
 
-#[test]
-fn single_value_range_proof() {
+#[firewood_macros::hash_mode]
+fn single_value_range_proof<H: HashMode>() {
     const RANDOM_KEY: u8 = 42;
 
-    let merkle = init_merkle((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
+    let merkle = init_merkle::<H, _, _, _>((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
 
     let rangeproof = merkle
         .range_proof(Some(&[RANDOM_KEY]), None, NonZeroUsize::new(1))
@@ -55,108 +56,83 @@ fn single_value_range_proof() {
     assert_eq!(rangeproof.key_values().len(), 1);
 }
 
-#[test]
-fn shared_path_proof() {
+#[firewood_macros::hash_mode]
+fn shared_path_proof<H: HashMode>() {
     let key1 = b"key1";
     let value1 = b"1";
 
     let key2 = b"key2";
     let value2 = b"2";
 
-    let merkle = init_merkle([(key1, value1), (key2, value2)]);
+    let merkle = init_merkle::<H, _, _, _>([(key1, value1), (key2, value2)]);
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let key = key1;
     let proof = merkle.prove(key).unwrap();
     proof
-        .verify(
-            key,
-            Some(value1),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(value1), &root_hash, H::ALGORITHM)
         .unwrap();
 
     let key = key2;
     let proof = merkle.prove(key).unwrap();
     proof
-        .verify(
-            key,
-            Some(value2),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(value2), &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn single_key_proof_with_one_node() {
+#[firewood_macros::hash_mode]
+fn single_key_proof_with_one_node<H: HashMode>() {
     let key = b"key";
     let value = b"value";
 
-    let merkle = init_merkle([(key, value)]);
+    let merkle = init_merkle::<H, _, _, _>([(key, value)]);
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let proof = merkle.prove(key).unwrap();
     proof
-        .verify(
-            key,
-            Some(value),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(value), &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn two_key_proof_without_shared_path() {
+#[firewood_macros::hash_mode]
+fn two_key_proof_without_shared_path<H: HashMode>() {
     let key1 = &[0x00];
     let key2 = &[0xff];
 
-    let merkle = init_merkle([(key1, key1), (key2, key2)]);
+    let merkle = init_merkle::<H, _, _, _>([(key1, key1), (key2, key2)]);
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let proof = merkle.prove(key1).unwrap();
     proof
-        .verify(
-            key1,
-            Some(key1),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key1, Some(key1), &root_hash, H::ALGORITHM)
         .unwrap();
 
     let proof = merkle.prove(key2).unwrap();
     proof
-        .verify(
-            key2,
-            Some(key2),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key2, Some(key2), &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn test_empty_tree_proof() {
+#[firewood_macros::hash_mode]
+fn test_empty_tree_proof<H: HashMode>() {
     let items: Vec<(&str, &str)> = Vec::new();
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let key = "x".as_ref();
 
     let proof_err = merkle.prove(key).unwrap_err();
     assert!(matches!(proof_err, ProofError::Empty), "{proof_err:?}");
 }
 
-#[test]
-fn test_proof() {
+#[firewood_macros::hash_mode]
+fn test_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
     let set = fixed_and_pseudorandom_data(&rng, 500);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
@@ -169,19 +145,14 @@ fn test_proof() {
         // committed, not what was originally inserted.
         let stored_val = merkle.get_value(key).unwrap().expect("key should exist");
         proof
-            .verify(
-                key,
-                Some(&stored_val),
-                &root_hash,
-                firewood_storage::DefaultHashMode::ALGORITHM,
-            )
+            .verify(key, Some(&stored_val), &root_hash, H::ALGORITHM)
             .unwrap();
     }
 }
 
-#[test]
-fn test_proof_end_with_leaf() {
-    let merkle = init_merkle([
+#[firewood_macros::hash_mode]
+fn test_proof_end_with_leaf<H: HashMode>() {
+    let merkle = init_merkle::<H, _, _, _>([
         ("do", "verb"),
         ("doe", "reindeer"),
         ("dog", "puppy"),
@@ -197,24 +168,19 @@ fn test_proof_end_with_leaf() {
     assert!(!proof.is_empty());
 
     proof
-        .verify(
-            key,
-            Some(b"reindeer"),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(b"reindeer"), &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn test_proof_end_with_branch() {
+#[firewood_macros::hash_mode]
+fn test_proof_end_with_branch<H: HashMode>() {
     let items = [
         ("d", "verb"),
         ("do", "verb"),
         ("doe", "reindeer"),
         ("e", "coin"),
     ];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let key = b"d";
@@ -223,22 +189,17 @@ fn test_proof_end_with_branch() {
     assert!(!proof.is_empty());
 
     proof
-        .verify(
-            key,
-            Some(b"verb"),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(b"verb"), &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn test_bad_proof() {
+#[firewood_macros::hash_mode]
+fn test_bad_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
     let set = fixed_and_pseudorandom_data(&rng, 800);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     for (key, value) in items {
@@ -252,21 +213,16 @@ fn test_bad_proof() {
         // TODO(demosdemon): verify error result matches expected error
         assert!(
             new_proof
-                .verify(
-                    key,
-                    Some(value),
-                    &root_hash,
-                    firewood_storage::DefaultHashMode::ALGORITHM
-                )
+                .verify(key, Some(value), &root_hash, H::ALGORITHM)
                 .is_err()
         );
     }
 }
 
-#[test]
-fn exclusion_with_proof_value_present() {
+#[firewood_macros::hash_mode]
+fn exclusion_with_proof_value_present<H: HashMode>() {
     // Build a trie where an ancestor on the path has a value
-    let mut merkle = crate::merkle::tests::create_in_memory_merkle();
+    let mut merkle = crate::merkle::tests::create_in_memory_merkle::<H>();
     // Parent has a value
     merkle.insert(&[0u8], Box::from([0u8])).unwrap();
     // Child under the same branch
@@ -282,8 +238,14 @@ fn exclusion_with_proof_value_present() {
     let proof = merkle.prove(&missing).unwrap();
 
     debug!("{proof:#?}");
+    // `Preimage::to_hash` (the inherent `.to_hash()` method) always hashes
+    // under the compile-time `DefaultHashMode`, not the mode this trie was
+    // actually built with — it hasn't been threaded over `H` yet (see the
+    // `Preimage` doc comment in `firewood-storage::hashednode`). Call the
+    // mode-aware `HashMode::to_hash` directly so this assertion holds under
+    // both wrappers regardless of which mode the binary defaults to.
     assert_eq!(
-        proof.as_ref().first().unwrap().to_hash(),
+        H::to_hash(proof.as_ref().first().unwrap()),
         HashType::from(root_hash.clone())
     );
 
@@ -292,21 +254,16 @@ fn exclusion_with_proof_value_present() {
 
     // Exclusion should verify with expected None even if proof includes node values
     proof
-        .verify(
-            missing,
-            Option::<&[u8]>::None,
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(missing, Option::<&[u8]>::None, &root_hash, H::ALGORITHM)
         .unwrap();
 }
 
-#[test]
-fn proof_path_construction_and_corruption() {
+#[firewood_macros::hash_mode]
+fn proof_path_construction_and_corruption<H: HashMode>() {
     use crate::{Proof, ProofNode};
 
     // Build a trie with several entries
-    let mut merkle = crate::merkle::tests::create_in_memory_merkle();
+    let mut merkle = crate::merkle::tests::create_in_memory_merkle::<H>();
     merkle.insert(b"a", Box::from(b"1".as_slice())).unwrap();
     merkle.insert(b"ab", Box::from(b"2".as_slice())).unwrap();
     merkle.insert(b"abc", Box::from(b"3".as_slice())).unwrap();
@@ -334,12 +291,7 @@ fn proof_path_construction_and_corruption() {
 
     // Sanity: proof verifies
     proof
-        .verify(
-            key,
-            Some(val.as_slice()),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(val.as_slice()), &root_hash, H::ALGORITHM)
         .unwrap();
 
     // Negative: corrupt the path by clearing children of the first node
@@ -350,12 +302,7 @@ fn proof_path_construction_and_corruption() {
     }
     let corrupt = corrupt.into_immutable();
     let err = corrupt
-        .verify(
-            key,
-            Some(val.as_slice()),
-            &root_hash,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-        )
+        .verify(key, Some(val.as_slice()), &root_hash, H::ALGORITHM)
         .unwrap_err();
     // Node traversal should fail
     assert!(matches!(
@@ -364,9 +311,9 @@ fn proof_path_construction_and_corruption() {
     ));
 }
 
-#[test]
-fn range_proof_serialization_roundtrip() {
-    let merkle = init_merkle((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
+#[firewood_macros::hash_mode]
+fn range_proof_serialization_roundtrip<H: HashMode>() {
+    let merkle = init_merkle::<H, _, _, _>((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
 
     let start_key = &[42u8];
     let end_key = &[84u8];
@@ -392,21 +339,17 @@ fn roundtrip_range_proof(proof: &FrozenRangeProof) -> FrozenRangeProof {
 /// is an ancestor of the proven key and has a child at the next nibble,
 /// the proof is incomplete — it must include that child to demonstrate
 /// the key's absence.
-#[test]
-fn truncated_exclusion_proof_rejected() {
+#[firewood_macros::hash_mode]
+fn truncated_exclusion_proof_rejected<H: HashMode>() {
     // \x10 and \x20 exist. \x15 does not.
-    let merkle = init_merkle([(b"\x10" as &[u8], b"a"), (b"\x20", b"b")]);
+    let merkle = init_merkle::<H, _, _, _>([(b"\x10" as &[u8], b"a"), (b"\x20", b"b")]);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     // Full exclusion proof for \x15 — proves it doesn't exist.
     let full_proof = merkle.prove(b"\x15").unwrap();
     assert!(
         full_proof
-            .value_digest(
-                b"\x15",
-                &root_hash,
-                firewood_storage::DefaultHashMode::ALGORITHM
-            )
+            .value_digest(b"\x15", &root_hash, H::ALGORITHM)
             .unwrap()
             .is_none(),
         "full proof should be a valid exclusion proof"
@@ -423,11 +366,7 @@ fn truncated_exclusion_proof_rejected() {
 
     // The truncated proof must be rejected — the remaining terminal node
     // has a child toward \x15 but the proof doesn't include it.
-    let result = truncated.value_digest(
-        b"\x15",
-        &root_hash,
-        firewood_storage::DefaultHashMode::ALGORITHM,
-    );
+    let result = truncated.value_digest(b"\x15", &root_hash, H::ALGORITHM);
     assert!(
         matches!(result, Err(crate::ProofError::ExclusionProofMissingChild)),
         "truncated exclusion proof should be rejected with ExclusionProofMissingChild, got {result:?}"

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -31,8 +31,8 @@ fn proof_node(nibbles: &[u8]) -> ProofNode {
 /// iterator applies the same fix, so iterator values match what the proof
 /// nodes contain. Panics if a key is not present in the trie — callers are
 /// expected to pass keys that were just committed.
-fn stored_key_values<K: AsRef<[u8]>>(
-    merkle: &Merkle<NodeStore<Committed, MemStore>>,
+fn stored_key_values<H: HashMode, K: AsRef<[u8]>>(
+    merkle: &Merkle<NodeStore<Committed, MemStore, H>>,
     keys: impl IntoIterator<Item = K>,
 ) -> KeyValuePairs {
     keys.into_iter()
@@ -206,12 +206,12 @@ fn outside_children_child_not_prefixed_by_parent() {
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests that missing keys can also be proven. The test explicitly uses a single
 // entry trie and checks for missing keys both before and after the single entry.
-fn test_missing_key_proof() {
+fn test_missing_key_proof<H: HashMode>() {
     let items = [("k", "v")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     for key in ["a", "j", "l", "z"] {
@@ -220,27 +220,22 @@ fn test_missing_key_proof() {
         assert_eq!(proof.len(), 1);
 
         proof
-            .verify(
-                key,
-                None::<&[u8]>,
-                &root_hash,
-                firewood_storage::DefaultHashMode::ALGORITHM,
-            )
+            .verify(key, None::<&[u8]>, &root_hash, H::ALGORITHM)
             .unwrap();
     }
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // A truncated bounded range proof: caller asks for [start, end] with a limit
 // that is hit, so the generator anchors `end_proof` at the last returned key
 // rather than at `end`. The verifier must accept the proof when called with
 // the originally requested `(start, end)` — those are the only bounds the
 // caller has; it cannot predict the post-truncation anchor.
-fn test_truncated_bounded_range_proof_round_trip() {
+fn test_truncated_bounded_range_proof_round_trip<H: HashMode>() {
     let items: Vec<([u8; 4], [u8; 4])> = (0u32..1000)
         .map(|i| (i.to_be_bytes(), i.to_be_bytes()))
         .collect();
-    let merkle = init_merkle(items.iter().map(|(k, v)| (k.as_slice(), v.as_slice())));
+    let merkle = init_merkle::<H, _, _, _>(items.iter().map(|(k, v)| (k.as_slice(), v.as_slice())));
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     // Bound covers many keys; limit forces truncation.
@@ -256,22 +251,31 @@ fn test_truncated_bounded_range_proof_round_trip() {
 
     // Verify with the *original* requested bounds — the only ones the caller
     // can provide. End_proof anchors at the last returned key, not `end`.
-    verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
+    verify_range_proof(
+        Some(&start),
+        Some(&end),
+        &root_hash,
+        H::ALGORITHM,
+        &range_proof,
+    )
+    .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Unbounded full-range proof: start_key = end_key = None. `Merkle::range_proof`
 // produces a proof with empty start_proof, empty end_proof, and every key in
 // the trie. The verifier must accept this shape — the root-hash reconstruction
 // is the safety net. Regression for the FFI path (TestRoundTripSerialization
 // et al.) where the prior check rejected empty end_proof whenever key_values
 // was non-empty.
-fn test_full_range_proof_verifies_unbounded() {
-    let merkle = init_merkle((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
+fn test_full_range_proof_verifies_unbounded<H: HashMode>() {
+    const FULL_KEY_RANGE_LEN: usize = 256; // u8::MAX + 1 keys
+
+    let merkle = init_merkle::<H, _, _, _>((u8::MIN..=u8::MAX).map(|k| ([k], [k])));
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let range_proof = merkle.range_proof(None, None, None).unwrap();
-    assert_eq!(range_proof.key_values().len(), u8::MAX as usize + 1);
+    assert_eq!(range_proof.key_values().len(), FULL_KEY_RANGE_LEN);
     assert!(range_proof.start_proof().is_empty());
     assert!(range_proof.end_proof().is_empty());
 
@@ -279,12 +283,13 @@ fn test_full_range_proof_verifies_unbounded() {
         Option::<&[u8]>::None,
         Option::<&[u8]>::None,
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     )
     .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // End-proof terminal is a value-node strict prefix of last_kv: trie
 // {0x05, 0x10, 0x10\x10, 0x10\x50}, range [0x05, 0x10\x30]. The end_proof
 // terminates at the branch node `0x10` (which has value "parent" and
@@ -293,14 +298,14 @@ fn test_full_range_proof_verifies_unbounded() {
 // requested bound `0x10\x30` (inclusive); verify_edge then anchors the
 // proof against `0x10\x30` and the hash check correctly catches any
 // tampering of `0x10\x10`'s value.
-fn test_terminal_strict_prefix_of_last_kv_verifies() {
+fn test_terminal_strict_prefix_of_last_kv_verifies<H: HashMode>() {
     let items: &[(&[u8], &[u8])] = &[
         (b"\x05", b"before"),
         (b"\x10", b"parent"),
         (b"\x10\x10", b"in_range"),
         (b"\x10\x50", b"after"),
     ];
-    let merkle = init_merkle(items.iter().copied());
+    let merkle = init_merkle::<H, _, _, _>(items.iter().copied());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let range_proof = merkle
@@ -314,12 +319,13 @@ fn test_terminal_strict_prefix_of_last_kv_verifies() {
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     )
     .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Dropped trailing key collapses to a smaller proven range: same trie as
 // `test_terminal_strict_prefix_of_last_kv_verifies`, but an attacker
 // omits `0x10\x10` from key_values. The end_proof's terminal is the
@@ -330,14 +336,14 @@ fn test_terminal_strict_prefix_of_last_kv_verifies() {
 // that `last_kv < the requested bound` and re-requests `(0x10, 0x10\x30]`
 // — that follow-up query is what surfaces the omitted `0x10\x10`. No
 // information is hidden.
-fn test_dropped_trailing_key_accepted_as_partial_coverage() {
+fn test_dropped_trailing_key_accepted_as_partial_coverage<H: HashMode>() {
     let items: &[(&[u8], &[u8])] = &[
         (b"\x05", b"before"),
         (b"\x10", b"parent"),
         (b"\x10\x10", b"in_range"),
         (b"\x10\x50", b"after"),
     ];
-    let merkle = init_merkle(items.iter().copied());
+    let merkle = init_merkle::<H, _, _, _>(items.iter().copied());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let honest = merkle
@@ -354,10 +360,11 @@ fn test_dropped_trailing_key_accepted_as_partial_coverage() {
     assert_eq!(tampered_kvs.len(), 2);
     assert_eq!(tampered_kvs.last().unwrap().0.as_ref(), b"\x10");
 
-    let tampered = RangeProof::new(
+    let tampered = RangeProof::with_hash_mode(
         crate::Proof::<Box<[ProofNode]>>::new(honest.start_proof().as_ref().into()),
         crate::Proof::<Box<[ProofNode]>>::new(honest.end_proof().as_ref().into()),
         tampered_kvs.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     // The verifier accepts: the proof is internally consistent and proves
@@ -368,6 +375,7 @@ fn test_dropped_trailing_key_accepted_as_partial_coverage() {
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &tampered,
     )
     .unwrap();
@@ -377,7 +385,7 @@ fn test_dropped_trailing_key_accepted_as_partial_coverage() {
     assert!(tampered.key_values().last().unwrap().0.as_ref() < b"\x10\x30".as_slice());
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tampering the *value* of an in-range key must be rejected. Same trie
 // and request as `test_terminal_strict_prefix_of_last_kv_verifies`, but
 // the value of `0x10\x10` is altered in key_values. With anchor =
@@ -385,14 +393,14 @@ fn test_dropped_trailing_key_accepted_as_partial_coverage() {
 // `compute_outside_children` keeps `0x10`'s child 1 in-range, so the
 // hash check recurses into the proving trie's tampered `0x10\x10` leaf
 // and the root hash mismatches.
-fn test_tampered_in_range_value_rejected() {
+fn test_tampered_in_range_value_rejected<H: HashMode>() {
     let items: &[(&[u8], &[u8])] = &[
         (b"\x05", b"before"),
         (b"\x10", b"parent"),
         (b"\x10\x10", b"in_range"),
         (b"\x10\x50", b"after"),
     ];
-    let merkle = init_merkle(items.iter().copied());
+    let merkle = init_merkle::<H, _, _, _>(items.iter().copied());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let honest = merkle
@@ -411,16 +419,18 @@ fn test_tampered_in_range_value_rejected() {
         }
     }
 
-    let tampered = RangeProof::new(
+    let tampered = RangeProof::with_hash_mode(
         crate::Proof::<Box<[ProofNode]>>::new(honest.start_proof().as_ref().into()),
         crate::Proof::<Box<[ProofNode]>>::new(honest.end_proof().as_ref().into()),
         tampered_kvs.into_boxed_slice(),
+        H::ALGORITHM,
     );
 
     let result = verify_range_proof(
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &tampered,
     );
     assert!(
@@ -429,7 +439,7 @@ fn test_tampered_in_range_value_rejected() {
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Divergent terminal past last_kv: trie {0x05, 0x10\x50}, range
 // [0x05, 0x10\x30]. The end_proof of `0x10\x30` walks root → leaf
 // `0x10\x50` (the leaf's path diverges from `0x10\x30` at the `5` vs `3`
@@ -437,9 +447,9 @@ fn test_tampered_in_range_value_rejected() {
 // last_kv 0x05 → right-edge anchor is **exclusive at 0x10\x50**. The
 // proof structurally proves `[0x05, 0x10\x50)`, which covers the
 // requested `[0x05, 0x10\x30]`.
-fn test_divergent_terminal_past_last_kv() {
+fn test_divergent_terminal_past_last_kv<H: HashMode>() {
     let items: &[(&[u8], &[u8])] = &[(b"\x05", b"a"), (b"\x10\x50", b"z")];
-    let merkle = init_merkle(items.iter().copied());
+    let merkle = init_merkle::<H, _, _, _>(items.iter().copied());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let range_proof = merkle
@@ -454,12 +464,13 @@ fn test_divergent_terminal_past_last_kv() {
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     )
     .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Symmetric mirror of `test_divergent_terminal_past_last_kv` on the left
 // edge: trie {0x05, 0x10}, range [0x07, 0x10]. `start_key = 0x07` doesn't
 // exist; `prove(0x07)` walks root → leaf 0x05 (divergent), so the
@@ -472,9 +483,9 @@ fn test_divergent_terminal_past_last_kv() {
 // on the left edge); if the existing logic implicitly handles this case
 // correctly, this test passes. If it doesn't, we'd need a `LeftOutOfRange`
 // variant for symmetry.
-fn test_divergent_terminal_before_first_kv() {
+fn test_divergent_terminal_before_first_kv<H: HashMode>() {
     let items: &[(&[u8], &[u8])] = &[(b"\x05", b"a"), (b"\x10", b"b")];
-    let merkle = init_merkle(items.iter().copied());
+    let merkle = init_merkle::<H, _, _, _>(items.iter().copied());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let range_proof = merkle
@@ -488,21 +499,23 @@ fn test_divergent_terminal_before_first_kv() {
         Some(b"\x07".as_slice()),
         Some(b"\x10".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     )
     .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests normal range proof with both edge proofs as the existent proof.
 // The test cases are generated randomly.
-fn test_range_proof() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_range_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     for _ in 0..10 {
         let start = rng.random_range(0..items.len() - 1);
@@ -513,7 +526,12 @@ fn test_range_proof() {
 
         let key_values = stored_key_values(&merkle, items[start..end].iter().map(|(k, _)| *k));
 
-        let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+        let range_proof = RangeProof::with_hash_mode(
+            start_proof,
+            end_proof,
+            key_values.into_boxed_slice(),
+            H::ALGORITHM,
+        );
 
         let root_hash = merkle.nodestore().root_hash().unwrap();
 
@@ -521,21 +539,23 @@ fn test_range_proof() {
             Some(items[start].0),
             Some(items[end - 1].0),
             &root_hash,
+            H::ALGORITHM,
             &range_proof,
         )
         .unwrap();
     }
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests that out-of-order key-value pairs in a range proof are rejected.
-fn test_bad_range_proof_out_of_order() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_bad_range_proof_out_of_order<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     for _ in 0..10 {
         let start = rng.random_range(0..items.len() - 2);
@@ -573,7 +593,12 @@ fn test_bad_range_proof_out_of_order() {
         let start_proof = merkle.prove(items[start].0).unwrap();
         let end_proof = merkle.prove(items[end - 1].0).unwrap();
 
-        let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+        let range_proof = RangeProof::with_hash_mode(
+            start_proof,
+            end_proof,
+            key_values.into_boxed_slice(),
+            H::ALGORITHM,
+        );
 
         let root_hash = merkle.nodestore().root_hash().unwrap();
 
@@ -582,22 +607,23 @@ fn test_bad_range_proof_out_of_order() {
                 Some(items[start].0),
                 Some(items[end - 1].0),
                 &root_hash,
-                &range_proof,
+                H::ALGORITHM,
+                &range_proof
             )
             .is_err()
         );
     }
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Detects a modified key via trie reconstruction and root hash mismatch.
-fn test_bad_range_proof_modified_key() {
+fn test_bad_range_proof_modified_key<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start = 100;
@@ -617,34 +643,36 @@ fn test_bad_range_proof_modified_key() {
     kvs[mid].0 = key.into_boxed_slice();
     kvs.sort_by(|(a, _), (b, _)| a.cmp(b));
 
-    let range_proof = RangeProof::new(start_proof, end_proof, kvs.into_boxed_slice());
+    let range_proof =
+        RangeProof::with_hash_mode(start_proof, end_proof, kvs.into_boxed_slice(), H::ALGORITHM);
     assert!(
         verify_range_proof(
             Some(items[start].0),
             Some(items[end - 1].0),
             &root_hash,
-            &range_proof,
+            H::ALGORITHM,
+            &range_proof
         )
         .is_err(),
         "modified key should be detected"
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode(merkledb)]
 // Detects a modified value via trie reconstruction and root hash mismatch.
 // In ethhash mode, account values at depth 32 have their storageRoot field
 // replaced with a computed hash during hashing. A blind XOR on the raw value
 // may only affect the storageRoot (or the RLP header that wraps it), making
 // the modification invisible to the hash. This test is not meaningful under
-// ethhash because the hashing intentionally ignores part of the value.
-#[cfg(not(feature = "ethhash"))]
-fn test_bad_range_proof_modified_value() {
+// ethhash because the hashing intentionally ignores part of the value, so it
+// is pinned to `MerkleDbHash` rather than dualized.
+fn test_bad_range_proof_modified_value<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start = 100;
@@ -663,29 +691,31 @@ fn test_bad_range_proof_modified_value() {
     val[0] ^= 0x01;
     kvs[mid].1 = val.into_boxed_slice();
 
-    let range_proof = RangeProof::new(start_proof, end_proof, kvs.into_boxed_slice());
+    let range_proof =
+        RangeProof::with_hash_mode(start_proof, end_proof, kvs.into_boxed_slice(), H::ALGORITHM);
     assert!(
         verify_range_proof(
             Some(items[start].0),
             Some(items[end - 1].0),
             &root_hash,
-            &range_proof,
+            H::ALGORITHM,
+            &range_proof
         )
         .is_err(),
         "modified value should be detected"
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Detects gapped entries (missing middle element) via trie reconstruction
 // and root hash mismatch.
-fn test_bad_range_proof_gapped_entries() {
+fn test_bad_range_proof_gapped_entries<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start = 100;
@@ -702,29 +732,32 @@ fn test_bad_range_proof_gapped_entries() {
     let mid = kvs.len() / 2;
     kvs.remove(mid);
 
-    let range_proof = RangeProof::new(start_proof, end_proof, kvs.into_boxed_slice());
+    let range_proof =
+        RangeProof::with_hash_mode(start_proof, end_proof, kvs.into_boxed_slice(), H::ALGORITHM);
     assert!(
         verify_range_proof(
             Some(items[start].0),
             Some(items[end - 1].0),
             &root_hash,
-            &range_proof,
+            H::ALGORITHM,
+            &range_proof
         )
         .is_err(),
         "gapped entries should be detected"
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests normal range proof with two non-existent proofs.
 // The test cases are generated randomly.
-fn test_range_proof_with_non_existent_proof() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_range_proof_with_non_existent_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     for _ in 0..10 {
         let start = rng.random_range(1..items.len() - 2);
@@ -754,11 +787,23 @@ fn test_range_proof_with_non_existent_proof() {
 
         let key_values = stored_key_values(&merkle, items[start..end].iter().map(|(k, _)| *k));
 
-        let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+        let range_proof = RangeProof::with_hash_mode(
+            start_proof,
+            end_proof,
+            key_values.into_boxed_slice(),
+            H::ALGORITHM,
+        );
 
         let root_hash = merkle.nodestore().root_hash().unwrap();
 
-        verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof).unwrap();
+        verify_range_proof(
+            Some(&first),
+            Some(&last),
+            &root_hash,
+            H::ALGORITHM,
+            &range_proof,
+        )
+        .unwrap();
     }
 
     // Special case, two edge proofs for two edge key.
@@ -770,25 +815,38 @@ fn test_range_proof_with_non_existent_proof() {
 
     let key_values = stored_key_values(&merkle, items.iter().map(|(k, _)| *k));
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    verify_range_proof(Some(first), Some(last), &root_hash, &range_proof).unwrap();
+    verify_range_proof(
+        Some(first),
+        Some(last),
+        &root_hash,
+        H::ALGORITHM,
+        &range_proof,
+    )
+    .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests such scenarios:
 // - There exists a gap between the first element and the left edge proof
 // - There exists a gap between the last element and the right edge proof
 // Detecting gaps requires full trie reconstruction, not yet implemented.
-fn test_range_proof_with_invalid_non_existent_proof() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_range_proof_with_invalid_non_existent_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     // Case 1
     let mut start = 100;
@@ -804,7 +862,12 @@ fn test_range_proof_with_invalid_non_existent_proof() {
         .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
@@ -813,7 +876,8 @@ fn test_range_proof_with_invalid_non_existent_proof() {
             Some(&first),
             Some(items[end - 1].0),
             &root_hash,
-            &range_proof,
+            H::ALGORITHM,
+            &range_proof
         )
         .is_err()
     );
@@ -832,8 +896,12 @@ fn test_range_proof_with_invalid_non_existent_proof() {
         .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
         .collect();
 
-    let range_proof_2 =
-        RangeProof::new(start_proof_2, end_proof_2, key_values_2.into_boxed_slice());
+    let range_proof_2 = RangeProof::with_hash_mode(
+        start_proof_2,
+        end_proof_2,
+        key_values_2.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let root_hash_2 = merkle.nodestore().root_hash().unwrap();
 
@@ -842,22 +910,23 @@ fn test_range_proof_with_invalid_non_existent_proof() {
             Some(items[start].0),
             Some(&last),
             &root_hash_2,
-            &range_proof_2,
+            H::ALGORITHM,
+            &range_proof_2
         )
         .is_err()
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests the proof with only one element. The first edge proof can be existent one or
 // non-existent one.
-fn test_one_element_range_proof() {
+fn test_one_element_range_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     // One element with existent edge proof, both edge proofs
     // point to the SAME key.
@@ -867,10 +936,11 @@ fn test_one_element_range_proof() {
 
     let key_values = stored_key_values(&merkle, std::iter::once(*items[start].0));
 
-    let range_proof = RangeProof::new(
+    let range_proof = RangeProof::with_hash_mode(
         proof.clone(), // Same proof for start and end
         proof,
         key_values.into(),
+        H::ALGORITHM,
     );
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
@@ -879,6 +949,7 @@ fn test_one_element_range_proof() {
         Some(items[start].0),
         Some(items[start].0),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     )
     .unwrap();
@@ -890,12 +961,18 @@ fn test_one_element_range_proof() {
 
     let key_values_2 = stored_key_values(&merkle, std::iter::once(*items[start].0));
 
-    let range_proof_2 = RangeProof::new(start_proof_2, end_proof_2, key_values_2.into());
+    let range_proof_2 = RangeProof::with_hash_mode(
+        start_proof_2,
+        end_proof_2,
+        key_values_2.into(),
+        H::ALGORITHM,
+    );
 
     verify_range_proof(
         Some(&first),
         Some(items[start].0),
         &root_hash,
+        H::ALGORITHM,
         &range_proof_2,
     )
     .unwrap();
@@ -907,12 +984,18 @@ fn test_one_element_range_proof() {
 
     let key_values_3 = stored_key_values(&merkle, std::iter::once(*items[start].0));
 
-    let range_proof_3 = RangeProof::new(start_proof_3, end_proof_3, key_values_3.into());
+    let range_proof_3 = RangeProof::with_hash_mode(
+        start_proof_3,
+        end_proof_3,
+        key_values_3.into(),
+        H::ALGORITHM,
+    );
 
     verify_range_proof(
         Some(items[start].0),
         Some(&last),
         &root_hash,
+        H::ALGORITHM,
         &range_proof_3,
     )
     .unwrap();
@@ -923,14 +1006,26 @@ fn test_one_element_range_proof() {
 
     let key_values_4 = stored_key_values(&merkle, std::iter::once(*items[start].0));
 
-    let range_proof_4 = RangeProof::new(start_proof_4, end_proof_4, key_values_4.into());
+    let range_proof_4 = RangeProof::with_hash_mode(
+        start_proof_4,
+        end_proof_4,
+        key_values_4.into(),
+        H::ALGORITHM,
+    );
 
-    verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof_4).unwrap();
+    verify_range_proof(
+        Some(&first),
+        Some(&last),
+        &root_hash,
+        H::ALGORITHM,
+        &range_proof_4,
+    )
+    .unwrap();
 
     // Test the mini trie with only a single element.
     let key = rng.random::<[u8; 32]>();
     let val = rng.random::<[u8; 20]>();
-    let merkle_mini = init_merkle(vec![(key, val)]);
+    let merkle_mini = init_merkle::<H, _, _, _>(vec![(key, val)]);
 
     let first = &[0; 32];
     let start_proof_5 = merkle_mini.prove(first).unwrap();
@@ -938,23 +1033,36 @@ fn test_one_element_range_proof() {
 
     let key_values_5 = stored_key_values(&merkle_mini, std::iter::once(key));
 
-    let range_proof_5 = RangeProof::new(start_proof_5, end_proof_5, key_values_5.into());
+    let range_proof_5 = RangeProof::with_hash_mode(
+        start_proof_5,
+        end_proof_5,
+        key_values_5.into(),
+        H::ALGORITHM,
+    );
 
     let root_hash_mini = merkle_mini.nodestore().root_hash().unwrap();
 
-    verify_range_proof(Some(first), Some(&key), &root_hash_mini, &range_proof_5).unwrap();
+    verify_range_proof(
+        Some(first),
+        Some(&key),
+        &root_hash_mini,
+        H::ALGORITHM,
+        &range_proof_5,
+    )
+    .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests the range proof with all elements.
 // The edge proofs can be nil.
-fn test_all_elements_proof() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_all_elements_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
@@ -966,13 +1074,18 @@ fn test_all_elements_proof() {
 
     let key_values_2 = stored_key_values(&merkle, items.iter().map(|(k, _)| *k));
 
-    let range_proof_2 =
-        RangeProof::new(start_proof_2, end_proof_2, key_values_2.into_boxed_slice());
+    let range_proof_2 = RangeProof::with_hash_mode(
+        start_proof_2,
+        end_proof_2,
+        key_values_2.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     verify_range_proof(
         Some(items[start].0),
         Some(items[end].0),
         &root_hash,
+        H::ALGORITHM,
         &range_proof_2,
     )
     .unwrap();
@@ -985,21 +1098,33 @@ fn test_all_elements_proof() {
 
     let key_values_3 = stored_key_values(&merkle, items.iter().map(|(k, _)| *k));
 
-    let range_proof_3 =
-        RangeProof::new(start_proof_3, end_proof_3, key_values_3.into_boxed_slice());
+    let range_proof_3 = RangeProof::with_hash_mode(
+        start_proof_3,
+        end_proof_3,
+        key_values_3.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
-    verify_range_proof(Some(first), Some(last), &root_hash, &range_proof_3).unwrap();
+    verify_range_proof(
+        Some(first),
+        Some(last),
+        &root_hash,
+        H::ALGORITHM,
+        &range_proof_3,
+    )
+    .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Empty key_values with a non-existent boundary key past the last entry.
-fn test_empty_range_proof() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_empty_range_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let first = increase_key(items[items.len() - 1].0);
@@ -1007,15 +1132,28 @@ fn test_empty_range_proof() {
     assert!(!proof.is_empty());
 
     let key_values: KeyValuePairs = Vec::new();
-    let range_proof = RangeProof::new(proof.clone(), proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        proof.clone(),
+        proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
-    verify_range_proof(Some(&first), Some(&first), &root_hash, &range_proof).unwrap();
+    verify_range_proof(
+        Some(&first),
+        Some(&first),
+        &root_hash,
+        H::ALGORITHM,
+        &range_proof,
+    )
+    .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Focuses on the small trie with embedded nodes. If the gapped
 // node is embedded in the trie, it should be detected too.
-fn test_gapped_range_proof() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_gapped_range_proof<H: HashMode>() {
     let mut items = Vec::new();
     // Sorted entries
     for i in 0..10_u32 {
@@ -1025,7 +1163,7 @@ fn test_gapped_range_proof() {
         }
         items.push((key, i.to_be_bytes()));
     }
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     let first = 2;
     let last = 8;
@@ -1045,7 +1183,12 @@ fn test_gapped_range_proof() {
         })
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
@@ -1054,22 +1197,23 @@ fn test_gapped_range_proof() {
             Some(&items[first].0),
             Some(&items[last - 1].0),
             &root_hash,
-            &range_proof,
+            H::ALGORITHM,
+            &range_proof
         )
         .is_err(),
         "gapped entries should be detected in small trie"
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests the element is not in the range covered by proofs.
-fn test_same_side_proof() {
+fn test_same_side_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 4096);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     let pos = 1000;
     let mut last = decrease_key(items[pos].0);
@@ -1084,11 +1228,25 @@ fn test_same_side_proof() {
         items[pos].1.to_vec().into_boxed_slice(),
     )];
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    assert!(verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof,).is_err());
+    assert!(
+        verify_range_proof(
+            Some(&first),
+            Some(&last),
+            &root_hash,
+            H::ALGORITHM,
+            &range_proof
+        )
+        .is_err()
+    );
 
     first = increase_key(items[pos].0);
     last = first;
@@ -1102,15 +1260,29 @@ fn test_same_side_proof() {
         items[pos].1.to_vec().into_boxed_slice(),
     )];
 
-    let range_proof_2 =
-        RangeProof::new(start_proof_2, end_proof_2, key_values_2.into_boxed_slice());
+    let range_proof_2 = RangeProof::with_hash_mode(
+        start_proof_2,
+        end_proof_2,
+        key_values_2.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
-    assert!(verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof_2,).is_err());
+    assert!(
+        verify_range_proof(
+            Some(&first),
+            Some(&last),
+            &root_hash,
+            H::ALGORITHM,
+            &range_proof_2
+        )
+        .is_err()
+    );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests the range starts from zero.
-fn test_single_side_range_proof() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_single_side_range_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     for _ in 0..10 {
@@ -1122,7 +1294,7 @@ fn test_single_side_range_proof() {
         }
         let mut items = set.iter().collect::<Vec<_>>();
         items.sort_unstable();
-        let merkle = init_merkle(items.clone());
+        let merkle = init_merkle::<H, _, _, _>(items.clone());
 
         let cases = vec![0, 1, 100, 1000, items.len() - 1];
         for case in cases {
@@ -1133,19 +1305,31 @@ fn test_single_side_range_proof() {
             let key_values =
                 stored_key_values(&merkle, items.iter().take(case + 1).map(|(k, _)| *k));
 
-            let range_proof =
-                RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+            let range_proof = RangeProof::with_hash_mode(
+                start_proof,
+                end_proof,
+                key_values.into_boxed_slice(),
+                H::ALGORITHM,
+            );
 
             let root_hash = merkle.nodestore().root_hash().unwrap();
 
-            verify_range_proof(Some(start), Some(items[case].0), &root_hash, &range_proof).unwrap();
+            verify_range_proof(
+                Some(start),
+                Some(items[case].0),
+                &root_hash,
+                H::ALGORITHM,
+                &range_proof,
+            )
+            .unwrap();
         }
     }
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests the range ends with 0xffff...fff.
-fn test_reverse_single_side_range_proof() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_reverse_single_side_range_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     for _ in 0..10 {
@@ -1157,7 +1341,7 @@ fn test_reverse_single_side_range_proof() {
         }
         let mut items = set.iter().collect::<Vec<_>>();
         items.sort_unstable();
-        let merkle = init_merkle(items.clone());
+        let merkle = init_merkle::<H, _, _, _>(items.clone());
 
         let cases = vec![0, 1, 100, 1000, items.len() - 1];
         for case in cases {
@@ -1168,19 +1352,30 @@ fn test_reverse_single_side_range_proof() {
 
             let key_values = stored_key_values(&merkle, items.iter().skip(case).map(|(k, _)| *k));
 
-            let range_proof =
-                RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+            let range_proof = RangeProof::with_hash_mode(
+                start_proof,
+                end_proof,
+                key_values.into_boxed_slice(),
+                H::ALGORITHM,
+            );
 
             let root_hash = merkle.nodestore().root_hash().unwrap();
 
-            verify_range_proof(Some(items[case].0), Some(end), &root_hash, &range_proof).unwrap();
+            verify_range_proof(
+                Some(items[case].0),
+                Some(end),
+                &root_hash,
+                H::ALGORITHM,
+                &range_proof,
+            )
+            .unwrap();
         }
     }
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests the range starts with zero and ends with 0xffff...fff.
-fn test_both_sides_range_proof() {
+fn test_both_sides_range_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     for _ in 0..10 {
@@ -1192,7 +1387,7 @@ fn test_both_sides_range_proof() {
         }
         let mut items = set.iter().collect::<Vec<_>>();
         items.sort_unstable();
-        let merkle = init_merkle(items.clone());
+        let merkle = init_merkle::<H, _, _, _>(items.clone());
 
         let start = &[0; 32];
         let end = &[255; 32];
@@ -1201,25 +1396,38 @@ fn test_both_sides_range_proof() {
 
         let key_values = stored_key_values(&merkle, items.iter().map(|(k, _)| *k));
 
-        let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+        let range_proof = RangeProof::with_hash_mode(
+            start_proof,
+            end_proof,
+            key_values.into_boxed_slice(),
+            H::ALGORITHM,
+        );
 
         let root_hash = merkle.nodestore().root_hash().unwrap();
 
-        verify_range_proof(Some(start), Some(end), &root_hash, &range_proof).unwrap();
+        verify_range_proof(
+            Some(start),
+            Some(end),
+            &root_hash,
+            H::ALGORITHM,
+            &range_proof,
+        )
+        .unwrap();
     }
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests normal range proof with both edge proofs
 // as the existent proof, but with an extra empty value included, which is a
 // noop technically, but practically should be rejected.
-fn test_empty_value_range_proof() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_empty_value_range_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 512);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     // Create a new entry with a slightly modified key
     let mid_index = items.len() / 2;
@@ -1240,7 +1448,12 @@ fn test_empty_value_range_proof() {
         .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
@@ -1249,23 +1462,25 @@ fn test_empty_value_range_proof() {
             Some(items[start].0),
             Some(items[end - 1].0),
             &root_hash,
-            &range_proof,
+            H::ALGORITHM,
+            &range_proof
         )
         .is_err()
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests the range proof with all elements,
 // but with an extra empty value included, which is a noop technically, but
 // practically should be rejected.
-fn test_all_elements_empty_value_range_proof() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_all_elements_empty_value_range_proof<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     let set = fixed_and_pseudorandom_data(&rng, 512);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     // Create a new entry with a slightly modified key
     let mid_index = items.len() / 2;
@@ -1284,7 +1499,12 @@ fn test_all_elements_empty_value_range_proof() {
         .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
@@ -1293,14 +1513,15 @@ fn test_all_elements_empty_value_range_proof() {
             Some(items[start].0),
             Some(items[end].0),
             &root_hash,
-            &range_proof,
+            H::ALGORITHM,
+            &range_proof
         )
         .is_err()
     );
 }
 
-#[test]
-fn test_range_proof_keys_with_shared_prefix() {
+#[firewood_macros::hash_mode]
+fn test_range_proof_keys_with_shared_prefix<H: HashMode>() {
     let items = vec![
         (
             hex::decode("aa10000000000000000000000000000000000000000000000000000000000000")
@@ -1313,7 +1534,7 @@ fn test_range_proof_keys_with_shared_prefix() {
             hex::decode("03").expect("Decoding failed"),
         ),
     ];
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     let start = hex::decode("0000000000000000000000000000000000000000000000000000000000000000")
         .expect("Decoding failed");
@@ -1325,17 +1546,29 @@ fn test_range_proof_keys_with_shared_prefix() {
 
     let key_values = stored_key_values(&merkle, items.iter().map(|(k, _)| k.as_slice()));
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
+    verify_range_proof(
+        Some(&start),
+        Some(&end),
+        &root_hash,
+        H::ALGORITHM,
+        &range_proof,
+    )
+    .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests a malicious proof, where the proof is more or less the
 // whole trie. This is to match corresponding test in geth.
-fn test_bloated_range_proof() {
+fn test_bloated_range_proof<H: HashMode>() {
     // Use a small trie
     let mut items = Vec::new();
     for i in 0..100_u32 {
@@ -1347,7 +1580,7 @@ fn test_bloated_range_proof() {
         }
         items.push((key, value));
     }
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
 
     // In the 'malicious' case, we add proofs for every single item
     // (but only one key/value pair used as leaf)
@@ -1366,18 +1599,30 @@ fn test_bloated_range_proof() {
 
     let key_values = stored_key_values(&merkle, std::iter::once(target.0));
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    verify_range_proof(Some(&target.0), Some(&target.0), &root_hash, &range_proof).unwrap();
+    verify_range_proof(
+        Some(&target.0),
+        Some(&target.0),
+        &root_hash,
+        H::ALGORITHM,
+        &range_proof,
+    )
+    .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Rejects a range proof containing keys below the requested start key.
-fn test_bad_range_proof_key_below_start() {
+fn test_bad_range_proof_key_below_start<H: HashMode>() {
     let items = [("bb", "v1"), ("cc", "v2"), ("dd", "v3")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start_proof = merkle.prove(b"cc").unwrap();
@@ -1394,12 +1639,18 @@ fn test_bad_range_proof_key_below_start() {
         })
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let result = verify_range_proof(
         Some(b"cc".as_slice()),
         Some(b"dd".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(
@@ -1411,11 +1662,11 @@ fn test_bad_range_proof_key_below_start() {
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Rejects a range proof containing keys above the requested end key.
-fn test_bad_range_proof_key_above_end() {
+fn test_bad_range_proof_key_above_end<H: HashMode>() {
     let items = [("bb", "v1"), ("cc", "v2"), ("dd", "v3")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start_proof = merkle.prove(b"bb").unwrap();
@@ -1432,12 +1683,18 @@ fn test_bad_range_proof_key_above_end() {
         })
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let result = verify_range_proof(
         Some(b"bb".as_slice()),
         Some(b"cc".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(
@@ -1449,11 +1706,11 @@ fn test_bad_range_proof_key_above_end() {
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Rejects a range proof with key-value pairs but no end proof.
-fn test_bad_range_proof_missing_end_proof() {
+fn test_bad_range_proof_missing_end_proof<H: HashMode>() {
     let items = [("bb", "v1"), ("cc", "v2")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start_proof = merkle.prove(b"bb").unwrap();
@@ -1469,12 +1726,18 @@ fn test_bad_range_proof_missing_end_proof() {
         .collect();
 
     let empty_end: Proof<Box<[ProofNode]>> = Proof::new(Vec::new().into_boxed_slice());
-    let range_proof = RangeProof::new(start_proof, empty_end, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        empty_end,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let result = verify_range_proof(
         Some(b"bb".as_slice()),
         Some(b"cc".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(
@@ -1486,11 +1749,11 @@ fn test_bad_range_proof_missing_end_proof() {
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Rejects a start proof when no start key is specified.
-fn test_bad_range_proof_unexpected_start_proof() {
+fn test_bad_range_proof_unexpected_start_proof<H: HashMode>() {
     let items = [("bb", "v1"), ("cc", "v2")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start_proof = merkle.prove(b"bb").unwrap();
@@ -1506,13 +1769,19 @@ fn test_bad_range_proof_unexpected_start_proof() {
         })
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     // Pass None as start key but provide a start proof — should be rejected
     let result = verify_range_proof(
         None::<&[u8]>,
         Some(b"cc".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(
@@ -1525,12 +1794,13 @@ fn test_bad_range_proof_unexpected_start_proof() {
         "expected UnexpectedStartProof, got {result:?}"
     );
 }
-#[test]
+#[firewood_macros::hash_mode]
 // Fuzz-style test that generates random data, creates range proofs for random
 // subranges, and verifies them standalone using only the root hash.
 // Covers: both-existent edges, left-nonexistent, right-nonexistent,
 // both-nonexistent, single-element, and full-range scenarios.
-fn test_range_proof_fuzz() {
+#[expect(clippy::arithmetic_side_effects, clippy::too_many_lines)]
+fn test_range_proof_fuzz<H: HashMode>() {
     let rng = firewood_storage::SeededRng::from_env_or_random();
 
     // 64 is big enough to provide a signal; 2048 starts to slow things down
@@ -1538,7 +1808,7 @@ fn test_range_proof_fuzz() {
     let set = fixed_and_pseudorandom_data(&rng, num_keys);
     let mut items = set.iter().collect::<Vec<_>>();
     items.sort_unstable();
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     for _ in 0..50 {
@@ -1555,6 +1825,7 @@ fn test_range_proof_fuzz() {
                     Some(items[start].0),
                     Some(items[end].0),
                     &root_hash,
+                    H::ALGORITHM,
                     &range_proof,
                 )
                 .unwrap();
@@ -1570,8 +1841,14 @@ fn test_range_proof_fuzz() {
                 let range_proof = merkle
                     .range_proof(Some(&first), Some(items[end].0), None)
                     .unwrap();
-                verify_range_proof(Some(&first), Some(items[end].0), &root_hash, &range_proof)
-                    .unwrap();
+                verify_range_proof(
+                    Some(&first),
+                    Some(items[end].0),
+                    &root_hash,
+                    H::ALGORITHM,
+                    &range_proof,
+                )
+                .unwrap();
             }
             // Right edge is non-existent
             2 => {
@@ -1586,8 +1863,14 @@ fn test_range_proof_fuzz() {
                 let range_proof = merkle
                     .range_proof(Some(items[start].0), Some(&last), None)
                     .unwrap();
-                verify_range_proof(Some(items[start].0), Some(&last), &root_hash, &range_proof)
-                    .unwrap();
+                verify_range_proof(
+                    Some(items[start].0),
+                    Some(&last),
+                    &root_hash,
+                    H::ALGORITHM,
+                    &range_proof,
+                )
+                .unwrap();
             }
             // Both edges are non-existent
             3 => {
@@ -1603,7 +1886,14 @@ fn test_range_proof_fuzz() {
                     continue;
                 }
                 let range_proof = merkle.range_proof(Some(&first), Some(&last), None).unwrap();
-                verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof).unwrap();
+                verify_range_proof(
+                    Some(&first),
+                    Some(&last),
+                    &root_hash,
+                    H::ALGORITHM,
+                    &range_proof,
+                )
+                .unwrap();
             }
             // Single element
             4 => {
@@ -1615,6 +1905,7 @@ fn test_range_proof_fuzz() {
                     Some(items[idx].0),
                     Some(items[idx].0),
                     &root_hash,
+                    H::ALGORITHM,
                     &range_proof,
                 )
                 .unwrap();
@@ -1624,11 +1915,11 @@ fn test_range_proof_fuzz() {
     }
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Rejects a range proof where the end proof has been truncated (missing last node).
-fn test_bad_range_proof_truncated_end_proof() {
+fn test_bad_range_proof_truncated_end_proof<H: HashMode>() {
     let items = [("aa", "v1"), ("bb", "v2"), ("cc", "v3")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start_proof = merkle.prove(b"aa").unwrap();
@@ -1649,22 +1940,28 @@ fn test_bad_range_proof_truncated_end_proof() {
         })
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, truncated_end, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        truncated_end,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let result = verify_range_proof(
         Some(b"aa".as_slice()),
         Some(b"cc".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(result.is_err(), "truncated end proof should be rejected");
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Rejects a range proof where the start proof has been truncated (missing last node).
-fn test_bad_range_proof_truncated_start_proof() {
+fn test_bad_range_proof_truncated_start_proof<H: HashMode>() {
     let items = [("aa", "v1"), ("bb", "v2"), ("cc", "v3")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start_proof = merkle.prove(b"aa").unwrap();
@@ -1685,25 +1982,31 @@ fn test_bad_range_proof_truncated_start_proof() {
         })
         .collect();
 
-    let range_proof = RangeProof::new(truncated_start, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        truncated_start,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let result = verify_range_proof(
         Some(b"aa".as_slice()),
         Some(b"cc".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(result.is_err(), "truncated start proof should be rejected");
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Rejects a range proof containing a proof node with a value at an odd nibble length.
 // The odd-nibble-with-value check is defense-in-depth: in practice, corrupting a proof
 // node to have an odd-nibble key breaks its hash, so UnexpectedHash is returned first.
 // This test verifies the corruption is detected regardless of which check fires.
-fn test_bad_range_proof_value_at_odd_nibble() {
+fn test_bad_range_proof_value_at_odd_nibble<H: HashMode>() {
     let items = [("aa", "v1"), ("bb", "v2"), ("cc", "v3")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start_proof = merkle.prove(b"aa").unwrap();
@@ -1728,12 +2031,18 @@ fn test_bad_range_proof_value_at_odd_nibble() {
         })
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, corrupt_end, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        corrupt_end,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let result = verify_range_proof(
         Some(b"aa".as_slice()),
         Some(b"cc".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(
@@ -1748,10 +2057,10 @@ fn test_bad_range_proof_value_at_odd_nibble() {
 // edge that actually tripped: corrupting the start proof reports `Left`, the
 // end proof reports `Right`. Without them, swapping `ProofEdge::{Left,Right}`
 // at the `verify_edge` call sites would go unnoticed.
-#[test]
-fn test_range_proof_left_edge_hash_mismatch() {
+#[firewood_macros::hash_mode]
+fn test_range_proof_left_edge_hash_mismatch<H: HashMode>() {
     let items = [("aa", "v1"), ("bb", "v2"), ("cc", "v3")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let end_proof = merkle.prove(b"cc").unwrap();
@@ -1773,12 +2082,18 @@ fn test_range_proof_left_edge_hash_mismatch() {
         })
         .collect();
 
-    let range_proof = RangeProof::new(corrupt_start, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        corrupt_start,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let err = verify_range_proof(
         Some(b"aa".as_slice()),
         Some(b"cc".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     )
     .unwrap_err();
@@ -1794,10 +2109,10 @@ fn test_range_proof_left_edge_hash_mismatch() {
     );
 }
 
-#[test]
-fn test_range_proof_right_edge_hash_mismatch() {
+#[firewood_macros::hash_mode]
+fn test_range_proof_right_edge_hash_mismatch<H: HashMode>() {
     let items = [("aa", "v1"), ("bb", "v2"), ("cc", "v3")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let start_proof = merkle.prove(b"aa").unwrap();
@@ -1820,12 +2135,18 @@ fn test_range_proof_right_edge_hash_mismatch() {
         })
         .collect();
 
-    let range_proof = RangeProof::new(start_proof, corrupt_end, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        corrupt_end,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let err = verify_range_proof(
         Some(b"aa".as_slice()),
         Some(b"cc".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     )
     .unwrap_err();
@@ -1841,15 +2162,15 @@ fn test_range_proof_right_edge_hash_mismatch() {
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Rejects a range proof that hides a key-value pair on an edge proof path by
 // omitting it from key_values.
-fn test_bad_range_proof_hidden_value_on_edge_path() {
+fn test_bad_range_proof_hidden_value_on_edge_path<H: HashMode>() {
     // Create a trie where "b" is an intermediate branch on the path to "ba" and "bc".
     // "b" has a value AND is on the edge proof path for "bc".
     // The range ["a", "bc"] should include "b" and "ba", but we omit "b" from key_values.
     let items = [("b", "v1"), ("ba", "v2"), ("bc", "v3")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     // Use a non-existent start key so the start proof is an exclusion proof
@@ -1868,12 +2189,18 @@ fn test_bad_range_proof_hidden_value_on_edge_path() {
         ),
     ];
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let result = verify_range_proof(
         Some(b"a".as_slice()),
         Some(b"bc".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(
@@ -1887,12 +2214,13 @@ fn test_bad_range_proof_hidden_value_on_edge_path() {
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Rejects a range proof with a non-existent edge proof that has its final node removed.
 // This is the subtle case: since the bound doesn't match any key in key_values,
 // verify_edge passes the truncated proof as an exclusion proof (expected_value=None).
 // The corruption must be caught by the final root hash check.
-fn test_bad_range_proof_truncated_non_existent_edge() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_bad_range_proof_truncated_non_existent_edge<H: HashMode>() {
     let items: Vec<([u8; 32], [u8; 32])> = (0..10_u32)
         .map(|i| {
             let mut key = [0u8; 32];
@@ -1911,7 +2239,7 @@ fn test_bad_range_proof_truncated_non_existent_edge() {
         })
         .collect();
 
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     // Use a non-existent start key (before the first item)
@@ -1935,12 +2263,18 @@ fn test_bad_range_proof_truncated_non_existent_edge() {
         .map(|(k, v)| (k.to_vec().into_boxed_slice(), v.to_vec().into_boxed_slice()))
         .collect();
 
-    let range_proof = RangeProof::new(truncated_start, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        truncated_start,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let result = verify_range_proof(
         Some(start_bound.as_slice()),
         Some(end_bound.as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(
@@ -1949,11 +2283,11 @@ fn test_bad_range_proof_truncated_non_existent_edge() {
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Rejects a range proof when start key > end key during verification.
-fn test_bad_range_proof_start_after_end() {
+fn test_bad_range_proof_start_after_end<H: HashMode>() {
     let items = [("bb", "v1"), ("cc", "v2"), ("dd", "v3")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     let range_proof = merkle
@@ -1965,6 +2299,7 @@ fn test_bad_range_proof_start_after_end() {
         Some(b"dd".as_slice()),
         Some(b"bb".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(
@@ -1976,10 +2311,11 @@ fn test_bad_range_proof_start_after_end() {
     );
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Tests range_proof() with a limit parameter. When limit truncates, the
 // end proof should anchor at the last returned key, not the requested end_key.
-fn test_range_proof_with_limit() {
+#[expect(clippy::arithmetic_side_effects)]
+fn test_range_proof_with_limit<H: HashMode>() {
     let items: Vec<([u8; 32], [u8; 20])> = (0..10u32)
         .map(|i| {
             let mut key = [0u8; 32];
@@ -1998,7 +2334,7 @@ fn test_range_proof_with_limit() {
         })
         .collect();
 
-    let merkle = init_merkle(items.clone());
+    let merkle = init_merkle::<H, _, _, _>(items.clone());
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     // Request range [items[0], items[9]] with limit=3. Should return items[0..3].
@@ -2015,6 +2351,7 @@ fn test_range_proof_with_limit() {
         Some(&items[0].0),
         Some(&items[2].0),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     )
     .unwrap();
@@ -2029,12 +2366,13 @@ fn test_range_proof_with_limit() {
         Some(&items[0].0),
         Some(&items[9].0),
         &root_hash,
+        H::ALGORITHM,
         &full_proof,
     )
     .unwrap();
 }
 
-#[test]
+#[firewood_macros::hash_mode]
 // Demonstrates that verify_range_proof does not verify that proof node values
 // match the corresponding values in key_values. A malicious prover can supply
 // correct proof nodes (with the real value) but incorrect key_values at an
@@ -2047,9 +2385,9 @@ fn test_range_proof_with_limit() {
 // The end proof for "bc" traverses the "b" node (which carries "v1").
 // We change "b"'s value in key_values to "WRONG" — verification should fail
 // but currently passes.
-fn test_bad_range_proof_value_mismatch_on_proof_path() {
+fn test_bad_range_proof_value_mismatch_on_proof_path<H: HashMode>() {
     let items = [("b", "v1"), ("ba", "v2"), ("bc", "v3")];
-    let merkle = init_merkle(items);
+    let merkle = init_merkle::<H, _, _, _>(items);
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
     // "a" is not in the trie → exclusion proof for start
@@ -2073,12 +2411,18 @@ fn test_bad_range_proof_value_mismatch_on_proof_path() {
         ),
     ];
 
-    let range_proof = RangeProof::new(start_proof, end_proof, key_values.into_boxed_slice());
+    let range_proof = RangeProof::with_hash_mode(
+        start_proof,
+        end_proof,
+        key_values.into_boxed_slice(),
+        H::ALGORITHM,
+    );
 
     let result = verify_range_proof(
         Some(b"a".as_slice()),
         Some(b"bc".as_slice()),
         &root_hash,
+        H::ALGORITHM,
         &range_proof,
     );
     assert!(
@@ -2096,9 +2440,9 @@ fn test_bad_range_proof_value_mismatch_on_proof_path() {
 /// a branch node with children. Keys are \x10, \x20, and \x20\xab. Proof is
 /// generated from None to \x20. Children of the \x20 node should not be
 /// included in the proof.
-#[test]
-fn test_right_edge_boundary_prefix_of_terminal() {
-    let merkle = init_merkle([
+#[firewood_macros::hash_mode]
+fn test_right_edge_boundary_prefix_of_terminal<H: HashMode>() {
+    let merkle = init_merkle::<H, _, _, _>([
         (b"\x10" as &[u8], b"a"),
         (b"\x20", b"b"),
         (b"\x20\xab", b"c"),
@@ -2117,7 +2461,14 @@ fn test_right_edge_boundary_prefix_of_terminal() {
     );
     // End proof should only have 2 proof nodes.
     assert_eq!(proof.end_proof().len(), 2);
-    verify_range_proof(None::<&[u8]>, Some(b"\x20"), &root_hash, &proof).unwrap();
+    verify_range_proof(
+        None::<&[u8]>,
+        Some(b"\x20"),
+        &root_hash,
+        H::ALGORITHM,
+        &proof,
+    )
+    .unwrap();
 }
 
 /// Regression test: range proof verification must handle `ValueDigest::Hash`
@@ -2130,17 +2481,13 @@ fn test_right_edge_boundary_prefix_of_terminal() {
 /// Setup: \x10 is a prefix of \x10\x20, making \x10 a branch with a value
 /// AND children. The 32-byte value at \x10 triggers `ValueDigest::Hash` after
 /// serialization round-trip.
-// `ValueDigest::Hash` only arises from MerkleDB's ≥32-byte value capping, so
 // `ValueDigest::Hash` only arises from MerkleDB's ≥32-byte value capping,
-// which never happens in an ethhash build, so this stays MerkleDB-only.
-#[cfg(not(feature = "ethhash"))]
-#[test]
-fn test_range_proof_with_hashed_value() {
-    use firewood_storage::{MerkleDbHash, NodeHashAlgorithm};
-
+// which never happens under Ethereum hashing, so this stays MerkleDB-only.
+#[firewood_macros::hash_mode(merkledb)]
+fn test_range_proof_with_hashed_value<H: HashMode>() {
     // Value >= 32 bytes triggers ValueDigest::Hash in merkledb mode
     let big_value = vec![0xab_u8; 32];
-    let merkle = init_merkle_in_mode::<MerkleDbHash, _, _, _>([
+    let merkle = init_merkle::<H, _, _, _>([
         (b"\x10" as &[u8], big_value.as_slice()),
         (b"\x10\x20", b"child"),
         (b"\x30", b"other"),
@@ -2168,11 +2515,11 @@ fn test_range_proof_with_hashed_value() {
     );
 
     // This must pass — the Hash digest matches the branch value.
-    verify_range_proof_in_mode(
+    verify_range_proof(
         Some(b"\x10"),
         Some(b"\x30"),
         &root_hash,
-        NodeHashAlgorithm::MerkleDB,
+        H::ALGORITHM,
         &deserialized,
     )
     .unwrap();
@@ -2183,15 +2530,14 @@ fn test_range_proof_with_hashed_value() {
 /// pairs inserted). The Hash proof node is out of range, so its value
 /// contribution comes from the parent's proof child hash — the branch value
 /// doesn't matter and reconcile should not reject.
-#[cfg(not(feature = "ethhash"))]
-#[test]
-fn test_empty_range_proof_with_hashed_value() {
-    use firewood_storage::{MerkleDbHash, NodeHashAlgorithm};
-
+// `ValueDigest::Hash` only arises from MerkleDB's ≥32-byte value capping, so
+// this stays MerkleDB-only (see `test_range_proof_with_hashed_value`).
+#[firewood_macros::hash_mode(merkledb)]
+fn test_empty_range_proof_with_hashed_value<H: HashMode>() {
     // \x10 has a large value (>= 32 bytes), \x10\x20 makes \x10 a branch.
     // Range is past all keys — empty key-value list.
     let big_value = vec![0xab_u8; 32];
-    let merkle = init_merkle_in_mode::<MerkleDbHash, _, _, _>([
+    let merkle = init_merkle::<H, _, _, _>([
         (b"\x10" as &[u8], big_value.as_slice()),
         (b"\x10\x20", b"child"),
     ]);
@@ -2209,11 +2555,11 @@ fn test_empty_range_proof_with_hashed_value() {
     let deserialized = crate::api::FrozenRangeProof::from_slice(&serialized).unwrap();
 
     // This must pass — the Hash proof node is out of range.
-    verify_range_proof_in_mode(
+    verify_range_proof(
         Some(b"\x30"),
         Some(b"\x40"),
         &root_hash,
-        NodeHashAlgorithm::MerkleDB,
+        H::ALGORITHM,
         &deserialized,
     )
     .unwrap();
@@ -2234,12 +2580,11 @@ fn test_empty_range_proof_with_hashed_value() {
 /// from the proof node fallback in `compute_root_hash_with_proofs`. "abcdef"
 /// is in-range, its Hash matches the branch value via the fast path in
 /// `reconcile_branch_proof_node`.
-#[cfg(not(feature = "ethhash"))]
-#[test]
-fn test_multi_level_range_proof_with_hashed_values() {
-    use firewood_storage::{MerkleDbHash, NodeHashAlgorithm};
-
-    let merkle = init_merkle_in_mode::<MerkleDbHash, _, _, _>([
+// `ValueDigest::Hash` only arises from MerkleDB's ≥32-byte value capping, so
+// this stays MerkleDB-only (see `test_range_proof_with_hashed_value`).
+#[firewood_macros::hash_mode(merkledb)]
+fn test_multi_level_range_proof_with_hashed_values<H: HashMode>() {
+    let merkle = init_merkle::<H, _, _, _>([
         (b"abc" as &[u8], [0; 64].as_slice()),
         (b"abc123", [1; 64].as_slice()),
         (b"abcdef", [2; 64].as_slice()),
@@ -2277,11 +2622,11 @@ fn test_multi_level_range_proof_with_hashed_values() {
     // This exercises:
     // - "abc" out-of-range: Hash fallback in compute_root_hash_with_proofs
     // - "abcdef" in-range: Hash fast path in reconcile_branch_proof_node
-    verify_range_proof_in_mode(
+    verify_range_proof(
         Some(b"abc123"),
         Some(b"\xff"),
         &root_hash,
-        NodeHashAlgorithm::MerkleDB,
+        H::ALGORITHM,
         &deserialized,
     )
     .unwrap();

--- a/firewood/src/merkle/tests/reconcile.rs
+++ b/firewood/src/merkle/tests/reconcile.rs
@@ -1,13 +1,21 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+//! Ethereum-only: pinned to `EthHash` throughout because
+//! `test_reconcile_branch_proof_node_account_storage_root_relaxation` below
+//! exercises the account-depth storageRoot relaxation in
+//! `reconcile_branch_proof_node`, which only exists under Ethereum hashing.
+//! The other tests in this module reconcile generic branch proof nodes and
+//! don't depend on the hash mode, but are pinned to the same concrete type
+//! for consistency (and because they share this module's `use super::*;`
+//! helpers with the account-relaxation test).
+
 use super::*;
-#[cfg(feature = "ethhash")]
 use test_case::test_case;
 
 #[test]
 fn test_reconcile_branch_proof_node_creates_missing_branch_without_value() {
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::EthHash>();
 
     let proof_node = test_branch_proof_node(&[0xa, 0xb, 0xc], None);
 
@@ -25,7 +33,7 @@ fn test_reconcile_branch_proof_node_creates_missing_branch_without_value() {
 
 #[test]
 fn test_reconcile_branch_proof_node_sets_missing_value_via_callback() {
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::EthHash>();
     merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
 
     let proof_node =
@@ -46,7 +54,7 @@ fn test_reconcile_branch_proof_node_sets_missing_value_via_callback() {
 
 #[test]
 fn test_reconcile_branch_proof_node_clears_value_via_callback() {
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::EthHash>();
     merkle.insert(&[0xab], Box::from([3u8])).unwrap();
     merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
 
@@ -64,7 +72,7 @@ fn test_reconcile_branch_proof_node_clears_value_via_callback() {
 
 #[test]
 fn test_reconcile_branch_proof_node_rejects_conflict_via_callback() {
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::EthHash>();
     merkle.insert(&[0xab], Box::from([1u8])).unwrap();
     merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
 
@@ -90,7 +98,6 @@ fn test_reconcile_branch_proof_node_rejects_conflict_via_callback() {
 /// still conflicts.
 ///
 /// This exercises the helper directly, without constructing any proofs.
-#[cfg(feature = "ethhash")]
 #[test_case(100, true  ; "storage_root_only_diff_is_forgiven")]
 #[test_case(999, false ; "extra_balance_diff_still_conflicts")]
 fn test_reconcile_branch_proof_node_account_storage_root_relaxation(
@@ -108,7 +115,7 @@ fn test_reconcile_branch_proof_node_account_storage_root_relaxation(
     let branch_value = rlp_encode_account(1, 100, &[0xAA; 32], &empty_code_hash());
     let proof_value = rlp_encode_account(1, proof_balance, &[0xBB; 32], &empty_code_hash());
 
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::EthHash>();
     merkle.insert(&account_key, branch_value.clone()).unwrap();
     merkle.insert_branch_from_nibbles(&account_nibbles).unwrap();
 

--- a/firewood/src/merkle/tests/reconcile.rs
+++ b/firewood/src/merkle/tests/reconcile.rs
@@ -1,14 +1,23 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+//! Ethereum-focused: most tests are pinned to `EthHash` because
+//! `test_reconcile_branch_proof_node_account_storage_root_relaxation` below
+//! exercises the account-depth storageRoot relaxation in
+//! `reconcile_branch_proof_node`, which only exists under Ethereum hashing.
+//! The other tests in this module reconcile generic branch proof nodes and
+//! don't depend on the hash mode, but are pinned to the same concrete type
+//! for consistency (and because they share this module's `use super::*;`
+//! helpers with the account-relaxation test). The hashed-digest guard test is
+//! the exception: it deliberately uses the opposite structural type to prove
+//! that validation follows the explicit runtime algorithm.
+
 use super::*;
-#[cfg(feature = "ethhash")]
 use test_case::test_case;
 
-#[cfg(feature = "ethhash")]
 #[test]
 fn test_reconcile_branch_proof_node_rejects_hashed_value_digest() {
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::MerkleDbHash>();
     let proof_node = test_branch_proof_node(
         &[0xa, 0xb],
         Some(ValueDigest::Hash(TrieHash::from([0xabu8; 32]).into())),
@@ -29,16 +38,12 @@ fn test_reconcile_branch_proof_node_rejects_hashed_value_digest() {
 
 #[test]
 fn test_reconcile_branch_proof_node_creates_missing_branch_without_value() {
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::EthHash>();
 
     let proof_node = test_branch_proof_node(&[0xa, 0xb, 0xc], None);
 
     merkle
-        .reconcile_branch_proof_node(
-            &proof_node,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-            |_, _| unreachable!(),
-        )
+        .reconcile_branch_proof_node(&proof_node, EthHash::ALGORITHM, |_, _| unreachable!())
         .unwrap();
 
     let node = merkle
@@ -51,7 +56,7 @@ fn test_reconcile_branch_proof_node_creates_missing_branch_without_value() {
 
 #[test]
 fn test_reconcile_branch_proof_node_sets_missing_value_via_callback() {
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::EthHash>();
     merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
 
     let proof_node =
@@ -59,14 +64,12 @@ fn test_reconcile_branch_proof_node_sets_missing_value_via_callback() {
 
     // Proof has a value but trie doesn't — callback resolves it.
     merkle
-        .reconcile_branch_proof_node(
-            &proof_node,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-            |pn, _| match &pn.value_digest {
+        .reconcile_branch_proof_node(&proof_node, EthHash::ALGORITHM, |pn, _| {
+            match &pn.value_digest {
                 Some(ValueDigest::Value(v)) => Ok(Some(v.clone())),
                 _ => Ok(None),
-            },
-        )
+            }
+        })
         .unwrap();
 
     let node = merkle.get_node_from_nibbles(&[0xa, 0xb]).unwrap().unwrap();
@@ -76,7 +79,7 @@ fn test_reconcile_branch_proof_node_sets_missing_value_via_callback() {
 
 #[test]
 fn test_reconcile_branch_proof_node_clears_value_via_callback() {
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::EthHash>();
     merkle.insert(&[0xab], Box::from([3u8])).unwrap();
     merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
 
@@ -84,11 +87,7 @@ fn test_reconcile_branch_proof_node_clears_value_via_callback() {
 
     // Proof says no value, trie has one — callback returns None to clear it.
     merkle
-        .reconcile_branch_proof_node(
-            &proof_node,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-            |_, _| Ok(None),
-        )
+        .reconcile_branch_proof_node(&proof_node, EthHash::ALGORITHM, |_, _| Ok(None))
         .unwrap();
 
     let node = merkle.get_node_from_nibbles(&[0xa, 0xb]).unwrap().unwrap();
@@ -98,7 +97,7 @@ fn test_reconcile_branch_proof_node_clears_value_via_callback() {
 
 #[test]
 fn test_reconcile_branch_proof_node_rejects_conflict_via_callback() {
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::EthHash>();
     merkle.insert(&[0xab], Box::from([1u8])).unwrap();
     merkle.insert_branch_from_nibbles(&[0xa, 0xb]).unwrap();
 
@@ -107,11 +106,9 @@ fn test_reconcile_branch_proof_node_rejects_conflict_via_callback() {
 
     // Callback rejects the conflict.
     let err = merkle
-        .reconcile_branch_proof_node(
-            &proof_node,
-            firewood_storage::DefaultHashMode::ALGORITHM,
-            |_, _| Err(ProofError::UnexpectedValue),
-        )
+        .reconcile_branch_proof_node(&proof_node, EthHash::ALGORITHM, |_, _| {
+            Err(ProofError::UnexpectedValue)
+        })
         .unwrap_err();
     assert!(matches!(err, ProofError::UnexpectedValue));
 
@@ -128,7 +125,6 @@ fn test_reconcile_branch_proof_node_rejects_conflict_via_callback() {
 /// still conflicts.
 ///
 /// This exercises the helper directly, without constructing any proofs.
-#[cfg(feature = "ethhash")]
 #[test_case(100, true  ; "storage_root_only_diff_is_forgiven")]
 #[test_case(999, false ; "extra_balance_diff_still_conflicts")]
 fn test_reconcile_branch_proof_node_account_storage_root_relaxation(
@@ -146,7 +142,7 @@ fn test_reconcile_branch_proof_node_account_storage_root_relaxation(
     let branch_value = rlp_encode_account(1, 100, &[0xAA; 32], &empty_code_hash());
     let proof_value = rlp_encode_account(1, proof_balance, &[0xBB; 32], &empty_code_hash());
 
-    let mut merkle = create_in_memory_merkle();
+    let mut merkle = create_in_memory_merkle::<firewood_storage::EthHash>();
     merkle.insert(&account_key, branch_value.clone()).unwrap();
     merkle.insert_branch_from_nibbles(&account_nibbles).unwrap();
 

--- a/firewood/src/merkle/tests/triehash.rs
+++ b/firewood/src/merkle/tests/triehash.rs
@@ -1,6 +1,8 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+//! MerkleDB-only: sha256 golden vectors.
+
 use super::*;
 use test_case::test_case;
 
@@ -13,7 +15,7 @@ use test_case::test_case;
 #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1]),(&[0,1,2],&[0,1,2])], Some("229011c50ad4d5c2f4efe02b8db54f361ad295c4eee2bf76ea4ad1bb92676f97"); "root with branch child")]
 #[test_case(vec![(&[0],&[0]),(&[0,1],&[0,1]),(&[0,8],&[0,8]),(&[0,1,2],&[0,1,2])], Some("a683b4881cb540b969f885f538ba5904699d480152f350659475a962d6240ef9"); "root with branch child and leaf child")]
 fn test_root_hash_merkledb_compatible(kvs: Vec<(&[u8], &[u8])>, expected_hash: Option<&str>) {
-    let merkle = init_merkle(kvs);
+    let merkle = init_merkle::<MerkleDbHash, _, _, _>(kvs);
     let Some(got_hash) = merkle.nodestore.root_hash() else {
         assert!(expected_hash.is_none());
         return;

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -5,12 +5,12 @@ use integer_encoding::VarInt;
 use test_case::test_case;
 
 use firewood_storage::{
-    Children, HashType, NodeHashAlgorithm, PathComponent, SeededRng, TrieHash, ValueDigest,
-    logger::debug,
+    Children, EthHash, HashMode, HashType, MerkleDbHash, NodeHashAlgorithm, PathComponent,
+    SeededRng, TrieHash, ValueDigest, logger::debug,
 };
 
 use super::{
-    header::InvalidHeader,
+    header::{Header, InvalidHeader},
     magic,
     reader::{ProofReader, ReadError},
     types::{Proof, ProofError, ProofNode, ProofType},
@@ -18,8 +18,12 @@ use super::{
 use crate::api::{FrozenChangeProof, FrozenRangeProof};
 use crate::db::BatchOp;
 
-fn create_valid_range_proof() -> (FrozenRangeProof, Vec<u8>) {
-    let merkle = crate::merkle::tests::init_merkle((0u8..=10).map(|k| ([k], [k])));
+/// Builds a valid range proof over a small real trie. Genuinely builds a trie
+/// (unlike the other helpers in this file, which hand-construct proof nodes),
+/// so it is generic over `H` per the `#[hash_mode]` composition rule rather
+/// than value-parametrized by [`NodeHashAlgorithm`] — tests that build a real trie are dualized with `#[hash_mode]`, while those that hand-construct nodes parametrize by algorithm value.
+fn create_valid_range_proof<H: HashMode>() -> (FrozenRangeProof, Vec<u8>) {
+    let merkle = crate::merkle::tests::init_merkle::<H, _, _, _>((0u8..=10).map(|k| ([k], [k])));
     let proof = merkle
         .range_proof(Some(&[2u8]), Some(&[8u8]), std::num::NonZeroUsize::new(5))
         .unwrap();
@@ -28,8 +32,12 @@ fn create_valid_range_proof() -> (FrozenRangeProof, Vec<u8>) {
     (proof, serialized)
 }
 
-fn create_valid_change_proof() -> (FrozenChangeProof, Vec<u8>) {
-    let proof = FrozenChangeProof::new(
+/// Builds a valid change proof stamped with `algorithm`. Unlike
+/// [`create_valid_range_proof`], this never touches a real trie (both
+/// boundary proofs are empty), so it is value-parametrized by
+/// [`NodeHashAlgorithm`] rather than generic over `H`.
+fn create_valid_change_proof(algorithm: NodeHashAlgorithm) -> (FrozenChangeProof, Vec<u8>) {
+    let proof = FrozenChangeProof::with_hash_mode(
         Proof::new(Box::<[ProofNode]>::from([])),
         Proof::new(Box::<[ProofNode]>::from([])),
         Box::new([
@@ -44,24 +52,27 @@ fn create_valid_change_proof() -> (FrozenChangeProof, Vec<u8>) {
                 prefix: Box::from(b"key3".as_slice()),
             },
         ]),
+        algorithm,
     );
     let mut serialized = Vec::new();
     proof.write_to_vec(&mut serialized);
     (proof, serialized)
 }
 
-#[test]
-fn test_range_proof_roundtrip() {
-    let (_, serialized) = create_valid_range_proof();
+// Genuinely builds a trie (via `create_valid_range_proof`), so it's dualized with `#[hash_mode]` rather than value-parametrized — this exercises both hash modes in the real trie-construction path.
+#[firewood_macros::hash_mode]
+fn test_range_proof_roundtrip<H: HashMode>() {
+    let (_, serialized) = create_valid_range_proof::<H>();
     let parsed = FrozenRangeProof::from_slice(&serialized).expect("roundtrip should succeed");
     let mut re_serialized = Vec::new();
     parsed.write_to_vec(&mut re_serialized);
     assert_eq!(serialized, re_serialized);
 }
 
-#[test]
-fn test_change_proof_roundtrip() {
-    let (_, serialized) = create_valid_change_proof();
+#[test_case(NodeHashAlgorithm::MerkleDB; "merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum; "eth")]
+fn test_change_proof_roundtrip(algorithm: NodeHashAlgorithm) {
+    let (_, serialized) = create_valid_change_proof(algorithm);
     let parsed = FrozenChangeProof::from_slice(&serialized).expect("roundtrip should succeed");
     let mut re_serialized = Vec::new();
     parsed.write_to_vec(&mut re_serialized);
@@ -98,11 +109,14 @@ fn test_change_proof_roundtrip() {
     |err| matches!(err, InvalidHeader::InvalidProofType { found: 2, expected: Some(ProofType::Range) });
     "wrong proof type"
 )]
+// Mode-free: every case corrupts a fixed header byte (or the proof-type byte)
+// to a value with no valid interpretation, independent of which mode built
+// the underlying scaffold proof. `MerkleDbHash` is an arbitrary fixed choice.
 fn test_invalid_header(
     mutator: impl FnOnce(&mut Vec<u8>),
     expected: impl FnOnce(&InvalidHeader) -> bool,
 ) {
-    let (_, mut data) = create_valid_range_proof();
+    let (_, mut data) = create_valid_range_proof::<MerkleDbHash>();
 
     mutator(&mut data);
 
@@ -134,13 +148,16 @@ fn test_invalid_header(
     "no varint after header"
 )]
 
+// Mode-free: every case truncates within the fixed 32-byte header or the
+// array-length varint right after it, before any mode-dependent bytes.
+// `MerkleDbHash` is an arbitrary fixed choice.
 fn test_incomplete_item(
     mutator: impl FnOnce(&FrozenRangeProof, &mut Vec<u8>),
     item: &'static str,
     expected_len: usize,
     found_len: usize,
 ) {
-    let (proof, mut data) = create_valid_range_proof();
+    let (proof, mut data) = create_valid_range_proof::<MerkleDbHash>();
 
     debug!("data len: {}", data.len());
     debug!("proof: {proof:#?}");
@@ -213,13 +230,17 @@ fn test_incomplete_item(
     "2 > (1 / 5)";
     "truncated node key"
 )]
+// Mode-free: every case corrupts bytes strictly before the children region
+// (value-digest discriminant, header-adjacent varint, trailing bytes, or a
+// truncation that cuts off before any child hash). `MerkleDbHash` is an
+// arbitrary fixed choice.
 fn test_invalid_item(
     mutator: impl FnOnce(&FrozenRangeProof, &mut Vec<u8>),
     item: &'static str,
     expected: &'static str,
     found: &'static str,
 ) {
-    let (proof, mut data) = create_valid_range_proof();
+    let (proof, mut data) = create_valid_range_proof::<MerkleDbHash>();
 
     mutator(&proof, &mut data);
 
@@ -247,9 +268,12 @@ fn test_invalid_item(
     }
 }
 
+// Mode-free: corrupts the `partial_len` varint immediately after the first
+// node's key bytes, before any mode-dependent bytes. `MerkleDbHash` is an
+// arbitrary fixed choice.
 #[test]
 fn test_partial_key_len_exceeds_key_len() {
-    let (proof, mut data) = create_valid_range_proof();
+    let (proof, mut data) = create_valid_range_proof::<MerkleDbHash>();
 
     let node = &proof.start_proof()[0];
     let key_len = node.key.len();
@@ -334,11 +358,14 @@ fn test_empty_proof() {
     |err| matches!(err, InvalidHeader::InvalidProofType { found: 1, expected: Some(ProofType::Change) });
     "wrong proof type"
 )]
+// Mode-free: every case corrupts a fixed header byte, independent of the
+// scaffold proof's algorithm. `NodeHashAlgorithm::MerkleDB` is an arbitrary
+// fixed choice.
 fn test_change_proof_invalid_header(
     mutator: impl FnOnce(&mut Vec<u8>),
     expected: impl FnOnce(&InvalidHeader) -> bool,
 ) {
-    let (_, mut data) = create_valid_change_proof();
+    let (_, mut data) = create_valid_change_proof(NodeHashAlgorithm::MerkleDB);
 
     mutator(&mut data);
 
@@ -369,13 +396,16 @@ fn test_change_proof_invalid_header(
     0; // found len
     "no varint after header"
 )]
+// Mode-free: every case truncates within the fixed 32-byte header or the
+// array-length varint right after it. `NodeHashAlgorithm::MerkleDB` is an
+// arbitrary fixed choice.
 fn test_change_proof_incomplete_item(
     mutator: impl FnOnce(&mut Vec<u8>),
     item: &'static str,
     expected_len: usize,
     found_len: usize,
 ) {
-    let (_, mut data) = create_valid_change_proof();
+    let (_, mut data) = create_valid_change_proof(NodeHashAlgorithm::MerkleDB);
 
     mutator(&mut data);
 
@@ -426,13 +456,16 @@ fn test_change_proof_incomplete_item(
     "99";
     "invalid batch op discriminant"
 )]
+// Mode-free: every case corrupts a fixed-offset byte outside any
+// mode-dependent encoding (change proofs here never carry child hashes).
+// `NodeHashAlgorithm::MerkleDB` is an arbitrary fixed choice.
 fn test_change_proof_invalid_item(
     mutator: impl FnOnce(&FrozenChangeProof, &mut Vec<u8>),
     item: &'static str,
     expected: &'static str,
     found: &'static str,
 ) {
-    let (proof, mut data) = create_valid_change_proof();
+    let (proof, mut data) = create_valid_change_proof(NodeHashAlgorithm::MerkleDB);
 
     mutator(&proof, &mut data);
 
@@ -485,12 +518,17 @@ fn make_proof_node(
     }
 }
 
-/// Wraps a single `ProofNode` in a minimal `FrozenRangeProof` and serializes it.
-fn make_range_proof_from_single_node(node: ProofNode) -> (FrozenRangeProof, Vec<u8>) {
-    let proof = FrozenRangeProof::new(
+/// Wraps a single `ProofNode` in a minimal `FrozenRangeProof` stamped with
+/// `algorithm` and serializes it.
+fn make_range_proof_from_single_node(
+    node: ProofNode,
+    algorithm: NodeHashAlgorithm,
+) -> (FrozenRangeProof, Vec<u8>) {
+    let proof = FrozenRangeProof::with_hash_mode(
         Proof::new(Box::new([node])),
         Proof::new(Box::<[ProofNode]>::from([])),
         Box::new([]),
+        algorithm,
     );
     let mut serialized = Vec::new();
     proof.write_to_vec(&mut serialized);
@@ -505,60 +543,62 @@ fn assert_range_proof_round_trip(serialized: Vec<u8>) {
     assert_eq!(serialized, re_serialized, "round-trip bytes must match");
 }
 
-#[test]
-fn test_proof_node_leaf_round_trip() {
+#[test_case(NodeHashAlgorithm::MerkleDB; "merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum; "eth")]
+fn test_proof_node_leaf_round_trip(algorithm: NodeHashAlgorithm) {
     // Leaf: no children, no value, empty key
     let node = make_proof_node(&[], 0, None, &[]);
-    let (_, serialized) = make_range_proof_from_single_node(node);
+    let (_, serialized) = make_range_proof_from_single_node(node, algorithm);
     assert_range_proof_round_trip(serialized);
 }
 
-#[test]
-fn test_proof_node_single_child_round_trip() {
+#[test_case(NodeHashAlgorithm::MerkleDB; "merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum; "eth")]
+fn test_proof_node_single_child_round_trip(algorithm: NodeHashAlgorithm) {
     // Branch with one child at nibble index 7
     let node = make_proof_node(&[1, 2, 3], 0, None, &[7]);
-    let (_, serialized) = make_range_proof_from_single_node(node);
+    let (_, serialized) = make_range_proof_from_single_node(node, algorithm);
     assert_range_proof_round_trip(serialized);
 }
 
-#[test]
-fn test_proof_node_all_children_round_trip() {
+#[test_case(NodeHashAlgorithm::MerkleDB; "merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum; "eth")]
+fn test_proof_node_all_children_round_trip(algorithm: NodeHashAlgorithm) {
     // Branch with all 16 children present (ChildMask = 0xFFFF)
     let all_nibbles: Vec<u8> = (0u8..16).collect();
     let node = make_proof_node(&[0], 0, None, &all_nibbles);
-    let (_, serialized) = make_range_proof_from_single_node(node);
+    let (_, serialized) = make_range_proof_from_single_node(node, algorithm);
     assert_range_proof_round_trip(serialized);
 }
 
-#[cfg(not(feature = "ethhash"))]
+// MerkleDB-only: values >= 32 bytes are converted to a hash by make_hash()
+// during serialization ONLY under the MerkleDB scheme (the Ethereum scheme
+// never emits a `Hash` digest; see `ValueDigest::make_hash`). The round-trip
+// bytes should still match because re-serializing a Hash-variant node also
+// produces a hash discriminant (1) rather than a value discriminant (0).
 #[test]
 fn test_value_digest_hash_round_trip() {
-    // Values >= 32 bytes are converted to a hash by make_hash() during serialization.
-    // The round-trip bytes should still match because re-serializing a Hash-variant
-    // node also produces a hash discriminant (1) rather than a value discriminant (0).
     let value: Box<[u8]> = vec![0xABu8; 32].into_boxed_slice();
     let node = make_proof_node(&[1, 2], 0, Some(value), &[]);
-    let (_, serialized) = make_range_proof_from_single_node(node);
+    let (_, serialized) = make_range_proof_from_single_node(node, NodeHashAlgorithm::MerkleDB);
     assert_range_proof_round_trip(serialized);
 }
 
-#[test_case(
-    BatchOp::Put { key: Box::from(b"k".as_slice()), value: Box::from(b"v".as_slice()) };
-    "put"
-)]
-#[test_case(
-    BatchOp::Delete { key: Box::from(b"k".as_slice()) };
-    "delete"
-)]
-#[test_case(
-    BatchOp::DeleteRange { prefix: Box::from(b"k".as_slice()) };
-    "delete range"
-)]
-fn test_change_proof_batch_op_variant(op: BatchOp<Box<[u8]>, Box<[u8]>>) {
-    let proof = FrozenChangeProof::new(
+#[test_case(NodeHashAlgorithm::MerkleDB, BatchOp::Put { key: Box::from(b"k".as_slice()), value: Box::from(b"v".as_slice()) }; "put_merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum, BatchOp::Put { key: Box::from(b"k".as_slice()), value: Box::from(b"v".as_slice()) }; "put_eth")]
+#[test_case(NodeHashAlgorithm::MerkleDB, BatchOp::Delete { key: Box::from(b"k".as_slice()) }; "delete_merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum, BatchOp::Delete { key: Box::from(b"k".as_slice()) }; "delete_eth")]
+#[test_case(NodeHashAlgorithm::MerkleDB, BatchOp::DeleteRange { prefix: Box::from(b"k".as_slice()) }; "delete_range_merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum, BatchOp::DeleteRange { prefix: Box::from(b"k".as_slice()) }; "delete_range_eth")]
+fn test_change_proof_batch_op_variant(
+    algorithm: NodeHashAlgorithm,
+    op: BatchOp<Box<[u8]>, Box<[u8]>>,
+) {
+    let proof = FrozenChangeProof::with_hash_mode(
         Proof::new(Box::<[ProofNode]>::from([])),
         Proof::new(Box::<[ProofNode]>::from([])),
         Box::new([op]),
+        algorithm,
     );
     let mut serialized = Vec::new();
     proof.write_to_vec(&mut serialized);
@@ -569,16 +609,17 @@ fn test_change_proof_batch_op_variant(op: BatchOp<Box<[u8]>, Box<[u8]>>) {
     assert_eq!(serialized, re_serialized, "round-trip bytes must match");
 }
 
-#[test]
-fn test_proof_node_partial_len_boundaries() {
+#[test_case(NodeHashAlgorithm::MerkleDB; "merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum; "eth")]
+fn test_proof_node_partial_len_boundaries(algorithm: NodeHashAlgorithm) {
     // partial_len = 0: no shared prefix with the parent node
     let node = make_proof_node(&[1, 2, 3, 4], 0, None, &[]);
-    let (_, serialized) = make_range_proof_from_single_node(node);
+    let (_, serialized) = make_range_proof_from_single_node(node, algorithm);
     assert_range_proof_round_trip(serialized);
 
     // partial_len = key.len(): entire key is shared with the parent
     let node = make_proof_node(&[1, 2, 3, 4], 4, None, &[]);
-    let (_, serialized) = make_range_proof_from_single_node(node);
+    let (_, serialized) = make_range_proof_from_single_node(node, algorithm);
     assert_range_proof_round_trip(serialized);
 }
 
@@ -604,10 +645,13 @@ fn test_proof_node_partial_len_boundaries() {
 //   Non-ethhash: [39..71] = TrieHash (32 bytes)
 //   Ethhash:     [39] = HashType discriminant, [40..72] = TrieHash
 
+// Mode-free: this node has no children, so bytes up to (and including) [34]
+// are identical under both modes. `NodeHashAlgorithm::MerkleDB` is an
+// arbitrary fixed choice.
 #[test]
 fn test_invalid_path_nibble() {
     let node = make_proof_node(&[1, 2, 3], 0, None, &[]);
-    let (_, mut data) = make_range_proof_from_single_node(node);
+    let (_, mut data) = make_range_proof_from_single_node(node, NodeHashAlgorithm::MerkleDB);
     data[34] = 0x10; // first key byte set to an invalid nibble (16 > 15)
     match FrozenRangeProof::from_slice(&data) {
         Err(ReadError::InvalidItem { item, .. }) => assert_eq!(item, "path"),
@@ -615,10 +659,13 @@ fn test_invalid_path_nibble() {
     }
 }
 
+// Mode-free: this node has no children and a short (< 32 byte) value, so the
+// value-digest discriminant at [39] is identical under both modes.
+// `NodeHashAlgorithm::MerkleDB` is an arbitrary fixed choice.
 #[test]
 fn test_invalid_value_digest_discriminant() {
     let node = make_proof_node(&[1, 2, 3], 0, Some(Box::from(b"v".as_slice())), &[]);
-    let (_, mut data) = make_range_proof_from_single_node(node);
+    let (_, mut data) = make_range_proof_from_single_node(node, NodeHashAlgorithm::MerkleDB);
     data[39] = 2; // invalid ValueDigest discriminant (must be 0 or 1)
     match FrozenRangeProof::from_slice(&data) {
         Err(ReadError::InvalidItem {
@@ -637,6 +684,10 @@ fn test_invalid_value_digest_discriminant() {
     }
 }
 
+// Mode-free: this node has no children, so the ChildMask region truncated
+// here ([39], [40]) is identical under both modes (mode-dependent child hash
+// bytes only follow when the mask is non-zero).
+// `NodeHashAlgorithm::MerkleDB` is an arbitrary fixed choice.
 #[test_case(38, "option discriminant", 1, 0; "option discriminant")]
 #[test_case(39, "children map", 2, 0; "children map zero bytes")]
 #[test_case(40, "children map", 2, 1; "children map one byte")]
@@ -647,7 +698,7 @@ fn test_incomplete_item_known_layout(
     found_len: usize,
 ) {
     let node = make_proof_node(&[1, 2, 3], 0, None, &[]);
-    let (_, mut data) = make_range_proof_from_single_node(node);
+    let (_, mut data) = make_range_proof_from_single_node(node, NodeHashAlgorithm::MerkleDB);
     data.truncate(truncate_at);
     match FrozenRangeProof::from_slice(&data) {
         Err(ReadError::IncompleteItem {
@@ -664,11 +715,14 @@ fn test_incomplete_item_known_layout(
     }
 }
 
-#[cfg(not(feature = "ethhash"))]
+// MerkleDB-only: under MerkleDB, a child hash is a bare 32-byte `TrieHash`
+// with no discriminant, so truncating right after the ChildMask lands inside
+// the hash itself (the Ethereum layout instead expects a 1-byte hash-type
+// discriminant first; see `test_incomplete_hash_type_discriminant`).
 #[test]
 fn test_incomplete_trie_hash() {
     let node = make_proof_node(&[1], 0, None, &[7]);
-    let (_, mut data) = make_range_proof_from_single_node(node);
+    let (_, mut data) = make_range_proof_from_single_node(node, NodeHashAlgorithm::MerkleDB);
     data.truncate(39); // ChildMask ends at [38]; TrieHash starts at [39]
     match FrozenRangeProof::from_slice(&data) {
         Err(ReadError::IncompleteItem {
@@ -685,11 +739,13 @@ fn test_incomplete_trie_hash() {
     }
 }
 
-#[cfg(feature = "ethhash")]
+// Ethereum-only: under Ethereum, a child hash is prefixed with a 1-byte
+// hash-type discriminant (0 = keccak256 hash, 1 = inline RLP), which
+// MerkleDB's bare 32-byte layout doesn't have (see `test_incomplete_trie_hash`).
 #[test]
 fn test_incomplete_hash_type_discriminant() {
     let node = make_proof_node(&[1], 0, None, &[7]);
-    let (_, mut data) = make_range_proof_from_single_node(node);
+    let (_, mut data) = make_range_proof_from_single_node(node, NodeHashAlgorithm::Ethereum);
     data.truncate(39); // ChildMask ends at [38]; HashType discriminant is at [39]
     match FrozenRangeProof::from_slice(&data) {
         Err(ReadError::IncompleteItem {
@@ -708,11 +764,12 @@ fn test_incomplete_hash_type_discriminant() {
     }
 }
 
-#[cfg(feature = "ethhash")]
+// Ethereum-only: the hash-type discriminant grammar (0 = hash, 1 = rlp) only
+// exists on the Ethereum wire format; MerkleDB has no such discriminant byte.
 #[test]
 fn test_invalid_hash_type_discriminant() {
     let node = make_proof_node(&[1], 0, None, &[7]);
-    let (_, mut data) = make_range_proof_from_single_node(node);
+    let (_, mut data) = make_range_proof_from_single_node(node, NodeHashAlgorithm::Ethereum);
     data[39] = 2; // invalid HashType discriminant (must be 0 or 1)
     match FrozenRangeProof::from_slice(&data) {
         Err(ReadError::InvalidItem {
@@ -731,12 +788,15 @@ fn test_invalid_hash_type_discriminant() {
     }
 }
 
+// Mode-free: change proofs here never carry child hashes, so the only
+// mode-dependent byte is the header's hash_mode field, untouched here.
+// `NodeHashAlgorithm::MerkleDB` is an arbitrary fixed choice.
 #[test]
 fn test_change_proof_incomplete_batch_op_discriminant() {
     // Layout of create_valid_change_proof() after the 32-byte header:
     //   [32]=0x00 (start_proof count=0)  [33]=0x00 (end_proof count=0)
     //   [34]=0x03 (batch_ops count=3)    [35]=0x00 (first BatchOp discriminant)
-    let (_, mut data) = create_valid_change_proof();
+    let (_, mut data) = create_valid_change_proof(NodeHashAlgorithm::MerkleDB);
     data.truncate(35); // cut before the first BatchOp discriminant byte
     match FrozenChangeProof::from_slice(&data) {
         Err(ReadError::InvalidItem {
@@ -919,11 +979,14 @@ fn test_slow_malformed_proof_fuzz() {
     }
 }
 
+// Mode-free: corrupts the start_proof array-length varint right after the
+// fixed 32-byte header, before any mode-dependent bytes. `MerkleDbHash` is an
+// arbitrary fixed choice.
 #[test]
 fn test_dos_array_length_bounds() {
     use integer_encoding::VarInt;
 
-    let (proof, mut data) = create_valid_range_proof();
+    let (proof, mut data) = create_valid_range_proof::<MerkleDbHash>();
 
     // The first array length (for start_proof) is at offset 32.
     let original_len = proof.start_proof().len();
@@ -1095,9 +1158,23 @@ mod box_array_deserialization_tests {
     }
 }
 
+/// Reads the `Header` out of a serialized proof so its `validate` method can be
+/// exercised directly.
+fn parse_header(data: &[u8]) -> Header {
+    let mut reader = ProofReader::new(data);
+    reader.read_header().expect("header should parse")
+}
+
+// PR 4 Test 1 (plan Task 6.1): `Header::validate` accepts BOTH known hash modes
+// (so one binary can parse either wire format) and rejects only a truly-unknown
+// byte. Complements the `data[9] = 99` case in `test_invalid_header`.
+//
+// Mode-free: the loop below already exercises both hash_mode bytes directly by
+// overwriting byte [9], independent of which mode built the scaffold proof.
+// `MerkleDbHash` is an arbitrary fixed choice.
 #[test]
 fn test_header_validate_accepts_both_hash_modes() {
-    let (_, base) = create_valid_range_proof();
+    let (_, base) = create_valid_range_proof::<MerkleDbHash>();
 
     for (byte, expected) in [
         (0u8, NodeHashAlgorithm::MerkleDB),
@@ -1106,12 +1183,7 @@ fn test_header_validate_accepts_both_hash_modes() {
         let mut data = base.clone();
         data[9] = byte;
 
-        let mut reader = ProofReader::new(&data);
-        let header = reader
-            .read_header()
-            .expect("header should parse successfully");
-
-        let (proof_type, algorithm) = header
+        let (proof_type, algorithm) = parse_header(&data)
             .validate(Some(ProofType::Range))
             .expect("hash_mode should validate");
 
@@ -1125,12 +1197,7 @@ fn test_header_validate_accepts_both_hash_modes() {
     // A byte that maps to no known algorithm is still rejected.
     let mut data = base;
     data[9] = 99;
-    let mut reader = ProofReader::new(&data);
-    let header = reader
-        .read_header()
-        .expect("header should parse successfully");
-
-    match header.validate(Some(ProofType::Range)) {
+    match parse_header(&data).validate(Some(ProofType::Range)) {
         Err(InvalidHeader::UnsupportedHashMode { found: 99 }) => {}
         other => panic!("expected UnsupportedHashMode {{ found: 99 }}, got: {other:?}"),
     }
@@ -1162,9 +1229,15 @@ fn test_hash_type_read_dispatches_on_threaded_mode() {
     );
 }
 
-#[test]
-fn test_verify_range_proof_rejects_hash_mode_mismatch() {
-    let (proof, _) = create_valid_range_proof();
+// PR 4 Test 3 (plan Task 6.3): the explicit-mode verifier rejects a proof whose
+// self-describing header mode disagrees with the caller's expected mode, with
+// `ProofError::HashModeMismatch` — before any hashing. The proof is built with
+// mode `H`; only the expected mode is flipped. Dualized with `#[hash_mode]`
+// since `create_valid_range_proof` genuinely builds a trie,
+// exercising the mismatch guard in both directions — this is why it's generic over H rather than value-parametrized.
+#[firewood_macros::hash_mode]
+fn test_verify_range_proof_rejects_hash_mode_mismatch<H: HashMode>() {
+    let (proof, _) = create_valid_range_proof::<H>();
     let other_mode = if proof.hash_mode().is_ethereum() {
         NodeHashAlgorithm::MerkleDB
     } else {
@@ -1190,9 +1263,16 @@ fn test_verify_range_proof_rejects_hash_mode_mismatch() {
     }
 }
 
-#[test]
-fn test_verify_change_proof_structure_rejects_hash_mode_mismatch() {
-    let (proof, _) = create_valid_change_proof();
+// PR 4 (review follow-up): sibling of the range mismatch test above, for the
+// change-proof guard in `verify_change_proof_structure`. Without it, a
+// copy-paste regression (e.g. an inverted comparison) in the change path would
+// go undetected. Calls the real crate-level verifier, not the merkle-tests
+// shadow wrapper, so the guard is genuinely exercised. `create_valid_change_proof`
+// never builds a trie, so this is dualized by value (using `#[test_case]`) rather than by `H` — proof-structural tests parametrize by algorithm.
+#[test_case(NodeHashAlgorithm::MerkleDB; "merkledb")]
+#[test_case(NodeHashAlgorithm::Ethereum; "eth")]
+fn test_verify_change_proof_structure_rejects_hash_mode_mismatch(algorithm: NodeHashAlgorithm) {
+    let (proof, _) = create_valid_change_proof(algorithm);
     let other_mode = if proof.hash_mode().is_ethereum() {
         NodeHashAlgorithm::MerkleDB
     } else {

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -327,6 +327,36 @@ fn fwdctl_root_hash() {
 }
 
 #[test]
+fn fwdctl_merkledb_database_round_trip() {
+    with_tmpdir(|db_path| {
+        // Create in MerkleDB mode via the explicit flag…
+        cargo_bin_cmd!()
+            .arg("create")
+            .arg("--db")
+            .arg(db_path)
+            .args(["--hash-mode", "merkle-db"])
+            .assert()
+            .success();
+        // …then insert/get/root auto-detect the mode from the header.
+        insert_key_value(db_path, "year", "2026");
+        cargo_bin_cmd!()
+            .arg("get")
+            .arg("--db")
+            .arg(db_path)
+            .args(["year"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("2026"));
+        cargo_bin_cmd!()
+            .arg("root")
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success();
+    });
+}
+
+#[test]
 fn fwdctl_dump() {
     with_tmpdir(|db_path| {
         create_db(db_path);

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -352,6 +352,36 @@ fn fwdctl_root_hash() {
 }
 
 #[test]
+fn fwdctl_merkledb_database_round_trip() {
+    with_tmpdir(|db_path| {
+        // Create in MerkleDB mode via the explicit flag…
+        cargo_bin_cmd!()
+            .arg("create")
+            .arg("--db")
+            .arg(db_path)
+            .args(["--hash-mode", "merkle-db"])
+            .assert()
+            .success();
+        // …then insert/get/root auto-detect the mode from the header.
+        insert_key_value(db_path, "year", "2026");
+        cargo_bin_cmd!()
+            .arg("get")
+            .arg("--db")
+            .arg(db_path)
+            .args(["year"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("2026"));
+        cargo_bin_cmd!()
+            .arg("root")
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success();
+    });
+}
+
+#[test]
 fn fwdctl_dump() {
     with_tmpdir(|db_path| {
         create_db(db_path);

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -55,6 +55,7 @@ arity-arrays = { version = "0.2.0", default-features = false, features = ["16"] 
 [dev-dependencies]
 # Workspace dependencies
 criterion = { workspace = true, features = ["html_reports"] }
+firewood-macros.workspace = true
 insta.workspace = true
 metrics-util.workspace = true
 pprof = { workspace = true, features = ["flamegraph"] }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -55,6 +55,7 @@ arity-arrays = { version = "0.2.0", default-features = false, features = ["16"] 
 cfg-if = "1.0.4"
 # Workspace dependencies
 criterion = { workspace = true, features = ["html_reports"] }
+firewood-macros.workspace = true
 insta.workspace = true
 metrics-util.workspace = true
 pprof = { workspace = true, features = ["flamegraph"] }

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -974,7 +974,7 @@ mod test {
     // We use primitive calls here to do a low-level check.
     fn checker_traverse_correct_trie() {
         let memstore = MemStore::default();
-        let nodestore =
+        let nodestore: NodeStore<Committed, _> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let test_trie = gen_test_trie(&nodestore);
@@ -999,7 +999,7 @@ mod test {
     // This test permutes the simple trie with a wrong hash and checks that the checker detects it.
     fn checker_traverse_trie_with_wrong_hash() {
         let memstore = MemStore::default();
-        let nodestore =
+        let nodestore: NodeStore<Committed, _> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let mut test_trie = gen_test_trie(&nodestore);
@@ -1074,7 +1074,7 @@ mod test {
         let rng = crate::SeededRng::from_env_or_random();
 
         let memstore = MemStore::default();
-        let nodestore =
+        let nodestore: NodeStore<Committed, _> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         // write free areas
@@ -1121,7 +1121,7 @@ mod test {
     #[test]
     fn traverse_freelist_should_skip_offspring_of_incorrect_areas() {
         let memstore = MemStore::default();
-        let nodestore =
+        let nodestore: NodeStore<Committed, _> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
         let TestFreelist {
             high_watermark,
@@ -1143,7 +1143,7 @@ mod test {
     #[test]
     fn fix_freelist_with_overlap() {
         let memstore = MemStore::default();
-        let nodestore =
+        let nodestore: NodeStore<Committed, _> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
         let TestFreelist {
             high_watermark,
@@ -1187,7 +1187,7 @@ mod test {
         let mut rng = crate::SeededRng::from_env_or_random();
 
         let memstore = MemStore::default();
-        let nodestore =
+        let nodestore: NodeStore<Committed, _> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let num_areas = 10;
@@ -1245,7 +1245,7 @@ mod test {
     #[expect(clippy::arithmetic_side_effects)]
     fn split_range_of_zeros_into_leaked_areas() {
         let memstore = MemStore::default();
-        let nodestore =
+        let nodestore: NodeStore<Committed, _> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let expected_leaked_area_indices = vec![
@@ -1297,7 +1297,7 @@ mod test {
     #[expect(clippy::arithmetic_side_effects)]
     fn split_range_into_leaked_areas_test() {
         let memstore = MemStore::default();
-        let nodestore =
+        let nodestore: NodeStore<Committed, _> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         // write two free areas

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -976,7 +976,7 @@ mod test {
     // We use primitive calls here to do a low-level check.
     fn checker_traverse_correct_trie() {
         let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let nodestore: NodeStore<Committed, _, DefaultHashMode> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let test_trie = gen_test_trie(&nodestore);
@@ -1001,7 +1001,7 @@ mod test {
     // This test permutes the simple trie with a wrong hash and checks that the checker detects it.
     fn checker_traverse_trie_with_wrong_hash() {
         let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let nodestore: NodeStore<Committed, _, DefaultHashMode> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let mut test_trie = gen_test_trie(&nodestore);
@@ -1076,7 +1076,7 @@ mod test {
         let rng = crate::SeededRng::from_env_or_random();
 
         let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let nodestore: NodeStore<Committed, _, DefaultHashMode> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         // write free areas
@@ -1123,7 +1123,7 @@ mod test {
     #[test]
     fn traverse_freelist_should_skip_offspring_of_incorrect_areas() {
         let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let nodestore: NodeStore<Committed, _, DefaultHashMode> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
         let TestFreelist {
             high_watermark,
@@ -1190,7 +1190,7 @@ mod test {
         let mut rng = crate::SeededRng::from_env_or_random();
 
         let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let nodestore: NodeStore<Committed, _, DefaultHashMode> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let num_areas = 10;
@@ -1248,7 +1248,7 @@ mod test {
     #[expect(clippy::arithmetic_side_effects)]
     fn split_range_of_zeros_into_leaked_areas() {
         let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let nodestore: NodeStore<Committed, _, DefaultHashMode> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let expected_leaked_area_indices = vec![
@@ -1300,7 +1300,7 @@ mod test {
     #[expect(clippy::arithmetic_side_effects)]
     fn split_range_into_leaked_areas_test() {
         let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let nodestore: NodeStore<Committed, _, DefaultHashMode> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         // write two free areas

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -492,40 +492,39 @@ pub fn format_node_value<W: std::io::Write + ?Sized>(
 mod format_node_value_tests {
     use super::*;
 
-    fn fmt(value: &[u8]) -> String {
+    fn fmt<H: crate::HashMode>(value: &[u8]) -> String {
         let mut buf = Vec::new();
-        format_node_value(value, DefaultHashMode::ALGORITHM, &mut buf).unwrap();
+        format_node_value(value, H::ALGORITHM, &mut buf).unwrap();
         String::from_utf8(buf).unwrap()
     }
 
-    #[test]
-    fn alphanumeric_plaintext() {
-        assert_eq!(fmt(b"hello"), " val=hello");
-        assert_eq!(fmt(b"value1"), " val=value1");
+    #[firewood_macros::hash_mode]
+    fn alphanumeric_plaintext<H: crate::HashMode>() {
+        assert_eq!(fmt::<H>(b"hello"), " val=hello");
+        assert_eq!(fmt::<H>(b"value1"), " val=value1");
     }
 
-    #[test]
-    fn long_alphanumeric_truncated() {
-        assert_eq!(fmt(b"longvalue"), " val=longva...");
+    #[firewood_macros::hash_mode]
+    fn long_alphanumeric_truncated<H: crate::HashMode>() {
+        assert_eq!(fmt::<H>(b"longvalue"), " val=longva...");
     }
 
-    #[test]
-    fn non_utf8_as_hex() {
-        assert_eq!(fmt(&[0xff, 0xfe]), " val=fffe");
+    #[firewood_macros::hash_mode]
+    fn non_utf8_as_hex<H: crate::HashMode>() {
+        assert_eq!(fmt::<H>(&[0xff, 0xfe]), " val=fffe");
     }
 
-    #[test]
-    fn long_hex_truncated() {
-        assert_eq!(fmt(&[0xde, 0xad, 0xbe, 0xef]), " val=deadbe...");
+    #[firewood_macros::hash_mode]
+    fn long_hex_truncated<H: crate::HashMode>() {
+        assert_eq!(fmt::<H>(&[0xde, 0xad, 0xbe, 0xef]), " val=deadbe...");
     }
 
-    #[test]
-    fn non_alphanumeric_utf8_as_hex() {
+    #[firewood_macros::hash_mode]
+    fn non_alphanumeric_utf8_as_hex<H: crate::HashMode>() {
         // Space is not alphanumeric, so falls through to hex.
-        assert_eq!(fmt(b"hi there"), " val=686920...");
+        assert_eq!(fmt::<H>(b"hi there"), " val=686920...");
     }
 
-    #[cfg(feature = "ethhash")]
     #[test]
     fn rlp_list_decoded() {
         use ::rlp::RlpStream;
@@ -534,15 +533,14 @@ mod format_node_value_tests {
         rlp.append(&vec![0x01u8]);
         rlp.append(&vec![0x02u8]);
         let encoded = rlp.out();
-        assert_eq!(fmt(&encoded), " rlp=[01,02]");
+        assert_eq!(fmt::<EthHash>(&encoded), " rlp=[01,02]");
     }
 
-    #[cfg(feature = "ethhash")]
     #[test]
     fn empty_rlp_list_falls_through() {
         // 0xc0 is an empty RLP list — as_list returns Ok([]) which we
         // treat as non-RLP since there are no fields to display.
-        let result = fmt(&[0xc0]);
+        let result = fmt::<EthHash>(&[0xc0]);
         assert!(
             result.starts_with(" val="),
             "expected hex fallback, got: {result}"

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -385,12 +385,13 @@ mod test {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
+    use crate::{EthHash, HashMode, MerkleDbHash};
     use nonzero_ext::nonzero;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
-    #[test]
-    fn basic_reader_test() {
+    #[firewood_macros::hash_mode]
+    fn basic_reader_test<H: HashMode>() {
         let mut tf = NamedTempFile::new().unwrap();
         let path = tf.path().to_path_buf();
         let output = tf.as_file_mut();
@@ -405,7 +406,7 @@ mod test {
             false,
             true,
             CacheReadStrategy::WritesOnly,
-            <crate::DefaultHashMode as crate::HashMode>::ALGORITHM,
+            H::ALGORITHM,
         )
         .unwrap();
 
@@ -432,8 +433,8 @@ mod test {
         assert_eq!(buf, "world".to_owned());
     }
 
-    #[test]
-    fn big_file() {
+    #[firewood_macros::hash_mode]
+    fn big_file<H: HashMode>() {
         let mut tf = NamedTempFile::new().unwrap();
         let path = tf.path().to_path_buf();
         let output = tf.as_file_mut();
@@ -448,7 +449,7 @@ mod test {
             false,
             true,
             CacheReadStrategy::WritesOnly,
-            <crate::DefaultHashMode as crate::HashMode>::ALGORITHM,
+            H::ALGORITHM,
         )
         .unwrap();
 

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -416,7 +416,7 @@ impl std::ops::DerefMut for UnlockOnDrop {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{DefaultHashMode, HashMode};
+    use crate::{EthHash, HashMode, MerkleDbHash};
     use nonzero_ext::nonzero;
     use std::io::Write;
     use tempfile::NamedTempFile;
@@ -440,8 +440,8 @@ mod test {
         );
     }
 
-    #[test]
-    fn basic_reader_test() {
+    #[firewood_macros::hash_mode]
+    fn basic_reader_test<H: HashMode>() {
         let mut tf = NamedTempFile::new().unwrap();
         let path = tf.path().to_path_buf();
         let output = tf.as_file_mut();
@@ -456,7 +456,7 @@ mod test {
             false,
             true,
             CacheReadStrategy::WritesOnly,
-            DefaultHashMode::ALGORITHM,
+            H::ALGORITHM,
         )
         .unwrap();
 
@@ -483,8 +483,8 @@ mod test {
         assert_eq!(buf, "world".to_owned());
     }
 
-    #[test]
-    fn big_file() {
+    #[firewood_macros::hash_mode]
+    fn big_file<H: HashMode>() {
         let mut tf = NamedTempFile::new().unwrap();
         let path = tf.path().to_path_buf();
         let output = tf.as_file_mut();
@@ -499,7 +499,7 @@ mod test {
             false,
             true,
             CacheReadStrategy::WritesOnly,
-            DefaultHashMode::ALGORITHM,
+            H::ALGORITHM,
         )
         .unwrap();
 

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -542,9 +542,15 @@ mod snapshot_tests;
 #[cfg(test)]
 mod test {
     use crate::node::{BranchNode, LeafNode, Node};
-    use crate::{Child, Children, DefaultHashMode, LinearAddress, NibblesIterator, Path};
+    use crate::{
+        Child, Children, EthHash, HashMode, LinearAddress, MerkleDbHash, NibblesIterator, Path,
+    };
     use test_case::test_case;
 
+    // These are MerkleDB-only byte-length goldens: the eth encoding's
+    // `HashType` child-hash region has a different on-disk length, so this
+    // test locks the merkledb wire format only (see
+    // `test_eth_child_hash_region_exact_bytes` for the eth-mode equivalent).
     #[test_case(
         Node::Leaf(LeafNode {
             partial_path: Path::from(vec![0, 1, 2, 3]),
@@ -594,23 +600,16 @@ than 126 bytes as the length would be encoded in multiple bytes.
                 Some(Child::AddressWithHash(LinearAddress::new(1).unwrap(), std::array::from_fn::<u8, 32, _>(|i| i as u8).into()))
         )})), 1165; "full branch node with obnoxiously long partial path and long value"
     )]
-    // When ethhash is enabled, we don't actually check the `expected_length`
-    fn test_serialize_deserialize(
-        node: Node,
-        #[cfg_attr(feature = "ethhash", expect(unused_variables))] expected_length: usize,
-    ) {
+    fn test_serialize_deserialize(node: Node, expected_length: usize) {
         use crate::node::Node;
         use std::io::Cursor;
 
         let mut serialized = Vec::new();
-        let _area_index = node
-            .as_bytes::<DefaultHashMode, _>(&mut serialized)
-            .unwrap();
-        #[cfg(not(feature = "ethhash"))]
+        let _area_index = node.as_bytes::<MerkleDbHash, _>(&mut serialized).unwrap();
         assert_eq!(serialized.len(), expected_length);
         let mut cursor = Cursor::new(&serialized);
         cursor.set_position(1);
-        let deserialized = Node::from_reader::<DefaultHashMode>(&mut cursor).unwrap();
+        let deserialized = Node::from_reader::<MerkleDbHash>(&mut cursor).unwrap();
 
         assert_eq!(node, deserialized);
     }
@@ -619,7 +618,10 @@ than 126 bytes as the length would be encoded in multiple bytes.
     /// child-hash region in eth mode: an 8-byte native-endian address followed
     /// by the hash codec output (`0x00` + 32 raw bytes for a full hash). These
     /// bytes must stay byte-for-byte stable so existing databases keep working.
-    #[cfg(feature = "ethhash")]
+    ///
+    /// Eth-only golden (not `#[cfg(feature = "ethhash")]`-gated): both hashers
+    /// compile into one binary since PR 3, so the test names `EthHash`
+    /// explicitly instead of relying on a compile-time feature gate.
     #[test]
     fn test_eth_child_hash_region_exact_bytes() {
         // A partial branch with a single child at slot 15, no value. Distinct
@@ -642,8 +644,7 @@ than 126 bytes as the length would be encoded in multiple bytes.
         }));
 
         let mut serialized = Vec::new();
-        node.as_bytes::<DefaultHashMode, _>(&mut serialized)
-            .unwrap();
+        node.as_bytes::<EthHash, _>(&mut serialized).unwrap();
 
         // The child record is the tail of the encoding.
         let mut expected_tail = Vec::new();
@@ -661,14 +662,12 @@ than 126 bytes as the length would be encoded in multiple bytes.
         // And the whole thing must round-trip.
         let mut cursor = std::io::Cursor::new(&serialized);
         cursor.set_position(1);
-        assert_eq!(
-            node,
-            Node::from_reader::<DefaultHashMode>(&mut cursor).unwrap()
-        );
+        assert_eq!(node, Node::from_reader::<EthHash>(&mut cursor).unwrap());
     }
 
-    #[test]
-    fn test_area_index_with_non_empty_buffer() {
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn test_area_index_with_non_empty_buffer<H: HashMode>() {
         use crate::node::Node;
         use crate::nodestore::AreaIndex;
 
@@ -680,16 +679,12 @@ than 126 bytes as the length would be encoded in multiple bytes.
 
         // First, encode into an empty buffer to get the expected area index
         let mut empty_buffer = Vec::new();
-        let expected_area_index = node
-            .as_bytes::<DefaultHashMode, _>(&mut empty_buffer)
-            .unwrap();
+        let expected_area_index = node.as_bytes::<H, _>(&mut empty_buffer).unwrap();
         let expected_size = empty_buffer.len();
 
         // Now encode into a non-empty buffer with a 100-byte prefix
         let mut non_empty_buffer = vec![0xFF; 100];
-        let area_index = node
-            .as_bytes::<DefaultHashMode, _>(&mut non_empty_buffer)
-            .unwrap();
+        let area_index = node.as_bytes::<H, _>(&mut non_empty_buffer).unwrap();
 
         // The area index should be the same regardless of buffer prefix
         assert_eq!(

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -542,9 +542,16 @@ mod snapshot_tests;
 #[cfg(test)]
 mod test {
     use crate::node::{BranchNode, LeafNode, Node};
-    use crate::{Child, Children, DefaultHashMode, LinearAddress, NibblesIterator, Path};
+    use crate::{
+        Child, Children, EthHash, HashMode, LinearAddress, MerkleDbHash, NibblesIterator, Path,
+    };
     use test_case::test_case;
 
+    // These are MerkleDB-only byte-length goldens: the eth encoding's
+    // `HashType` child-hash region has a different on-disk length, so this
+    // test locks the merkledb wire format only (see
+    // `test_eth_child_hash_region_exact_bytes` for the eth-mode equivalent).
+    #[firewood_macros::hash_mode(merkledb)]
     #[test_case(
         Node::Leaf(LeafNode {
             partial_path: Path::from(vec![0, 1, 2, 3]),
@@ -592,23 +599,16 @@ than 126 bytes as the length would be encoded in multiple bytes.
                 Some(Child::AddressWithHash(LinearAddress::new(1).unwrap(), std::array::from_fn::<u8, 32, _>(|i| i as u8).into()))
         )})), 1165; "full branch node with obnoxiously long partial path and long value"
     )]
-    // When ethhash is enabled, we don't actually check the `expected_length`
-    fn test_serialize_deserialize(
-        node: Node,
-        #[cfg_attr(feature = "ethhash", expect(unused_variables))] expected_length: usize,
-    ) {
+    fn test_serialize_deserialize<H: HashMode>(node: Node, expected_length: usize) {
         use crate::node::Node;
         use std::io::Cursor;
 
         let mut serialized = Vec::new();
-        let _area_index = node
-            .as_bytes::<DefaultHashMode, _>(&mut serialized)
-            .unwrap();
-        #[cfg(not(feature = "ethhash"))]
+        let _area_index = node.as_bytes::<H, _>(&mut serialized).unwrap();
         assert_eq!(serialized.len(), expected_length);
         let mut cursor = Cursor::new(&serialized);
         cursor.set_position(1);
-        let deserialized = Node::from_reader::<DefaultHashMode>(&mut cursor).unwrap();
+        let deserialized = Node::from_reader::<H>(&mut cursor).unwrap();
 
         assert_eq!(node, deserialized);
     }
@@ -617,9 +617,12 @@ than 126 bytes as the length would be encoded in multiple bytes.
     /// child-hash region in eth mode: an 8-byte native-endian address followed
     /// by the hash codec output (`0x00` + 32 raw bytes for a full hash). These
     /// bytes must stay byte-for-byte stable so existing databases keep working.
-    #[cfg(feature = "ethhash")]
-    #[test]
-    fn test_eth_child_hash_region_exact_bytes() {
+    ///
+    /// Eth-only golden (not `#[cfg(feature = "ethhash")]`-gated): both hashers
+    /// compile into one binary since PR 3, so the mode is pinned via
+    /// `#[hash_mode(eth)]` instead of a compile-time feature gate.
+    #[firewood_macros::hash_mode(eth)]
+    fn test_eth_child_hash_region_exact_bytes<H: HashMode>() {
         // A partial branch with a single child at slot 15, no value. Distinct
         // per-byte values make a mismatch easy to spot in the failure hex dump.
         let hash_bytes: [u8; 32] = std::array::from_fn(|i| i as u8);
@@ -640,8 +643,7 @@ than 126 bytes as the length would be encoded in multiple bytes.
         }));
 
         let mut serialized = Vec::new();
-        node.as_bytes::<DefaultHashMode, _>(&mut serialized)
-            .unwrap();
+        node.as_bytes::<H, _>(&mut serialized).unwrap();
 
         // The child record is the tail of the encoding.
         let mut expected_tail = Vec::new();
@@ -659,14 +661,12 @@ than 126 bytes as the length would be encoded in multiple bytes.
         // And the whole thing must round-trip.
         let mut cursor = std::io::Cursor::new(&serialized);
         cursor.set_position(1);
-        assert_eq!(
-            node,
-            Node::from_reader::<DefaultHashMode>(&mut cursor).unwrap()
-        );
+        assert_eq!(node, Node::from_reader::<H>(&mut cursor).unwrap());
     }
 
-    #[test]
-    fn test_area_index_with_non_empty_buffer() {
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn test_area_index_with_non_empty_buffer<H: HashMode>() {
         use crate::node::Node;
         use crate::nodestore::AreaIndex;
 
@@ -678,16 +678,12 @@ than 126 bytes as the length would be encoded in multiple bytes.
 
         // First, encode into an empty buffer to get the expected area index
         let mut empty_buffer = Vec::new();
-        let expected_area_index = node
-            .as_bytes::<DefaultHashMode, _>(&mut empty_buffer)
-            .unwrap();
+        let expected_area_index = node.as_bytes::<H, _>(&mut empty_buffer).unwrap();
         let expected_size = empty_buffer.len();
 
         // Now encode into a non-empty buffer with a 100-byte prefix
         let mut non_empty_buffer = vec![0xFF; 100];
-        let area_index = node
-            .as_bytes::<DefaultHashMode, _>(&mut non_empty_buffer)
-            .unwrap();
+        let area_index = node.as_bytes::<H, _>(&mut non_empty_buffer).unwrap();
 
         // The area index should be the same regardless of buffer prefix
         assert_eq!(

--- a/storage/src/node/snapshot_tests.rs
+++ b/storage/src/node/snapshot_tests.rs
@@ -18,14 +18,16 @@
 //! name is required: `test_case` would otherwise make all cases of one function
 //! resolve to the same auto-derived name).
 //!
-//! Tests whose bytes differ between hash modes (branch child encoding) build in
-//! both modes from a single function; [`hash_mode_name`] prefixes their
-//! snapshot name with `merkledb__` or `ethhash__` so each mode gets its own
-//! snapshot file. Tests whose bytes are mode-independent share a single file.
+//! The node-hashing scheme is a runtime, per-database choice (issue #1088), so
+//! tests whose bytes differ between hash modes (branch child encoding) take the
+//! [`NodeHashAlgorithm`] as an explicit case argument and run once per mode;
+//! [`hash_mode_name`] prefixes their snapshot name with `merkledb__` or
+//! `ethhash__` so each mode gets its own snapshot file. Tests whose bytes are
+//! mode-independent pick a single mode and share one snapshot file.
 //!
 //! # Test coverage
 //!
-//! ## `Serializable` implementations (feature-agnostic)
+//! ## `Serializable` implementations (mode-independent)
 //!
 //! | Function | Case | Subject |
 //! |----------|------|---------|
@@ -39,8 +41,8 @@
 //!
 //! Leaf nodes produce identical bytes under both hash modes (no child hashes),
 //! so the [`leaf`] cases share a single snapshot file. Branch nodes encode
-//! child hashes differently per mode, so [`branch`] cases are prefixed via
-//! [`hash_mode_name`].
+//! child hashes differently per mode, so [`branch`] cases run under both modes
+//! and are prefixed via [`hash_mode_name`].
 //!
 //! | Function | Case | Subject |
 //! |----------|------|---------|
@@ -49,7 +51,7 @@
 //! | [`branch`] | `one_child` | Branch: one child (`merkledb__`/`ethhash__`) |
 //! | [`branch`] | `with_value` | Branch: value + one child (`merkledb__`/`ethhash__`) |
 //!
-//! ## `HashType` serialization (ethhash feature only)
+//! ## `HashType` serialization
 //!
 //! | Function | Case | Subject |
 //! |----------|------|---------|
@@ -62,7 +64,8 @@ use crate::node::branch::Serializable;
 use crate::node::{BranchNode, LeafNode, Node};
 use crate::nodestore::alloc::FreeArea;
 use crate::{
-    Child, Children, DefaultHashMode, LinearAddress, NibblesIterator, Path, PathComponent, TrieHash,
+    Child, Children, EthHash, LinearAddress, MerkleDbHash, NibblesIterator, NodeHashAlgorithm,
+    Path, PathComponent, TrieHash,
 };
 
 /// Serializes a [`Serializable`] value into a fresh `Vec<u8>`.
@@ -72,19 +75,26 @@ fn write_to_vec<T: Serializable>(t: &T) -> Vec<u8> {
     buf
 }
 
-/// Calls [`Node::as_bytes`] and returns the full encoded bytes (including the
-/// leading `AreaIndex` byte at position 0).
-fn node_as_bytes(node: &Node) -> Vec<u8> {
+/// Calls [`Node::as_bytes`] under the given runtime hash mode and returns the
+/// full encoded bytes (including the leading `AreaIndex` byte at position 0).
+fn node_as_bytes(node: &Node, algorithm: NodeHashAlgorithm) -> Vec<u8> {
     let mut buf = Vec::new();
-    node.as_bytes::<DefaultHashMode, _>(&mut buf).unwrap();
+    match algorithm {
+        NodeHashAlgorithm::Ethereum => {
+            node.as_bytes::<EthHash, _>(&mut buf).unwrap();
+        }
+        NodeHashAlgorithm::MerkleDB => {
+            node.as_bytes::<MerkleDbHash, _>(&mut buf).unwrap();
+        }
+    }
     buf
 }
 
-/// Prefixes a snapshot name with the active hash mode so feature-split tests
-/// write distinct snapshot files. Bytes differ between modes, so `merkledb` and
+/// Prefixes a snapshot name with the given hash mode so mode-split tests write
+/// distinct snapshot files. Bytes differ between modes, so `merkledb` and
 /// `ethhash` snapshots must not share a filename.
-fn hash_mode_name(name: &str) -> String {
-    let mode = if cfg!(feature = "ethhash") {
+fn hash_mode_name(algorithm: NodeHashAlgorithm, name: &str) -> String {
+    let mode = if algorithm.is_ethereum() {
         "ethhash"
     } else {
         "merkledb"
@@ -129,7 +139,8 @@ fn free_area(name: &str, addr: Option<u64>) {
 }
 
 /// Leaf node serialization. Leaf encoding is identical under both hash modes
-/// (no child hashes), so these cases are not prefixed.
+/// (no child hashes), so these cases are not prefixed and a single fixed mode
+/// (MerkleDB) is used to produce the shared snapshot.
 ///
 /// Encoded first byte: `is_leaf=1 | path_len_low_bits`. Followed by path
 /// nibbles, then varint value length, then value bytes. `long_partial_path` has
@@ -149,36 +160,49 @@ fn leaf(name: &str, partial_path: Path) {
         partial_path,
         value: vec![4, 5, 6, 7].into(),
     });
-    insta::assert_snapshot!(name, hex::encode(node_as_bytes(&node)));
+    insta::assert_snapshot!(
+        name,
+        hex::encode(node_as_bytes(&node, NodeHashAlgorithm::MerkleDB))
+    );
 }
 
 /// Branch node serialization. Child hashes encode differently per hash mode
 /// (flat 32-byte `TrieHash` for MerkleDB; a 1-byte discriminant prefix for
-/// ethhash), so [`hash_mode_name`] keeps the two modes in separate files.
+/// ethhash), so each case runs under both modes and [`hash_mode_name`] keeps the
+/// two modes in separate files.
 ///
 /// `one_child` places a single child at nibble 15 (`0xF`) with no value.
 /// `with_value` exercises the has-value bit and value-length varint with a
 /// child at nibble 0 and a longer partial path.
-#[test_case("one_child", vec![0, 1], None, 15 ; "one_child")]
-#[test_case("with_value", vec![0, 1, 2, 3], Some(vec![4, 5, 6, 7]), 0 ; "with_value")]
-fn branch(name: &str, path: Vec<u8>, value: Option<Vec<u8>>, child: u8) {
+#[test_case("one_child", NodeHashAlgorithm::MerkleDB, vec![0, 1], None, 15 ; "one_child_merkledb")]
+#[test_case("one_child", NodeHashAlgorithm::Ethereum, vec![0, 1], None, 15 ; "one_child_ethhash")]
+#[test_case("with_value", NodeHashAlgorithm::MerkleDB, vec![0, 1, 2, 3], Some(vec![4, 5, 6, 7]), 0 ; "with_value_merkledb")]
+#[test_case("with_value", NodeHashAlgorithm::Ethereum, vec![0, 1, 2, 3], Some(vec![4, 5, 6, 7]), 0 ; "with_value_ethhash")]
+fn branch(
+    name: &str,
+    algorithm: NodeHashAlgorithm,
+    path: Vec<u8>,
+    value: Option<Vec<u8>>,
+    child: u8,
+) {
     let node = Node::Branch(Box::new(BranchNode {
         partial_path: Path::from(path),
         value: value.map(Into::into),
         children: Children::from_fn(child_at(child)),
     }));
-    insta::assert_snapshot!(hash_mode_name(name), hex::encode(node_as_bytes(&node)));
+    insta::assert_snapshot!(
+        hash_mode_name(algorithm, name),
+        hex::encode(node_as_bytes(&node, algorithm))
+    );
 }
 
-/// [`crate::HashType`] serialization — available only when the
-/// `ethhash` feature is enabled. Each value is prefixed with a 1-byte
+/// [`crate::HashType`] serialization. Each value is prefixed with a 1-byte
 /// discriminant: `0x00` for a full 32-byte Keccak hash, non-zero (the RLP
 /// length) for an inline RLP value.
 ///
 /// `keccak_hash` is discriminant `0x00` followed by 32 zero bytes. `rlp_bytes`
 /// is a single-byte RLP payload `0xC0` (empty RLP list): length byte `0x01`
 /// followed by `0xC0`.
-#[cfg(feature = "ethhash")]
 #[test_case("keccak_hash", crate::HashType::Hash(TrieHash::from([0u8; 32])) ; "keccak_hash")]
 #[test_case("rlp_bytes", crate::HashType::Rlp(smallvec::SmallVec::from_slice(&[0xC0u8])) ; "rlp_bytes")]
 fn hash_or_rlp(name: &str, h: crate::HashType) {

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -635,21 +635,19 @@ fn read_bincode_varint_u64_le(reader: &mut impl Read) -> std::io::Result<u64> {
 pub mod test_utils {
     use super::*;
 
+    use crate::HashMode;
     use crate::node::Node;
     use crate::nodestore::header::RootNodeInfo;
     use crate::nodestore::{Committed, NodeStore, NodeStoreHeader};
-    use crate::{DefaultHashMode, HashMode};
 
     // Helper function to wrap the node in a StoredArea and write it to the given offset. Returns the size of the area on success.
-    pub fn test_write_new_node<S: WritableStorage>(
-        nodestore: &NodeStore<Committed, S>,
+    pub fn test_write_new_node<H: HashMode, S: WritableStorage>(
+        nodestore: &NodeStore<Committed, S, H>,
         node: &Node,
         offset: u64,
     ) -> (u64, u64) {
         let mut stored_area_bytes = Vec::new();
-        let area_size_index = node
-            .as_bytes::<DefaultHashMode, _>(&mut stored_area_bytes)
-            .unwrap();
+        let area_size_index = node.as_bytes::<H, _>(&mut stored_area_bytes).unwrap();
         let bytes_written = stored_area_bytes.len() as u64;
         nodestore
             .storage
@@ -659,8 +657,8 @@ pub mod test_utils {
     }
 
     // Helper function to write a free area to the given offset.
-    pub fn test_write_free_area<S: WritableStorage>(
-        nodestore: &NodeStore<Committed, S>,
+    pub fn test_write_free_area<H: HashMode, S: WritableStorage>(
+        nodestore: &NodeStore<Committed, S, H>,
         next_free_block: Option<LinearAddress>,
         area_size_index: AreaIndex,
         offset: u64,
@@ -671,13 +669,13 @@ pub mod test_utils {
     }
 
     // Helper function to write the NodeStoreHeader and return it
-    pub fn test_write_header<S: WritableStorage>(
-        nodestore: &NodeStore<Committed, S>,
+    pub fn test_write_header<H: HashMode, S: WritableStorage>(
+        nodestore: &NodeStore<Committed, S, H>,
         size: u64,
         root_node_info: Option<RootNodeInfo>,
         free_lists: FreeLists,
     ) -> NodeStoreHeader {
-        let mut header = NodeStoreHeader::new(DefaultHashMode::ALGORITHM);
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
         header.set_size(size);
         header.set_root_location(root_node_info);
         *header.free_lists_mut() = free_lists;
@@ -686,8 +684,8 @@ pub mod test_utils {
     }
 
     // Helper function to write a random stored area to the given offset.
-    pub(crate) fn test_write_zeroed_area<S: WritableStorage>(
-        nodestore: &NodeStore<Committed, S>,
+    pub(crate) fn test_write_zeroed_area<H: HashMode, S: WritableStorage>(
+        nodestore: &NodeStore<Committed, S, H>,
         size: u64,
         offset: u64,
     ) {
@@ -702,6 +700,8 @@ mod tests {
     use crate::DeletedNodeTracking;
     use crate::area_index;
     use crate::linear::memory::MemStore;
+    use crate::nodestore::Committed;
+    use crate::{EthHash, MerkleDbHash};
     use rand::seq::IteratorRandom;
     use test_case::test_case;
     use test_utils::{test_write_free_area, test_write_header};
@@ -723,12 +723,13 @@ mod tests {
         assert_eq!(result, expected, "Failed to parse FreeArea from {reader:?}");
     }
 
-    #[test]
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
     // Create a random free list and test that `FreeListIterator` is able to traverse all the free areas
-    fn free_list_iterator() {
+    fn free_list_iterator<H: HashMode>() {
         let mut rng = crate::SeededRng::from_env_or_random();
-        let memstore = MemStore::default();
-        let nodestore =
+        let memstore = MemStore::new(Vec::new(), H::ALGORITHM);
+        let nodestore: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let area_index = rng.random_range(0..AreaIndex::NUM_AREA_SIZES as u8);
@@ -778,11 +779,12 @@ mod tests {
     }
 
     // Create two free lists and check that `free_list_iter_with_metadata` correctly returns the free areas and their parents
-    #[test]
-    fn free_list_iter_with_metadata() {
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn free_list_iter_with_metadata<H: HashMode>() {
         let rng = crate::SeededRng::from_env_or_random();
-        let memstore = MemStore::default();
-        let nodestore =
+        let memstore = MemStore::new(Vec::new(), H::ALGORITHM);
+        let nodestore: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let mut free_lists = FreeLists::default();
@@ -898,9 +900,9 @@ mod tests {
         }
     }
 
-    #[test]
+    #[firewood_macros::hash_mode]
     #[expect(clippy::arithmetic_side_effects)]
-    fn free_lists_iter_skip_to_next_free_list() {
+    fn free_lists_iter_skip_to_next_free_list<H: HashMode>() {
         use test_utils::{test_write_free_area, test_write_header};
 
         const AREA_INDEX1: AreaIndex = area_index!(3);
@@ -908,8 +910,8 @@ mod tests {
         const AREA_INDEX2: AreaIndex = area_index!(5);
         const AREA_INDEX2_PLUS_1: AreaIndex = area_index!(6);
 
-        let memstore = MemStore::default();
-        let nodestore =
+        let memstore = MemStore::new(Vec::new(), H::ALGORITHM);
+        let nodestore: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let mut free_lists = FreeLists::default();

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -694,21 +694,19 @@ fn read_bincode_varint_u64_le(reader: &mut impl Read) -> std::io::Result<u64> {
 pub mod test_utils {
     use super::*;
 
+    use crate::HashMode;
     use crate::node::Node;
     use crate::nodestore::header::RootNodeInfo;
     use crate::nodestore::{Committed, NodeStore, NodeStoreHeader};
-    use crate::{DefaultHashMode, HashMode};
 
     // Helper function to wrap the node in a StoredArea and write it to the given offset. Returns the size of the area on success.
-    pub fn test_write_new_node<S: WritableStorage>(
-        nodestore: &NodeStore<Committed, S, DefaultHashMode>,
+    pub fn test_write_new_node<H: HashMode, S: WritableStorage>(
+        nodestore: &NodeStore<Committed, S, H>,
         node: &Node,
         offset: u64,
     ) -> (u64, u64) {
         let mut stored_area_bytes = Vec::new();
-        let area_size_index = node
-            .as_bytes::<DefaultHashMode, _>(&mut stored_area_bytes)
-            .unwrap();
+        let area_size_index = node.as_bytes::<H, _>(&mut stored_area_bytes).unwrap();
         let bytes_written = stored_area_bytes.len() as u64;
         nodestore
             .storage
@@ -718,8 +716,8 @@ pub mod test_utils {
     }
 
     // Helper function to write a free area to the given offset.
-    pub fn test_write_free_area<S: WritableStorage>(
-        nodestore: &NodeStore<Committed, S, DefaultHashMode>,
+    pub fn test_write_free_area<H: HashMode, S: WritableStorage>(
+        nodestore: &NodeStore<Committed, S, H>,
         next_free_block: Option<LinearAddress>,
         area_size_index: AreaIndex,
         offset: u64,
@@ -730,13 +728,13 @@ pub mod test_utils {
     }
 
     // Helper function to write the NodeStoreHeader and return it
-    pub fn test_write_header<S: WritableStorage>(
-        nodestore: &NodeStore<Committed, S, DefaultHashMode>,
+    pub fn test_write_header<H: HashMode, S: WritableStorage>(
+        nodestore: &NodeStore<Committed, S, H>,
         size: u64,
         root_node_info: Option<RootNodeInfo>,
         free_lists: FreeLists,
     ) -> NodeStoreHeader {
-        let mut header = NodeStoreHeader::new(DefaultHashMode::ALGORITHM);
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
         header.set_size(size);
         header.set_root_location(root_node_info);
         *header.free_lists_mut() = free_lists;
@@ -745,8 +743,8 @@ pub mod test_utils {
     }
 
     // Helper function to write a random stored area to the given offset.
-    pub(crate) fn test_write_zeroed_area<S: WritableStorage>(
-        nodestore: &NodeStore<Committed, S, DefaultHashMode>,
+    pub(crate) fn test_write_zeroed_area<H: HashMode, S: WritableStorage>(
+        nodestore: &NodeStore<Committed, S, H>,
         size: u64,
         offset: u64,
     ) {
@@ -760,7 +758,8 @@ mod tests {
     use super::*;
     use crate::area_index;
     use crate::linear::memory::MemStore;
-    use crate::{DefaultHashMode, DeletedNodeTracking, HashMode};
+    use crate::nodestore::Committed;
+    use crate::{DeletedNodeTracking, EthHash, HashMode, MerkleDbHash};
     use rand::seq::IteratorRandom;
     use test_case::test_case;
     use test_utils::{test_write_free_area, test_write_header};
@@ -782,12 +781,13 @@ mod tests {
         assert_eq!(result, expected, "Failed to parse FreeArea from {reader:?}");
     }
 
-    #[test]
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
     // Create a random free list and test that `FreeListIterator` is able to traverse all the free areas
-    fn free_list_iterator() {
+    fn free_list_iterator<H: HashMode>() {
         let mut rng = crate::SeededRng::from_env_or_random();
-        let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let memstore = MemStore::new(Vec::new(), H::ALGORITHM);
+        let nodestore: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let area_index = rng.random_range(0..AreaIndex::NUM_AREA_SIZES as u8);
@@ -837,11 +837,12 @@ mod tests {
     }
 
     // Create two free lists and check that `free_list_iter_with_metadata` correctly returns the free areas and their parents
-    #[test]
-    fn free_list_iter_with_metadata() {
+    #[firewood_macros::hash_mode]
+    #[expect(clippy::arithmetic_side_effects)]
+    fn free_list_iter_with_metadata<H: HashMode>() {
         let rng = crate::SeededRng::from_env_or_random();
-        let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let memstore = MemStore::new(Vec::new(), H::ALGORITHM);
+        let nodestore: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let mut free_lists = FreeLists::default();
@@ -957,9 +958,9 @@ mod tests {
         }
     }
 
-    #[test]
+    #[firewood_macros::hash_mode]
     #[expect(clippy::arithmetic_side_effects)]
-    fn free_lists_iter_skip_to_next_free_list() {
+    fn free_lists_iter_skip_to_next_free_list<H: HashMode>() {
         use test_utils::{test_write_free_area, test_write_header};
 
         const AREA_INDEX1: AreaIndex = area_index!(3);
@@ -967,8 +968,8 @@ mod tests {
         const AREA_INDEX2: AreaIndex = area_index!(5);
         const AREA_INDEX2_PLUS_1: AreaIndex = area_index!(6);
 
-        let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let memstore = MemStore::new(Vec::new(), H::ALGORITHM);
+        let nodestore: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         let mut free_lists = FreeLists::default();
@@ -1075,8 +1076,8 @@ mod tests {
         use crate::node::{LeafNode, Node};
         use test_utils::{test_write_free_area, test_write_new_node};
 
-        let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let nodestore =
+        let memstore = MemStore::new(Vec::new(), MerkleDbHash::ALGORITHM);
+        let nodestore: NodeStore<Committed, _, MerkleDbHash> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         // write a free area

--- a/storage/src/nodestore/header.rs
+++ b/storage/src/nodestore/header.rs
@@ -604,6 +604,7 @@ const fn const_copy(src: &[u8], dst: &mut [u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{EthHash, HashMode, MerkleDbHash};
     use test_case::test_case;
 
     #[test]
@@ -620,9 +621,9 @@ mod tests {
         assert!(Version { bytes }.validate().is_err());
     }
 
-    #[test]
-    fn test_header_new() {
-        let header = NodeStoreHeader::new(<crate::DefaultHashMode as crate::HashMode>::ALGORITHM);
+    #[firewood_macros::hash_mode]
+    fn test_header_new<H: HashMode>() {
+        let header = NodeStoreHeader::new(H::ALGORITHM);
 
         // Check the header is correctly initialized.
         assert_eq!(header.version, Version::new());

--- a/storage/src/nodestore/header.rs
+++ b/storage/src/nodestore/header.rs
@@ -629,7 +629,7 @@ const fn const_copy(src: &[u8], dst: &mut [u8]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DefaultHashMode, HashMode};
+    use crate::{EthHash, HashMode, MerkleDbHash};
     use test_case::test_case;
 
     #[test]
@@ -646,9 +646,9 @@ mod tests {
         assert!(Version { bytes }.validate().is_err());
     }
 
-    #[test]
-    fn test_header_new() {
-        let header = NodeStoreHeader::new(DefaultHashMode::ALGORITHM);
+    #[firewood_macros::hash_mode]
+    fn test_header_new<H: HashMode>() {
+        let header = NodeStoreHeader::new(H::ALGORITHM);
 
         // Check the header is correctly initialized.
         assert_eq!(header.version, Version::new());

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -1510,7 +1510,7 @@ where
     }
 }
 
-impl<S: WritableStorage> NodeStore<Arc<ImmutableProposal>, S, DefaultHashMode> {
+impl<S: WritableStorage, H: HashMode> NodeStore<Arc<ImmutableProposal>, S, H> {
     /// Returns the slice of deleted nodes in this proposal (test only).
     #[cfg(any(test, feature = "test_utils"))]
     #[must_use]
@@ -1570,9 +1570,11 @@ mod tests {
 
     use crate::BranchNode;
     use crate::Children;
+    use crate::EthHash;
     use crate::FileBacked;
     use crate::HashMode;
     use crate::LeafNode;
+    use crate::MerkleDbHash;
     use crate::NibblesIterator;
     use crate::PathComponent;
     use crate::linear::memory::MemStore;
@@ -1617,16 +1619,16 @@ mod tests {
         assert!(AreaIndex::from_size(AreaIndex::MAX_AREA_SIZE + 1).is_err());
     }
 
-    #[test]
-    fn test_reparent() {
+    #[firewood_macros::hash_mode]
+    fn test_reparent<H: HashMode>() {
         // create an empty base revision
-        let memstore = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let base: NodeStore<Committed, _, DefaultHashMode> =
+        let memstore = MemStore::new(Vec::new(), H::ALGORITHM);
+        let base: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         // create an empty r1, check that it's parent is the empty committed version
         let r1 = NodeStore::new(&base).unwrap();
-        let r1: NodeStore<Arc<ImmutableProposal>, _, DefaultHashMode> = r1.try_into().unwrap();
+        let r1: NodeStore<Arc<ImmutableProposal>, _, H> = r1.try_into().unwrap();
         {
             let parent = r1.kind.parent.lock();
             assert!(matches!(
@@ -1636,8 +1638,8 @@ mod tests {
         }
 
         // create an empty r2, check that it's parent is the proposed version r1
-        let r2: NodeStore<Mutable<Propose>, _, DefaultHashMode> = NodeStore::new(&r1).unwrap();
-        let r2: NodeStore<Arc<ImmutableProposal>, _, DefaultHashMode> = r2.try_into().unwrap();
+        let r2: NodeStore<Mutable<Propose>, _, H> = NodeStore::new(&r1).unwrap();
+        let r2: NodeStore<Arc<ImmutableProposal>, _, H> = r2.try_into().unwrap();
         {
             let parent = r2.kind.parent.lock();
             assert!(matches!(*parent, NodeStoreParent::Proposed(_)));
@@ -1656,11 +1658,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_slow_giant_node() {
-        let memstore = Arc::new(MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM));
-        let mut header = NodeStoreHeader::new(DefaultHashMode::ALGORITHM);
-        let empty_root: NodeStore<Committed, _, DefaultHashMode> =
+    #[firewood_macros::hash_mode]
+    fn test_slow_giant_node<H: HashMode>() {
+        let memstore = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
+        let empty_root: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(Arc::clone(&memstore), DeletedNodeTracking::Enabled);
 
         let mut node_store = NodeStore::new(&empty_root).unwrap();
@@ -1674,8 +1676,7 @@ mod tests {
 
         node_store.root_mut().replace(giant_leaf);
 
-        let node_store =
-            NodeStore::<Arc<ImmutableProposal>, _, DefaultHashMode>::try_from(node_store).unwrap();
+        let node_store = NodeStore::<Arc<ImmutableProposal>, _, H>::try_from(node_store).unwrap();
 
         let node_store = node_store.as_committed();
 
@@ -1712,8 +1713,8 @@ mod tests {
     /// The fix calls `allocate_at` immediately after allocating storage for a node
     /// but before adding it to the batch, ensuring children have addresses when
     /// their parents are serialized.
-    #[test]
-    fn persist_branch_with_children() -> Result<(), Box<dyn Error>> {
+    #[firewood_macros::hash_mode]
+    fn persist_branch_with_children<H: HashMode>() -> Result<(), Box<dyn Error>> {
         let tmpdir = tempfile::tempdir()?;
         let dbfile = tmpdir.path().join("nodestore_branch_persist_test.db");
 
@@ -1724,10 +1725,10 @@ mod tests {
             false,
             true,
             CacheReadStrategy::WritesOnly,
-            DefaultHashMode::ALGORITHM,
+            H::ALGORITHM,
         )?);
-        let mut header = NodeStoreHeader::new(DefaultHashMode::ALGORITHM);
-        let nodestore: NodeStore<Committed, _, DefaultHashMode> =
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
+        let nodestore: NodeStore<Committed, _, H> =
             NodeStore::open(&header, storage, DeletedNodeTracking::Enabled)?;
 
         let mut proposal = NodeStore::new(&nodestore)?;
@@ -1777,7 +1778,7 @@ mod tests {
             })));
         }
 
-        let proposal = NodeStore::<Arc<ImmutableProposal>, _, DefaultHashMode>::try_from(proposal)?;
+        let proposal = NodeStore::<Arc<ImmutableProposal>, _, H>::try_from(proposal)?;
 
         let nodestore = proposal.as_committed();
         nodestore.persist(&mut header)?;
@@ -1792,8 +1793,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn with_root_success() -> Result<(), Box<dyn Error>> {
+    #[firewood_macros::hash_mode]
+    fn with_root_success<H: HashMode>() -> Result<(), Box<dyn Error>> {
         let tmpdir = tempfile::tempdir()?;
         let dbfile = tmpdir.path().join("with_root_test.db");
 
@@ -1804,10 +1805,10 @@ mod tests {
             false,
             true,
             CacheReadStrategy::WritesOnly,
-            DefaultHashMode::ALGORITHM,
+            H::ALGORITHM,
         )?);
-        let mut header = NodeStoreHeader::new(DefaultHashMode::ALGORITHM);
-        let base: NodeStore<Committed, _, DefaultHashMode> =
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
+        let base: NodeStore<Committed, _, H> =
             NodeStore::open(&header, Arc::clone(&storage), DeletedNodeTracking::Enabled)?;
 
         // Create a proposal with a leaf node and persist it
@@ -1816,7 +1817,7 @@ mod tests {
             partial_path: Path::from_nibbles_iterator(NibblesIterator::new(b"key")),
             value: b"value".to_vec().into_boxed_slice(),
         }));
-        let proposal = NodeStore::<Arc<ImmutableProposal>, _, DefaultHashMode>::try_from(proposal)?;
+        let proposal = NodeStore::<Arc<ImmutableProposal>, _, H>::try_from(proposal)?;
         let committed = proposal.as_committed();
         committed.persist(&mut header)?;
 
@@ -1825,7 +1826,7 @@ mod tests {
         let root_hash = HashType::from(header.root_hash().unwrap());
 
         // Reconstruct using with_root
-        let restored: NodeStore<Committed, _, DefaultHashMode> = NodeStore::with_root(
+        let restored: NodeStore<Committed, _, H> = NodeStore::with_root(
             root_hash.clone(),
             root_address,
             storage,
@@ -1837,8 +1838,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn with_root_wrong_hash() -> Result<(), Box<dyn Error>> {
+    #[firewood_macros::hash_mode]
+    fn with_root_wrong_hash<H: HashMode>() -> Result<(), Box<dyn Error>> {
         let tmpdir = tempfile::tempdir()?;
         let dbfile = tmpdir.path().join("with_root_bad_hash_test.db");
 
@@ -1849,10 +1850,10 @@ mod tests {
             false,
             true,
             CacheReadStrategy::WritesOnly,
-            DefaultHashMode::ALGORITHM,
+            H::ALGORITHM,
         )?);
-        let mut header = NodeStoreHeader::new(DefaultHashMode::ALGORITHM);
-        let base: NodeStore<Committed, _, DefaultHashMode> =
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
+        let base: NodeStore<Committed, _, H> =
             NodeStore::open(&header, Arc::clone(&storage), DeletedNodeTracking::Enabled)?;
 
         // Create a proposal with a leaf node and persist it
@@ -1861,7 +1862,7 @@ mod tests {
             partial_path: Path::from_nibbles_iterator(NibblesIterator::new(b"key")),
             value: b"value".to_vec().into_boxed_slice(),
         }));
-        let proposal = NodeStore::<Arc<ImmutableProposal>, _, DefaultHashMode>::try_from(proposal)?;
+        let proposal = NodeStore::<Arc<ImmutableProposal>, _, H>::try_from(proposal)?;
         let committed = proposal.as_committed();
         committed.persist(&mut header)?;
 
@@ -1869,7 +1870,7 @@ mod tests {
 
         // Use a bogus hash
         let bad_hash = HashType::from([0xAB; 32]);
-        let result = NodeStore::<Committed, _, DefaultHashMode>::with_root(
+        let result = NodeStore::<Committed, _, H>::with_root(
             bad_hash,
             root_address,
             storage,
@@ -1887,51 +1888,51 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn reconstructed_root_address_is_none() {
-        let storage = Arc::new(MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM));
-        let mut recon = NodeStore::new_empty_recon(Arc::clone(&storage));
+    #[firewood_macros::hash_mode]
+    fn reconstructed_root_address_is_none<H: HashMode>() {
+        let storage = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let mut recon: NodeStore<Mutable<Recon<_, H>>, _, H> =
+            NodeStore::new_empty_recon(Arc::clone(&storage));
 
         recon.root_mut().replace(Node::Leaf(LeafNode {
             partial_path: Path::new(),
             value: b"value".to_vec().into_boxed_slice(),
         }));
 
-        let reconstructed: NodeStore<Reconstructed<_, DefaultHashMode>, _, DefaultHashMode> =
-            recon.into();
+        let reconstructed: NodeStore<Reconstructed<_, H>, _, H> = recon.into();
 
         assert_eq!(reconstructed.root_address(), None);
     }
 
-    #[test]
-    fn reconstructed_conversion_defers_hashing() {
-        let storage = Arc::new(MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM));
-        let mut recon = NodeStore::new_empty_recon(Arc::clone(&storage));
+    #[firewood_macros::hash_mode]
+    fn reconstructed_conversion_defers_hashing<H: HashMode>() {
+        let storage = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let mut recon: NodeStore<Mutable<Recon<_, H>>, _, H> =
+            NodeStore::new_empty_recon(Arc::clone(&storage));
 
         recon.root_mut().replace(Node::Leaf(LeafNode {
             partial_path: Path::new(),
             value: b"value".to_vec().into_boxed_slice(),
         }));
 
-        let reconstructed: NodeStore<Reconstructed<_, DefaultHashMode>, _, DefaultHashMode> =
-            recon.into();
+        let reconstructed: NodeStore<Reconstructed<_, H>, _, H> = recon.into();
 
         // Conversion should not eagerly hash reconstructed roots.
         assert!(reconstructed.kind.hash.get().is_none());
     }
 
-    #[test]
-    fn reconstructed_root_hash_is_memoized() {
-        let storage = Arc::new(MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM));
-        let mut recon = NodeStore::new_empty_recon(Arc::clone(&storage));
+    #[firewood_macros::hash_mode]
+    fn reconstructed_root_hash_is_memoized<H: HashMode>() {
+        let storage = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let mut recon: NodeStore<Mutable<Recon<_, H>>, _, H> =
+            NodeStore::new_empty_recon(Arc::clone(&storage));
 
         recon.root_mut().replace(Node::Leaf(LeafNode {
             partial_path: Path::new(),
             value: b"value".to_vec().into_boxed_slice(),
         }));
 
-        let reconstructed: NodeStore<Reconstructed<_, DefaultHashMode>, _, DefaultHashMode> =
-            recon.into();
+        let reconstructed: NodeStore<Reconstructed<_, H>, _, H> = recon.into();
 
         // Before hashing, the OnceLock is empty
         assert!(reconstructed.kind.hash.get().is_none());
@@ -1944,24 +1945,25 @@ mod tests {
         assert_eq!(first_hash, second_hash);
     }
 
-    #[test]
-    fn reconstructed_empty_root_hash_is_none() {
-        let storage = Arc::new(MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM));
-        let recon = NodeStore::new_empty_recon(Arc::clone(&storage));
+    #[firewood_macros::hash_mode]
+    fn reconstructed_empty_root_hash_is_none<H: HashMode>() {
+        let storage = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let recon: NodeStore<Mutable<Recon<_, H>>, _, H> =
+            NodeStore::new_empty_recon(Arc::clone(&storage));
 
-        let reconstructed: NodeStore<Reconstructed<_, DefaultHashMode>, _, DefaultHashMode> =
-            recon.into();
+        let reconstructed: NodeStore<Reconstructed<_, H>, _, H> = recon.into();
 
         assert_eq!(reconstructed.root_hash(), None);
     }
 
-    #[test]
-    fn reconstructed_root_hash_rewrites_root_children() {
+    #[firewood_macros::hash_mode]
+    fn reconstructed_root_hash_rewrites_root_children<H: HashMode>() {
         // After root_hash() runs, the swapped-in root must have no Child::Node
         // children — they should all be Child::MaybePersisted. hash_helper works
         // bottom-up, so if no Child::Node remains at the root, none remains below.
-        let storage = Arc::new(MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM));
-        let mut recon = NodeStore::new_empty_recon(Arc::clone(&storage));
+        let storage = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let mut recon: NodeStore<Mutable<Recon<_, H>>, _, H> =
+            NodeStore::new_empty_recon(Arc::clone(&storage));
 
         let mut children = Children::new();
         children[PathComponent::ALL[0x0]] = Some(Child::Node(Node::Leaf(LeafNode {
@@ -1978,8 +1980,7 @@ mod tests {
             children,
         })));
 
-        let reconstructed: NodeStore<Reconstructed<_, DefaultHashMode>, _, DefaultHashMode> =
-            recon.into();
+        let reconstructed: NodeStore<Reconstructed<_, H>, _, H> = recon.into();
 
         // Sanity: pre-hash, the root branch has at least one Child::Node.
         let before = reconstructed.root_node().expect("root present");
@@ -2009,23 +2010,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn reconstructed_pins_committed_parent() {
+    #[firewood_macros::hash_mode]
+    fn reconstructed_pins_committed_parent<H: HashMode>() {
         // A Reconstructed must hold a strong Arc to its committed parent so
         // the RevisionManager cannot reap the revision (and free its on-disk
         // nodes) while a derived view is still alive.
-        let storage = Arc::new(MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM));
-        let committed = Arc::new(NodeStore::new_empty_committed(
+        let storage = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let committed = Arc::new(NodeStore::<Committed, _, H>::new_empty_committed(
             Arc::clone(&storage),
             DeletedNodeTracking::Enabled,
         ));
         assert_eq!(Arc::strong_count(&committed), 1);
 
-        let recon = NodeStore::<
-            Mutable<Recon<_, DefaultHashMode>>,
-            _,
-            DefaultHashMode,
-        >::new_for_reconstruction(
+        let recon = NodeStore::<Mutable<Recon<_, H>>, _, H>::new_for_reconstruction(
             &*committed,
             Arc::clone(&committed),
         )
@@ -2036,8 +2033,7 @@ mod tests {
             "Mutable<Recon> should pin the committed parent"
         );
 
-        let reconstructed: NodeStore<Reconstructed<_, DefaultHashMode>, _, DefaultHashMode> =
-            recon.into();
+        let reconstructed: NodeStore<Reconstructed<_, H>, _, H> = recon.into();
         assert_eq!(
             Arc::strong_count(&committed),
             2,

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -1496,7 +1496,7 @@ where
     }
 }
 
-impl<S: WritableStorage> NodeStore<Arc<ImmutableProposal>, S> {
+impl<S: WritableStorage, H: HashMode> NodeStore<Arc<ImmutableProposal>, S, H> {
     /// Returns the slice of deleted nodes in this proposal (test only).
     #[cfg(any(test, feature = "test_utils"))]
     #[must_use]
@@ -1557,8 +1557,10 @@ mod tests {
 
     use crate::BranchNode;
     use crate::Children;
+    use crate::EthHash;
     use crate::FileBacked;
     use crate::LeafNode;
+    use crate::MerkleDbHash;
     use crate::NibblesIterator;
     use crate::PathComponent;
     use crate::linear::memory::MemStore;
@@ -1603,16 +1605,16 @@ mod tests {
         assert!(AreaIndex::from_size(AreaIndex::MAX_AREA_SIZE + 1).is_err());
     }
 
-    #[test]
-    fn test_reparent() {
+    #[firewood_macros::hash_mode]
+    fn test_reparent<H: HashMode>() {
         // create an empty base revision
-        let memstore = MemStore::default();
-        let base: NodeStore<Committed, _> =
+        let memstore = MemStore::new(Vec::new(), H::ALGORITHM);
+        let base: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(memstore.into(), DeletedNodeTracking::Enabled);
 
         // create an empty r1, check that it's parent is the empty committed version
         let r1 = NodeStore::new(&base).unwrap();
-        let r1: NodeStore<Arc<ImmutableProposal>, _> = r1.try_into().unwrap();
+        let r1: NodeStore<Arc<ImmutableProposal>, _, H> = r1.try_into().unwrap();
         {
             let parent = r1.kind.parent.lock();
             assert!(matches!(
@@ -1622,8 +1624,8 @@ mod tests {
         }
 
         // create an empty r2, check that it's parent is the proposed version r1
-        let r2: NodeStore<Mutable<Propose>, _> = NodeStore::new(&r1).unwrap();
-        let r2: NodeStore<Arc<ImmutableProposal>, _> = r2.try_into().unwrap();
+        let r2: NodeStore<Mutable<Propose>, _, H> = NodeStore::new(&r1).unwrap();
+        let r2: NodeStore<Arc<ImmutableProposal>, _, H> = r2.try_into().unwrap();
         {
             let parent = r2.kind.parent.lock();
             assert!(matches!(*parent, NodeStoreParent::Proposed(_)));
@@ -1642,12 +1644,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_slow_giant_node() {
-        let memstore = Arc::new(MemStore::default());
-        let mut header =
-            NodeStoreHeader::new(<crate::DefaultHashMode as crate::HashMode>::ALGORITHM);
-        let empty_root: NodeStore<Committed, _> =
+    #[firewood_macros::hash_mode]
+    fn test_slow_giant_node<H: HashMode>() {
+        let memstore = Arc::new(MemStore::new(Vec::new(), H::ALGORITHM));
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
+        let empty_root: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(Arc::clone(&memstore), DeletedNodeTracking::Enabled);
 
         let mut node_store = NodeStore::new(&empty_root).unwrap();
@@ -1661,7 +1662,7 @@ mod tests {
 
         node_store.root_mut().replace(giant_leaf);
 
-        let node_store = NodeStore::<Arc<ImmutableProposal>, _>::try_from(node_store).unwrap();
+        let node_store = NodeStore::<Arc<ImmutableProposal>, _, H>::try_from(node_store).unwrap();
 
         let node_store = node_store.as_committed();
 
@@ -1698,8 +1699,8 @@ mod tests {
     /// The fix calls `allocate_at` immediately after allocating storage for a node
     /// but before adding it to the batch, ensuring children have addresses when
     /// their parents are serialized.
-    #[test]
-    fn persist_branch_with_children() -> Result<(), Box<dyn Error>> {
+    #[firewood_macros::hash_mode]
+    fn persist_branch_with_children<H: HashMode>() -> Result<(), Box<dyn Error>> {
         let tmpdir = tempfile::tempdir()?;
         let dbfile = tmpdir.path().join("nodestore_branch_persist_test.db");
 
@@ -1710,11 +1711,10 @@ mod tests {
             false,
             true,
             CacheReadStrategy::WritesOnly,
-            <crate::DefaultHashMode as crate::HashMode>::ALGORITHM,
+            H::ALGORITHM,
         )?);
-        let mut header =
-            NodeStoreHeader::new(<crate::DefaultHashMode as crate::HashMode>::ALGORITHM);
-        let nodestore: NodeStore<Committed, _> =
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
+        let nodestore: NodeStore<Committed, _, H> =
             NodeStore::open(&header, storage, DeletedNodeTracking::Enabled)?;
 
         let mut proposal = NodeStore::new(&nodestore)?;
@@ -1764,7 +1764,7 @@ mod tests {
             })));
         }
 
-        let proposal = NodeStore::<Arc<ImmutableProposal>, _>::try_from(proposal)?;
+        let proposal = NodeStore::<Arc<ImmutableProposal>, _, H>::try_from(proposal)?;
 
         let nodestore = proposal.as_committed();
         nodestore.persist(&mut header)?;
@@ -1779,8 +1779,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn with_root_success() -> Result<(), Box<dyn Error>> {
+    #[firewood_macros::hash_mode]
+    fn with_root_success<H: HashMode>() -> Result<(), Box<dyn Error>> {
         let tmpdir = tempfile::tempdir()?;
         let dbfile = tmpdir.path().join("with_root_test.db");
 
@@ -1791,11 +1791,10 @@ mod tests {
             false,
             true,
             CacheReadStrategy::WritesOnly,
-            <crate::DefaultHashMode as crate::HashMode>::ALGORITHM,
+            H::ALGORITHM,
         )?);
-        let mut header =
-            NodeStoreHeader::new(<crate::DefaultHashMode as crate::HashMode>::ALGORITHM);
-        let base: NodeStore<Committed, _> =
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
+        let base: NodeStore<Committed, _, H> =
             NodeStore::open(&header, Arc::clone(&storage), DeletedNodeTracking::Enabled)?;
 
         // Create a proposal with a leaf node and persist it
@@ -1804,7 +1803,7 @@ mod tests {
             partial_path: Path::from_nibbles_iterator(NibblesIterator::new(b"key")),
             value: b"value".to_vec().into_boxed_slice(),
         }));
-        let proposal = NodeStore::<Arc<ImmutableProposal>, _>::try_from(proposal)?;
+        let proposal = NodeStore::<Arc<ImmutableProposal>, _, H>::try_from(proposal)?;
         let committed = proposal.as_committed();
         committed.persist(&mut header)?;
 
@@ -1813,7 +1812,7 @@ mod tests {
         let root_hash = HashType::from(header.root_hash().unwrap());
 
         // Reconstruct using with_root
-        let restored: NodeStore<Committed, _> = NodeStore::with_root(
+        let restored: NodeStore<Committed, _, H> = NodeStore::with_root(
             root_hash.clone(),
             root_address,
             storage,
@@ -1825,8 +1824,8 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn with_root_wrong_hash() -> Result<(), Box<dyn Error>> {
+    #[firewood_macros::hash_mode]
+    fn with_root_wrong_hash<H: HashMode>() -> Result<(), Box<dyn Error>> {
         let tmpdir = tempfile::tempdir()?;
         let dbfile = tmpdir.path().join("with_root_bad_hash_test.db");
 
@@ -1837,11 +1836,10 @@ mod tests {
             false,
             true,
             CacheReadStrategy::WritesOnly,
-            <crate::DefaultHashMode as crate::HashMode>::ALGORITHM,
+            H::ALGORITHM,
         )?);
-        let mut header =
-            NodeStoreHeader::new(<crate::DefaultHashMode as crate::HashMode>::ALGORITHM);
-        let base: NodeStore<Committed, _> =
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
+        let base: NodeStore<Committed, _, H> =
             NodeStore::open(&header, Arc::clone(&storage), DeletedNodeTracking::Enabled)?;
 
         // Create a proposal with a leaf node and persist it
@@ -1850,7 +1848,7 @@ mod tests {
             partial_path: Path::from_nibbles_iterator(NibblesIterator::new(b"key")),
             value: b"value".to_vec().into_boxed_slice(),
         }));
-        let proposal = NodeStore::<Arc<ImmutableProposal>, _>::try_from(proposal)?;
+        let proposal = NodeStore::<Arc<ImmutableProposal>, _, H>::try_from(proposal)?;
         let committed = proposal.as_committed();
         committed.persist(&mut header)?;
 
@@ -1858,7 +1856,7 @@ mod tests {
 
         // Use a bogus hash
         let bad_hash = HashType::from([0xAB; 32]);
-        let result = NodeStore::<Committed, _, DefaultHashMode>::with_root(
+        let result = NodeStore::<Committed, _, H>::with_root(
             bad_hash,
             root_address,
             storage,
@@ -1876,6 +1874,7 @@ mod tests {
         Ok(())
     }
 
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     #[test]
     fn reconstructed_root_address_is_none() {
         let storage = Arc::new(MemStore::default());
@@ -1891,6 +1890,7 @@ mod tests {
         assert_eq!(reconstructed.root_address(), None);
     }
 
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     #[test]
     fn reconstructed_conversion_defers_hashing() {
         let storage = Arc::new(MemStore::default());
@@ -1907,6 +1907,7 @@ mod tests {
         assert!(reconstructed.kind.hash.get().is_none());
     }
 
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     #[test]
     fn reconstructed_root_hash_is_memoized() {
         let storage = Arc::new(MemStore::default());
@@ -1930,6 +1931,7 @@ mod tests {
         assert_eq!(first_hash, second_hash);
     }
 
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     #[test]
     fn reconstructed_empty_root_hash_is_none() {
         let storage = Arc::new(MemStore::default());
@@ -1940,6 +1942,7 @@ mod tests {
         assert_eq!(reconstructed.root_hash(), None);
     }
 
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     #[test]
     fn reconstructed_root_hash_rewrites_root_children() {
         // After root_hash() runs, the swapped-in root must have no Child::Node
@@ -1994,6 +1997,7 @@ mod tests {
     }
 
     #[test]
+    // Reconstruction is DefaultHashMode-only until the flag-removal PR pins it to EthHash (#1088 follow-up).
     fn reconstructed_pins_committed_parent() {
         // A Reconstructed must hold a strong Arc to its committed parent so
         // the RevisionManager cannot reap the revision (and free its on-disk

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -306,26 +306,28 @@ impl<S: WritableStorage, H: HashMode> NodeStore<Committed, S, H> {
 mod tests {
     use super::*;
     use crate::{
-        Child, Children, DeletedNodeTracking, HashType, ImmutableProposal, LinearAddress,
-        NodeStore, NodeStoreHeader, Path, PathComponent, SharedNode,
+        Child, Children, DeletedNodeTracking, EthHash, HashType, ImmutableProposal, LinearAddress,
+        MerkleDbHash, NodeStore, NodeStoreHeader, Path, PathComponent, SharedNode,
         linear::memory::MemStore,
         node::{BranchNode, LeafNode, Node},
         nodestore::{Mutable, Propose},
     };
     use std::sync::Arc;
 
-    fn into_committed(
-        ns: NodeStore<std::sync::Arc<ImmutableProposal>, MemStore>,
+    fn into_committed<H: HashMode>(
+        ns: NodeStore<std::sync::Arc<ImmutableProposal>, MemStore, H>,
         header: &mut NodeStoreHeader,
-    ) -> NodeStore<Committed, MemStore> {
+    ) -> NodeStore<Committed, MemStore, H> {
         let ns = ns.as_committed();
         ns.persist(header).unwrap();
         ns
     }
 
     /// Helper to create a test node store with a specific root
-    fn create_test_store_with_root(root: Node) -> NodeStore<Mutable<Propose>, MemStore> {
-        let mem_store = MemStore::default().into();
+    fn create_test_store_with_root<H: HashMode>(
+        root: Node,
+    ) -> NodeStore<Mutable<Propose>, MemStore, H> {
+        let mem_store = MemStore::new(Vec::new(), H::ALGORITHM).into();
         let mut store = NodeStore::new_empty_proposal(mem_store, DeletedNodeTracking::Enabled);
         store.root_mut().replace(root);
         store
@@ -361,20 +363,20 @@ mod tests {
         Node::Branch(Box::new(branch))
     }
 
-    #[test]
-    fn test_empty_nodestore() {
-        let mem_store = MemStore::default().into();
-        let store: NodeStore<Mutable<Propose>, _> =
+    #[firewood_macros::hash_mode]
+    fn test_empty_nodestore<H: HashMode>() {
+        let mem_store = MemStore::new(Vec::new(), H::ALGORITHM).into();
+        let store: NodeStore<Mutable<Propose>, _, H> =
             NodeStore::new_empty_proposal(mem_store, DeletedNodeTracking::Enabled);
         let mut iter = UnPersistedNodeIterator::new(&store);
 
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn test_single_leaf_node() {
+    #[firewood_macros::hash_mode]
+    fn test_single_leaf_node<H: HashMode>() {
         let leaf = create_leaf(&[1, 2, 3], &[4, 5, 6]);
-        let store = create_test_store_with_root(leaf.clone());
+        let store = create_test_store_with_root::<H>(leaf.clone());
         let mut iter =
             UnPersistedNodeIterator::new(&store).map(|node| node.as_shared_node(&store).unwrap());
 
@@ -386,15 +388,15 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn test_branch_with_single_child() {
+    #[firewood_macros::hash_mode]
+    fn test_branch_with_single_child<H: HashMode>() {
         let leaf = create_leaf(&[7, 8], &[9, 10]);
         let branch = create_branch(
             &[1, 2],
             Some(&[3, 4]),
             vec![(PathComponent::ALL[5], leaf.clone())],
         );
-        let store = create_test_store_with_root(branch.clone());
+        let store = create_test_store_with_root::<H>(branch.clone());
         let mut iter =
             UnPersistedNodeIterator::new(&store).map(|node| node.as_shared_node(&store).unwrap());
 
@@ -412,8 +414,8 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn test_branch_with_multiple_children() {
+    #[firewood_macros::hash_mode]
+    fn test_branch_with_multiple_children<H: HashMode>() {
         let leaves = [
             create_leaf(&[1], &[10]),
             create_leaf(&[2], &[20]),
@@ -428,7 +430,7 @@ mod tests {
                 (PathComponent::ALL[10], leaves[2].clone()),
             ],
         );
-        let store = create_test_store_with_root(branch.clone());
+        let store = create_test_store_with_root::<H>(branch.clone());
 
         // Collect all nodes
         let nodes: Vec<_> = UnPersistedNodeIterator::new(&store)
@@ -448,8 +450,8 @@ mod tests {
         assert!(children_nodes.iter().any(|n| **n == leaves[2]));
     }
 
-    #[test]
-    fn test_nested_branches() {
+    #[firewood_macros::hash_mode]
+    fn test_nested_branches<H: HashMode>() {
         let leaves = [
             create_leaf(&[1], &[100]),
             create_leaf(&[2], &[200]),
@@ -500,7 +502,7 @@ mod tests {
         }
         .into();
 
-        let store = create_test_store_with_root(root_branch.clone());
+        let store = create_test_store_with_root::<H>(root_branch.clone());
 
         // Collect all nodes
         let nodes: Vec<_> = UnPersistedNodeIterator::new(&store)
@@ -524,13 +526,12 @@ mod tests {
         assert!(inner_branch_pos < root_pos);
     }
 
-    #[test]
-    fn test_into_committed_with_generic_storage() {
+    #[firewood_macros::hash_mode]
+    fn test_into_committed_with_generic_storage<H: HashMode>() {
         // Create a base committed store with MemStore
-        let mem_store = MemStore::default();
-        let mut header =
-            NodeStoreHeader::new(<crate::DefaultHashMode as crate::HashMode>::ALGORITHM);
-        let base_committed: NodeStore<Committed, _> =
+        let mem_store = MemStore::new(Vec::new(), H::ALGORITHM);
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
+        let base_committed: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(mem_store.into(), DeletedNodeTracking::Enabled);
 
         // Create a mutable proposal from the base
@@ -551,7 +552,7 @@ mod tests {
         mutable_store.root_mut().replace(branch.clone());
 
         // Convert to immutable proposal
-        let immutable_store: NodeStore<Arc<ImmutableProposal>, _> =
+        let immutable_store: NodeStore<Arc<ImmutableProposal>, _, H> =
             mutable_store.try_into().unwrap();
 
         // Commit the immutable store

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -308,29 +308,28 @@ impl<S: WritableStorage, H: HashMode> NodeStore<Committed, S, H> {
 mod tests {
     use super::*;
     use crate::{
-        Child, Children, DefaultHashMode, DeletedNodeTracking, HashMode, HashType,
-        ImmutableProposal, LinearAddress, NodeStore, NodeStoreHeader, Path, PathComponent,
-        SharedNode,
+        Child, Children, DeletedNodeTracking, EthHash, HashMode, HashType, ImmutableProposal,
+        LinearAddress, MerkleDbHash, NodeStore, NodeStoreHeader, Path, PathComponent, SharedNode,
         linear::memory::MemStore,
         node::{BranchNode, LeafNode, Node},
         nodestore::{Mutable, Propose},
     };
     use std::sync::Arc;
 
-    fn into_committed(
-        ns: NodeStore<std::sync::Arc<ImmutableProposal>, MemStore, DefaultHashMode>,
+    fn into_committed<H: HashMode>(
+        ns: NodeStore<std::sync::Arc<ImmutableProposal>, MemStore, H>,
         header: &mut NodeStoreHeader,
-    ) -> NodeStore<Committed, MemStore, DefaultHashMode> {
+    ) -> NodeStore<Committed, MemStore, H> {
         let ns = ns.as_committed();
         ns.persist(header).unwrap();
         ns
     }
 
     /// Helper to create a test node store with a specific root
-    fn create_test_store_with_root(
+    fn create_test_store_with_root<H: HashMode>(
         root: Node,
-    ) -> NodeStore<Mutable<Propose>, MemStore, DefaultHashMode> {
-        let mem_store = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM).into();
+    ) -> NodeStore<Mutable<Propose>, MemStore, H> {
+        let mem_store = MemStore::new(Vec::new(), H::ALGORITHM).into();
         let mut store = NodeStore::new_empty_proposal(mem_store, DeletedNodeTracking::Enabled);
         store.root_mut().replace(root);
         store
@@ -366,20 +365,20 @@ mod tests {
         Node::Branch(Box::new(branch))
     }
 
-    #[test]
-    fn test_empty_nodestore() {
-        let mem_store = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM).into();
-        let store: NodeStore<Mutable<Propose>, _, DefaultHashMode> =
+    #[firewood_macros::hash_mode]
+    fn test_empty_nodestore<H: HashMode>() {
+        let mem_store = MemStore::new(Vec::new(), H::ALGORITHM).into();
+        let store: NodeStore<Mutable<Propose>, _, H> =
             NodeStore::new_empty_proposal(mem_store, DeletedNodeTracking::Enabled);
         let mut iter = UnPersistedNodeIterator::new(&store);
 
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn test_single_leaf_node() {
+    #[firewood_macros::hash_mode]
+    fn test_single_leaf_node<H: HashMode>() {
         let leaf = create_leaf(&[1, 2, 3], &[4, 5, 6]);
-        let store = create_test_store_with_root(leaf.clone());
+        let store = create_test_store_with_root::<H>(leaf.clone());
         let mut iter =
             UnPersistedNodeIterator::new(&store).map(|node| node.as_shared_node(&store).unwrap());
 
@@ -391,15 +390,15 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn test_branch_with_single_child() {
+    #[firewood_macros::hash_mode]
+    fn test_branch_with_single_child<H: HashMode>() {
         let leaf = create_leaf(&[7, 8], &[9, 10]);
         let branch = create_branch(
             &[1, 2],
             Some(&[3, 4]),
             vec![(PathComponent::ALL[5], leaf.clone())],
         );
-        let store = create_test_store_with_root(branch.clone());
+        let store = create_test_store_with_root::<H>(branch.clone());
         let mut iter =
             UnPersistedNodeIterator::new(&store).map(|node| node.as_shared_node(&store).unwrap());
 
@@ -417,8 +416,8 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[test]
-    fn test_branch_with_multiple_children() {
+    #[firewood_macros::hash_mode]
+    fn test_branch_with_multiple_children<H: HashMode>() {
         let leaves = [
             create_leaf(&[1], &[10]),
             create_leaf(&[2], &[20]),
@@ -433,7 +432,7 @@ mod tests {
                 (PathComponent::ALL[10], leaves[2].clone()),
             ],
         );
-        let store = create_test_store_with_root(branch.clone());
+        let store = create_test_store_with_root::<H>(branch.clone());
 
         // Collect all nodes
         let nodes: Vec<_> = UnPersistedNodeIterator::new(&store)
@@ -453,8 +452,8 @@ mod tests {
         assert!(children_nodes.iter().any(|n| **n == leaves[2]));
     }
 
-    #[test]
-    fn test_nested_branches() {
+    #[firewood_macros::hash_mode]
+    fn test_nested_branches<H: HashMode>() {
         let leaves = [
             create_leaf(&[1], &[100]),
             create_leaf(&[2], &[200]),
@@ -505,7 +504,7 @@ mod tests {
         }
         .into();
 
-        let store = create_test_store_with_root(root_branch.clone());
+        let store = create_test_store_with_root::<H>(root_branch.clone());
 
         // Collect all nodes
         let nodes: Vec<_> = UnPersistedNodeIterator::new(&store)
@@ -529,12 +528,12 @@ mod tests {
         assert!(inner_branch_pos < root_pos);
     }
 
-    #[test]
-    fn test_into_committed_with_generic_storage() {
+    #[firewood_macros::hash_mode]
+    fn test_into_committed_with_generic_storage<H: HashMode>() {
         // Create a base committed store with MemStore
-        let mem_store = MemStore::new(Vec::new(), DefaultHashMode::ALGORITHM);
-        let mut header = NodeStoreHeader::new(DefaultHashMode::ALGORITHM);
-        let base_committed: NodeStore<Committed, _, DefaultHashMode> =
+        let mem_store = MemStore::new(Vec::new(), H::ALGORITHM);
+        let mut header = NodeStoreHeader::new(H::ALGORITHM);
+        let base_committed: NodeStore<Committed, _, H> =
             NodeStore::new_empty_committed(mem_store.into(), DeletedNodeTracking::Enabled);
 
         // Create a mutable proposal from the base
@@ -555,7 +554,7 @@ mod tests {
         mutable_store.root_mut().replace(branch.clone());
 
         // Convert to immutable proposal
-        let immutable_store: NodeStore<Arc<ImmutableProposal>, _, DefaultHashMode> =
+        let immutable_store: NodeStore<Arc<ImmutableProposal>, _, H> =
             mutable_store.try_into().unwrap();
 
         // Commit the immutable store

--- a/storage/src/root_store.rs
+++ b/storage/src/root_store.rs
@@ -196,11 +196,12 @@ mod tests {
     use crate::CacheReadStrategy;
     use crate::linear::filebacked::FileBacked;
     use crate::nodestore::NodeStore;
+    use crate::{EthHash, MerkleDbHash};
     use std::num::NonZero;
     use std::sync::Arc;
 
-    #[test]
-    fn test_cache_hit() {
+    #[firewood_macros::hash_mode]
+    fn test_cache_hit<H: HashMode>() {
         let tmpdir = tempfile::tempdir().unwrap();
 
         let db_path = tmpdir.as_ref().join("testdb");
@@ -212,18 +213,18 @@ mod tests {
                 false,
                 true,
                 CacheReadStrategy::WritesOnly,
-                <crate::DefaultHashMode as crate::HashMode>::ALGORITHM,
+                H::ALGORITHM,
             )
             .unwrap(),
         );
 
         let root_store_dir = tmpdir.as_ref().join("root_store");
-        let root_store: RootStore =
+        let root_store: RootStore<H> =
             RootStore::new(root_store_dir, file_backed.clone(), false).unwrap();
 
         // Create a revision to cache. `RootStore` implies archival mode,
         // where deleted nodes are never tracked.
-        let revision: CommittedRevision = Arc::new(NodeStore::new_empty_committed(
+        let revision: CommittedRevision<H> = Arc::new(NodeStore::new_empty_committed(
             file_backed.clone(),
             DeletedNodeTracking::Disabled,
         ));
@@ -241,8 +242,8 @@ mod tests {
         assert!(Arc::ptr_eq(&revision, &retrieved_revision));
     }
 
-    #[test]
-    fn test_nonexistent_revision() {
+    #[firewood_macros::hash_mode]
+    fn test_nonexistent_revision<H: HashMode>() {
         let tmpdir = tempfile::tempdir().unwrap();
 
         let db_path = tmpdir.as_ref().join("testdb");
@@ -254,13 +255,13 @@ mod tests {
                 false,
                 true,
                 CacheReadStrategy::WritesOnly,
-                <crate::DefaultHashMode as crate::HashMode>::ALGORITHM,
+                H::ALGORITHM,
             )
             .unwrap(),
         );
 
         let root_store_dir = tmpdir.as_ref().join("root_store");
-        let root_store: RootStore =
+        let root_store: RootStore<H> =
             RootStore::new(root_store_dir, file_backed.clone(), false).unwrap();
 
         // Try to get a hash that doesn't exist in the cache nor in the underlying datastore.

--- a/storage/src/root_store.rs
+++ b/storage/src/root_store.rs
@@ -193,15 +193,15 @@ impl<H: HashMode> RootStore<H> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::DefaultHashMode;
+    use crate::CacheReadStrategy;
     use crate::linear::filebacked::FileBacked;
     use crate::nodestore::NodeStore;
-    use crate::{CacheReadStrategy, HashMode};
+    use crate::{EthHash, MerkleDbHash};
     use std::num::NonZero;
     use std::sync::Arc;
 
-    #[test]
-    fn test_cache_hit() {
+    #[firewood_macros::hash_mode]
+    fn test_cache_hit<H: HashMode>() {
         let tmpdir = tempfile::tempdir().unwrap();
 
         let db_path = tmpdir.as_ref().join("testdb");
@@ -213,20 +213,21 @@ mod tests {
                 false,
                 true,
                 CacheReadStrategy::WritesOnly,
-                DefaultHashMode::ALGORITHM,
+                H::ALGORITHM,
             )
             .unwrap(),
         );
 
         let root_store_dir = tmpdir.as_ref().join("root_store");
-        let root_store: RootStore<DefaultHashMode> =
+        let root_store: RootStore<H> =
             RootStore::new(root_store_dir, file_backed.clone(), false).unwrap();
 
         // Create a revision to cache. `RootStore` implies archival mode,
         // where deleted nodes are never tracked.
-        let revision: CommittedRevision<DefaultHashMode> = Arc::new(
-            NodeStore::new_empty_committed(file_backed.clone(), DeletedNodeTracking::Disabled),
-        );
+        let revision: CommittedRevision<H> = Arc::new(NodeStore::new_empty_committed(
+            file_backed.clone(),
+            DeletedNodeTracking::Disabled,
+        ));
 
         let hash = TrieHash::from_bytes([1; 32]);
         root_store
@@ -241,8 +242,8 @@ mod tests {
         assert!(Arc::ptr_eq(&revision, &retrieved_revision));
     }
 
-    #[test]
-    fn test_nonexistent_revision() {
+    #[firewood_macros::hash_mode]
+    fn test_nonexistent_revision<H: HashMode>() {
         let tmpdir = tempfile::tempdir().unwrap();
 
         let db_path = tmpdir.as_ref().join("testdb");
@@ -254,13 +255,13 @@ mod tests {
                 false,
                 true,
                 CacheReadStrategy::WritesOnly,
-                DefaultHashMode::ALGORITHM,
+                H::ALGORITHM,
             )
             .unwrap(),
         );
 
         let root_store_dir = tmpdir.as_ref().join("root_store");
-        let root_store: RootStore<DefaultHashMode> =
+        let root_store: RootStore<H> =
             RootStore::new(root_store_dir, file_backed.clone(), false).unwrap();
 
         // Try to get a hash that doesn't exist in the cache nor in the underlying datastore.


### PR DESCRIPTION
## Why this should be merged

Removing the feature matrix would otherwise leave many mode-agnostic tests running against only one concrete implementation. Both runtime-selectable paths need direct coverage in the same binary before the compile-time feature is removed.

In the stack, this is the confidence layer between enabling runtime selection in PR 7 and deleting the compile-time fallback in PR 9. It adds no new production selection mechanism; instead, it demonstrates that shared behavior
really works through both implementations and keeps single-mode assumptions explicit in tests.

## How this works

This change extends the argument-free `#[firewood_macros::hash_mode]` test attribute to generate Ethereum and MerkleDB wrappers for a generic test. It supports `test_case`, forwards test attributes and return types, and rejects
arguments so single-mode tests stay explicit: they use `#[test]` and name the concrete mode or pass the runtime algorithm directly.

Mode-agnostic helpers and tests are genericized and run under both modes. Genuinely mode-specific vectors remain explicitly pinned, while existing cross-mode and golden-format tests keep their purpose. `fwdctl` also gains a
MerkleDB create/insert/get/root smoke path.

## How this was tested

Added compile-pass coverage for the bare macro and `test_case` composition, compile-fail coverage for macro arguments and invalid function signatures, and the MerkleDB `fwdctl` smoke test. The defensive value-digest regression also explicitly verifies that the runtime algorithm, not the structural trie type, controls the guard.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl