### PR TITLE
fix(ffi): make RangeProof finalizer registration idempotent

### DIFF
--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -226,7 +226,7 @@ func (db *Database) VerifyRangeProof(
 	// https://github.com/ava-labs/firewood/issues/1539 is deferred for
 	// both proof types.
 	proof.lease.attachUnregistered(db.keepAlives)
-	runtime.SetFinalizer(proof, (*RangeProof).Free)
+	proof.setFreeFinalizer()
 	return nil
 }
 
@@ -358,7 +358,7 @@ func (p *RangeProof) UnmarshalBinary(data []byte) error {
 	if err == nil {
 		p.handle = handle.handle
 		handle.handle = nil
-		runtime.SetFinalizer(p, (*RangeProof).Free)
+		p.setFreeFinalizer()
 	}
 
 	return err
@@ -381,6 +381,18 @@ func (p *RangeProof) Free() error {
 		p.handle = nil
 		return nil
 	})
+}
+
+// setFreeFinalizer registers (*RangeProof).Free as p's finalizer, replacing any
+// finalizer a previous life of p may already carry. runtime.SetFinalizer
+// fatally panics if a finalizer is already set, and a RangeProof can
+// legitimately reach a finalizer-setting path more than once (a repeated
+// UnmarshalBinary, or UnmarshalBinary followed by Database.VerifyRangeProof), so
+// clear any existing finalizer first. SetFinalizer(p, nil) is a no-op when none
+// is set.
+func (p *RangeProof) setFreeFinalizer() {
+	runtime.SetFinalizer(p, nil)
+	runtime.SetFinalizer(p, (*RangeProof).Free)
 }
 
 // ChangeProof returns a proof that the changes between [startRoot] and

