### PR TITLE
fix(ffi): fix ChangeProof use-after-free and double-SetFinalizer bugs

### DIFF
--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -438,7 +438,7 @@ func (db *Database) ChangeProof(
 		return nil, err
 	}
 
-	runtime.SetFinalizer(proof, (*ChangeProof).Free)
+	proof.setFreeFinalizer()
 	return proof, nil
 }
 
@@ -508,6 +508,10 @@ func (db *Database) VerifyAndCommitChangeProof(
 func (proof *ChangeProof) FindNextKey(endKey Maybe[[]byte]) (*NextKeyRange, error) {
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
+	// Keep the proof reachable across the cgo call so its GC finalizer cannot
+	// free the handle mid-call once the receiver is otherwise dead. (ChangeProof
+	// holds no lease, so KeepAlive stands in for RangeProof's read-lock.)
+	defer runtime.KeepAlive(proof)
 
 	return getNextKeyRangeFromNextKeyRangeResult(
 		C.fwd_change_proof_find_next_key(proof.handle, newMaybeBorrowedBytes(endKey, &pinner)),
@@ -525,17 +529,27 @@ func (proof *ChangeProof) FindNextKey(endKey Maybe[[]byte]) (*NextKeyRange, erro
 // DeleteRange entries are skipped.
 func (p *ChangeProof) CodeHashes() iter.Seq2[Hash, error] {
 	return func(yield func(Hash, error) bool) {
-		iter, err := getCodeHashIteratorFromCodeHashIteratorResult(C.fwd_change_proof_code_hash_iter(p.handle))
+		it, err := getCodeHashIteratorFromCodeHashIteratorResult(C.fwd_change_proof_code_hash_iter(p.handle))
 		if err != nil {
 			yield(EmptyRoot, err)
 			return
 		}
+		// The Rust code iterator borrows the proof's data for its whole lifetime
+		// (CodeIteratorHandle<'p>), so the proof must stay alive until iteration
+		// finishes, not just for the create call above. Free the iterator and
+		// then KeepAlive p in the same deferred call: freeing releases the
+		// borrow, and the trailing KeepAlive keeps the proof reachable across the
+		// loop so its GC finalizer cannot free the borrowed-from context
+		// mid-iteration. Concurrently calling Free during iteration remains
+		// unsupported, as elsewhere on ChangeProof.
 		defer func() {
-			if err := iter.Free(); err != nil {
-				panic(err)
+			freeErr := it.Free()
+			runtime.KeepAlive(p)
+			if freeErr != nil {
+				panic(freeErr)
 			}
 		}()
-		for hash, err := iter.Next(); ; hash, err = iter.Next() {
+		for hash, err := it.Next(); ; hash, err = it.Next() {
 			if err != nil {
 				yield(EmptyRoot, err)
 				return
@@ -554,6 +568,8 @@ func (p *ChangeProof) CodeHashes() iter.Seq2[Hash, error] {
 //
 // The format is unspecified and opaque to firewood.
 func (p *ChangeProof) MarshalBinary() ([]byte, error) {
+	defer runtime.KeepAlive(p)
+
 	start := time.Now()
 	result, err := getValueFromValueResult(C.fwd_change_proof_to_bytes(p.handle))
 	proofMarshalDuration.WithLabelValues("change").Observe(time.Since(start).Seconds())
@@ -578,7 +594,7 @@ func (p *ChangeProof) UnmarshalBinary(data []byte) error {
 	if err == nil {
 		p.handle = handle.handle
 		handle.handle = nil
-		runtime.SetFinalizer(p, (*ChangeProof).Free)
+		p.setFreeFinalizer()
 	}
 
 	return err
@@ -607,6 +623,17 @@ func (p *ChangeProof) Free() error {
 	p.handle = nil
 
 	return nil
+}
+
+// setFreeFinalizer registers (*ChangeProof).Free as p's finalizer, replacing any
+// finalizer a previous life of p may already carry. runtime.SetFinalizer fatally
+// panics if a finalizer is already set, and a ChangeProof can legitimately reach
+// a finalizer-setting path more than once (a from-create proof re-loaded via
+// UnmarshalBinary, or a repeated UnmarshalBinary), so clear any existing
+// finalizer first. SetFinalizer(p, nil) is a no-op when none is set.
+func (p *ChangeProof) setFreeFinalizer() {
+	runtime.SetFinalizer(p, nil)
+	runtime.SetFinalizer(p, (*ChangeProof).Free)
 }
 
 // StartKey returns the inclusive start key of this key range.

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -100,11 +100,10 @@ func newSerializedChangeProof(
 	db *Database,
 	startRoot, endRoot Hash,
 	startKey, endKey maybe,
-	proofLen uint32,
 ) []byte {
 	r := require.New(t)
 
-	proof, err := db.ChangeProof(startRoot, endRoot, startKey, endKey, proofLen)
+	proof, err := db.ChangeProof(startRoot, endRoot, startKey, endKey, changeProofLenUnbounded)
 	r.NoError(err)
 
 	proofBytes, err := proof.MarshalBinary()
@@ -707,6 +706,107 @@ func TestRangeProofFinalizerCleanup(t *testing.T) {
 	r.NoError(db.Close(t.Context()), "Database should be closeable after proof is garbage collected")
 }
 
+// TestChangeProofSetFinalizerReset guards against a double-SetFinalizer panic on
+// ChangeProof, mirroring TestRangeProofSetFinalizerReset. Both
+// Database.ChangeProof and UnmarshalBinary register the Free finalizer, and Free
+// does not clear it, so a proof that reaches a finalizer-setting path twice (a
+// from-create proof re-loaded via UnmarshalBinary, or a repeated UnmarshalBinary)
+// fatally panicked with "finalizer already set". Each sequence must leave the
+// proof with exactly one finalizer.
+//
+// (VerifyChangeProof does not set a finalizer, so there is no verify variant, and
+// ChangeProof has no lease, so there is no lease-attach variant.)
+func TestChangeProofSetFinalizerReset(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	_, _, batch := kvForTest(100)
+	startRoot, err := db.Update(batch[:50])
+	r.NoError(err)
+	endRoot, err := db.Update(batch)
+	r.NoError(err)
+	proofBytes := newSerializedChangeProof(t, db, startRoot, endRoot, nothing(), nothing())
+
+	tests := []struct {
+		name string
+		// run performs a sequence that reaches a finalizer-setting path twice
+		// and returns the resulting proof for cleanup. It must not panic.
+		run func(*require.Assertions) *ChangeProof
+	}{
+		{"create_then_unmarshal", func(r *require.Assertions) *ChangeProof {
+			p, err := db.ChangeProof(startRoot, endRoot, nothing(), nothing(), changeProofLenUnbounded)
+			r.NoError(err)
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			return p
+		}},
+		{"unmarshal_then_unmarshal", func(r *require.Assertions) *ChangeProof {
+			p := new(ChangeProof)
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			return p
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			p := tt.run(r) // must not fatally panic with "finalizer already set"
+			t.Cleanup(func() { _ = p.Free() })
+		})
+	}
+}
+
+// TestChangeProofCodeHashesKeepsProofAlive is the ChangeProof analogue of
+// TestRangeProofCodeHashesKeepsProofAlive. The Rust code iterator borrows the
+// proof's data for its whole lifetime (CodeIteratorHandle<'p>), so
+// ChangeProof.CodeHashes must keep the proof alive across iteration; otherwise
+// the proof can be garbage-collected mid-iteration and its finalizer frees the
+// key-values the iterator is still reading. A runtime.AddCleanup canary detects
+// that condition directly.
+func TestChangeProofCodeHashesKeepsProofAlive(t *testing.T) {
+	r := require.New(t)
+	mode, err := inferHashingMode(t.Context())
+	r.NoError(err)
+	if mode != ethhashKey {
+		t.Skip("code hashes are only produced in ethhash mode")
+	}
+
+	db := newTestDatabase(t)
+	startRoot, err := db.Update([]BatchOp{Put([]byte("baseline"), []byte("v"))})
+	r.NoError(err)
+	key := [32]byte{0x12, 0x34, 0x56} // account key must be length 32
+	val, err := hex.DecodeString("f8440164a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
+	r.NoError(err)
+	endRoot, err := db.Update([]BatchOp{Put(key[:], val)})
+	r.NoError(err)
+	proofBytes := newSerializedChangeProof(t, db, startRoot, endRoot, nothing(), nothing())
+
+	collected := make(chan struct{})
+	// Build the iterator in a nested scope so the only remaining reference to the
+	// proof is the one captured by the CodeHashes closure.
+	seq := func() iter.Seq2[Hash, error] {
+		p := new(ChangeProof)
+		r.NoError(p.UnmarshalBinary(proofBytes)) // arms the Free finalizer
+		runtime.AddCleanup(p, func(struct{}) { close(collected) }, struct{}{})
+		return p.CodeHashes()
+	}()
+
+	for _, err := range seq {
+		r.NoError(err)
+		// Mid-iteration: try hard to reclaim the proof. If CodeHashes stopped
+		// referencing it after creating the iterator, it is collectible here.
+		for range 50 {
+			runtime.GC()
+			select {
+			case <-collected:
+				r.FailNow("ChangeProof was garbage-collected mid-iteration; CodeHashes must keep the proof alive while its borrowed iterator is live")
+			default:
+			}
+			runtime.Gosched()
+		}
+	}
+}
+
 func TestChangeProofEmptyDB(t *testing.T) {
 	r := require.New(t)
 	db := newTestDatabase(t)
@@ -748,7 +848,7 @@ func TestChangeProofDiffersAfterUpdate(t *testing.T) {
 	r.NotEqual(root1, root2)
 
 	// Get a proof
-	proof1 := newSerializedChangeProof(t, db, root1, root2, nothing(), nothing(), changeProofLenUnbounded)
+	proof1 := newSerializedChangeProof(t, db, root1, root2, nothing(), nothing())
 	r.NoError(err)
 
 	// Insert more data
@@ -757,7 +857,7 @@ func TestChangeProofDiffersAfterUpdate(t *testing.T) {
 	r.NotEqual(root2, root3)
 
 	// Get a proof again
-	proof2 := newSerializedChangeProof(t, db, root2, root3, nothing(), nothing(), changeProofLenUnbounded)
+	proof2 := newSerializedChangeProof(t, db, root2, root3, nothing(), nothing())
 	// Ensure the proofs are different
 	r.NotEqual(proof1, proof2)
 }
@@ -775,7 +875,7 @@ func TestRoundTripChangeProofSerialization(t *testing.T) {
 	r.NoError(err)
 
 	// get a proof
-	proofBytes := newSerializedChangeProof(t, db, root1, root2, nothing(), nothing(), changeProofLenUnbounded)
+	proofBytes := newSerializedChangeProof(t, db, root1, root2, nothing(), nothing())
 
 	// Deserialize the proof.
 	proof := new(ChangeProof)

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -721,33 +721,23 @@ func TestChangeProofSetFinalizerReset(t *testing.T) {
 	r.NoError(err)
 	proofBytes := newSerializedChangeProof(t, db, startRoot, endRoot, nothing(), nothing())
 
-	tests := []struct {
-		name string
-		// run performs a sequence that reaches a finalizer-setting path twice
-		// and returns the resulting proof for cleanup. It must not panic.
-		run func(*require.Assertions) *ChangeProof
-	}{
-		{"create_then_unmarshal", func(r *require.Assertions) *ChangeProof {
-			p, err := db.ChangeProof(startRoot, endRoot, nothing(), nothing(), changeProofLenUnbounded)
-			r.NoError(err)
-			r.NoError(p.UnmarshalBinary(proofBytes))
-			return p
-		}},
-		{"unmarshal_then_unmarshal", func(r *require.Assertions) *ChangeProof {
-			p := new(ChangeProof)
-			r.NoError(p.UnmarshalBinary(proofBytes))
-			r.NoError(p.UnmarshalBinary(proofBytes))
-			return p
-		}},
-	}
+	t.Run("create_then_unmarshal", func(t *testing.T) {
+		r := require.New(t)
+		p, err := db.ChangeProof(startRoot, endRoot, nothing(), nothing(), changeProofLenUnbounded)
+		r.NoError(err)
+		r.NoError(p.UnmarshalBinary(proofBytes))
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := require.New(t)
-			p := tt.run(r) // must not fatally panic with "finalizer already set"
-			t.Cleanup(func() { _ = p.Free() })
-		})
-	}
+		t.Cleanup(func() { _ = p.Free() })
+	})
+
+	t.Run("unmarshal_then_unmarshal", func(t *testing.T) {
+		r := require.New(t)
+		p := new(ChangeProof)
+		r.NoError(p.UnmarshalBinary(proofBytes))
+		r.NoError(p.UnmarshalBinary(proofBytes))
+
+		t.Cleanup(func() { _ = p.Free() })
+	})
 }
 
 // TestChangeProofCodeHashesKeepsProofAlive is the ChangeProof analogue of

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -100,11 +100,10 @@ func newSerializedChangeProof(
 	db *Database,
 	startRoot, endRoot Hash,
 	startKey, endKey maybe,
-	proofLen uint32,
 ) []byte {
 	r := require.New(t)
 
-	proof, err := db.ChangeProof(startRoot, endRoot, startKey, endKey, proofLen)
+	proof, err := db.ChangeProof(startRoot, endRoot, startKey, endKey, changeProofLenUnbounded)
 	r.NoError(err)
 
 	proofBytes, err := proof.MarshalBinary()
@@ -701,6 +700,105 @@ func TestRangeProofFinalizerCleanup(t *testing.T) {
 	r.NoError(db.Close(t.Context()), "Database should be closeable after proof is garbage collected")
 }
 
+// TestChangeProofSetFinalizerReset guards against a double-SetFinalizer panic on
+// ChangeProof, mirroring TestRangeProofSetFinalizerReset. Both
+// Database.ChangeProof and UnmarshalBinary register the Free finalizer, and Free
+// does not clear it, so a proof that reaches a finalizer-setting path twice (a
+// from-create proof re-loaded via UnmarshalBinary, or a repeated UnmarshalBinary)
+// fatally panicked with "finalizer already set". Each sequence must leave the
+// proof with exactly one finalizer.
+//
+// (VerifyChangeProof does not set a finalizer, so there is no verify variant, and
+// ChangeProof has no lease, so there is no lease-attach variant.)
+func TestChangeProofSetFinalizerReset(t *testing.T) {
+	r := require.New(t)
+	db := newTestDatabase(t)
+
+	_, _, batch := kvForTest(100)
+	startRoot, err := db.Update(batch[:50])
+	r.NoError(err)
+	endRoot, err := db.Update(batch)
+	r.NoError(err)
+	proofBytes := newSerializedChangeProof(t, db, startRoot, endRoot, nothing(), nothing())
+
+	tests := []struct {
+		name string
+		// run performs a sequence that reaches a finalizer-setting path twice
+		// and returns the resulting proof for cleanup. It must not panic.
+		run func(*require.Assertions) *ChangeProof
+	}{
+		{"create_then_unmarshal", func(r *require.Assertions) *ChangeProof {
+			p, err := db.ChangeProof(startRoot, endRoot, nothing(), nothing(), changeProofLenUnbounded)
+			r.NoError(err)
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			return p
+		}},
+		{"unmarshal_then_unmarshal", func(r *require.Assertions) *ChangeProof {
+			p := new(ChangeProof)
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			r.NoError(p.UnmarshalBinary(proofBytes))
+			return p
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			p := tt.run(r) // must not fatally panic with "finalizer already set"
+			t.Cleanup(func() { _ = p.Free() })
+		})
+	}
+}
+
+// TestChangeProofCodeHashesKeepsProofAlive is the ChangeProof analogue of
+// TestRangeProofCodeHashesKeepsProofAlive. The Rust code iterator borrows the
+// proof's data for its whole lifetime (CodeIteratorHandle<'p>), so
+// ChangeProof.CodeHashes must keep the proof alive across iteration; otherwise
+// the proof can be garbage-collected mid-iteration and its finalizer frees the
+// key-values the iterator is still reading. A runtime.AddCleanup canary detects
+// that condition directly.
+func TestChangeProofCodeHashesKeepsProofAlive(t *testing.T) {
+	r := require.New(t)
+	if selectedHashMode != ethhashKey {
+		t.Skip("code hashes are only produced in ethhash mode")
+	}
+
+	db := newTestDatabase(t)
+	startRoot, err := db.Update([]BatchOp{Put([]byte("baseline"), []byte("v"))})
+	r.NoError(err)
+	key := [32]byte{0x12, 0x34, 0x56} // account key must be length 32
+	val, err := hex.DecodeString("f8440164a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
+	r.NoError(err)
+	endRoot, err := db.Update([]BatchOp{Put(key[:], val)})
+	r.NoError(err)
+	proofBytes := newSerializedChangeProof(t, db, startRoot, endRoot, nothing(), nothing())
+
+	collected := make(chan struct{})
+	// Build the iterator in a nested scope so the only remaining reference to the
+	// proof is the one captured by the CodeHashes closure.
+	seq := func() iter.Seq2[Hash, error] {
+		p := new(ChangeProof)
+		r.NoError(p.UnmarshalBinary(proofBytes)) // arms the Free finalizer
+		runtime.AddCleanup(p, func(struct{}) { close(collected) }, struct{}{})
+		return p.CodeHashes()
+	}()
+
+	for _, err := range seq {
+		r.NoError(err)
+		// Mid-iteration: try hard to reclaim the proof. If CodeHashes stopped
+		// referencing it after creating the iterator, it is collectible here.
+		for range 50 {
+			runtime.GC()
+			select {
+			case <-collected:
+				r.FailNow("ChangeProof was garbage-collected mid-iteration; CodeHashes must keep the proof alive while its borrowed iterator is live")
+			default:
+			}
+			runtime.Gosched()
+		}
+	}
+}
+
 func TestChangeProofEmptyDB(t *testing.T) {
 	r := require.New(t)
 	db := newTestDatabase(t)
@@ -742,7 +840,7 @@ func TestChangeProofDiffersAfterUpdate(t *testing.T) {
 	r.NotEqual(root1, root2)
 
 	// Get a proof
-	proof1 := newSerializedChangeProof(t, db, root1, root2, nothing(), nothing(), changeProofLenUnbounded)
+	proof1 := newSerializedChangeProof(t, db, root1, root2, nothing(), nothing())
 	r.NoError(err)
 
 	// Insert more data
@@ -751,7 +849,7 @@ func TestChangeProofDiffersAfterUpdate(t *testing.T) {
 	r.NotEqual(root2, root3)
 
 	// Get a proof again
-	proof2 := newSerializedChangeProof(t, db, root2, root3, nothing(), nothing(), changeProofLenUnbounded)
+	proof2 := newSerializedChangeProof(t, db, root2, root3, nothing(), nothing())
 	// Ensure the proofs are different
 	r.NotEqual(proof1, proof2)
 }
@@ -769,7 +867,7 @@ func TestRoundTripChangeProofSerialization(t *testing.T) {
 	r.NoError(err)
 
 	// get a proof
-	proofBytes := newSerializedChangeProof(t, db, root1, root2, nothing(), nothing(), changeProofLenUnbounded)
+	proofBytes := newSerializedChangeProof(t, db, root1, root2, nothing(), nothing())
 
 	// Deserialize the proof.
 	proof := new(ChangeProof)


### PR DESCRIPTION
## Why this should be merged

`ChangeProof` carries the same lifetime bugs `RangeProof` had (#2140–#2143) with
none of the guards:

- **Double `SetFinalizer` panic.** `Database.ChangeProof` and `UnmarshalBinary`
  both register `Free`, and `Free` doesn't clear it, so `create` →
  `UnmarshalBinary` (or `UnmarshalBinary` twice) reaches
  `fatal error: runtime.SetFinalizer: finalizer already set`.
- **Finalizer use-after-free** in `FindNextKey`, `MarshalBinary`, and
  `CodeHashes` — the receiver is dead once its handle has been read into the cgo
  call, and for `CodeHashes` the Rust iterator borrows the proof's data for its
  whole lifetime.

## Notes

Per #1978 and the existing `ChangeProof.Free` doc, `ChangeProof` deliberately
holds no database reference, so every fix here is `runtime.KeepAlive` rather
than a lease read-lock. **No database handle is introduced** and no struct field
is added — `ChangeProof` stays pure proof data. That is the one place this
diverges from the `RangeProof` fixes it otherwise mirrors.

`FindNextKey` and `MarshalBinary` get the keepalive but no dedicated regression
test: a single fast cgo call leaves no forceable window for the finalizer, and
with no lock involved there is no data race for `-race` to catch. Concurrently
calling `Free` during a call or iteration remains unsupported, as elsewhere.

The `proofLen` parameter drop in `newSerializedChangeProof` isn't cleanup for its
own sake — `unparam` flags it once the new callers land.

## Breaking Changes

None — internal lifetime fixes; public C and Go APIs and behavior unchanged.
