### PR TITLE
fix(ffi): serialize RangeProof handle methods against Free

### DIFF
--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -90,6 +90,14 @@ type RangeProof struct {
 	// embedded proposal, the database must be kept alive. The proposal and
 	// reference to the database are released after calling
 	// `C.fwd_db_verify_and_commit_range_proof` or `C.fwd_free_range_proof`.
+	//
+	// Every method that passes handle to a C call must hold lease.mu.RLock for
+	// the duration of that call. Free — including the GC finalizer registered
+	// below — invalidates handle under lease.mu.Lock, so the read-lock both
+	// serializes the call against the free and keeps the proof reachable across
+	// the cgo call, preventing the finalizer from running mid-call. Omitting it
+	// is a use-after-free of the Rust RangeProofContext (see
+	// https://github.com/ava-labs/firewood/issues/2137).
 	handle *C.RangeProofContext
 
 	// lease keeps the database alive while this range proof owns an
@@ -155,6 +163,9 @@ func (p *RangeProof) Verify(
 	startKey, endKey Maybe[[]byte],
 	maxLength uint32,
 ) error {
+	p.lease.mu.RLock()
+	defer p.lease.mu.RUnlock()
+
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
 
@@ -271,6 +282,8 @@ func (db *Database) VerifyAndCommitRangeProof(
 //
 // TODO(#352): the start key will be inclusive in the future; update documentation then.
 func (p *RangeProof) FindNextKey() (*NextKeyRange, error) {
+	p.lease.mu.RLock()
+	defer p.lease.mu.RUnlock()
 	return getNextKeyRangeFromNextKeyRangeResult(C.fwd_range_proof_find_next_key(p.handle))
 }
 
@@ -318,6 +331,9 @@ func (it *codeIterator) Free() error {
 //
 // The format is unspecified and opaque to firewood.
 func (p *RangeProof) MarshalBinary() ([]byte, error) {
+	p.lease.mu.RLock()
+	defer p.lease.mu.RUnlock()
+
 	start := time.Now()
 	result, err := getValueFromValueResult(C.fwd_range_proof_to_bytes(p.handle))
 	proofMarshalDuration.WithLabelValues("range").Observe(time.Since(start).Seconds())

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -6,6 +6,7 @@ package ffi
 import (
 	"encoding/hex"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -319,6 +320,90 @@ func TestRangeProofFindNextKey(t *testing.T) {
 	r.NotNil(nextRange)
 	r.Equal(nextRange.StartKey(), startKey)
 	r.NoError(nextRange.Free())
+}
+
+// TestRangeProofMethodFreeRace is a regression test for ava-labs/firewood#2137.
+//
+// Several (*RangeProof) methods read p.handle and pass it into a cgo call
+// without holding p.lease.mu, so they are not serialized against
+// (*RangeProof).Free, which frees the underlying Rust RangeProofContext under
+// p.lease.mu. In production the racing Free is the GC finalizer that
+// (*RangeProof) registers: once the proof becomes unreachable — which it is for
+// the duration of the cgo call, since these methods never touch p again after
+// loading the handle — the finalizer may run concurrently and free the context
+// out from under the in-flight call. The result is a use-after-free: the issue
+// reported "SIGSEGV ... signal arrived during cgo execution" inside
+// fwd_range_proof_find_next_key (FindNextKey); Verify and MarshalBinary share
+// the identical defect.
+//
+// The finalizer's exact timing cannot be forced from Go — the proof must be
+// reachable to call a method on it, yet unreachable for the finalizer to run —
+// so this test drives the identical concurrent code paths directly: the method
+// and Free (the very method the finalizer calls) race on the same proof. Under
+// -race — which CI runs the ffi suite under — the unsynchronized p.handle
+// access is reported deterministically. Without -race the same race can surface
+// as the reported SIGSEGV, but the timing window is narrow and does not
+// reliably crash in a bounded run, so -race is the signal this test relies on.
+// Guarding each method with p.lease.mu fixes all of them.
+func TestRangeProofMethodFreeRace(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	_, _, batch := kvForTest(100)
+	root, err := db.Update(batch)
+	r.NoError(err)
+
+	// Cheaply mint fresh, independent RangeProofContexts by unmarshalling the
+	// same serialized proof each iteration. UnmarshalBinary arms the Free
+	// finalizer but attaches no database lease, so nothing keeps the handle
+	// alive across the cgo call — exactly the production shape.
+	proofBytes := newSerializedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenTruncated)
+
+	// Each op reads p.handle and passes it into a single cgo call. None may race
+	// (*RangeProof).Free on p.handle. (CodeHashes is intentionally excluded: its
+	// Rust iterator borrows from the proof and is consumed across multiple calls,
+	// so it needs an iteration-spanning guard rather than this single-call one.)
+	ops := []struct {
+		name string
+		call func(*RangeProof)
+	}{
+		{"FindNextKey", func(p *RangeProof) { _, _ = p.FindNextKey() }},
+		{"Verify", func(p *RangeProof) {
+			_ = p.Verify(root, nothing(), nothing(), rangeProofLenTruncated)
+		}},
+		{"MarshalBinary", func(p *RangeProof) { _, _ = p.MarshalBinary() }},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			r := require.New(t)
+			// -race flags the conflicting p.handle access as soon as one
+			// iteration's method and Free overlap, which the start barrier makes
+			// near-certain per iteration; a few thousand iterations is ample
+			// margin while keeping the -race CI run fast.
+			const iterations = 10_000
+			for range iterations {
+				p := new(RangeProof)
+				r.NoError(p.UnmarshalBinary(proofBytes))
+
+				start := make(chan struct{})
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					<-start
+					op.call(p) // reads p.handle across cgo, unsynchronized
+				}()
+				go func() {
+					defer wg.Done()
+					<-start
+					_ = p.Free() // frees the Rust context (the finalizer's code path)
+				}()
+				close(start)
+				wg.Wait()
+			}
+		})
+	}
 }
 
 func TestRangeProofCodeHashes(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

Fixes #2137 — an intermittent `SIGSEGV: ... signal arrived during cgo execution` inside `fwd_range_proof_find_next_key`, hit during avalanchego state sync.

`RangeProof.FindNextKey` (and `Verify`, `MarshalBinary`) read `p.handle` and pass it into a cgo call **without** holding `p.lease.mu`, so they are not serialized against `(*RangeProof).Free`, which frees the underlying Rust `RangeProofContext` under that lock. In production the racing `Free` is the **GC finalizer** `RangeProof` registers: once the proof becomes unreachable — which it is for the duration of the cgo call, since these methods never touch `p` again after loading the handle — the finalizer runs concurrently and frees the context out from under the in-flight call → use-after-free.

`RangeProof` was the *only* handle type missing the `lease.mu.RLock` guard that `Proposal`, `Revision`, and `Iterator` already hold across every cgo call, and it intentionally stays out of the keep-alive registry so its finalizer can run — which is exactly what made the race reachable.

## How this works

Hold `p.lease.mu.RLock()` across the cgo call in `FindNextKey`, `Verify`, and `MarshalBinary`. The read lock both serializes against `Free` (which takes `lease.mu.Lock`) and keeps `p` reachable for the duration of the call, closing the finalizer window. The invariant is documented on the `handle` field so future methods preserve it.

## How this was tested

| Check | Result |
| --- | --- |
| `TestRangeProofMethodFreeRace` (races each method vs `Free`), **unfixed**, `go test -race` | data race on `p.handle` → FAIL |
| same, **with the fix** | PASS |
| full `ffi` package, `go test -race` + `GOEXPERIMENT=cgocheck2` (ethhash) | PASS |
| `gofmt` / `golangci-lint` | clean / 0 issues |

CI already runs the ffi suite under `-race` for both hash modes, so `TestRangeProofMethodFreeRace` guards this regression there.

## Breaking Changes

No breaking changes — internal locking only; the C and Go APIs and their observable behavior are unchanged.

---

> [!NOTE]
> Same-class issues intentionally left out of this focused fix (distinct shapes; to be handled separately):
>
> - **`RangeProof.CodeHashes`** — its Rust iterator borrows from the proof and is consumed across multiple calls, so it needs an iteration-spanning guard rather than the single-call one used here.
> - **`ChangeProof` method family** — the type has no `lease` field and needs its own keep-alive mechanism (it is slated for redesign).
> - **`UnmarshalBinary` then `VerifyRangeProof`** panics with `runtime.SetFinalizer: finalizer already set` — a separate latent bug surfaced while building the reproducer.