### PR TITLE
feat(fwdctl): support hex and Ethereum keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,6 +1913,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha3",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ nonzero_ext = "0.3.0"
 parking_lot = "0.12.5"
 rand_distr = "0.6.0"
 sha2 = "0.11.0"
+sha3 = "0.12.0"
 smallvec = { version = "1.15.2", features = ["write", "union", "const_new"] }
 test-case = "3.3.1"
 thiserror = "2.0.18"

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -32,6 +32,7 @@ firewood-storage.workspace = true
 hex.workspace = true
 log.workspace = true
 nonzero_ext.workspace = true
+sha3 = { version = "0.12.0", optional = true }
 # Regular dependencies
 csv = "1.4.0"
 humantime = "2.4.0"
@@ -53,7 +54,7 @@ thiserror = { version = "2.0", optional = true }
 tokio = { version = "1.52", features = ["rt-multi-thread", "sync", "time"], optional = true }
 
 [features]
-ethhash = ["firewood/ethhash"]
+ethhash = ["firewood/ethhash", "dep:sha3"]
 logger = ["firewood/logger"]
 launch = [
     "dep:aws-config",

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -32,7 +32,7 @@ firewood-storage.workspace = true
 hex.workspace = true
 log.workspace = true
 nonzero_ext.workspace = true
-sha3 = { version = "0.12.0", optional = true }
+sha3 = { workspace = true, optional = true }
 # Regular dependencies
 csv = "1.4.0"
 humantime = "2.4.0"

--- a/fwdctl/README.md
+++ b/fwdctl/README.md
@@ -24,6 +24,37 @@ To use
 * `fwdctl dump`: Dump the contents of the key/value store.
 * `fwdctl launch` (requires `--features launch`): Launch and manage AWS benchmark runs.
 
+## Key input modes
+
+The `get`, `insert`, and `delete` commands accept UTF-8 or hexadecimal keys.
+Build with the `ethhash` feature to also derive Firewood keys from Ethereum
+inputs:
+
+```sh
+cargo build --release --bin fwdctl --features ethhash
+```
+
+The `get`, `insert`, and `delete` commands accept the following key modes:
+
+* With no key option, `KEY` remains a UTF-8 string, preserving the default
+  behavior.
+* `--hex` decodes `KEY` as hexadecimal bytes. This mode is available in both
+  default and `ethhash` builds.
+* `--account` decodes `KEY` as an Ethereum address (exactly 20 bytes of hex) and
+  uses `keccak256(address)` as the database key.
+* `--storage SLOT` decodes `KEY` as a 20-byte Ethereum address and `SLOT` as a
+  32-byte storage key, then uses
+  `keccak256(address) || keccak256(slot)` as the database key.
+
+Hex inputs may start with `0x`. For example:
+
+```sh
+fwdctl get --hex 79656172
+fwdctl get --account 0x00112233445566778899aabbccddeeff00112233
+fwdctl get --storage 0x0000000000000000000000000000000000000000000000000000000000000001 \
+  0x00112233445566778899aabbccddeeff00112233
+```
+
 ## Launch command
 
 `fwdctl launch` provisions and manages EC2 instances for benchmark workflows.

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -19,6 +19,7 @@ pub struct Options {
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("deleting key {opts:?}");
     let key = opts.key.database_key()?;
+    let hex_key = hex::encode(&key);
     let cfg = DbConfig::builder()
         .node_hash_algorithm(opts.database.node_hash_algorithm.into())
         .create_if_missing(false)
@@ -30,6 +31,6 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let proposal = db.propose(batch)?;
     proposal.commit()?;
 
-    println!("key {} deleted successfully", opts.key.key);
+    println!("key 0x{hex_key} deleted successfully");
     db.close()
 }

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -5,20 +5,20 @@ use clap::Args;
 use firewood::api::{self, Db as _, Proposal as _};
 use firewood::db::{BatchOp, Db, DbConfig};
 
-use crate::DatabasePath;
+use crate::{DatabasePath, key::KeyArgument};
 
 #[derive(Debug, Args)]
 pub struct Options {
     #[command(flatten)]
     pub database: DatabasePath,
 
-    /// The key to delete
-    #[arg(required = true, value_name = "KEY", help = "Key to delete")]
-    pub key: String,
+    #[command(flatten)]
+    pub key: KeyArgument,
 }
 
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("deleting key {opts:?}");
+    let key = opts.key.database_key()?;
     let cfg = DbConfig::builder()
         .node_hash_algorithm(opts.database.node_hash_algorithm.into())
         .create_if_missing(false)
@@ -26,12 +26,10 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
 
     let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
 
-    let batch: Vec<BatchOp<String, String>> = vec![BatchOp::Delete {
-        key: opts.key.clone(),
-    }];
+    let batch: Vec<BatchOp<Vec<u8>, Vec<u8>>> = vec![BatchOp::Delete { key }];
     let proposal = db.propose(batch)?;
     proposal.commit()?;
 
-    println!("key {} deleted successfully", opts.key);
+    println!("key {} deleted successfully", opts.key.key);
     db.close()
 }

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -6,20 +6,20 @@ use clap::Args;
 use firewood::api::{self, Db as _, DbView as _};
 use firewood::db::{Db, DbConfig};
 
