### PR TITLE
fix(ffi): make repeated VerifyRangeProof idempotent

### DIFF
--- a/ffi/keepalive.go
+++ b/ffi/keepalive.go
@@ -328,6 +328,16 @@ func (l *lease) attach(registry *keepAliveRegistry, dropFn func() error) error {
 // [WithForceCloseHandles] will not auto-drop a still-referenced
 // RangeProof; graceful [Database.Close] still waits on the count.
 //
+// Re-attaching the same lease to the same registry is a no-op. Unlike a
+// registered handle (see [lease.attach]), which gets a fresh lease per
+// construction, a RangeProof can legitimately reach this path more than once:
+// [Database.VerifyRangeProof] prepares a proposal and may be called repeatedly
+// on the same proof (the Rust side and the finalizer are already idempotent).
+// Making it idempotent keeps the count balanced — one attach, one release —
+// rather than crashing on a redundant prepare. Re-attaching to a *different*
+// registry is still a bug the count/registry bookkeeping cannot represent, so
+// it panics.
+//
 // Callers must serialize against [Database.Close] (e.g. via
 // db.handleLock.RLock) before invoking this — there is no closed-registry
 // guard here. The change-proof family is being redesigned, so a
@@ -336,8 +346,12 @@ func (l *lease) attachUnregistered(registry *keepAliveRegistry) {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
 
+	if l.registry == registry {
+		// Already attached to this registry — idempotent; do not double-count.
+		return
+	}
 	if l.registry != nil {
-		panic("lease already attached")
+		panic("lease already attached to a different registry")
 	}
 	registry.count++
 	l.registry = registry

--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -226,7 +226,7 @@ func (db *Database) VerifyRangeProof(
 	// https://github.com/ava-labs/firewood/issues/1539 is deferred for
 	// both proof types.
 	proof.lease.attachUnregistered(db.keepAlives)
-	runtime.SetFinalizer(proof, (*RangeProof).Free)
+	proof.setFreeFinalizer()
 	return nil
 }
 
@@ -358,7 +358,7 @@ func (p *RangeProof) UnmarshalBinary(data []byte) error {
 	if err == nil {
 		p.handle = handle.handle
 		handle.handle = nil
-		runtime.SetFinalizer(p, (*RangeProof).Free)
+		p.setFreeFinalizer()
 	}
 
 	return err
@@ -381,6 +381,18 @@ func (p *RangeProof) Free() error {
 		p.handle = nil
 		return nil
 	})
+}
+
+// setFreeFinalizer registers (*RangeProof).Free as p's finalizer, replacing any
+// finalizer a previous life of p may already carry. runtime.SetFinalizer
+// fatally panics if a finalizer is already set, and a RangeProof can
+// legitimately reach a finalizer-setting path more than once (a repeated
+// UnmarshalBinary, or UnmarshalBinary followed by Database.VerifyRangeProof), so
+// clear any existing finalizer first. SetFinalizer(p, nil) is a no-op when none
+// is set.
+func (p *RangeProof) setFreeFinalizer() {
+	runtime.SetFinalizer(p, nil)
+	runtime.SetFinalizer(p, (*RangeProof).Free)
 }
 
 // ChangeProof returns a proof that the changes between [startRoot] and

--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -90,6 +90,14 @@ type RangeProof struct {
 	// embedded proposal, the database must be kept alive. The proposal and
 	// reference to the database are released after calling
 	// `C.fwd_db_verify_and_commit_range_proof` or `C.fwd_free_range_proof`.
+	//
+	// Every method that passes handle to a C call must hold lease.mu.RLock for
+	// the duration of that call. Free — including the GC finalizer registered
+	// below — invalidates handle under lease.mu.Lock, so the read-lock both
+	// serializes the call against the free and keeps the proof reachable across
+	// the cgo call, preventing the finalizer from running mid-call. Omitting it
+	// is a use-after-free of the Rust RangeProofContext (see
+	// https://github.com/ava-labs/firewood/issues/2137).
 	handle *C.RangeProofContext
 
 	// lease keeps the database alive while this range proof owns an
@@ -155,6 +163,9 @@ func (p *RangeProof) Verify(
 	startKey, endKey Maybe[[]byte],
 	maxLength uint32,
 ) error {
+	p.lease.mu.RLock()
+	defer p.lease.mu.RUnlock()
+
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
 
@@ -271,6 +282,8 @@ func (db *Database) VerifyAndCommitRangeProof(
 //
 // TODO(#352): the start key will be inclusive in the future; update documentation then.
 func (p *RangeProof) FindNextKey() (*NextKeyRange, error) {
+	p.lease.mu.RLock()
+	defer p.lease.mu.RUnlock()
 	return getNextKeyRangeFromNextKeyRangeResult(C.fwd_range_proof_find_next_key(p.handle))
 }
 
@@ -318,6 +331,9 @@ func (it *codeIterator) Free() error {
 //
 // The format is unspecified and opaque to firewood.
 func (p *RangeProof) MarshalBinary() ([]byte, error) {
+	p.lease.mu.RLock()
+	defer p.lease.mu.RUnlock()
+
 	start := time.Now()
 	result, err := getValueFromValueResult(C.fwd_range_proof_to_bytes(p.handle))
 	proofMarshalDuration.WithLabelValues("range").Observe(time.Since(start).Seconds())

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -6,6 +6,7 @@ package ffi
 import (
 	"encoding/hex"
 	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -319,6 +320,90 @@ func TestRangeProofFindNextKey(t *testing.T) {
 	r.NotNil(nextRange)
 	r.Equal(nextRange.StartKey(), startKey)
 	r.NoError(nextRange.Free())
+}
+
+// TestRangeProofMethodFreeRace is a regression test for ava-labs/firewood#2137.
+//
+// Several (*RangeProof) methods read p.handle and pass it into a cgo call
+// without holding p.lease.mu, so they are not serialized against
+// (*RangeProof).Free, which frees the underlying Rust RangeProofContext under
+// p.lease.mu. In production the racing Free is the GC finalizer that
+// (*RangeProof) registers: once the proof becomes unreachable — which it is for
+// the duration of the cgo call, since these methods never touch p again after
+// loading the handle — the finalizer may run concurrently and free the context
+// out from under the in-flight call. The result is a use-after-free: the issue
+// reported "SIGSEGV ... signal arrived during cgo execution" inside
+// fwd_range_proof_find_next_key (FindNextKey); Verify and MarshalBinary share
+// the identical defect.
+//
+// The finalizer's exact timing cannot be forced from Go — the proof must be
+// reachable to call a method on it, yet unreachable for the finalizer to run —
+// so this test drives the identical concurrent code paths directly: the method
+// and Free (the very method the finalizer calls) race on the same proof. Under
+// -race — which CI runs the ffi suite under — the unsynchronized p.handle
+// access is reported deterministically. Without -race the same race can surface
+// as the reported SIGSEGV, but the timing window is narrow and does not
+// reliably crash in a bounded run, so -race is the signal this test relies on.
+// Guarding each method with p.lease.mu fixes all of them.
+func TestRangeProofMethodFreeRace(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	_, _, batch := kvForTest(100)
+	root, err := db.Update(batch)
+	r.NoError(err)
+
+	// Cheaply mint fresh, independent RangeProofContexts by unmarshalling the
+	// same serialized proof each iteration. UnmarshalBinary arms the Free
+	// finalizer but attaches no database lease, so nothing keeps the handle
+	// alive across the cgo call — exactly the production shape.
+	proofBytes := newSerializedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenTruncated)
+
+	// Each op reads p.handle and passes it into a single cgo call. None may race
+	// (*RangeProof).Free on p.handle. (CodeHashes is intentionally excluded: its
+	// Rust iterator borrows from the proof and is consumed across multiple calls,
+	// so it needs an iteration-spanning guard rather than this single-call one.)
+	ops := []struct {
+		name string
+		call func(*RangeProof)
+	}{
+		{"FindNextKey", func(p *RangeProof) { _, _ = p.FindNextKey() }},
+		{"Verify", func(p *RangeProof) {
+			_ = p.Verify(root, nothing(), nothing(), rangeProofLenTruncated)
+		}},
+		{"MarshalBinary", func(p *RangeProof) { _, _ = p.MarshalBinary() }},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			r := require.New(t)
+			// -race flags the conflicting p.handle access as soon as one
+			// iteration's method and Free overlap, which the start barrier makes
+			// near-certain per iteration; a few thousand iterations is ample
+			// margin while keeping the -race CI run fast.
+			const iterations = 10_000
+			for range iterations {
+				p := new(RangeProof)
+				r.NoError(p.UnmarshalBinary(proofBytes))
+
+				start := make(chan struct{})
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					<-start
+					op.call(p) // reads p.handle across cgo, unsynchronized
+				}()
+				go func() {
+					defer wg.Done()
+					<-start
+					_ = p.Free() // frees the Rust context (the finalizer's code path)
+				}()
+				close(start)
+				wg.Wait()
+			}
+		})
+	}
 }
 
 func TestRangeProofCodeHashes(t *testing.T) {

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -406,6 +406,65 @@ func TestRangeProofMethodFreeRace(t *testing.T) {
 	}
 }
 
+// TestRangeProofSetFinalizerReset guards against a double-SetFinalizer panic.
+//
+// runtime.SetFinalizer fatally panics ("finalizer already set") if it is called
+// with a non-nil finalizer on an object that already has one. A RangeProof can
+// legitimately reach a finalizer-setting path more than once: UnmarshalBinary
+// documents that it overwrites existing contents (so it may be called again),
+// and a from-bytes proof can then be prepared with Database.VerifyRangeProof —
+// which also sets the finalizer. Because Free does not clear the finalizer,
+// each of these sequences re-set the finalizer on the unfixed code and crashed
+// the process. They must instead leave the proof with exactly one finalizer.
+//
+// (Calling VerifyRangeProof twice is a separate matter: it panics earlier on
+// lease.attachUnregistered, so it is not exercised here.)
+func TestRangeProofSetFinalizerReset(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	_, _, batch := kvForTest(100)
+	root, err := db.Update(batch)
+	r.NoError(err)
+
+	proofBytes := newSerializedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenTruncated)
+
+	tests := []struct {
+		name string
+		// run performs a sequence that reaches a finalizer-setting path twice
+		// and returns the resulting proof for cleanup. It must not panic.
+		run func(*require.Assertions) *RangeProof
+	}{
+		{"unmarshal_then_unmarshal", func(r *require.Assertions) *RangeProof {
+			p := new(RangeProof)
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			return p
+		}},
+		{"unmarshal_then_verify", func(r *require.Assertions) *RangeProof {
+			p := new(RangeProof)
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			r.NoError(db.VerifyRangeProof(p, nothing(), nothing(), root, rangeProofLenTruncated))
+			return p
+		}},
+		{"verify_then_unmarshal", func(r *require.Assertions) *RangeProof {
+			p, err := db.RangeProof(root, nothing(), nothing(), rangeProofLenTruncated)
+			r.NoError(err)
+			r.NoError(db.VerifyRangeProof(p, nothing(), nothing(), root, rangeProofLenTruncated))
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			return p
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			p := tt.run(r) // must not fatally panic with "finalizer already set"
+			t.Cleanup(func() { _ = p.Free() })
+		})
+	}
+}
+
 func TestRangeProofCodeHashes(t *testing.T) {
 	r := require.New(t)
 	db := newTestDatabase(t)

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -465,6 +465,40 @@ func TestRangeProofSetFinalizerReset(t *testing.T) {
 	}
 }
 
+// TestRangeProofVerifyTwiceIdempotent verifies that preparing the same proof
+// against the same database more than once is a safe no-op rather than a panic
+// ("lease already attached"), and that the redundant call does not leak a
+// second keep-alive lease (which would leave Database.Close waiting on a
+// phantom outstanding handle).
+func TestRangeProofVerifyTwiceIdempotent(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	_, _, batch := kvForTest(100)
+	root, err := db.Update(batch)
+	r.NoError(err)
+
+	proof, err := db.RangeProof(root, nothing(), nothing(), rangeProofLenTruncated)
+	r.NoError(err)
+
+	r.NoError(db.VerifyRangeProof(proof, nothing(), nothing(), root, rangeProofLenTruncated))
+	r.NoError(db.VerifyRangeProof(proof, nothing(), nothing(), root, rangeProofLenTruncated))
+
+	// The proof is still usable after the redundant verify.
+	nkr, err := proof.FindNextKey()
+	r.NoError(err)
+	if nkr != nil {
+		r.NoError(nkr.Free())
+	}
+
+	// Exactly one lease was taken: a single Free drops the outstanding-handle
+	// count to zero, so a graceful Close finds nothing to wait on. A leaked
+	// second lease would make this Close return ErrActiveKeepAliveHandles.
+	// (db.Close is idempotent, so newTestDatabase's cleanup close is a no-op.)
+	r.NoError(proof.Free())
+	r.NoError(db.Close(oneSecCtx(t)))
+}
+
 func TestRangeProofCodeHashes(t *testing.T) {
 	r := require.New(t)
 	db := newTestDatabase(t)


### PR DESCRIPTION
## Why this should be merged

`lease.attachUnregistered` panicked (`lease already attached`) whenever a `RangeProof`'s lease was attached a second time, so calling `Database.VerifyRangeProof` more than once on the same proof crashed the process — even though the operation is otherwise idempotent (the Rust `verify_and_propose` returns early once a proposal exists, and finalizer registration was made idempotent in #2141).

Note this is the panic that actually fires on a repeated `VerifyRangeProof`: `attachUnregistered` runs *before* `setFreeFinalizer`, so it — not the finalizer — was the crash, and it was the last non-idempotent step on that path.

## How this works

`attachUnregistered` is used only by `RangeProof`; registered handles use `attach`, which still panics on double-attach because each construction gets a fresh lease. Make `attachUnregistered` a **no-op when the lease is already attached to the same registry**, so the outstanding-handle count stays balanced (one attach, one release) instead of crashing on a redundant prepare.

Re-attaching to a **different** registry (a proof verified against two different databases) remains a genuine misuse the count/registry bookkeeping cannot represent, so it still panics — now with a clearer message. A blanket removal of the panic was rejected for exactly this reason: it would silently no-op the different-database case, which the Rust side also mishandles silently.

## How this was tested

`TestRangeProofVerifyTwiceIdempotent` prepares the same proof against the same db twice and asserts:

- no panic, and the proof is still usable (`FindNextKey` works);
- exactly one lease is taken — a single `Free` drains the keep-alive count so `Database.Close` returns cleanly (a leaked second lease would return `ErrActiveKeepAliveHandles`).

RED before the change was `panic: lease already attached`. Full `ffi` package passes under `go test -race` + `GOEXPERIMENT=cgocheck2` (ethhash); `gofmt` / `golangci-lint` clean.

## Breaking Changes

No breaking changes — a previously-panicking redundant call is now a safe no-op; the different-registry misuse still panics. Public C and Go APIs are unchanged.
