### PR TITLE
refactor(storage)!: back Children with arity_arrays::FixedArray (PR 3/3)

### DIFF
--- a/firewood/src/proofs/eth.rs
+++ b/firewood/src/proofs/eth.rs
@@ -125,11 +125,8 @@ pub fn proof_node_to_mpt_rlp(node: &ProofNode) -> SmallVec<[Box<[u8]>; 2]> {
     // hasher hashed.
     let inner_bytes: Box<[u8]> = if is_account {
         match value_bytes {
-            Some(v) => fix_account_storage_root_value(
-                v,
-                &firewood_storage::children_from_dense(&node.child_hashes),
-            )
-            .unwrap_or_else(|| Box::from(v)),
+            Some(v) => fix_account_storage_root_value(v, &Children::from(&node.child_hashes))
+                .unwrap_or_else(|| Box::from(v)),
             None => branch_bytes,
         }
     } else {

--- a/firewood/src/proofs/types.rs
+++ b/firewood/src/proofs/types.rs
@@ -373,7 +373,7 @@ impl Hashable for ProofNode {
     }
 
     fn children(&self) -> Children<Option<HashType>> {
-        firewood_storage::children_from_dense(&self.child_hashes)
+        Children::from(&self.child_hashes)
     }
 }
 
@@ -429,7 +429,7 @@ impl From<PathIterItem> for ProofNode {
             key: item.key_nibbles,
             partial_len,
             value_digest,
-            child_hashes: firewood_storage::dense_from_children(&child_hashes),
+            child_hashes: child_hashes.to_dense(),
         }
     }
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -64,7 +64,6 @@ pub use linear::{FileIoError, ReadableStorage, WritableStorage};
 pub use node::path::{NibblesIterator, Path};
 pub use node::{
     BranchNode, Child, Children, ChildrenSlots, DenseChildren, LeafNode, Node, PathIterItem,
-    children_from_dense, dense_from_children,
 };
 pub use nodestore::{
     AreaIndex, Committed, CommittedId, CommittedParentHash, DeletedNodeTracking, HashedNodeReader,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -66,7 +66,6 @@ pub use linear::{FileIoError, ReadableStorage, WritableStorage};
 pub use node::path::{NibblesIterator, Path};
 pub use node::{
     BranchNode, Child, Children, ChildrenSlots, DenseChildren, LeafNode, Node, PathIterItem,
-    children_from_dense, dense_from_children,
 };
 pub use nodestore::{
     AreaIndex, Committed, CommittedId, CommittedParentHash, DeletedNodeTracking, HashedNodeReader,

--- a/storage/src/node/children.rs
+++ b/storage/src/node/children.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
-use arity_arrays::{Arity16, PackedArray};
+use arity_arrays::{Arity16, FixedArray, PackedArray};
 
 use crate::PathComponent;
 
@@ -27,8 +27,12 @@ pub type IterPresentMut<'a, T> = std::iter::FilterMap<
 >;
 
 /// Type alias for a collection of children in a branch node.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Children<T>([T; MAX_CHILDREN]);
+///
+/// Backed by [`arity_arrays::FixedArray`], indexed by [`PathComponent`]. Unlike
+/// the previous inline-array representation this type is not `Copy` (the backing
+/// array is heap-free but move-only); clone explicitly where a copy is needed.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Children<T>(FixedArray<T, Arity16>);
 
 impl<T: std::fmt::Debug> std::fmt::Debug for Children<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -42,60 +46,60 @@ impl<T> Children<T> {
     /// Creates a new [`Children`] by calling `f` for each possible
     /// [`PathComponent`].
     #[must_use]
-    pub fn from_fn(f: impl FnMut(PathComponent) -> T) -> Self {
-        Self(PathComponent::ALL.map(f))
+    pub fn from_fn(mut f: impl FnMut(PathComponent) -> T) -> Self {
+        Self(FixedArray::from_fn(|index| f(PathComponent(index))))
     }
 
     /// Borrows each element and returns a [`Children`] wrapping the references.
     #[must_use]
-    pub const fn each_ref(&self) -> Children<&T> {
-        Children(self.0.each_ref())
+    pub fn each_ref(&self) -> Children<&T> {
+        Children(FixedArray::from_fn(|index| self.0.get(index)))
     }
 
     /// Borrows each element mutably and returns a [`Children`] wrapping the
     /// mutable references.
     #[must_use]
-    pub const fn each_mut(&mut self) -> Children<&mut T> {
-        Children(self.0.each_mut())
+    pub fn each_mut(&mut self) -> Children<&mut T> {
+        // `iter_mut` (via `Deref<[T]>`) hands out the 16 disjoint `&mut T` in
+        // ascending slot order; `FixedArray::from_fn` fills slot i with the i-th,
+        // so slot i ends up borrowing element i.
+        let mut slots = self.0.iter_mut();
+        Children(FixedArray::from_fn(|_index| {
+            slots
+                .next()
+                .expect("FixedArray::iter_mut yields exactly MAX_CHILDREN items")
+        }))
     }
 
     /// Returns a reference to the element at `index`.
     ///
     /// This is infallible because `index` is guaranteed to be in-bounds.
     #[must_use]
-    pub const fn get(&self, index: PathComponent) -> &T {
-        #![expect(clippy::indexing_slicing)]
-        &self.0[index.as_usize()]
+    pub fn get(&self, index: PathComponent) -> &T {
+        self.0.get(index.0)
     }
 
     /// Returns a mutable reference to the element at `index`.
     ///
     /// This is infallible because `index` is guaranteed to be in-bounds.
     #[must_use]
-    pub const fn get_mut(&mut self, index: PathComponent) -> &mut T {
-        #![expect(clippy::indexing_slicing)]
-        &mut self.0[index.as_usize()]
+    pub fn get_mut(&mut self, index: PathComponent) -> &mut T {
+        self.0.get_mut(index.0)
     }
 
     /// Replaces the element at `index` with `value`, returning the previous
     /// value.
     ///
     /// This is infallible because `index` is guaranteed to be in-bounds.
-    pub const fn replace(&mut self, index: PathComponent, value: T) -> T {
-        #![expect(clippy::indexing_slicing)]
-        std::mem::replace(&mut self.0[index.as_usize()], value)
+    pub fn replace(&mut self, index: PathComponent, value: T) -> T {
+        self.0.replace(index.0, value)
     }
 
     /// Maps each element to another value using `f`, returning a new
     /// [`Children`] containing the results.
     #[must_use]
     pub fn map<O>(self, mut f: impl FnMut(PathComponent, T) -> O) -> Children<O> {
-        let mut pc = const { PathComponent::ALL[0] };
-        Children(self.0.map(|child| {
-            let out = f(pc, child);
-            pc = pc.wrapping_next();
-            out
-        }))
+        Children(self.0.map(|index, value| f(PathComponent(index), value)))
     }
 
     /// Returns an iterator over each element with its corresponding
@@ -121,35 +125,31 @@ impl<T> Children<T> {
         other: Children<U>,
         mut merge: impl FnMut(PathComponent, T, U) -> Result<Option<V>, E>,
     ) -> Result<Children<Option<V>>, E> {
-        let iter = self.0.into_iter().zip(other.0);
-        let mut output = [const { None }; MAX_CHILDREN];
-        for (slot, (pc, (a, b))) in output
-            .iter_mut()
-            .zip(PathComponent::ALL.into_iter().zip(iter))
-        {
-            *slot = merge(pc, a, b)?;
+        let mut output = Children::<Option<V>>::new();
+        for ((pc, a), (_, b)) in self.into_iter().zip(other) {
+            output[pc] = merge(pc, a, b)?;
         }
-        Ok(Children(output))
+        Ok(output)
     }
 }
 
 impl<T> Children<Option<T>> {
     /// Creates a new [`Children`] with all elements set to `None`.
     #[must_use]
-    pub const fn new() -> Self {
-        Self([const { None }; MAX_CHILDREN])
+    pub fn new() -> Self {
+        Self(FixedArray::new())
     }
 
     /// Returns the number of [`Some`] elements in this collection.
     #[must_use]
     pub fn count(&self) -> usize {
-        self.0.iter().filter(|c| c.is_some()).count()
+        self.0.count()
     }
 
     /// Sets the element at `index` to `None`, returning the previous value.
     #[must_use]
-    pub const fn take(&mut self, index: PathComponent) -> Option<T> {
-        self.replace(index, None)
+    pub fn take(&mut self, index: PathComponent) -> Option<T> {
+        self.0.take(index.0)
     }
 
     /// Returns an iterator over each [`Some`] element with its corresponding
@@ -231,7 +231,16 @@ impl<T> IntoIterator for Children<T> {
     type IntoIter = ChildrenSlots<T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        PathComponent::ALL.into_iter().zip(self.0)
+        // Collect the owned values (ascending slot order) into an array so the
+        // iterator type stays `Zip<array::IntoIter<PathComponent>, array::IntoIter<T>>`.
+        let mut values = self.0.into_iter();
+        let values: [T; MAX_CHILDREN] = std::array::from_fn(|_| {
+            values
+                .next()
+                .expect("FixedArray yields exactly MAX_CHILDREN items")
+                .1
+        });
+        PathComponent::ALL.into_iter().zip(values)
     }
 }
 
@@ -240,7 +249,10 @@ impl<'a, T: 'a> IntoIterator for &'a Children<T> {
     type IntoIter = ChildrenSlots<&'a T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.each_ref().into_iter()
+        let mut refs = self.0.iter();
+        let refs: [&'a T; MAX_CHILDREN] =
+            std::array::from_fn(|_| refs.next().expect("FixedArray has MAX_CHILDREN slots"));
+        PathComponent::ALL.into_iter().zip(refs)
     }
 }
 
@@ -249,7 +261,10 @@ impl<'a, T: 'a> IntoIterator for &'a mut Children<T> {
     type IntoIter = ChildrenSlots<&'a mut T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.each_mut().into_iter()
+        let mut refs = self.0.iter_mut();
+        let refs: [&'a mut T; MAX_CHILDREN] =
+            std::array::from_fn(|_| refs.next().expect("FixedArray has MAX_CHILDREN slots"));
+        PathComponent::ALL.into_iter().zip(refs)
     }
 }
 
@@ -258,25 +273,21 @@ impl<'a, T: 'a> IntoIterator for &'a mut Children<T> {
 /// [`arity_arrays::PackedArray`], indexed by [`crate::U4`].
 pub type DenseChildren<T> = PackedArray<T, Arity16>;
 
-/// Builds a [`DenseChildren`] holding only the present (`Some`) entries of
-/// `children`, cloning each present value.
-#[must_use]
-pub fn dense_from_children<T: Clone>(children: &Children<Option<T>>) -> DenseChildren<T> {
-    children
-        .iter_present()
-        .map(|(pc, value)| (pc.0, value.clone()))
-        .collect()
+impl<T: Clone> Children<Option<T>> {
+    /// Packs the present (`Some`) entries into a [`DenseChildren`], cloning each
+    /// present value; empty slots are dropped (zero heap when empty).
+    #[must_use]
+    pub fn to_dense(&self) -> DenseChildren<T> {
+        PackedArray::from(&self.0)
+    }
 }
 
-/// Expands a [`DenseChildren`] back into a full 16-slot [`Children`], cloning each
-/// present value; absent slots become `None`.
-#[must_use]
-pub fn children_from_dense<T: Clone>(dense: &DenseChildren<T>) -> Children<Option<T>> {
-    let mut children = Children::new();
-    for (index, value) in dense.iter_present() {
-        children[PathComponent(index)] = Some(value.clone());
+impl<T: Clone> From<&DenseChildren<T>> for Children<Option<T>> {
+    /// Expands a [`DenseChildren`] back into a full 16-slot [`Children`], cloning
+    /// each present value; absent slots become `None`.
+    fn from(dense: &DenseChildren<T>) -> Self {
+        Children(FixedArray::from(dense))
     }
-    children
 }
 
 #[cfg(test)]
@@ -291,19 +302,19 @@ mod tests {
         c[PathComponent::ALL[9]] = Some(90);
         c[PathComponent::ALL[15]] = Some(150);
 
-        let dense = dense_from_children(&c);
+        let dense = c.to_dense();
         assert_eq!(dense.count(), 3);
         assert_eq!(dense.get(PathComponent::ALL[1].0), Some(&10));
         assert_eq!(dense.get(PathComponent::ALL[9].0), Some(&90));
         assert_eq!(dense.get(PathComponent::ALL[0].0), None);
 
-        let back = children_from_dense(&dense);
+        let back = Children::from(&dense);
         assert_eq!(back, c);
 
         // Empty round-trips with zero allocation (the #2099 property).
         let empty: Children<Option<u32>> = Children::new();
-        let dense_empty = dense_from_children(&empty);
+        let dense_empty = empty.to_dense();
         assert!(dense_empty.is_empty());
-        assert_eq!(children_from_dense(&dense_empty), empty);
+        assert_eq!(Children::from(&dense_empty), empty);
     }
 }

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -20,9 +20,7 @@ use crate::{HashType, LinearAddress, Path, PathBuf, PathComponent, SharedNode};
 use bitfield::bitfield;
 use branch::Serializable as _;
 pub use branch::{BranchNode, Child};
-pub use children::{
-    Children, ChildrenSlots, DenseChildren, children_from_dense, dense_from_children,
-};
+pub use children::{Children, ChildrenSlots, DenseChildren};
 use enum_as_inner::EnumAsInner;
 use integer_encoding::{VarInt, VarIntReader as _};
 pub use leaf::LeafNode;

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -20,9 +20,7 @@ use crate::{HashType, LinearAddress, Path, PathBuf, PathComponent, SharedNode};
 use bitfield::bitfield;
 use branch::Serializable as _;
 pub use branch::{BranchNode, Child};
-pub use children::{
-    Children, ChildrenSlots, DenseChildren, children_from_dense, dense_from_children,
-};
+pub use children::{Children, ChildrenSlots, DenseChildren};
 use enum_as_inner::EnumAsInner;
 use integer_encoding::{VarInt, VarIntReader as _};
 pub use leaf::LeafNode;
@@ -570,8 +568,10 @@ mod test {
     #[test_case(Node::Branch(Box::new(BranchNode {
         partial_path: Path::from(vec![0, 1, 2, 3]),
         value: Some(vec![4, 5, 6, 7].into()),
-        children: Children::from_fn(|_|
-                Some(Child::AddressWithHash(LinearAddress::new(1).unwrap(), std::array::from_fn::<u8, 32, _>(|i| i as u8).into()))
+        // Each child's hash starts with its own nibble so a decode that pairs
+        // slots with the wrong wire entries fails the round-trip comparison.
+        children: Children::from_fn(|pc|
+                Some(Child::AddressWithHash(LinearAddress::new(1).unwrap(), std::array::from_fn::<u8, 32, _>(|i| if i == 0 { pc.as_u8() } else { i as u8 }).into()))
         )})), 652; "full branch node with long partial path and value"
     )]
     #[test_case(Node::Branch(Box::new(BranchNode {

--- a/storage/src/path/component.rs
+++ b/storage/src/path/component.rs
@@ -115,13 +115,6 @@ impl PathComponent {
         // arity's `U4` provides no `join`; compute it directly.
         (self.0.as_u8() << 4) | other.0.as_u8()
     }
-
-    pub(crate) const fn wrapping_next(self) -> Self {
-        match crate::u4::U4::try_new(self.0.as_u8().wrapping_add(1)) {
-            Some(next) => Self(next),
-            None => Self(crate::u4::U4::MIN),
-        }
-    }
 }
 
 impl std::fmt::Debug for PathComponent {


### PR DESCRIPTION
## Why this should be merged

PRs 1 and 2 moved `U4` and `ProofNode.child_hashes` (the #2099 P0 fix) onto arity-arrays, leaving `Children<T>` as the last hand-rolled container plus a pair of temporary `Children`<->`DenseChildren` conversion helpers (introduced in PR 2 as scaffolding). This PR retires both, so the child containers now have a single backing implementation.

## How this works

- `Children<T>` becomes a newtype over `arity_arrays::FixedArray<T, Arity16>` (was an inline `[T; 16]`). The full public API is reimplemented over FixedArray primitives, so no external call site changes. `iter`/`iter_mut`/`each_ref`/ `each_mut`/`merge` are hand-rolled (FixedArray has no equivalents); the iterator aliases stay a `Zip` of two `array::IntoIter` (built via `core::array::from_fn`) so they remain `Clone` + `DoubleEndedIterator`, which two call sites rely on (`node/mod.rs`, `merkle/changes.rs`).
- PR 2's `dense_from_children`/`children_from_dense` free functions are removed. The `DenseChildren`->`Children` direction becomes a by-reference `From` impl; the `Children`->`DenseChildren` direction becomes an inherent `Children::to_dense` method. A forward `From` impl is orphan-rule-blocked (E0210): the uncovered `T` sits in the foreign `PackedArray` self type ahead of the local `Children`.

## How this was tested

- On-disk and hash-preimage byte formats are unchanged: FixedArray iterators preserve ascending nibble order 0->15, so `BranchNode` serialization and every computed hash stay byte-identical. Node + proof snapshot suites pass with no regeneration in BOTH hash modes (SHA-256 default and Keccak-256 ethhash).
- Full suite: 735/735 (ethhash,logger) and 697/697 (default), all targets. clippy clean (standard + maxperf, both feature sets). cargo doc clean.

## Breaking Changes

- `firewood-storage`: `Children<T>` is no longer `Copy`, and its accessors (`get`/`get_mut`/`replace`/`each_ref`/`each_mut`/`new`/`take`) are no longer `const fn`. No workspace consumer relied on either (verified across all 23 consumer files).
- `firewood-storage`: the `dense_from_children`/`children_from_dense` free functions are removed. They were temporary scaffolding added in PR 2 and never appeared in a released version.

## Follow-ups (optional, not in this PR)

- A `const _: () = assert!(MAX_CHILDREN == <Arity16 as arity_arrays::Arity>::LEN);` would harden the (currently trivially-true) coupling that the iterator reconstruction relies on, at zero runtime cost.
- PR 2's +6.9% single-key proof-generation cost is unchanged here; recovering it needs a dense-producing `BranchNode::children_hashes()`, a separate change.