-use crate::DatabasePath;
+use crate::{DatabasePath, key::KeyArgument};
 
 #[derive(Debug, Args)]
 pub struct Options {
     #[command(flatten)]
     pub database: DatabasePath,
 
-    /// The key to get the value for
-    #[arg(required = true, value_name = "KEY", help = "Key to get")]
-    pub key: String,
+    #[command(flatten)]
+    pub key: KeyArgument,
 }
 
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("get key value pair {opts:?}");
+    let key = opts.key.database_key()?;
     let cfg = DbConfig::builder()
         .node_hash_algorithm(opts.database.node_hash_algorithm.into())
         .create_if_missing(false)
@@ -36,13 +36,13 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
 
     let rev = db.revision(hash)?;
 
-    match rev.val(opts.key.as_bytes()) {
+    match rev.val(&key) {
         Ok(Some(val)) => {
             let s = String::from_utf8_lossy(val.as_ref());
             println!("{s:?}");
         }
         Ok(None) => {
-            eprintln!("Key '{}' not found", opts.key);
+            eprintln!("Key '{}' not found", opts.key.key);
         }
         Err(e) => return Err(e),
     }

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -42,7 +42,7 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
             println!("{s:?}");
         }
         Ok(None) => {
-            eprintln!("Key '{}' not found", opts.key.key);
+            eprintln!("Key '0x{}' not found", hex::encode(&key));
         }
         Err(e) => return Err(e),
     }

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -5,16 +5,15 @@ use clap::Args;
 use firewood::api::{self, Db as _, Proposal as _};
 use firewood::db::{BatchOp, Db, DbConfig};
 
-use crate::DatabasePath;
+use crate::{DatabasePath, key::KeyArgument};
 
 #[derive(Debug, Args)]
 pub struct Options {
     #[command(flatten)]
     pub database: DatabasePath,
 
-    /// The key to insert
-    #[arg(required = true, value_name = "KEY", help = "Key to insert")]
-    pub key: String,
+    #[command(flatten)]
+    pub key: KeyArgument,
 
     /// The value to insert
     #[arg(required = true, value_name = "VALUE", help = "Value to insert")]
@@ -23,6 +22,7 @@ pub struct Options {
 
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("inserting key value pair {opts:?}");
+    let key = opts.key.database_key()?;
     let cfg = DbConfig::builder()
         .node_hash_algorithm(opts.database.node_hash_algorithm.into())
         .create_if_missing(false)
@@ -31,12 +31,12 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
 
     let batch: Vec<BatchOp<Vec<u8>, Vec<u8>>> = vec![BatchOp::Put {
-        key: opts.key.clone().into(),
+        key,
         value: opts.value.bytes().collect(),
     }];
     let proposal = db.propose(batch)?;
     proposal.commit()?;
 
-    println!("{}", opts.key);
+    println!("{}", opts.key.key);
     db.close()
 }

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -23,6 +23,7 @@ pub struct Options {
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("inserting key value pair {opts:?}");
     let key = opts.key.database_key()?;
+    let hex_key = hex::encode(&key);
     let cfg = DbConfig::builder()
         .node_hash_algorithm(opts.database.node_hash_algorithm.into())
         .create_if_missing(false)
@@ -37,6 +38,6 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     let proposal = db.propose(batch)?;
     proposal.commit()?;
 
-    println!("{}", opts.key.key);
+    println!("0x{hex_key}");
     db.close()
 }

--- a/fwdctl/src/key.rs
+++ b/fwdctl/src/key.rs
@@ -9,8 +9,12 @@ use sha3::{Digest, Keccak256};
 
 #[derive(Debug, Args)]
 pub struct KeyArgument {
-    /// The key. Used as a UTF-8 string unless an Ethereum hashing option is set
-    #[arg(required = true, value_name = "KEY", help = "Key to operate on")]
+    /// The key. Used as UTF-8 unless `--hex` or an Ethereum hashing option is set
+    #[arg(
+        required = true,
+        value_name = "KEY",
+        help = "Key to operate on (UTF-8 by default; decoded or hashed when a key mode is set)"
+    )]
     pub key: String,
 
     /// Decode KEY as hexadecimal bytes

