### PR TITLE
fix(changelog): detect the bare breaking-change label

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -27,9 +27,17 @@ body = """
         - {% if commit.scope %}*({{ commit.scope }})* {% endif -%}
             {%- set_global breaking = commit.breaking -%}
             {%- set_global breaking_scopes = [] -%}
+            {#- Breaking-change labels must stay in sync with .github/labels.yml, which
+                declares bare `breaking-change` as canonical and keeps the per-crate
+                `breaking-change/<crate>` forms as aliases. Handle both: the bare label
+                marks the entry breaking with no scope list, the scoped form additionally
+                names the affected crate. Update this block whenever that label taxonomy
+                changes. -#}
             {%- if commit.remote.pr_labels is defined -%}
               {%- for label in commit.remote.pr_labels -%}
-                {%- if label is starting_with("breaking-change/") -%}
+                {%- if label == "breaking-change" -%}
+                  {%- set_global breaking = true -%}
+                {%- elif label is starting_with("breaking-change/") -%}
                   {%- set_global breaking = true -%}
                   {%- set scope = label | trim_start_matches(pat="breaking-change/") -%}
                   {%- set_global breaking_scopes = breaking_scopes | concat(with=scope) -%}


### PR DESCRIPTION
## Why this should be merged

The label taxonomy refactor made `breaking-change` the canonical label and demoted the per-crate `breaking-change/<crate>` forms to aliases in `.github/labels.yml`, but `cliff.toml` was not updated with it. Its matcher gates on `starting_with("breaking-change/")`, which a bare `breaking-change` label never satisfies, so label-driven breaking-change marking has been silently dead since the refactor.

Silently is the problem. Conventional-commit detection (`feat!:`, `BREAKING CHANGE:` footer) still works, so most breaking entries were still marked and the gap was invisible. Only a change that is breaking *by label alone* — no `!` in its subject — went unmarked. PR #2000 is exactly that case: labelled `breaking-change`, subject `fix(storage): pin committed parent in Reconstructed to prevent reaping`, and absent from the changelog's breaking entries.

## How this works

The matcher now handles both label forms. The bare label marks the entry breaking with no scope list; the scoped form additionally records the crate, as before. The render at the end of the loop already tolerated an empty scope list, emitting `[**breaking**]` without a trailing scope, so no template change was needed there.

Both forms are kept rather than replacing one with the other, because `labels.yml` retains the scoped names as aliases — they can still arrive from the API on a PR labelled before a sync run. A comment now ties this block to `labels.yml` explicitly, so the next taxonomy change updates both files instead of drifting again; nothing previously connected them, which is how this was missed.

## How this was tested

Rendered real history through git-cliff 2.13.1 with the GitHub integration live, before and after:

- #2000 (bare label, no `!`) — unmarked before, `[**breaking**]` after. The bug, fixed.
- #2147 and #1858 (bare label *and* `!`) — marked exactly once both before and after; the two signals are idempotent, not additive.
- #2134 (no label, no `!`) — unmarked, so the new branch does not over-match.
- #2068 (`no-changelog`) — still skipped entirely.

Regenerating the whole changelog at v0.8.0 with and without the fix differs by exactly one line: #2000's marker. No other historical entry changes.
