### PR TITLE
fix(proofs)!: store ProofNode.child_hashes as DenseChildren

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,6 +1807,7 @@ name = "firewood"
 version = "0.8.0"
 dependencies = [
  "aquamarine",
+ "arity-arrays",
  "bytemuck",
  "bytemuck_derive",
  "clap",

--- a/firewood/Cargo.toml
+++ b/firewood/Cargo.toml
@@ -35,6 +35,7 @@ hex.workspace = true
 integer-encoding.workspace = true
 thiserror.workspace = true
 # Regular dependencies
+arity-arrays = { version = "0.2.0", default-features = false, features = ["16"] }
 typed-builder = "0.23.2"
 rayon = "1.12.0"
 parking_lot.workspace = true
@@ -80,6 +81,11 @@ required-features = ["test_utils"]
 
 [[bench]]
 name = "defer_persist"
+harness = false
+required-features = ["test_utils"]
+
+[[bench]]
+name = "proofs"
 harness = false
 required-features = ["test_utils"]
 

--- a/firewood/benches/proofs.rs
+++ b/firewood/benches/proofs.rs
@@ -1,0 +1,78 @@
+// Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+//! Proof generation and verification throughput.
+//!
+//! Builds a hashed in-memory 16-ary trie of 1000 random 32-byte keys (so branch
+//! nodes near the root are densely populated) and benchmarks single-key and range
+//! proof generation and verification. Guards the `ProofNode.child_hashes`
+//! representation change against throughput regressions.
+
+use std::iter::repeat_with;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use firewood::Merkle;
+use firewood::api::DbView as _;
+use firewood::verify_range_proof_structure;
+use firewood_storage::{DeletedNodeTracking, MemStore, NodeStore, SeededRng};
+use rand::{RngExt, distr::Alphanumeric};
+
+#[expect(clippy::unwrap_used, clippy::indexing_slicing)]
+fn bench_proofs(criterion: &mut Criterion) {
+    // Fixture: 1000 random 32-byte keys, 1-byte values, hashed and frozen.
+    let rng = &SeededRng::from_option(Some(1234));
+    let store = Arc::new(MemStore::default());
+    let nodestore = NodeStore::new_empty_proposal(store, DeletedNodeTracking::Enabled);
+    let mut merkle = Merkle::from(nodestore);
+
+    let mut keys: Vec<Vec<u8>> =
+        repeat_with(|| rng.sample_iter(&Alphanumeric).take(32).collect::<Vec<u8>>())
+            .take(1000)
+            .collect();
+    keys.sort();
+    keys.dedup();
+    for key in &keys {
+        merkle.insert(key, Box::new(*b"v")).unwrap();
+    }
+
+    let frozen = merkle.hash();
+    let view = frozen.nodestore();
+    let root_hash = view.root_hash().expect("a non-empty trie has a root hash");
+
+    let first = keys.first().expect("at least one key").as_slice();
+    let last = keys.last().expect("at least one key").as_slice();
+    let mid = keys[keys.len() / 2].as_slice();
+    let limit = NonZeroUsize::new(500);
+
+    let mut group = criterion.benchmark_group("Proofs");
+    group.sample_size(30);
+
+    group.bench_function("single_key_proof/generate", |b| {
+        b.iter(|| view.single_key_proof(mid).unwrap());
+    });
+    group.bench_function("single_key_proof/verify", |b| {
+        let proof = view.single_key_proof(mid).unwrap();
+        b.iter(|| {
+            proof
+                .verify(mid, Some(b"v".as_slice()), &root_hash)
+                .unwrap();
+        });
+    });
+    group.bench_function("range_proof/generate", |b| {
+        b.iter(|| view.range_proof(Some(first), Some(last), limit).unwrap());
+    });
+    group.bench_function("range_proof/verify", |b| {
+        let proof = view.range_proof(Some(first), Some(last), limit).unwrap();
+        b.iter(|| {
+            verify_range_proof_structure(&proof, root_hash.clone(), Some(first), Some(last), limit)
+                .unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_proofs);
+criterion_main!(benches);

--- a/firewood/src/eth_proof.rs
+++ b/firewood/src/eth_proof.rs
@@ -385,10 +385,7 @@ fn fetch_only_storage_child<V>(
 where
     V: DbView + ?Sized,
 {
-    let Some((nibble, _)) = (&account_node.child_hashes)
-        .into_iter()
-        .find(|(_, c)| c.is_some())
-    else {
+    let Some((nibble, _)) = account_node.child_hashes.iter_present().next() else {
         return Ok(None);
     };
 

--- a/firewood/src/merkle/childmask.rs
+++ b/firewood/src/merkle/childmask.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use firewood_storage::{Children, PathComponent, U4};
+use firewood_storage::{PathComponent, U4};
 
 /// Compact u16 bitmap for tracking which of a branch node's 16 children
 /// are present or "outside" the proven range.
@@ -38,14 +38,6 @@ impl ChildMask {
     /// Sets the bit at `nibble`, returning the updated mask.
     pub(crate) const fn set(self, nibble: U4) -> Self {
         Self(self.0 | 1u16.wrapping_shl(nibble.as_u8() as u32))
-    }
-
-    /// Create a new `ChildMask` from the given children array, setting a bit
-    /// for each child that is `Some`.
-    pub(crate) fn from_children<T>(children: &Children<Option<T>>) -> Self {
-        Self(children.iter_present().fold(0, |bits, (i, _)| {
-            bits | 1u16.wrapping_shl(u32::from(i.as_u8()))
-        }))
     }
 
     /// Iterates over the indices of all set bits, yielding `PathComponent`s.
@@ -206,33 +198,6 @@ mod tests {
         assert!(!mask.is_set(u4(1)));
         assert!(mask.is_set(u4(4)));
         assert!(mask.is_set(u4(15)));
-    }
-
-    #[test]
-    fn child_mask_from_children_empty() {
-        let children: Children<Option<()>> = Children::new();
-        let mask = ChildMask::from_children(&children);
-        assert_eq!(mask.0, 0);
-    }
-
-    #[test]
-    fn child_mask_from_children_some() {
-        let mut children: Children<Option<()>> = Children::new();
-        children[PathComponent::ALL[0]] = Some(());
-        children[PathComponent::ALL[5]] = Some(());
-        children[PathComponent::ALL[15]] = Some(());
-        let mask = ChildMask::from_children(&children);
-        assert!(mask.is_set(u4(0)));
-        assert!(!mask.is_set(u4(1)));
-        assert!(mask.is_set(u4(5)));
-        assert!(mask.is_set(u4(15)));
-    }
-
-    #[test]
-    fn child_mask_from_children_all() {
-        let children: Children<Option<()>> = Children::from_fn(|_| Some(()));
-        let mask = ChildMask::from_children(&children);
-        assert_eq!(mask, ChildMask::ALL);
     }
 
     #[test]

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -517,7 +517,8 @@ fn build_branch_parts<'b>(
 
     // For children outside the proven range, use proof node hashes.
     if let (Some(pn), Some(outside)) = (proof_node, outside_mask) {
-        for (nibble, hash) in pn.child_hashes.iter_present() {
+        for (index, hash) in pn.child_hashes.iter_present() {
+            let nibble = PathComponent(index);
             if outside.is_set(nibble.0) {
                 child_hashes[nibble] = Some(hash.clone());
             }
@@ -572,7 +573,8 @@ fn single_effective_account_child(
     }
     // Out-of-range children, taken from the proof node.
     if let (Some(pn), Some(mask)) = (proof_node, outside_mask) {
-        for (nibble, _) in pn.child_hashes.iter_present() {
+        for (index, _) in pn.child_hashes.iter_present() {
+            let nibble = PathComponent(index);
             if mask.is_set(nibble.0) {
                 if only_child.is_some() {
                     return None;

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -519,7 +519,8 @@ fn build_branch_parts<'b>(
 
     // For children outside the proven range, use proof node hashes.
     if let (Some(pn), Some(outside)) = (proof_node, outside_mask) {
-        for (nibble, hash) in pn.child_hashes.iter_present() {
+        for (index, hash) in pn.child_hashes.iter_present() {
+            let nibble = PathComponent(index);
             if outside.is_set(nibble.0) {
                 child_hashes[nibble] = Some(hash.clone());
             }
@@ -574,7 +575,8 @@ fn single_effective_account_child(
     }
     // Out-of-range children, taken from the proof node.
     if let (Some(pn), Some(mask)) = (proof_node, outside_mask) {
-        for (nibble, _) in pn.child_hashes.iter_present() {
+        for (index, _) in pn.child_hashes.iter_present() {
+            let nibble = PathComponent(index);
             if mask.is_set(nibble.0) {
                 if only_child.is_some() {
                     return None;

--- a/firewood/src/merkle/tests/change/attack.rs
+++ b/firewood/src/merkle/tests/change/attack.rs
@@ -388,8 +388,9 @@ fn test_crafted_conflicting_proof_nodes_rejected() {
     let root_node = &mut end_nodes[0];
     let child_hash = root_node
         .child_hashes
-        .iter_mut()
-        .find_map(|(_, h)| h.as_mut())
+        .iter_present_mut()
+        .next()
+        .map(|(_, h)| h)
         .expect("root node should have at least one child hash");
     let bytes: [u8; 32] = child_hash.clone().into_triehash().into();
     let mut new_bytes = bytes;
@@ -617,7 +618,7 @@ fn test_crafted_stripped_divergent_child_rejected() {
         .expect("should have a proof node at [1, 0, 5]");
 
     let nibble_8 = firewood_storage::PathComponent::try_new(8).unwrap();
-    start_nodes[branch_idx].child_hashes[nibble_8] = None;
+    start_nodes[branch_idx].child_hashes.remove(nibble_8.0);
 
     let crafted = FrozenChangeProof::new(
         crate::Proof::new(start_nodes.into_boxed_slice()),

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -20,7 +20,7 @@ use std::fmt::Write;
 use super::*;
 use crate::{ProofError, ProofNode};
 use firewood_storage::{
-    Children, Committed, DeletedNodeTracking, MemStore, Mutable, NodeHashAlgorithm, NodeStore,
+    Committed, DeletedNodeTracking, DenseChildren, MemStore, Mutable, NodeHashAlgorithm, NodeStore,
     NodeStoreHeader, PathComponent, Propose, RootReader, TrieHash, ValueDigest,
 };
 
@@ -222,7 +222,7 @@ fn test_branch_proof_node(
         key,
         partial_len: 0,
         value_digest,
-        child_hashes: Children::new(),
+        child_hashes: DenseChildren::new(),
     }
 }
 

--- a/firewood/src/merkle/tests/proof.rs
+++ b/firewood/src/merkle/tests/proof.rs
@@ -269,7 +269,7 @@ fn proof_path_construction_and_corruption() {
     let mut corrupt: Proof<Vec<ProofNode>> = proof.clone().into_mutable();
     if let Some(first) = (*corrupt).first_mut() {
         // Set all child hashes to empty so traversal fails
-        first.child_hashes = Children::new();
+        first.child_hashes = DenseChildren::new();
     }
     let corrupt = corrupt.into_immutable();
     let err = corrupt

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -21,7 +21,7 @@ fn proof_node(nibbles: &[u8]) -> ProofNode {
         key: nibble_path(nibbles),
         partial_len: 0,
         value_digest: None,
-        child_hashes: Children::new(),
+        child_hashes: DenseChildren::new(),
     }
 }
 

--- a/firewood/src/proofs/de.rs
+++ b/firewood/src/proofs/de.rs
@@ -19,9 +19,7 @@ use crate::{
     merkle::{Key, Value},
     proofs::magic::{BATCH_DELETE, BATCH_DELETE_RANGE, BATCH_PUT},
 };
-#[cfg(feature = "ethhash")]
-use firewood_storage::HashType;
-use firewood_storage::{Children, PathBuf, TrieHash, TriePathFromUnpackedBytes, ValueDigest};
+use firewood_storage::{HashType, PathBuf, TrieHash, TriePathFromUnpackedBytes, ValueDigest};
 use integer_encoding::VarInt;
 use std::num::NonZeroUsize;
 
@@ -194,10 +192,12 @@ impl Version0 for ProofNode {
 
         let children_map = reader.read_item::<ChildMask>()?;
 
-        let mut child_hashes = Children::new();
+        let mut child_hashes =
+            arity_arrays::FixedArray::<Option<HashType>, arity_arrays::Arity16>::new();
         for idx in children_map.iter_indices() {
-            child_hashes[idx] = Some(reader.read_item()?);
+            child_hashes.replace(idx.0, Some(reader.read_item()?));
         }
+        let child_hashes = firewood_storage::DenseChildren::from(child_hashes);
 
         Ok(ProofNode {
             key,

--- a/firewood/src/proofs/eth.rs
+++ b/firewood/src/proofs/eth.rs
@@ -106,8 +106,8 @@ pub fn proof_node_to_mpt_rlp(node: &ProofNode) -> SmallVec<[Box<[u8]>; 2]> {
     // Branch (has children).
     let mut items: [RlpItem<'_>; BranchNode::MAX_CHILDREN + 1] =
         [RlpItem::Empty; BranchNode::MAX_CHILDREN + 1];
-    for ((_, child), slot) in (&node.child_hashes).into_iter().zip(items.iter_mut()) {
-        *slot = proof_child_rlp_item(child.as_ref());
+    for ((_, child), slot) in node.child_hashes.iter().zip(items.iter_mut()) {
+        *slot = proof_child_rlp_item(child);
     }
     // The 17th element is the value. Account nodes carry their value in
     // account RLP that gets spliced in below, not in the branch slot.
@@ -125,8 +125,11 @@ pub fn proof_node_to_mpt_rlp(node: &ProofNode) -> SmallVec<[Box<[u8]>; 2]> {
     // hasher hashed.
     let inner_bytes: Box<[u8]> = if is_account {
         match value_bytes {
-            Some(v) => fix_account_storage_root_value(v, &node.child_hashes)
-                .unwrap_or_else(|| Box::from(v)),
+            Some(v) => fix_account_storage_root_value(
+                v,
+                &firewood_storage::children_from_dense(&node.child_hashes),
+            )
+            .unwrap_or_else(|| Box::from(v)),
             None => branch_bytes,
         }
     } else {
@@ -186,11 +189,8 @@ pub fn account_storage_root_rlp(account_node: &ProofNode) -> Option<Box<[u8]>> {
     }
     let mut items: [RlpItem<'_>; BranchNode::MAX_CHILDREN + 1] =
         [RlpItem::Empty; BranchNode::MAX_CHILDREN + 1];
-    for ((_, child), slot) in (&account_node.child_hashes)
-        .into_iter()
-        .zip(items.iter_mut())
-    {
-        *slot = proof_child_rlp_item(child.as_ref());
+    for ((_, child), slot) in account_node.child_hashes.iter().zip(items.iter_mut()) {
+        *slot = proof_child_rlp_item(child);
     }
     // The 17th slot stays empty: at the storage trie root there is no value.
     Some(encode_list(&items))
@@ -297,7 +297,9 @@ fn proof_child_rlp_item(child: Option<&HashType>) -> RlpItem<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use firewood_storage::{IntoHashType, PathBuf, RlpList, TrieHash, TriePathFromUnpackedBytes};
+    use firewood_storage::{
+        DenseChildren, IntoHashType, PathBuf, RlpList, TrieHash, TriePathFromUnpackedBytes,
+    };
 
     fn pathbuf_from_nibbles(nibbles: &[u8]) -> PathBuf {
         let components =
@@ -310,7 +312,7 @@ mod tests {
             key: pathbuf_from_nibbles(nibbles),
             partial_len: 0,
             value_digest: Some(ValueDigest::Value(value.into())),
-            child_hashes: Children::new(),
+            child_hashes: DenseChildren::new(),
         }
     }
 
@@ -331,7 +333,7 @@ mod tests {
             key: pathbuf_from_nibbles(&[1, 2]),
             partial_len: 0,
             value_digest: None,
-            child_hashes: Children::new(),
+            child_hashes: DenseChildren::new(),
         };
         let bytes = proof_node_to_mpt_rlp(&node);
         assert_eq!(bytes.len(), 1);
@@ -352,8 +354,8 @@ mod tests {
     fn branch_empty_partial_path_emits_seventeen_field_list() {
         // Branch with one 32-byte hash child at index 7, no value, empty
         // partial path. Expected output: a single 17-element RLP list.
-        let mut children: Children<Option<HashType>> = Children::new();
-        children.replace(PathComponent::ALL[7], Some(hash_child(0xAB)));
+        let mut children = DenseChildren::new();
+        children.insert(PathComponent::ALL[7].0, hash_child(0xAB));
         let node = ProofNode {
             key: pathbuf_from_nibbles(&[]),
             partial_len: 0,
@@ -381,8 +383,8 @@ mod tests {
         // Non-account branch with non-empty partial path; the 17-element
         // branch RLP exceeds 31 bytes, so the verifier needs both the
         // inner branch and an outer extension that hash-references it.
-        let mut children: Children<Option<HashType>> = Children::new();
-        children.replace(PathComponent::ALL[3], Some(hash_child(0xCD)));
+        let mut children = DenseChildren::new();
+        children.insert(PathComponent::ALL[3].0, hash_child(0xCD));
         let node = ProofNode {
             key: pathbuf_from_nibbles(&[5, 6, 7]),
             partial_len: 0,

--- a/firewood/src/proofs/ser.rs
+++ b/firewood/src/proofs/ser.rs
@@ -151,7 +151,7 @@ impl WriteItem for ProofNode {
         self.key.write_item(out);
         out.push_var_int(self.partial_len);
         self.value_digest.write_item(out);
-        ChildMask::from_children(&self.child_hashes).write_item(out);
+        out.extend_from_slice(&self.child_hashes.bitmap().to_le_bytes());
         for (_, child) in self.child_hashes.iter_present() {
             child.write_item(out);
         }

--- a/firewood/src/proofs/snapshot_tests.rs
+++ b/firewood/src/proofs/snapshot_tests.rs
@@ -74,7 +74,7 @@
 
 use test_case::test_case;
 
-use firewood_storage::{Children, IntoHashType, PathComponent, TrieHash, ValueDigest};
+use firewood_storage::{DenseChildren, IntoHashType, PathComponent, TrieHash, ValueDigest};
 
 use super::types::{Proof, ProofNode};
 use crate::api::{FrozenChangeProof, FrozenRangeProof};
@@ -124,10 +124,12 @@ fn make_node(
         .iter()
         .map(|&n| PathComponent::try_new(n).unwrap())
         .collect();
-    let mut child_hashes = Children::new();
+    let mut child_hashes = DenseChildren::new();
     for &nibble in child_nibbles {
-        child_hashes[PathComponent::try_new(nibble).unwrap()] =
-            Some(TrieHash::from([0u8; 32]).into_hash_type());
+        child_hashes.insert(
+            PathComponent::try_new(nibble).unwrap().0,
+            TrieHash::from([0u8; 32]).into_hash_type(),
+        );
     }
     ProofNode {
         key,

--- a/firewood/src/proofs/tests.rs
+++ b/firewood/src/proofs/tests.rs
@@ -5,7 +5,7 @@ use integer_encoding::VarInt;
 use test_case::test_case;
 
 use firewood_storage::{
-    Children, IntoHashType, PathComponent, SeededRng, TrieHash, ValueDigest, logger::debug,
+    DenseChildren, IntoHashType, PathComponent, SeededRng, TrieHash, ValueDigest, logger::debug,
 };
 
 use super::{
@@ -471,10 +471,12 @@ fn make_proof_node(
         .iter()
         .map(|&n| PathComponent::try_new(n).unwrap())
         .collect();
-    let mut child_hashes = Children::new();
+    let mut child_hashes = DenseChildren::new();
     for &nibble in child_nibbles {
-        child_hashes[PathComponent::try_new(nibble).unwrap()] =
-            Some(TrieHash::from([0u8; 32]).into_hash_type());
+        child_hashes.insert(
+            PathComponent::try_new(nibble).unwrap().0,
+            TrieHash::from([0u8; 32]).into_hash_type(),
+        );
     }
     ProofNode {
         key,
@@ -773,11 +775,13 @@ fn generate_random_proof_node(rng: &SeededRng) -> ProofNode {
         let value: Box<[u8]> = (0..val_len).map(|_| rng.random::<u8>()).collect();
         ValueDigest::Value(value)
     });
-    let mut child_hashes = Children::new();
+    let mut child_hashes = DenseChildren::new();
     for nibble in 0u8..16 {
         if rng.random::<bool>() {
-            child_hashes[PathComponent::try_new(nibble).unwrap()] =
-                Some(TrieHash::from(rng.random::<[u8; 32]>()).into_hash_type());
+            child_hashes.insert(
+                PathComponent::try_new(nibble).unwrap().0,
+                TrieHash::from(rng.random::<[u8; 32]>()).into_hash_type(),
+            );
         }
     }
     ProofNode {

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -50,9 +50,9 @@
 use crate::proofs::eth::ACCOUNT_DEPTH_NIBBLES;
 use firewood_storage::hash_node_as_storage_trie_root_parts;
 use firewood_storage::{
-    Children, FileIoError, HashType, Hashable, IntoHashType, IntoSplitPath, NibblesIterator, Path,
-    PathBuf, PathComponent, PathIterItem, Preimage, RlpError, SplitPath, TrieHash, TriePath,
-    ValueDigest,
+    Children, DenseChildren, FileIoError, HashType, Hashable, IntoHashType, IntoSplitPath,
+    NibblesIterator, Path, PathBuf, PathComponent, PathIterItem, Preimage, RlpError, SplitPath,
+    TrieHash, TriePath, ValueDigest,
 };
 use thiserror::Error;
 
@@ -310,7 +310,7 @@ pub struct ProofNode {
     /// Otherwise, the node's value or the hash of its value.
     pub value_digest: Option<ValueDigest<Value>>,
     /// The hash of each child, or None if the child does not exist.
-    pub child_hashes: Children<Option<HashType>>,
+    pub child_hashes: DenseChildren<HashType>,
 }
 
 impl std::fmt::Debug for ProofNode {
@@ -373,7 +373,7 @@ impl Hashable for ProofNode {
     }
 
     fn children(&self) -> Children<Option<HashType>> {
-        self.child_hashes.clone()
+        firewood_storage::children_from_dense(&self.child_hashes)
     }
 }
 
@@ -429,7 +429,7 @@ impl From<PathIterItem> for ProofNode {
             key: item.key_nibbles,
             partial_len,
             value_digest,
-            child_hashes,
+            child_hashes: firewood_storage::dense_from_children(&child_hashes),
         }
     }
 }
@@ -853,7 +853,7 @@ mod tests {
         nibbles: &[u8],
         parent_prefix_len: usize,
         value: Option<&[u8]>,
-        child_hashes: Children<Option<HashType>>,
+        child_hashes: DenseChildren<HashType>,
     ) -> ProofNode {
         let key: PathBuf = nibbles
             .iter()
@@ -883,10 +883,10 @@ mod tests {
         let mut child_nibbles = account_nibbles.clone();
         child_nibbles.push(1); // branch nibble
         child_nibbles.extend([0u8; 63]);
-        let storage_child = make_node(&child_nibbles, 0, Some(b"v"), Children::new());
+        let storage_child = make_node(&child_nibbles, 0, Some(b"v"), DenseChildren::new());
 
-        let mut account_children: Children<Option<HashType>> = Children::new();
-        account_children[PathComponent(U4::new_masked(1))] = Some(HashType::from([0xABu8; 32]));
+        let mut account_children = DenseChildren::new();
+        account_children.insert(U4::new_masked(1), HashType::from([0xABu8; 32]));
         let account = make_node(&account_nibbles, 0, None, account_children);
         let root_hash: TrieHash = account.to_hash().into_triehash();
 
@@ -909,14 +909,16 @@ mod tests {
     #[test]
     fn proof_for_wrong_branch_is_rejected() {
         // Leaf at nibble path [3, 0] with a value.
-        let leaf = make_node(&[3, 0], 1, Some(b"val_b"), Children::new());
+        let leaf = make_node(&[3, 0], 1, Some(b"val_b"), DenseChildren::new());
         let leaf_hash = leaf.to_hash();
 
         // Root branch with children at nibbles 3 and 5.
-        let mut root_children: Children<Option<HashType>> = Children::new();
-        root_children[PathComponent(firewood_storage::U4::new_masked(3))] = Some(leaf_hash);
-        root_children[PathComponent(firewood_storage::U4::new_masked(5))] =
-            Some(HashType::from([0xCC; 32]));
+        let mut root_children = DenseChildren::new();
+        root_children.insert(firewood_storage::U4::new_masked(3), leaf_hash);
+        root_children.insert(
+            firewood_storage::U4::new_masked(5),
+            HashType::from([0xCC; 32]),
+        );
         let root = make_node(&[], 0, None, root_children);
         let root_hash: TrieHash = root.to_hash().into_triehash();
 

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -50,9 +50,9 @@
 use crate::proofs::eth::ACCOUNT_DEPTH_NIBBLES;
 use firewood_storage::hash_node_as_storage_trie_root_parts;
 use firewood_storage::{
-    Children, DefaultHashMode, FileIoError, HashMode, HashType, Hashable, IntoHashType,
-    IntoSplitPath, NibblesIterator, Path, PathBuf, PathComponent, PathIterItem, Preimage, RlpError,
-    SplitPath, TrieHash, TriePath, ValueDigest,
+    Children, DefaultHashMode, DenseChildren, FileIoError, HashMode, HashType, Hashable,
+    IntoHashType, IntoSplitPath, NibblesIterator, Path, PathBuf, PathComponent, PathIterItem,
+    Preimage, RlpError, SplitPath, TrieHash, TriePath, ValueDigest,
 };
 use thiserror::Error;
 
@@ -288,7 +288,7 @@ pub enum ProofError {
     #[error("missing end proof: end_key is set or batch_ops is non-empty")]
     MissingEndProof,
 
-    /// Proof node is unreachable in the proving trie during collapse                                                 
+    /// Proof node is unreachable in the proving trie during collapse
     #[error("proof node unreachable in proving trie")]
     ProofNodeUnreachable,
 
@@ -310,7 +310,7 @@ pub struct ProofNode {
     /// Otherwise, the node's value or the hash of its value.
     pub value_digest: Option<ValueDigest<Value>>,
     /// The hash of each child, or None if the child does not exist.
-    pub child_hashes: Children<Option<HashType>>,
+    pub child_hashes: DenseChildren<HashType>,
 }
 
 impl std::fmt::Debug for ProofNode {
@@ -373,7 +373,7 @@ impl Hashable for ProofNode {
     }
 
     fn children(&self) -> Children<Option<HashType>> {
-        self.child_hashes.clone()
+        firewood_storage::children_from_dense(&self.child_hashes)
     }
 }
 
@@ -429,7 +429,7 @@ impl From<PathIterItem> for ProofNode {
             key: item.key_nibbles,
             partial_len,
             value_digest,
-            child_hashes,
+            child_hashes: firewood_storage::dense_from_children(&child_hashes),
         }
     }
 }
@@ -853,7 +853,7 @@ mod tests {
         nibbles: &[u8],
         parent_prefix_len: usize,
         value: Option<&[u8]>,
-        child_hashes: Children<Option<HashType>>,
+        child_hashes: DenseChildren<HashType>,
     ) -> ProofNode {
         let key: PathBuf = nibbles
             .iter()
@@ -883,10 +883,10 @@ mod tests {
         let mut child_nibbles = account_nibbles.clone();
         child_nibbles.push(1); // branch nibble
         child_nibbles.extend([0u8; 63]);
-        let storage_child = make_node(&child_nibbles, 0, Some(b"v"), Children::new());
+        let storage_child = make_node(&child_nibbles, 0, Some(b"v"), DenseChildren::new());
 
-        let mut account_children: Children<Option<HashType>> = Children::new();
-        account_children[PathComponent(U4::new_masked(1))] = Some(HashType::from([0xABu8; 32]));
+        let mut account_children = DenseChildren::new();
+        account_children.insert(U4::new_masked(1), HashType::from([0xABu8; 32]));
         let account = make_node(&account_nibbles, 0, None, account_children);
         let root_hash: TrieHash = account.to_hash().into_triehash();
 
@@ -909,14 +909,16 @@ mod tests {
     #[test]
     fn proof_for_wrong_branch_is_rejected() {
         // Leaf at nibble path [3, 0] with a value.
-        let leaf = make_node(&[3, 0], 1, Some(b"val_b"), Children::new());
+        let leaf = make_node(&[3, 0], 1, Some(b"val_b"), DenseChildren::new());
         let leaf_hash = leaf.to_hash();
 
         // Root branch with children at nibbles 3 and 5.
-        let mut root_children: Children<Option<HashType>> = Children::new();
-        root_children[PathComponent(firewood_storage::U4::new_masked(3))] = Some(leaf_hash);
-        root_children[PathComponent(firewood_storage::U4::new_masked(5))] =
-            Some(HashType::from([0xCC; 32]));
+        let mut root_children = DenseChildren::new();
+        root_children.insert(firewood_storage::U4::new_masked(3), leaf_hash);
+        root_children.insert(
+            firewood_storage::U4::new_masked(5),
+            HashType::from([0xCC; 32]),
+        );
         let root = make_node(&[], 0, None, root_children);
         let root_hash: TrieHash = root.to_hash().into_triehash();
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -62,7 +62,10 @@ pub use hashedshunt::HashableShunt;
 pub use hashtype::{HashType, IntoHashType, InvalidTrieHashLength, TrieHash};
 pub use linear::{FileIoError, ReadableStorage, WritableStorage};
 pub use node::path::{NibblesIterator, Path};
-pub use node::{BranchNode, Child, Children, ChildrenSlots, LeafNode, Node, PathIterItem};
+pub use node::{
+    BranchNode, Child, Children, ChildrenSlots, DenseChildren, LeafNode, Node, PathIterItem,
+    children_from_dense, dense_from_children,
+};
 pub use nodestore::{
     AreaIndex, Committed, CommittedId, CommittedParentHash, DeletedNodeTracking, HashedNodeReader,
     ImmutableProposal, LinearAddress, Mutable, MutableKind, NodeHashAlgorithm,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -64,7 +64,10 @@ pub use hashmode::{DefaultHashMode, EthHash, HashMode, MerkleDbHash};
 pub use hashtype::{HashType, IntoHashType, InvalidTrieHashLength, TrieHash};
 pub use linear::{FileIoError, ReadableStorage, WritableStorage};
 pub use node::path::{NibblesIterator, Path};
-pub use node::{BranchNode, Child, Children, ChildrenSlots, LeafNode, Node, PathIterItem};
+pub use node::{
+    BranchNode, Child, Children, ChildrenSlots, DenseChildren, LeafNode, Node, PathIterItem,
+    children_from_dense, dense_from_children,
+};
 pub use nodestore::{
     AreaIndex, Committed, CommittedId, CommittedParentHash, DeletedNodeTracking, HashedNodeReader,
     ImmutableProposal, LinearAddress, Mutable, MutableKind, NodeHashAlgorithm,

--- a/storage/src/node/children.rs
+++ b/storage/src/node/children.rs
@@ -1,6 +1,8 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use arity_arrays::{Arity16, PackedArray};
+
 use crate::PathComponent;
 
 const MAX_CHILDREN: usize = PathComponent::LEN;
@@ -248,5 +250,60 @@ impl<'a, T: 'a> IntoIterator for &'a mut Children<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.each_mut().into_iter()
+    }
+}
+
+/// A pointer-sized, present-only container of a branch node's children, sized to
+/// exactly the children that exist (zero heap when empty). Backed by
+/// [`arity_arrays::PackedArray`], indexed by [`crate::U4`].
+pub type DenseChildren<T> = PackedArray<T, Arity16>;
+
+/// Builds a [`DenseChildren`] holding only the present (`Some`) entries of
+/// `children`, cloning each present value.
+#[must_use]
+pub fn dense_from_children<T: Clone>(children: &Children<Option<T>>) -> DenseChildren<T> {
+    children
+        .iter_present()
+        .map(|(pc, value)| (pc.0, value.clone()))
+        .collect()
+}
+
+/// Expands a [`DenseChildren`] back into a full 16-slot [`Children`], cloning each
+/// present value; absent slots become `None`.
+#[must_use]
+pub fn children_from_dense<T: Clone>(dense: &DenseChildren<T>) -> Children<Option<T>> {
+    let mut children = Children::new();
+    for (index, value) in dense.iter_present() {
+        children[PathComponent(index)] = Some(value.clone());
+    }
+    children
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dense_children_round_trips_with_children() {
+        // Children -> DenseChildren -> Children is the identity on present slots.
+        let mut c: Children<Option<u32>> = Children::new();
+        c[PathComponent::ALL[1]] = Some(10);
+        c[PathComponent::ALL[9]] = Some(90);
+        c[PathComponent::ALL[15]] = Some(150);
+
+        let dense = dense_from_children(&c);
+        assert_eq!(dense.count(), 3);
+        assert_eq!(dense.get(PathComponent::ALL[1].0), Some(&10));
+        assert_eq!(dense.get(PathComponent::ALL[9].0), Some(&90));
+        assert_eq!(dense.get(PathComponent::ALL[0].0), None);
+
+        let back = children_from_dense(&dense);
+        assert_eq!(back, c);
+
+        // Empty round-trips with zero allocation (the #2099 property).
+        let empty: Children<Option<u32>> = Children::new();
+        let dense_empty = dense_from_children(&empty);
+        assert!(dense_empty.is_empty());
+        assert_eq!(children_from_dense(&dense_empty), empty);
     }
 }

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -20,7 +20,9 @@ use crate::{HashType, LinearAddress, Path, PathBuf, PathComponent, SharedNode};
 use bitfield::bitfield;
 use branch::Serializable as _;
 pub use branch::{BranchNode, Child};
-pub use children::{Children, ChildrenSlots};
+pub use children::{
+    Children, ChildrenSlots, DenseChildren, children_from_dense, dense_from_children,
+};
 use enum_as_inner::EnumAsInner;
 use integer_encoding::{VarInt, VarIntReader as _};
 pub use leaf::LeafNode;


### PR DESCRIPTION
## Why this should be merged

Closes #2099, a P0 proof-deserialization memory-amplification vulnerability: `ProofNode.child_hashes` was a fixed 16-slot `Children<Option<HashType>>` (~500+ bytes per node regardless of occupancy), so a stream of near-empty proof nodes could drive roughly a 100x memory-amplification ratio (a ~50 MB payload allocating multiple GB of heap). This is the second PR of the arity-arrays migration; it builds on PR 1 (the `U4` alias).

## How this works

- `ProofNode.child_hashes` becomes `DenseChildren<HashType>` (`arity_arrays::PackedArray<HashType, Arity16>`): a pointer-sized handle to a heap block sized to exactly the present children, with zero heap allocation for an empty node. Per-node memory is now O(present children) instead of a fixed 16-slot array, so total memory is O(wire bytes), not O(nodes x 16).
- `firewood-storage` gains the `DenseChildren<T>` alias plus `dense_from_children` / `children_from_dense` conversion helpers (temporary; they become native `From` impls in PR 3).
- Deserialization (`proofs/de.rs`) reads the child bitmap and populates a transient, inline `FixedArray` (per-node stack, freed on return), then converts once to the packed representation — a single count-sized allocation, no per-insert reallocation on the DoS-sensitive path.
- The hashing/verification surface stays on `Children`: `Hashable::children()` still returns `Children<Option<HashType>>` and `fix_account_storage_root_value` still takes `&Children<Option<HashType>>`, with `DenseChildren`->`Children` conversion at those seams. Every other consumer (the RLP branch encoding in `eth.rs`, the child-count and present-child walks in `eth_proof.rs` and `merkle/mod.rs`) reads the packed container directly.
- `ChildMask::from_children` (whose sole caller was the old serializer) is removed; the rest of `ChildMask` (the verification/outside-range bitmap) is unchanged.

## How this was tested

- Full workspace suite: 735 passed with `--features ethhash,logger`, 697 passed in the default (SHA-256) hash mode.
- clippy (default and maxperf profiles, `-D warnings`) and `cargo doc --no-deps` clean.
- **The proof wire format is byte-identical.** The proof snapshots (`firewood/src/proofs/snapshots/*`) and the byte-offset tests in `proofs/tests.rs` pass unchanged in BOTH hash modes, with no snapshot regenerated — `DenseChildren`'s little-endian `u16` bitmap and ascending present-child order reproduce the exact bytes the previous `ChildMask` encoding produced.
- New proof gen/verify benchmark: range-proof generation and verification are within noise of the pre-change baseline; single-key proof verification improved ~2.7%.

## Breaking Changes

- `firewood`: `ProofNode.child_hashes` is now `DenseChildren<HashType>` instead of `Children<Option<HashType>>`. `ProofNode` is `#[non_exhaustive]`.
- `firewood-storage`: adds `DenseChildren`, `dense_from_children`, `children_from_dense` to the public surface.
- `firewood` now takes a direct `arity-arrays` dependency (for the deserialization transient); it becomes internal-only again once PR 3 removes the conversion seams.

## Performance note

Single-key proof *generation* regresses ~6.9%: building a proof node now allocates once per non-empty branch (converting the live node's children into the packed form), where the old fixed inline array allocated nothing. This is the inverse of the memory win and is inherent to present-only storage; it is a bounded, one allocation per node (not quadratic), and range-proof generation — the more representative path — stays within noise. A follow-up (a dense-producing `BranchNode::children_hashes()`, or a move-based conversion) can recover it.