--- a/fwdctl/src/key.rs
+++ b/fwdctl/src/key.rs
@@ -15,7 +15,7 @@ pub struct KeyArgument {
         value_name = "KEY",
         help = "Key to operate on (UTF-8 by default; decoded or hashed when a key mode is set)"
     )]
-    pub key: String,
+    key: String,
 
     /// Decode KEY as hexadecimal bytes
     #[arg(long)]

--- a/fwdctl/src/key.rs
+++ b/fwdctl/src/key.rs
@@ -1,0 +1,99 @@
+// Copyright (C) 2026, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use clap::Args;
+use firewood::api;
+
+#[cfg(feature = "ethhash")]
+use sha3::{Digest, Keccak256};
+
+#[derive(Debug, Args)]
+pub struct KeyArgument {
+    /// The key. Used as a UTF-8 string unless an Ethereum hashing option is set
+    #[arg(required = true, value_name = "KEY", help = "Key to operate on")]
+    pub key: String,
+
+    /// Decode KEY as hexadecimal bytes
+    #[arg(long)]
+    hex: bool,
+
+    /// Hash KEY as a 20-byte hex Ethereum account address
+    #[cfg(feature = "ethhash")]
+    #[arg(long, conflicts_with_all = ["hex", "storage"])]
+    account: bool,
+
+    /// Hash KEY as a 20-byte hex Ethereum account address and SLOT as a 32-byte hex storage key
+    #[cfg(feature = "ethhash")]
+    #[arg(long, value_name = "SLOT", conflicts_with_all = ["hex", "account"])]
+    storage: Option<String>,
+}
+
+impl KeyArgument {
+    /// Converts the CLI key input into the key stored by Firewood.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-input error when an Ethereum account or storage key
+    /// is not valid hexadecimal of the required length.
+    pub fn database_key(&self) -> Result<Vec<u8>, api::Error> {
+        if self.hex {
+            let hex_input = self.key.strip_prefix("0x").unwrap_or(&self.key);
+            return hex::decode(hex_input)
+                .map_err(|error| invalid_input(format!("key must be hexadecimal: {error}")));
+        }
+
+        #[cfg(feature = "ethhash")]
+        {
+            if self.account {
+                return Ok(keccak256(decode_hex_exact("account", &self.key, 20)?).to_vec());
+            }
+
+            if let Some(storage) = &self.storage {
+                let account_hash = keccak256(decode_hex_exact("account", &self.key, 20)?);
+                let storage_hash = keccak256(decode_hex_exact("storage key", storage, 32)?);
+                let mut key = Vec::with_capacity(64);
+                key.extend_from_slice(&account_hash);
+                key.extend_from_slice(&storage_hash);
+                return Ok(key);
+            }
+        }
+
+        Ok(self.key.as_bytes().to_vec())
+    }
+}
+
+#[cfg(feature = "ethhash")]
+fn decode_hex_exact(
+    label: &str,
+    input: &str,
+    expected_bytes: usize,
+) -> Result<Vec<u8>, api::Error> {
+    let hex_input = input.strip_prefix("0x").unwrap_or(input);
+    let expected_digits = expected_bytes.saturating_mul(2);
+
+    if hex_input.len() != expected_digits {
+        let actual = if hex_input.len().is_multiple_of(2) {
+            format!("{} bytes", hex_input.len() / 2)
+        } else {
+            format!("{} hex digits", hex_input.len())
+        };
+        return Err(invalid_input(format!(
+            "{label} must be exactly {expected_bytes} bytes ({expected_digits} hex digits); got {actual}"
+        )));
+    }
+
+    hex::decode(hex_input).map_err(|error| {
+        invalid_input(format!(
+            "{label} must be exactly {expected_bytes} bytes of hexadecimal: {error}"
+        ))
+    })
+}
+
+#[cfg(feature = "ethhash")]
+fn keccak256(input: impl AsRef<[u8]>) -> [u8; 32] {
+    Keccak256::digest(input).into()
+}
+
+fn invalid_input(message: String) -> api::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidInput, message).into()
+}

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -16,6 +16,7 @@ pub mod get;
 pub mod graph;
 pub mod import;
 pub mod insert;
+pub mod key;
 #[cfg(feature = "launch")]
 pub mod launch;
 pub mod replay;

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -46,6 +46,188 @@ fn insert_key_value(db_path: &Path, key: &str, value: &str) {
         .stdout(predicate::str::contains(key));
 }
 
