### PR TITLE
fix(ffi): keep RangeProof alive during CodeHashes iteration

### DIFF
--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -294,17 +294,29 @@ func (p *RangeProof) FindNextKey() (*NextKeyRange, error) {
 // This method can only be called anytime after the proof is created.
 func (p *RangeProof) CodeHashes() iter.Seq2[Hash, error] {
 	return func(yield func(Hash, error) bool) {
-		iter, err := getCodeHashIteratorFromCodeHashIteratorResult(C.fwd_range_proof_code_hash_iter(p.handle))
+		p.lease.mu.RLock()
+		it, err := getCodeHashIteratorFromCodeHashIteratorResult(C.fwd_range_proof_code_hash_iter(p.handle))
+		p.lease.mu.RUnlock()
 		if err != nil {
 			yield(EmptyRoot, err)
 			return
 		}
+		// The Rust code iterator borrows the proof's key-values for its whole
+		// lifetime (CodeIteratorHandle<'p>), so the proof must stay alive until
+		// iteration finishes, not just for the create call above. Free the
+		// iterator and then KeepAlive p in the same deferred call: freeing first
+		// releases the borrow, and the trailing KeepAlive keeps the proof
+		// reachable across the entire loop so its GC finalizer cannot free the
+		// borrowed-from context mid-iteration. Concurrently calling Free during
+		// iteration remains unsupported, as elsewhere on RangeProof.
 		defer func() {
-			if err := iter.Free(); err != nil {
-				panic(err)
+			freeErr := it.Free()
+			runtime.KeepAlive(p)
+			if freeErr != nil {
+				panic(freeErr)
 			}
 		}()
-		for hash, err := iter.Next(); ; hash, err = iter.Next() {
+		for hash, err := it.Next(); ; hash, err = it.Next() {
 			if err != nil {
 				yield(EmptyRoot, err)
 				return

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -5,6 +5,7 @@ package ffi
 
 import (
 	"encoding/hex"
+	"iter"
 	"runtime"
 	"sync"
 	"testing"
@@ -497,6 +498,59 @@ func TestRangeProofVerifyTwiceIdempotent(t *testing.T) {
 	// (db.Close is idempotent, so newTestDatabase's cleanup close is a no-op.)
 	r.NoError(proof.Free())
 	r.NoError(db.Close(oneSecCtx(t)))
+}
+
+// TestRangeProofCodeHashesKeepsProofAlive is a regression test for the
+// code-hash iterator's borrow of the proof. The Rust CodeIteratorHandle holds
+// Box<dyn Iterator + 'p> over the proof's key-values, so the RangeProof must
+// stay alive for the whole iteration, not just the create call. CodeHashes uses
+// p only to create the iterator and then iterates the borrowing handle, so
+// without an explicit keepalive the proof can be garbage-collected mid-iteration
+// and its finalizer frees the key-values the iterator is still reading.
+//
+// A runtime.AddCleanup canary detects the root condition directly: if the proof
+// is reclaimed while the iterator is live, the cleanup fires. It is dropped from
+// the caller's scope so only the CodeHashes closure references it.
+func TestRangeProofCodeHashesKeepsProofAlive(t *testing.T) {
+	r := require.New(t)
+	mode, err := inferHashingMode(t.Context())
+	r.NoError(err)
+	if mode != ethhashKey {
+		t.Skip("code hashes are only produced in ethhash mode")
+	}
+
+	db := newTestDatabase(t)
+	key := [32]byte{0x12, 0x34, 0x56} // account key must be length 32
+	val, err := hex.DecodeString("f8440164a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
+	r.NoError(err)
+	root, err := db.Update([]BatchOp{Put(key[:], val)})
+	r.NoError(err)
+	proofBytes := newSerializedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenUnbounded)
+
+	collected := make(chan struct{})
+	// Build the iterator in a nested scope so the only remaining reference to the
+	// proof is the one captured by the CodeHashes closure.
+	seq := func() iter.Seq2[Hash, error] {
+		p := new(RangeProof)
+		r.NoError(p.UnmarshalBinary(proofBytes)) // arms the Free finalizer
+		runtime.AddCleanup(p, func(struct{}) { close(collected) }, struct{}{})
+		return p.CodeHashes()
+	}()
+
+	for _, err := range seq {
+		r.NoError(err)
+		// Mid-iteration: try hard to reclaim the proof. If CodeHashes stopped
+		// referencing it after creating the iterator, it is collectible here.
+		for range 50 {
+			runtime.GC()
+			select {
+			case <-collected:
+				r.FailNow("RangeProof was garbage-collected mid-iteration; CodeHashes must keep the proof alive while its borrowed iterator is live")
+			default:
+			}
+			runtime.Gosched()
+		}
+	}
 }
 
 func TestRangeProofCodeHashes(t *testing.T) {

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -5,6 +5,7 @@ package ffi
 
 import (
 	"encoding/hex"
+	"iter"
 	"runtime"
 	"sync"
 	"testing"
@@ -497,6 +498,57 @@ func TestRangeProofVerifyTwiceIdempotent(t *testing.T) {
 	// (db.Close is idempotent, so newTestDatabase's cleanup close is a no-op.)
 	r.NoError(proof.Free())
 	r.NoError(db.Close(oneSecCtx(t)))
+}
+
+// TestRangeProofCodeHashesKeepsProofAlive is a regression test for the
+// code-hash iterator's borrow of the proof. The Rust CodeIteratorHandle holds
+// Box<dyn Iterator + 'p> over the proof's key-values, so the RangeProof must
+// stay alive for the whole iteration, not just the create call. CodeHashes uses
+// p only to create the iterator and then iterates the borrowing handle, so
+// without an explicit keepalive the proof can be garbage-collected mid-iteration
+// and its finalizer frees the key-values the iterator is still reading.
+//
+// A runtime.AddCleanup canary detects the root condition directly: if the proof
+// is reclaimed while the iterator is live, the cleanup fires. It is dropped from
+// the caller's scope so only the CodeHashes closure references it.
+func TestRangeProofCodeHashesKeepsProofAlive(t *testing.T) {
+	r := require.New(t)
+	if selectedHashMode != ethhashKey {
+		t.Skip("code hashes are only produced in ethhash mode")
+	}
+
+	db := newTestDatabase(t)
+	key := [32]byte{0x12, 0x34, 0x56} // account key must be length 32
+	val, err := hex.DecodeString("f8440164a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
+	r.NoError(err)
+	root, err := db.Update([]BatchOp{Put(key[:], val)})
+	r.NoError(err)
+	proofBytes := newSerializedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenUnbounded)
+
+	collected := make(chan struct{})
+	// Build the iterator in a nested scope so the only remaining reference to the
+	// proof is the one captured by the CodeHashes closure.
+	seq := func() iter.Seq2[Hash, error] {
+		p := new(RangeProof)
+		r.NoError(p.UnmarshalBinary(proofBytes)) // arms the Free finalizer
+		runtime.AddCleanup(p, func(struct{}) { close(collected) }, struct{}{})
+		return p.CodeHashes()
+	}()
+
+	for _, err := range seq {
+		r.NoError(err)
+		// Mid-iteration: try hard to reclaim the proof. If CodeHashes stopped
+		// referencing it after creating the iterator, it is collectible here.
+		for range 50 {
+			runtime.GC()
+			select {
+			case <-collected:
+				r.FailNow("RangeProof was garbage-collected mid-iteration; CodeHashes must keep the proof alive while its borrowed iterator is live")
+			default:
+			}
+			runtime.Gosched()
+		}
+	}
 }
 
 func TestRangeProofCodeHashes(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

The Rust code-hash iterator *borrows* the proof for its whole lifetime —
`CodeIteratorHandle<'p>` wraps a `Box<dyn Iterator + 'p>` built from
`key_values.iter()`. `RangeProof.CodeHashes` referenced `p` only long enough to
create the iterator, so once the closure stopped mentioning it the GC could
reclaim the proof *mid-iteration* and run its finalizer, freeing the key-values
the iterator was still reading. Same use-after-free family as #2137, but
spanning the whole loop rather than a single call.

## Notes

`Next()` and `Free()` operate on the iterator's own handle, not `p.handle`, and
are deliberately left unlocked. The involuntary threat is the finalizer, which
the keepalive already prevents; a per-`Next` lock could not close a concurrent
explicit `Free` anyway, since that can still land between `Next`s. Concurrently
calling `Free` during iteration remains unsupported, as elsewhere on
`RangeProof`. This is why `codeIterator` differs from the registered `Iterator`,
which *does* lock per `Next`: that one is force-droppable via
`WithForceCloseHandles`.

Finalizer timing can't be forced, and `iter.Pull2` would *mask* the bug by
retaining the closure, so the regression test drops every reference to the proof
except the one `CodeHashes` captures and uses a `runtime.AddCleanup` canary to
assert the proof survives the iteration. Stashing the fix turns it red
("garbage-collected mid-iteration").

## Breaking Changes

None — internal lifetime fix; public API and behavior unchanged.