--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -90,6 +90,14 @@ type RangeProof struct {
 	// embedded proposal, the database must be kept alive. The proposal and
 	// reference to the database are released after calling
 	// `C.fwd_db_verify_and_commit_range_proof` or `C.fwd_free_range_proof`.
+	//
+	// Every method that passes handle to a C call must hold lease.mu.RLock for
+	// the duration of that call. Free — including the GC finalizer registered
+	// below — invalidates handle under lease.mu.Lock, so the read-lock both
+	// serializes the call against the free and keeps the proof reachable across
+	// the cgo call, preventing the finalizer from running mid-call. Omitting it
+	// is a use-after-free of the Rust RangeProofContext (see
+	// https://github.com/ava-labs/firewood/issues/2137).
 	handle *C.RangeProofContext
 
 	// lease keeps the database alive while this range proof owns an
@@ -155,6 +163,9 @@ func (p *RangeProof) Verify(
 	startKey, endKey Maybe[[]byte],
 	maxLength uint32,
 ) error {
+	p.lease.mu.RLock()
+	defer p.lease.mu.RUnlock()
+
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
 
@@ -271,6 +282,8 @@ func (db *Database) VerifyAndCommitRangeProof(
 //
 // TODO(#352): the start key will be inclusive in the future; update documentation then.
 func (p *RangeProof) FindNextKey() (*NextKeyRange, error) {
+	p.lease.mu.RLock()
+	defer p.lease.mu.RUnlock()
 	return getNextKeyRangeFromNextKeyRangeResult(C.fwd_range_proof_find_next_key(p.handle))
 }
 
@@ -318,6 +331,9 @@ func (it *codeIterator) Free() error {
 //
 // The format is unspecified and opaque to firewood.
 func (p *RangeProof) MarshalBinary() ([]byte, error) {
+	p.lease.mu.RLock()
+	defer p.lease.mu.RUnlock()
+
 	start := time.Now()
 	result, err := getValueFromValueResult(C.fwd_range_proof_to_bytes(p.handle))
 	proofMarshalDuration.WithLabelValues("range").Observe(time.Since(start).Seconds())

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -6,6 +6,7 @@ package ffi
 import (
 	"encoding/hex"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -319,6 +320,90 @@ func TestRangeProofFindNextKey(t *testing.T) {
 	r.NotNil(nextRange)
 	r.Equal(nextRange.StartKey(), startKey)
 	r.NoError(nextRange.Free())
+}
+
+// TestRangeProofMethodFreeRace is a regression test for ava-labs/firewood#2137.
+//
+// Several (*RangeProof) methods read p.handle and pass it into a cgo call
+// without holding p.lease.mu, so they are not serialized against
+// (*RangeProof).Free, which frees the underlying Rust RangeProofContext under
+// p.lease.mu. In production the racing Free is the GC finalizer that
+// (*RangeProof) registers: once the proof becomes unreachable — which it is for
+// the duration of the cgo call, since these methods never touch p again after
+// loading the handle — the finalizer may run concurrently and free the context
+// out from under the in-flight call. The result is a use-after-free: the issue
+// reported "SIGSEGV ... signal arrived during cgo execution" inside
+// fwd_range_proof_find_next_key (FindNextKey); Verify and MarshalBinary share
+// the identical defect.
+//
+// The finalizer's exact timing cannot be forced from Go — the proof must be
+// reachable to call a method on it, yet unreachable for the finalizer to run —
+// so this test drives the identical concurrent code paths directly: the method
+// and Free (the very method the finalizer calls) race on the same proof. Under
+// -race — which CI runs the ffi suite under — the unsynchronized p.handle
+// access is reported deterministically. Without -race the same race can surface
+// as the reported SIGSEGV, but the timing window is narrow and does not
+// reliably crash in a bounded run, so -race is the signal this test relies on.
+// Guarding each method with p.lease.mu fixes all of them.
+func TestRangeProofMethodFreeRace(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	_, _, batch := kvForTest(100)
+	root, err := db.Update(batch)
+	r.NoError(err)
+
+	// Cheaply mint fresh, independent RangeProofContexts by unmarshalling the
+	// same serialized proof each iteration. UnmarshalBinary arms the Free
+	// finalizer but attaches no database lease, so nothing keeps the handle
+	// alive across the cgo call — exactly the production shape.
+	proofBytes := newSerializedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenTruncated)
+
+	// Each op reads p.handle and passes it into a single cgo call. None may race
+	// (*RangeProof).Free on p.handle. (CodeHashes is intentionally excluded: its
+	// Rust iterator borrows from the proof and is consumed across multiple calls,
+	// so it needs an iteration-spanning guard rather than this single-call one.)
+	ops := []struct {
+		name string
+		call func(*RangeProof)
+	}{
+		{"FindNextKey", func(p *RangeProof) { _, _ = p.FindNextKey() }},
+		{"Verify", func(p *RangeProof) {
+			_ = p.Verify(root, nothing(), nothing(), rangeProofLenTruncated)
+		}},
+		{"MarshalBinary", func(p *RangeProof) { _, _ = p.MarshalBinary() }},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			r := require.New(t)
+			// -race flags the conflicting p.handle access as soon as one
+			// iteration's method and Free overlap, which the start barrier makes
+			// near-certain per iteration; a few thousand iterations is ample
+			// margin while keeping the -race CI run fast.
+			const iterations = 10_000
+			for range iterations {
+				p := new(RangeProof)
+				r.NoError(p.UnmarshalBinary(proofBytes))
+
+				start := make(chan struct{})
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					<-start
+					op.call(p) // reads p.handle across cgo, unsynchronized
+				}()
+				go func() {
+					defer wg.Done()
+					<-start
+					_ = p.Free() // frees the Rust context (the finalizer's code path)
+				}()
+				close(start)
+				wg.Wait()
+			}
+		})
+	}
 }
 
 func TestRangeProofCodeHashes(t *testing.T) {

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -406,6 +406,65 @@ func TestRangeProofMethodFreeRace(t *testing.T) {
 	}
 }
 
+// TestRangeProofSetFinalizerReset guards against a double-SetFinalizer panic.
+//
+// runtime.SetFinalizer fatally panics ("finalizer already set") if it is called
+// with a non-nil finalizer on an object that already has one. A RangeProof can
+// legitimately reach a finalizer-setting path more than once: UnmarshalBinary
+// documents that it overwrites existing contents (so it may be called again),
+// and a from-bytes proof can then be prepared with Database.VerifyRangeProof —
+// which also sets the finalizer. Because Free does not clear the finalizer,
+// each of these sequences re-set the finalizer on the unfixed code and crashed
+// the process. They must instead leave the proof with exactly one finalizer.
+//
+// (Calling VerifyRangeProof twice is a separate matter: it panics earlier on
+// lease.attachUnregistered, so it is not exercised here.)
+func TestRangeProofSetFinalizerReset(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	_, _, batch := kvForTest(100)
+	root, err := db.Update(batch)
+	r.NoError(err)
+
+	proofBytes := newSerializedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenTruncated)
+
+	tests := []struct {
+		name string
+		// run performs a sequence that reaches a finalizer-setting path twice
+		// and returns the resulting proof for cleanup. It must not panic.
+		run func(*require.Assertions) *RangeProof
+	}{
+		{"unmarshal_then_unmarshal", func(r *require.Assertions) *RangeProof {
+			p := new(RangeProof)
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			return p
+		}},
+		{"unmarshal_then_verify", func(r *require.Assertions) *RangeProof {
+			p := new(RangeProof)
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			r.NoError(db.VerifyRangeProof(p, nothing(), nothing(), root, rangeProofLenTruncated))
+			return p
+		}},
+		{"verify_then_unmarshal", func(r *require.Assertions) *RangeProof {
+			p, err := db.RangeProof(root, nothing(), nothing(), rangeProofLenTruncated)
+			r.NoError(err)
+			r.NoError(db.VerifyRangeProof(p, nothing(), nothing(), root, rangeProofLenTruncated))
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			return p
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			p := tt.run(r) // must not fatally panic with "finalizer already set"
+			t.Cleanup(func() { _ = p.Free() })
+		})
+	}
+}
+
 func TestRangeProofCodeHashes(t *testing.T) {
 	r := require.New(t)
 	db := newTestDatabase(t)


### PR DESCRIPTION
## Why this should be merged

`RangeProof.UnmarshalBinary` and `Database.VerifyRangeProof` both register `(*RangeProof).Free` as the proof's finalizer via `runtime.SetFinalizer`, and `Free` never clears it. `runtime.SetFinalizer` **fatally panics** with `finalizer already set` when called on an object that already has one, so a proof that reaches a second finalizer-setting path crashes the whole process.

Both sequences are legitimate:

- `UnmarshalBinary` documents that it overwrites existing contents, so it may be called more than once on the same proof.
- A from-bytes proof (`UnmarshalBinary`) can be prepared with `VerifyRangeProof` before being committed.

Surfaced while fixing the `FindNextKey` use-after-free (#2137); it is an independent latent bug.

## How this works

Add `(*RangeProof).setFreeFinalizer`, which clears any existing finalizer (`SetFinalizer(p, nil)` is a no-op when none is set) before registering `Free`, and call it from both sites. The proof is left with exactly one finalizer regardless of the path taken to reach it.

> [!NOTE]
> Calling `VerifyRangeProof` twice is a separate matter — it panics earlier on `lease.attachUnregistered` ("lease already attached") — so it is not addressed here.

## How this was tested

| Ordering (`TestRangeProofSetFinalizerReset`) | Before | After |
| --- | --- | --- |
| `unmarshal_then_unmarshal` | `fatal error: runtime.SetFinalizer: finalizer already set` | PASS |
| `unmarshal_then_verify` | same fatal panic | PASS |
| `verify_then_unmarshal` | same fatal panic | PASS |

Full `ffi` package passes under `go test -race` + `GOEXPERIMENT=cgocheck2` (ethhash). `gofmt` / `golangci-lint` clean.

## Breaking Changes

No breaking changes — the fix only makes finalizer registration idempotent; public C and Go APIs and their behavior are unchanged.