+#[cfg(feature = "ethhash")]
+const ACCOUNT: &str = "00112233445566778899aabbccddeeff00112233";
+#[cfg(feature = "ethhash")]
+const SLOT: &str = "0000000000000000000000000000000000000000000000000000000000000001";
+#[cfg(feature = "ethhash")]
+const ACCOUNT_HASH: &str = "b7ff4d50bd18751616802a406c94b190f1a3fd4fc82b06db40943e0119c5e8bc";
+#[cfg(feature = "ethhash")]
+const STORAGE_KEY: &str = "b7ff4d50bd18751616802a406c94b190f1a3fd4fc82b06db40943e0119c5e8bcb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6";
+
+#[test]
+fn fwdctl_hex_key_round_trip() {
+    with_tmpdir(|db_path| {
+        create_db(db_path);
+
+        cargo_bin_cmd!()
+            .args(["insert", "--hex", "79656172", "2023"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success();
+
+        cargo_bin_cmd!()
+            .args(["get", "year"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("2023"));
+
+        cargo_bin_cmd!()
+            .args(["delete", "--hex", "79656172"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success();
+
+        #[cfg(not(feature = "ethhash"))]
+        cargo_bin_cmd!()
+            .args(["get", "year"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Database is empty"));
+
+        #[cfg(feature = "ethhash")]
+        cargo_bin_cmd!()
+            .args(["get", "year"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stderr(predicate::str::contains("Key 'year' not found"));
+    });
+}
+
+#[test]
+fn fwdctl_hex_key_rejects_malformed_input() {
+    cargo_bin_cmd!()
+        .args(["get", "--hex", "not-hex"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("key must be hexadecimal"));
+}
+
+#[cfg(feature = "ethhash")]
+#[test]
+fn fwdctl_key_modes_conflict() {
+    cargo_bin_cmd!()
+        .args(["get", "--hex", "--account", ACCOUNT])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "the argument '--hex' cannot be used with '--account'",
+        ));
+}
+
+#[cfg(feature = "ethhash")]
+#[test]
+fn fwdctl_key_hashing_is_documented_in_help() {
+    cargo_bin_cmd!()
+        .args(["get", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "--account\n          Hash KEY as a 20-byte hex Ethereum account address",
+        ))
+        .stdout(predicate::str::contains(
+            "--storage <SLOT>\n          Hash KEY as a 20-byte hex Ethereum account address and SLOT as a 32-byte hex storage key",
+        ));
+}
+
+#[cfg(feature = "ethhash")]
+#[test]
+fn fwdctl_account_key_round_trip() {
+    with_tmpdir(|db_path| {
+        create_db(db_path);
+
+        cargo_bin_cmd!()
+            .args(["insert", "--account", ACCOUNT, "account value"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success();
+
+        cargo_bin_cmd!()
+            .args(["get", "--account", ACCOUNT])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("account value"));
+
+        cargo_bin_cmd!()
+            .args(["dump", "--hex"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(ACCOUNT_HASH));
+    });
+}
+
+#[cfg(feature = "ethhash")]
+#[test]
+fn fwdctl_storage_key_round_trip() {
+    with_tmpdir(|db_path| {
+        create_db(db_path);
+
+        cargo_bin_cmd!()
+            .args(["insert", "--storage", SLOT, ACCOUNT, "storage value"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success();
+
+        cargo_bin_cmd!()
+            .args(["get", "--storage", SLOT, ACCOUNT])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("storage value"));
+
+        cargo_bin_cmd!()
+            .args(["dump", "--hex"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains(STORAGE_KEY));
+    });
+}
+
+#[cfg(feature = "ethhash")]
+#[test]
+fn fwdctl_account_rejects_malformed_hex() {
+    cargo_bin_cmd!()
+        .args([
+            "get",
+            "--account",
+            "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "account must be exactly 20 bytes of hexadecimal",
+        ));
+}
+
+#[cfg(feature = "ethhash")]
+#[test]
+fn fwdctl_storage_rejects_wrong_length() {
+    cargo_bin_cmd!()
+        .args(["get", "--storage", "abcd", ACCOUNT])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "storage key must be exactly 32 bytes (64 hex digits); got 2 bytes",
+        ));
+}
+
 #[test]
 fn fwdctl_prints_version() {
     let expected_version_output: String = format!("{PRG} {VERSION}");

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -130,11 +130,13 @@ fn fwdctl_key_hashing_is_documented_in_help() {
         .args(["get", "--help"])
         .assert()
         .success()
+        .stdout(predicate::str::contains("--account"))
         .stdout(predicate::str::contains(
-            "--account\n          Hash KEY as a 20-byte hex Ethereum account address",
+            "Hash KEY as a 20-byte hex Ethereum account address",
         ))
+        .stdout(predicate::str::contains("--storage <SLOT>"))
         .stdout(predicate::str::contains(
-            "--storage <SLOT>\n          Hash KEY as a 20-byte hex Ethereum account address and SLOT as a 32-byte hex storage key",
+            "Hash KEY as a 20-byte hex Ethereum account address and SLOT as a 32-byte hex storage key",
         ));
 }
 

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -43,7 +43,7 @@ fn insert_key_value(db_path: &Path, key: &str, value: &str) {
         .args([value])
         .assert()
         .success()
-        .stdout(predicate::str::contains(key));
+        .stdout(format!("0x{}\n", hex::encode(key)));
 }
 
 #[cfg(feature = "ethhash")]
@@ -65,7 +65,8 @@ fn fwdctl_hex_key_round_trip() {
             .arg("--db")
             .arg(db_path)
             .assert()
-            .success();
+            .success()
+            .stdout("0x79656172\n");
 
         cargo_bin_cmd!()
             .args(["get", "year"])
@@ -80,7 +81,8 @@ fn fwdctl_hex_key_round_trip() {
             .arg("--db")
             .arg(db_path)
             .assert()
-            .success();
+            .success()
+            .stdout("key 0x79656172 deleted successfully\n");
 
         #[cfg(not(feature = "ethhash"))]
         cargo_bin_cmd!()
@@ -98,7 +100,7 @@ fn fwdctl_hex_key_round_trip() {
             .arg(db_path)
             .assert()
             .success()
-            .stderr(predicate::str::contains("Key 'year' not found"));
+            .stderr("Key '0x79656172' not found\n");
     });
 }
 
@@ -151,7 +153,8 @@ fn fwdctl_account_key_round_trip() {
             .arg("--db")
             .arg(db_path)
             .assert()
-            .success();
+            .success()
+            .stdout(format!("0x{ACCOUNT_HASH}\n"));
 
         cargo_bin_cmd!()
             .args(["get", "--account", ACCOUNT])
@@ -182,7 +185,8 @@ fn fwdctl_storage_key_round_trip() {
             .arg("--db")
             .arg(db_path)
             .assert()
-            .success();
+            .success()
+            .stdout(format!("0x{STORAGE_KEY}\n"));
 
         cargo_bin_cmd!()
             .args(["get", "--storage", SLOT, ACCOUNT])
@@ -199,6 +203,22 @@ fn fwdctl_storage_key_round_trip() {
             .assert()
             .success()
             .stdout(predicate::str::contains(STORAGE_KEY));
+
+        cargo_bin_cmd!()
+            .args(["delete", "--storage", SLOT, ACCOUNT])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stdout(format!("key 0x{STORAGE_KEY} deleted successfully\n"));
+
+        cargo_bin_cmd!()
+            .args(["get", "--storage", SLOT, ACCOUNT])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stderr(format!("Key '0x{STORAGE_KEY}' not found\n"));
     });
 }
 
@@ -286,7 +306,7 @@ fn fwdctl_delete_successful() {
             .arg(db_path)
             .assert()
             .success()
-            .stdout(predicate::str::contains("key year deleted successfully"));
+            .stdout("key 0x79656172 deleted successfully\n");
     });
 }
 


### PR DESCRIPTION
## Summary

- add generic `--hex` key decoding to `fwdctl get`, `insert`, and `delete`
- add feature-gated `--account` and `--storage <SLOT>` modes for Ethereum key derivation
- validate hex input lengths, reject conflicting modes, and document the CLI contract
- add integration coverage for round trips, Keccak-derived keys, malformed input, conflicts, and deletion

## Key derivation

- account: `keccak256(address)`
- storage: `keccak256(address) || keccak256(slot)`

Closes #1000.

## Validation

- `cargo fmt --check`
- `cargo test -p firewood-fwdctl --test cli` (19 passed)
- `cargo test -p firewood-fwdctl --features ethhash,logger --all-targets` (25 passed)
- `cargo nextest run --workspace --features ethhash,logger --all-targets` (824 passed, 17 profile-skipped)
- `cargo +nightly-2026-07-05 clippy -p firewood-fwdctl --features ethhash,logger --all-targets -- -D warnings`
- `cargo +nightly-2026-07-05 clippy --profile maxperf -p firewood-fwdctl --features ethhash,logger --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p firewood-fwdctl --features ethhash,logger --no-deps`
- `markdownlint-cli2 fwdctl/README.md`
