### PR TITLE
docs: establish the design-doc subsystem with date-prefixed filenames

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,32 @@ The `fwdctl` tool provides command-line operations on databases. See `fwdctl/REA
 
 For more information on coding conventions and constraints, please refer to [CONTRIBUTING.md](./CONTRIBUTING.md)
 
+## Design Documents
+
+Firewood records designs as living documentation in a single flat directory,
+`docs/src/designs/` (rendered in the mdBook site). Every design is
+`YYYY-MM-DD-<slug>.md`, where the date is the day the design was written; it is
+assigned once and never changes. A design's lifecycle state lives in the `status`
+frontmatter field, not in its location or filename. Follow this workflow when writing
+a design document:
+
+- **Propose:** run `just new-design <slug>` to scaffold
+  `docs/src/designs/YYYY-MM-DD-<slug>.md` (with `status: proposed`) from the RFC-style
+  template, fill it in, and open a pull request for review.
+- **Promote:** once the design is implemented, promote it in place — a status flip,
+  not a file move, so its `YYYY-MM-DD-<slug>.md` path stays stable and its date prefix
+  goes on recording when the design was proposed. Following the checklist in
+  `docs/src/designs/README.md`: flip the frontmatter `status` to `active`, drop the
+  proposal-only sections, rewrite future-tense prose into the present tense, add
+  cross-links to the implementing PR(s), and update the index in
+  `docs/src/designs/README.md` and `docs/src/SUMMARY.md`.
+- `active` designs describe what the code does today; keep them up to date as the
+  design changes.
+
+Never write a date into a design's frontmatter or body. The filename records when the
+design was proposed; `just design-age` reports how fresh each design is from git
+history. A hand-maintained date inside a document only drifts out of sync.
+
 ## Commit and PR Title Convention
 
 Commit messages and PR titles **must** follow the

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -32,3 +32,6 @@ command = "../scripts/mdbook-frontmatter-strip.sh"
 
 [output.linkcheck2]
 follow-web-links = false
+# Exclude deployed-site paths that resolve only on the production GitHub Pages site
+# (/firewood/rustdoc/, /firewood/ffi/, /firewood/bench/).
+exclude = ['^/firewood/(rustdoc|ffi|bench)/']

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,7 +13,9 @@
 
 # Design Documents
 
-- [Designs]()
+- [Designs](designs/README.md)
+  - [mdBook documentation site](designs/2026-06-17-mdbook-documentation-site.md)
+  - [Template](designs/template.md)
 
 # Integration
 
@@ -25,7 +27,7 @@
 
 # Reference
 
-- [Reference]()
+- [Reference](reference/README.md)
 
 # Meta
 

--- a/docs/src/designs/2026-06-17-mdbook-documentation-site.md
+++ b/docs/src/designs/2026-06-17-mdbook-documentation-site.md
@@ -21,19 +21,20 @@ peer-reviewable, RFC-style workflow for proposing designs and promoting them to
 living documentation — a `status` frontmatter flip, not a file move — once
 implemented. Additional sections (Concepts,
 AvalancheGo/EVM Integration, Operations & Benchmarking, Reference, Meta) each ship an
-authored landing page; not-yet-written sub-pages are listed as mdBook draft chapters
-(greyed-out sidebar entries) rather than empty stub files.
+authored landing page; not-yet-written sub-pages are omitted from the sidebar until
+their content lands, rather than shipped as empty stub files.
 
 > [!NOTE]
-> **Bootstrapping note.** This is the first design and is numbered accordingly:
-> `docs/src/designs/0001-mdbook-documentation-site.md`. It is a chicken-and-egg
-> artifact — the flat layout, the frontmatter schema, the single template, and the
+> **Bootstrapping note.** This design is a chicken-and-egg artifact: the flat layout,
+> the naming convention, the frontmatter schema, the single template, and the
 > `new-design`/`design-age` tooling it specifies do not exist until this work lands, so
 > the document that defines the conventions could not originally follow them. As the
 > foundation landed it was retrofitted to its own schema (YAML frontmatter, no in-doc
-> date) and its `status` flipped from `proposed` to `active`; the design of the
-> documentation system itself becomes living documentation in the book's `meta/`
-> section (see below).
+> date) and its `status` flipped from `proposed` to `active`. Its filename,
+> `docs/src/designs/2026-06-17-mdbook-documentation-site.md`, carries the date the
+> design was first written rather than the date of the retrofit — the same rule every
+> other design follows. The design of the documentation system itself becomes living
+> documentation in the book's `meta/` section (see below).
 
 ## Goals
 
@@ -54,7 +55,7 @@ authored landing page; not-yet-written sub-pages are listed as mdBook draft chap
 - Backfilling every existing design. This MVP writes exactly one fully-realized
   active design (on-disk format & addressing) and lists the rest as TODO.
 - Authoring full content for the scaffolded sections beyond an authored landing page;
-  their deeper sub-pages remain draft chapters until written.
+  their deeper sub-pages are omitted from `SUMMARY.md` until written.
 - Changing how benchmark data is collected or stored (`track-performance.yml` and
   the `benchmark-data` branch are unchanged).
 - Custom mdBook theming beyond the preprocessor-provided assets and standard
@@ -105,17 +106,20 @@ output into a subdirectory.
 4. **Design lifecycle:** A single flat `designs/` directory; lifecycle state lives in
    the `status` frontmatter field, not in the directory layout. Promotion from
    `proposed` to `active` is a status flip plus a prose pass (documented checklist in
-   `designs/README.md`), not a file move — so a design keeps its stable `NNNN-slug.md`
-   path and review-thread and cross-doc references never break.
+   `designs/README.md`), not a file move — so a design keeps its stable
+   `YYYY-MM-DD-slug.md` path and review-thread and cross-doc references never break.
 5. **Backfill scope:** One template + one fully-written seed (`on-disk format &
-   addressing`) + a TODO backfill index (in `designs/README.md`) for the rest.
+   addressing`) + a backfill index (a GitHub issue linked from `designs/README.md`)
+   for the rest.
 6. **Extra sections:** Concepts/Architecture, AvalancheGo/EVM Integration, Operations
    & Benchmarking, Reference (generated artifacts), and Meta (self-documenting docs +
    repository-process docs: release, contributing, code review). Sections with real
-   seed content are authored at landing-page depth; sections (and sub-pages) without
-   content yet are listed as mdBook **draft chapters** (link-less `SUMMARY.md` entries,
-   which render as greyed-out/disabled sidebar items) rather than empty stub pages —
-   see "Scaffolding via draft chapters" below.
+   seed content are authored at landing-page depth. Every section ships an authored
+   landing page; not-yet-written *sub-pages* are omitted from `SUMMARY.md` until their
+   content lands, rather than shipped as empty stub pages. mdBook **draft chapters**
+   (link-less `SUMMARY.md` entries that render greyed-out) remain available if the
+   outline should later advertise a "coming soon" page — see "Scaffolding via draft
+   chapters" below.
 7. **Preprocessors and callouts:** Two preprocessors: `mdbook-mermaid` (diagrams) and
    an in-repo frontmatter stripper (`scripts/mdbook-frontmatter-strip.sh`, a small jq
    script that removes each chapter's YAML frontmatter so the schema metadata does not
@@ -166,15 +170,15 @@ docs/
     │   └── dev-environment.md # FULLY AUTHORED: macOS / Docker / remote SSH
     ├── concepts/
     │   └── README.md          # authored landing: promoted README terminology + architecture prose
-    ├── designs/                  # FLAT: every design is NNNN-slug.md; status lives in frontmatter
-    │   ├── README.md             # explains the model + how to propose + status-flip promotion checklist + design-age tooling + TODO backfill list
+    ├── designs/                  # FLAT: every design is YYYY-MM-DD-slug.md; status lives in frontmatter
+    │   ├── README.md             # explains the model + how to propose + status-flip promotion checklist + design-age tooling + backfill issue link
     │   ├── template.md           # single RFC-style template carrying the frontmatter schema
-    │   ├── 0001-mdbook-documentation-site.md      # this design (status: active)
-    │   └── NNNN-on-disk-format-and-addressing.md  # the one FULLY WRITTEN seed (status: active; NNNN assigned by new-design)
+    │   ├── 2024-08-13-on-disk-format-and-addressing.md  # the one FULLY WRITTEN seed (status: active)
+    │   └── 2026-06-17-mdbook-documentation-site.md      # this design (status: active)
     ├── integration/
     │   └── README.md          # authored: Go API (Database/Proposal/Revision) + firewood-go-ethhash publish relationship
     ├── operations/
-    │   └── README.md          # authored landing: fwdctl, benchmarks, dashboards; links benchmark/docs/* + /bench/ (sub-pages are draft chapters until written)
+    │   └── README.md          # authored landing: fwdctl, benchmarks, dashboards; links benchmark/docs/* + /bench/ (sub-pages omitted until written)
     ├── reference/
     │   └── README.md          # authored landing: link-out hub for GENERATED artifacts: rustdoc ↗, godoc ↗, benchmarks ↗
     └── meta/
@@ -188,8 +192,9 @@ docs/
 > seed content, linked in `SUMMARY.md`; **thin** = a short real page that mostly links
 > out; **draft chapter** = a `SUMMARY.md` entry written with empty link parentheses
 > (`- [Title]()`), which has **no file** and renders greyed-out (see "Scaffolding via
-> draft chapters"). Every section above ships an authored landing page at MVP; only
-> not-yet-written *sub-pages* are draft chapters.
+> draft chapters"). Every section above ships an authored landing page at MVP;
+> not-yet-written *sub-pages* are omitted from `SUMMARY.md` until written (the MVP
+> ships no draft chapters).
 
 ### Architecture diagram asset (relocation)
 
@@ -228,23 +233,44 @@ work — old external deep links 404, accepted in exchange for the cleaner root 
 
 ### How the book links to generated docs
 
-`SUMMARY.md` supports raw-URL entries, which render as sidebar items. A
-`reference/` section and sidebar entries link to the deployed paths
-(`/firewood/rustdoc/`, `/firewood/ffi/`, `/firewood/bench/`). These resolve on the
-deployed site; under local `mdbook serve` they point at the live production site.
-The `reference/README.md` page notes this explicitly. `mdbook-linkcheck2` is
-configured with `follow-web-links = false` so these external link-outs do not break
-local/CI builds.
+The generated docs are linked from the body of two pages — `reference/README.md`, a
+hub whose entire content is the three link-outs, and the Introduction, which points at
+rustdoc and godoc directly so the front page carries them. They are *not* sidebar
+entries: mdBook resolves every `SUMMARY.md` link as a path under `src/`, with no
+special case for URLs, so a raw-URL entry there fails the build rather than rendering
+as an external sidebar item. Reaching the generated docs therefore costs one click
+through Reference. The alternatives — thin link-out chapters per artifact, or custom
+theme JavaScript that injects sidebar links — were both rejected as more machinery than
+one click is worth.
+
+The link-outs use the deployed paths (`/firewood/rustdoc/`, `/firewood/ffi/`,
+`/firewood/bench/`). These are scheme-less absolute paths that resolve only on the
+deployed site; under local `mdbook serve` (or a fork's Pages deployment) they 404. The
+`reference/README.md` page notes this explicitly. Because they are scheme-less (not
+`http(s)://`) links, `follow-web-links = false` does not exempt them from link
+checking; an explicit `exclude = ['^/firewood/(rustdoc|ffi|bench)/']` under
+`[output.linkcheck2]` is what keeps them from breaking local/CI builds. The
+Introduction's links, being fully-qualified `https://` URLs, are covered by
+`follow-web-links = false` instead.
 
 ## Design-doc subsystem
 
 ### Model
 
-One flat `designs/` directory. Every design is `NNNN-slug.md` — a zero-padded
-sequence number (for ordering-independent, stable references in review threads)
-followed by a short slug. Sequence numbers only ever increase and are never reused or
-renumbered, so a design's path is a permanent identifier. Lifecycle state lives
-entirely in the `status` frontmatter field:
+One flat `designs/` directory. Every design is `YYYY-MM-DD-slug.md` — the date the
+design was written, followed by a short slug. The date is assigned once, when the file
+is created, and never changes: it records when the design was *proposed*, not when it
+was last touched, so a design's path is a permanent identifier and a stable reference
+in review threads. Designs written on the same day are distinguished by their slugs.
+
+A date prefix is preferred over a monotonic sequence number for two reasons. It needs
+no coordination: two authors proposing designs concurrently pick their filenames
+independently, whereas both would compute the same next sequence number and collide on
+merge. And it is self-describing — a reader scanning the directory sees a design's
+vintage without opening it or consulting git, which matters most for the oldest
+designs, where age is the first thing worth knowing.
+
+Lifecycle state lives entirely in the `status` frontmatter field:
 
 - **`proposed`** — under peer review, not yet built. A proposal typically lands in the
   repo *before* development so reviewers comment via normal PR review on the document —
@@ -288,16 +314,19 @@ tracking-issue: ava-labs/firewood#1229   # optional
 | `tracking-issue` | no | An `owner/repo#N` reference to the issue or PR tracking the work. |
 
 > [!IMPORTANT]
-> The schema carries **no date fields**. A design's age and freshness come from its
-> git history, never from a hand-maintained date that drifts out of sync. `just
-> design-age` (see [Local tooling](#local-tooling)) reports each design's last-commit
-> date; in-doc dates are refused by convention.
+> The schema carries **no date fields**, and neither does a design's body. The two
+> dates worth knowing about a design live outside the document: *when it was proposed*
+> is its filename prefix, written once at creation and never edited; *how fresh it is*
+> comes from git history, reported by `just design-age` (see
+> [Local tooling](#local-tooling)). Only a date maintained by hand *inside* the
+> document could drift out of sync with reality, so that is the one this convention
+> refuses.
 
 ### Lifecycle
 
 ```mermaid
 flowchart LR
-    A[Draft PR adds<br/>NNNN-x.md<br/>status: proposed] --> B[Peer review<br/>on the PR]
+    A[Draft PR adds<br/>YYYY-MM-DD-x.md<br/>status: proposed] --> B[Peer review<br/>on the PR]
     B --> C[Merge: proposal<br/>accepted, not built]
     C --> D[Implementation PRs<br/>reference the proposal]
     D --> E[Promotion: flip<br/>status to active]
@@ -314,8 +343,9 @@ the surviving prose is rewritten into imperative mood and simple present tense.
 
 ### Promotion checklist (documented in `designs/README.md`)
 
-Promotion is a status flip plus a prose pass — no file move, so the `NNNN-slug.md`
-path is stable across a design's whole life:
+Promotion is a status flip plus a prose pass — no file move, so the
+`YYYY-MM-DD-slug.md` path is stable across a design's whole life and its date prefix
+goes on recording when the design was proposed, not when it was promoted:
 
 1. Flip frontmatter `status: proposed` → `active`.
 2. Drop proposal-only sections (Drawbacks, Unresolved questions), folding survivors
@@ -326,18 +356,24 @@ path is stable across a design's whole life:
 
 ### Seed design — on-disk format & addressing
 
-Filed flat as `NNNN-on-disk-format-and-addressing.md`, its sequence number assigned by
-`new-design` at authoring time. Fully written (`status: active`) from `README.md` prose
+Filed flat as `2024-08-13-on-disk-format-and-addressing.md` — the date prefix is the
+day that design was originally written, well before this documentation site existed.
+Fully written (`status: active`) from `README.md` prose
 plus the `storage/` and `firewood/src/` sources. Covers: disk-offset addressing (root address = disk offset;
 branch nodes point to disk offsets), node allocation from end-of-file vs. free lists,
 free-list size-class management, the future-delete log (FDL), and recoverability
 guarantees (no references to new nodes before flush; careful free-list management
 across revision creation/expiration).
 
-### `designs/README.md` backfill TODO list
+### `designs/README.md` backfill list
 
-Revision management; free lists & FDL; hashing (SHA-256 vs. ethhash/Keccak-256);
-proposals & commits; archival mode (`RootStore`).
+The subsystems still to be documented — revision management; hashing (SHA-256 vs.
+ethhash/Keccak-256); proposals & commits; state sync & reconstruction (folding in
+archival mode / `RootStore`); and the Go FFI layer — are tracked in
+[ava-labs/firewood#2139](https://github.com/ava-labs/firewood/issues/2139), linked
+from `designs/README.md` rather than duplicated inline where the list would drift.
+Free lists & the FDL are already covered by the on-disk-format design and are
+deliberately not on the list.
 
 ## CI/CD changes (`gh-pages.yaml`)
 
@@ -454,11 +490,13 @@ end-to-end coverage; the build is not split into a book-only fast path.
 ### Link checking
 
 `mdbook-linkcheck2` runs as a backend during `mdbook build`, configured under
-`[output.linkcheck2]` with `follow-web-links = false`. It validates internal book
-links (broken `SUMMARY.md` entries, bad cross-references) without choking on the
-external `/rustdoc/` link-outs that exist only post-deploy. Broken internal links fail
-the PR build. Enabling this second renderer is what moves HTML output to
-`docs/book/html/` (see build step 4).
+`[output.linkcheck2]` with `follow-web-links = false` and an
+`exclude = ['^/firewood/(rustdoc|ffi|bench)/']`. It validates internal book links
+(broken `SUMMARY.md` entries, bad cross-references) while the `exclude` skips the
+site-absolute `/rustdoc/`, `/ffi/`, and `/bench/` link-outs that exist only
+post-deploy — `follow-web-links` alone would not skip them, since they are scheme-less
+(not web) links. Broken internal links fail the PR build. Enabling this second renderer
+is what moves HTML output to `docs/book/html/` (see build step 4).
 
 `mdbook-linkcheck2` is a maintained fork of the original `mdbook-linkcheck`. The
 original (last released 2022) rejects a `book.toml` whose `[rust]` table sets
@@ -508,7 +546,10 @@ relocation.
   not surface as a stray `<hr>` + heading. It is an in-repo jq script (needs `jq` on
   `PATH`; no binary to install). mdBook runs preprocessor commands from the book root,
   so the `command` path is relative to `docs/`, not the repo root.
-- `[output.linkcheck2]` with `follow-web-links = false`.
+- `[output.linkcheck2]` with `follow-web-links = false` and
+  `exclude = ['^/firewood/(rustdoc|ffi|bench)/']` (the `exclude`, not
+  `follow-web-links`, skips the site-absolute `/rustdoc/`, `/ffi/`, `/bench/`
+  link-outs — they are scheme-less paths, so `follow-web-links` never applies).
 
 ## Local tooling
 
@@ -528,20 +569,19 @@ relocation.
   stripper needs `jq` on `PATH`; mdBook runs both automatically per their `book.toml`
   tables. Neither needs an install step in `book-assets` — mermaid's *assets* do, its
   binary does not, and the stripper is already in the repo.
-- `new-design slug` → scaffolds `docs/src/designs/NNNN-slug.md` from `template.md` (with
-  `status: proposed`). Sequence-number algorithm: glob
-  `docs/src/designs/[0-9][0-9][0-9][0-9]-*.md`, parse the leading 4-digit number from
-  each, take the numeric maximum, add one, and zero-pad to four digits; if no matching
-  files exist, start at `0001`. Gaps left by deleted/superseded files are not backfilled
-  (numbers only ever increase). Two PRs that add a design concurrently compute the same
-  next number and collide on merge; resolve it by renumbering the later design rather
-  than treating it as a defect.
+- `new-design slug` → scaffolds `docs/src/designs/YYYY-MM-DD-slug.md` from `template.md`
+  (with `status: proposed`), where the date prefix is today's date at scaffold time. No
+  scan of existing designs is needed, so two PRs adding a design concurrently cannot
+  collide on a shared "next" value the way sequence numbers did. The recipe refuses to
+  overwrite an existing file, which catches the one remaining collision: a second design
+  with the same slug on the same day.
 - `design-age` → runs `scripts/design-doc-age.sh`: lists every
-  `docs/src/designs/NNNN-*.md` with its last git-commit date, sorted **oldest-first** so
+  `docs/src/designs/YYYY-MM-DD-*.md` with its last git-commit date, sorted **oldest-first** so
   the stalest designs sit at the top and uncommitted (not-yet-committed) designs sort
-  last. It reads git history only — never a doc's frontmatter or body — so it is both
-  the freshness report and the working embodiment of the no-in-doc-dates convention. Use
-  it to spot `active` designs that have drifted from the code.
+  last. It reads git history only — never a doc's frontmatter or body, and never the
+  proposal date in its filename — so it is both the freshness report and the working
+  embodiment of the no-in-doc-dates convention. Use it to spot `active` designs that have
+  drifted from the code.
 
 Recipes call `mdbook` directly; the dev-environment guide names the required tools
 and links to upstream install docs (and may include concrete install commands).
@@ -566,9 +606,9 @@ and links to upstream install docs (and may include concrete install commands).
 mdBook supports **draft chapters** — `SUMMARY.md` entries written with empty link
 parentheses (`- [Title]()`), which render as greyed-out/disabled items in the sidebar.
 Per the mdBook guide their purpose is "to signal future chapters still to be written."
-This is the idiomatic mdBook mechanism this design uses **instead of** creating empty
-stub `.md` files (hollow pages would be search-indexed and present as real-but-empty
-content). The rule:
+This is the idiomatic mdBook mechanism for signalling future chapters **instead of**
+creating empty stub `.md` files (hollow pages would be search-indexed and present as
+real-but-empty content). The rule:
 
 - A section or sub-page with real seed content gets an authored landing page and a
   *linked* `SUMMARY.md` entry.
@@ -576,8 +616,9 @@ content). The rule:
   it shows in the outline as "coming soon" without creating a hollow page, and is
   promoted to a linked entry when its first real content lands.
 
-Applying that rule to the extra sections (those with seed content are authored now;
-the rest are draft chapters):
+Applying that rule to the extra sections — all four ship an authored landing page, and
+no sub-page draft chapters ship in the MVP (unwritten sub-pages are omitted from
+`SUMMARY.md` until their content lands):
 
 - `concepts/` — authored: seeded by promoting the README terminology + architecture-
   diagram prose.
@@ -592,7 +633,7 @@ the rest are draft chapters):
   the new layout. Migrating their content into the book is a follow-up. The landing
   page links to `/bench/` for the live dashboards. **MVP scope:** exactly one file,
   `operations/README.md`; deeper sub-pages (e.g. `fwdctl.md`, `benchmarks.md`) are
-  draft-chapter entries in `SUMMARY.md` (no files) until their content is written.
+  omitted from `SUMMARY.md` until their content is written.
 - `reference/` — authored landing page (`reference/README.md`): a link-out hub for
   *generated* artifacts only (rustdoc ↗, godoc ↗, benchmarks ↗). It is authored (the
   three link-outs are its content), not a draft chapter. Repository-process docs
@@ -628,10 +669,10 @@ in `avalanchego/go.mod` and in the `graft/evm`, `graft/coreth`, and `graft/subne
 `go.mod`s. That published module tracks the `firewood-ffi` crate version: when
 `firewood-ffi` is released, CI builds the static libraries, copies the in-repo `ffi/`
 directory into the `ava-labs/firewood-go-ethhash` repository, and tags it (see
-[`RELEASE.md`](../../../RELEASE.md) and
-[`.github/workflows/attach-static-libs.yaml`](../../../.github/workflows/attach-static-libs.yaml)).
+[`RELEASE.md`](https://github.com/ava-labs/firewood/blob/main/RELEASE.md) and
+[`.github/workflows/attach-static-libs.yaml`](https://github.com/ava-labs/firewood/blob/main/.github/workflows/attach-static-libs.yaml)).
 The section documents how the in-repo `ffi/` crate is built (the `cargo build` →
-`go tool cgo` flow described in [`ffi/README.md`](../../../ffi/README.md)), packaged,
+`go tool cgo` flow described in [`ffi/README.md`](https://github.com/ava-labs/firewood/blob/main/ffi/README.md)), packaged,
 and published, and how a downstream consumer pins and upgrades it. It links to `/ffi/`
 (godoc) for the generated API reference and to `meta/release.md` for the publish/version
 cadence. Without this, the integration story is incomplete: a reader following the
@@ -685,14 +726,16 @@ Distilled from the [`mdbooks.yaml` catalog](https://github.com/szabgab/mdbooks.c
   and `/ffi/` — plus `/bench/` only when the `build` job reports benchmark history
   (`has_bench`) — failing the workflow on any non-success status. The build job
   additionally asserts `site/index.html` exists before upload.
-- **`new-design` recipe:** running it produces a correctly numbered
-  `docs/src/designs/NNNN-slug.md` from `template.md` with `status: proposed`.
+- **`new-design` recipe:** running it produces `docs/src/designs/YYYY-MM-DD-slug.md`
+  from `template.md` with `status: proposed`, dated today, and fails rather than
+  overwriting a file that already exists at that path.
 - **Frontmatter stripping:** the in-repo `frontmatter-strip` preprocessor removes each
-  chapter's YAML block; spot-check that `0001`'s frontmatter does not appear in the
-  rendered `docs/book/html/` output (no stray `<hr>` or metadata heading).
-- **`design-age` recipe:** `just design-age` lists every `docs/src/designs/NNNN-*.md`
-  by last git-commit date, oldest-first, with uncommitted docs last — and reads git
-  history only, never a doc's contents.
+  chapter's YAML block; spot-check that this design's own frontmatter does not appear in
+  the rendered `docs/book/html/` output (no stray `<hr>` or metadata heading).
+- **`design-age` recipe:** `just design-age` lists every
+  `docs/src/designs/YYYY-MM-DD-*.md` by last git-commit date, oldest-first, with
+  uncommitted docs last — and reads git history only, never a doc's contents and never
+  the date in its filename.
 - **Existing checks unaffected:** `cargo doc --no-deps`, `cargo fmt`, `cargo clippy`,
   and `cargo nextest` are unchanged; the repository's markdownlint check passes on the
   new Markdown. A book-scoped `docs/.markdownlint.json` disables `MD025` (multiple H1)
@@ -728,41 +771,42 @@ Distilled from the [`mdbooks.yaml` catalog](https://github.com/szabgab/mdbooks.c
       run the macOS and devcontainer command sequences end-to-end on a clean
       environment before merge; the remote-SSH section reuses the same commands and is
       reviewed for accuracy.
-- [ ] `designs/` is a flat directory: every design is `NNNN-slug.md` with lifecycle
-      state in a `status` frontmatter field (no `proposed/`/`active/` folders). It
-      contains a single RFC-style `template.md`, a `README.md` documenting the model +
-      status-flip promotion checklist + backfill TODO, and the fully-written
-      `NNNN-on-disk-format-and-addressing.md` seed (number assigned at authoring time).
-- [ ] Design docs carry the YAML frontmatter schema (`title`, `status`, `category`,
+- [x] `designs/` is a flat directory: every design is `YYYY-MM-DD-slug.md`, dated when
+      the design was written, with lifecycle state in a `status` frontmatter field (no
+      `proposed/`/`active/` folders). It contains a single RFC-style `template.md` and a
+      `README.md` documenting the model + status-flip promotion checklist + a link to the
+      backfill tracking issue.
+- [ ] The fully-written `2024-08-13-on-disk-format-and-addressing.md` seed is in place.
+- [x] Design docs carry the YAML frontmatter schema (`title`, `status`, `category`,
       `authors`, optional `tracking-issue`) with **no date fields**; the in-repo
-      `[preprocessor.frontmatter-strip]` jq script strips it so it does not render.
-      `0001` itself uses
-      the schema (its old `Status:`/`Date:`/`Author:` bullets are gone). *(The
-      foundation PR wires `book.toml` and converts `0001`; `template.md` and the
-      remaining docs land with the content PR.)*
+      `[preprocessor.frontmatter-strip]` jq script strips it so it does not render. This
+      design itself uses the schema (its old `Status:`/`Date:`/`Author:` bullets are
+      gone).
 - [x] `scripts/design-doc-age.sh` (run via `just design-age`) lists each design by last
-      git-commit date, oldest-first, from git history alone — never in-doc dates.
+      git-commit date, oldest-first, from git history alone — never a filename's date
+      prefix and never an in-doc date.
 - [ ] Sections with seed content (`concepts/`, `integration/`, `operations/`,
-      `reference/`) have authored landing pages and linked `SUMMARY.md` entries;
-      sections/sub-pages without content yet are mdBook draft chapters (link-less
-      `SUMMARY.md` entries that render greyed-out), not empty `.md` files. `reference/`
-      links only to generated artifacts (rustdoc/godoc/benchmarks). `integration/`
-      documents the Go wrapper types (`Database`/`Proposal`/`Revision`, mapping to the
-      Rust `Db`/`Proposal`/`DbView`) and the `firewood-go-ethhash` publish relationship
-      that AvalancheGo actually consumes.
+      `reference/`) have authored landing pages and linked `SUMMARY.md` entries.
+      Not-yet-written sub-pages are omitted from `SUMMARY.md` (added when their content
+      lands) rather than shipped as empty `.md` files; no sub-page draft chapters ship
+      in the MVP. `reference/` links only to generated artifacts
+      (rustdoc/godoc/benchmarks). `integration/` documents the Go wrapper types
+      (`Database`/`Proposal`/`Revision`, mapping to the Rust `Db`/`Proposal`/`DbView`)
+      and the `firewood-go-ethhash` publish relationship that AvalancheGo actually
+      consumes.
 - [ ] A `meta/` section exists with an **authored** `documentation.md` (how the docs
       work: tooling, layout, build/serve, authoring, design workflow) and thin
       repository-function pages (`release.md` plus link-out pointers to CONTRIBUTING /
       CODE_REVIEW); the process-doc link-outs are in `meta/`, not `reference/`.
-- [x] `justfile` gains `book-assets`, `book-serve`, and `book-build` (PR 1 — foundation).
-- [ ] `justfile` gains a `new-design` recipe scaffolding
-      `docs/src/designs/NNNN-slug.md` from `template.md` (PR 3 — content).
+- [x] `justfile` gains `book-assets`, `book-serve`, and `book-build`.
+- [x] `justfile` gains a `new-design` recipe scaffolding
+      `docs/src/designs/YYYY-MM-DD-slug.md` from `template.md`.
 - [x] Mermaid assets are installed at build time (not committed): CI and the
       `book-assets` recipe run `mdbook-mermaid install docs`, the generated asset paths
       are git-ignored, and a fresh checkout builds without a manual install step.
 - [x] `architecture.svg` is moved to `docs/src/assets/` and the root `README.md`
       reference is updated accordingly; the book renders the diagram.
-- [ ] `markdownlint-cli2 .` passes.
+- [x] `markdownlint-cli2 .` passes.
 
 ## Accepted trade-off
 

--- a/docs/src/designs/README.md
+++ b/docs/src/designs/README.md
@@ -1,0 +1,76 @@
+# Design Documents
+
+Firewood records its designs as living documentation in a single flat directory.
+Every design is `YYYY-MM-DD-slug.md` — the date the design was first written, followed
+by a short slug. The date is assigned once, when the file is created, and never
+changes afterwards: it records when the design was *proposed*, not when it was last
+touched, so a design's path stays a stable reference in review threads and
+cross-links. Two designs written on the same day are distinguished by their slugs.
+
+A design's lifecycle state lives in its `status` frontmatter field, not in its
+location:
+
+- **`proposed`** — under review, not yet built. A proposal typically lands before
+  development so reviewers comment on the document through normal pull-request review.
+- **`active`** — reflects what the code does today; a living document, updated as the
+  code evolves.
+- **`draft`**, **`superseded`**, **`rejected`** — a work in progress, a design replaced
+  by a newer one, or a design considered and declined; each kept for the record.
+
+> [!NOTE]
+> This is a lightweight convention, not a mandatory gate. A `proposed` design is
+> encouraged for significant or non-obvious work, where writing it down sharpens the
+> discussion; small or low-risk changes do not need one, and nothing blocks a pull
+> request for lacking one. An `active` design may also be written after the fact to
+> document something already built. Optimize for "more designs discussed and
+> recorded," not "process followed."
+
+## Designs
+
+| Design | Proposed | Status |
+| --- | --- | --- |
+| [mdBook documentation site](2026-06-17-mdbook-documentation-site.md) | 2026-06-17 | active |
+
+## Designs still to be written
+
+Several core subsystems are documented only in code, not yet as designs. The
+backlog — revision management, hashing, proposals & commits, state sync &
+reconstruction, and the Go FFI layer — is tracked in
+[ava-labs/firewood#2139](https://github.com/ava-labs/firewood/issues/2139).
+
+## Frontmatter
+
+Every design begins with a YAML frontmatter block, stripped from the rendered site by
+the in-repo `frontmatter-strip` preprocessor:
+
+| Field | Required | Values |
+| --- | --- | --- |
+| `title` | yes | Human-readable design title. |
+| `status` | yes | `draft`, `proposed`, `active`, `superseded`, or `rejected`. |
+| `category` | yes | A Firewood subsystem: `storage`, `ffi`, `revision-management`, `hashing`, `proposals`, `docs`, or `tooling`. |
+| `authors` | yes | List of GitHub handles. |
+| `tracking-issue` | no | An `owner/repo#N` reference to the issue or PR tracking the work. |
+
+The schema has **no date fields**. A design's proposal date is its filename prefix,
+fixed when the file is created; its freshness comes from git history. Neither is a
+hand-maintained date inside the document, which would only drift out of sync with
+reality. Run `just design-age` to list designs by last git-commit date, oldest first,
+to spot stale documents.
+
+## Propose a design
+
+Run `just new-design <slug>` to scaffold `YYYY-MM-DD-<slug>.md` — today's date plus the
+slug — from `template.md`, fill it in, and open a pull request.
+
+## Promote a design
+
+When a proposed design is implemented, promote it in place — a status flip, not a file
+move, so its `YYYY-MM-DD-slug.md` path stays stable and its date prefix goes on
+recording when the design was proposed:
+
+1. Flip the frontmatter `status: proposed` to `status: active`.
+2. Drop the proposal-only sections (Drawbacks, Unresolved questions), folding any
+   surviving content into the living structure.
+3. Rewrite any future-tense prose as present tense — the design now describes reality.
+4. Add cross-links to the implementing pull request(s) and commits.
+5. Update this index's status marker and `SUMMARY.md`.

--- a/docs/src/designs/template.md
+++ b/docs/src/designs/template.md
@@ -1,0 +1,48 @@
+---
+title:
+status: proposed
+category:
+authors: []
+tracking-issue:
+---
+
+# \<Title\>
+
+## Summary
+
+One paragraph describing the change.
+
+## Motivation
+
+Why this is worth doing; the problem it solves.
+
+## Guide-level explanation
+
+Explain the design as if teaching it to another contributor.
+
+## Detailed design
+
+The technical detail: data structures, algorithms, on-disk/runtime behavior,
+edge cases.
+
+## Drawbacks
+
+Reasons this design might not be worth doing. (Proposal-only; drop when promoting to
+`active`.)
+
+## Rationale and alternatives
+
+Why this design over others; what alternatives were considered.
+
+## Prior art
+
+Comparable designs in other systems, if any.
+
+## Unresolved questions
+
+Open questions to settle during review. (Proposal-only; drop when promoting to
+`active`.)
+
+## Future possibilities
+
+Natural extensions, explicitly out of scope here.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -9,15 +9,23 @@ as its on-disk index rather than emulating a trie on top of a generic key-value
 store such as LevelDB or RocksDB. It is compaction-less: trie nodes are written
 directly to a single database file, addressed by their offset within that file.
 
-This site is the front door to Firewood's documentation:
+Firewood's documentation is organized into the following sections:
 
 - **Getting Started** walks through setting up a development environment.
-- **Concepts & Architecture** explains the trie storage model, revisions, and hashing.
-- **Design Documents** records the designs behind Firewood's on-disk format and
+- **Concepts & Architecture** explains the trie storage model and revisions.
+- **Design Documents** captures the designs behind Firewood's on-disk format and
   subsystems, and describes how new designs are proposed and reviewed.
 - **Integration** covers the Go FFI and how AvalancheGo consumes Firewood.
 - **Operations & Benchmarking** covers the `fwdctl` CLI and performance dashboards.
 - **Reference** links to the generated Rust and Go API documentation.
+- **Meta** documents the repository's processes and how these docs are built.
+
+The generated API documentation is published alongside this site:
+
+- [Rust API documentation (rustdoc)](https://ava-labs.github.io/firewood/rustdoc/) —
+  the `firewood`, `firewood-storage`, and `firewood-ffi` crates.
+- [Go API documentation (godoc)](https://ava-labs.github.io/firewood/ffi/) — the Go
+  wrapper around the FFI layer.
 
 > [!WARNING]
 > Firewood is beta-level software. Its API is still evolving and stability is not

--- a/docs/src/reference/README.md
+++ b/docs/src/reference/README.md
@@ -1,0 +1,9 @@
+# Reference
+
+Generated API documentation and dashboards. These are site-absolute paths that
+resolve only on the deployed site; under local `mdbook serve` (or a fork's Pages
+deployment) they 404.
+
+- [Rust API documentation (rustdoc) ↗](/firewood/rustdoc/)
+- [Go API documentation (godoc) ↗](/firewood/ffi/)
+- [Benchmark dashboards ↗](/firewood/bench/)

--- a/justfile
+++ b/justfile
@@ -324,8 +324,27 @@ book-serve: book-assets
 book-build: book-assets
     mdbook build docs
 
+# Scaffold a new proposed design document from the template
+new-design slug:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    dir="docs/src/designs"
+    tmpl="$dir/template.md"
+    # The YYYY-MM-DD prefix records when the design was proposed. It is assigned once,
+    # here, and never changes again — not on promotion, not on later edits. Freshness
+    # is a separate question, answered by git history (`just design-age`).
+    out="$dir/$(date +%F)-{{slug}}.md"
+    if [[ -e "$out" ]]; then
+        # Dates are not unique the way sequence numbers were: a second design with the
+        # same slug on the same day would collide. Refuse rather than clobber.
+        echo "error: $out already exists" >&2
+        exit 1
+    fi
+    cp "$tmpl" "$out"
+    echo "Created $out"
+
 # List design docs by last git-commit date (oldest/stalest first).
-# Freshness comes from git history — design docs carry no in-doc dates.
+# Freshness comes from git history, never from the filename's proposal date.
 design-age:
     ./scripts/design-doc-age.sh
 

--- a/scripts/design-doc-age.sh
+++ b/scripts/design-doc-age.sh
@@ -4,15 +4,17 @@ set -euo pipefail
 
 # Lists Firewood design docs by their last git-commit date, oldest (stalest) first.
 #
-# Motivation: freshness for a design doc comes from git history, never from a
-# hand-maintained date written inside the document. The design-doc frontmatter
-# schema deliberately has no date field, so a date in a doc would only drift out
-# of sync with reality. This report is the working embodiment of that convention:
-# it reads git alone — never a document's frontmatter or body — and surfaces the
-# designs whose last commit is oldest, making an `active` design that has drifted
-# from the code easy to spot.
+# Motivation: a design's filename prefix records the date it was *proposed* — assigned
+# once, when the file is created, and never updated. Freshness is a different question,
+# and its answer comes from git history, never from a hand-maintained date written
+# inside the document. The design-doc frontmatter schema deliberately has no date
+# field, so a date in a doc body would only drift out of sync with reality. This report
+# is the working embodiment of that convention: it reads git alone — never the filename
+# prefix, never a document's frontmatter or body — and surfaces the designs whose last
+# commit is oldest, making an `active` design that has drifted from the code easy to
+# spot.
 #
-# Scope: only the numbered design docs, docs/src/designs/NNNN-*.md. The section
+# Scope: only the dated design docs, docs/src/designs/YYYY-MM-DD-*.md. The section
 # index (README.md) and the template (template.md) are not designs and are skipped.
 #
 # Ordering: oldest last-commit first, so the stalest designs sit at the top. A
@@ -28,10 +30,10 @@ usage() {
     cat <<'EOF'
 Usage: scripts/design-doc-age.sh [-h|--help]
 
-Lists docs/src/designs/NNNN-*.md by last git-commit date, oldest first, so the
-stalest designs appear at the top. Freshness is read from git history only, never
-from a date inside a document. Designs with no commit yet sort last as
-"(uncommitted)".
+Lists docs/src/designs/YYYY-MM-DD-*.md by last git-commit date, oldest first, so
+the stalest designs appear at the top. Freshness is read from git history only,
+never from the filename's proposal date or a date inside a document. Designs with
+no commit yet sort last as "(uncommitted)".
 
 Exit status: 0 on success.
 EOF
@@ -69,7 +71,7 @@ uncommitted_key=9999999999
 # in Unix seconds; the display date is the same commit's date as YYYY-MM-DD.
 rows=()
 shopt -s nullglob
-for doc in "$designs_dir"/[0-9][0-9][0-9][0-9]-*.md; do
+for doc in "$designs_dir"/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*.md; do
     # -1: the most recent commit touching this path. %ct is the committer date in
     # Unix seconds (the sort key); %cd with --date=short is YYYY-MM-DD (display).
     # A path with no commit yet yields empty output (git log exits 0).


### PR DESCRIPTION
First of a stack that breaks the mdBook content branch into one pull request per document. This one carries the structural pieces every later PR builds on: the design-doc naming convention, the subsystem's README and template, and the generated-docs link-outs.

## Why this should be merged

The scaffolded site has a design-doc directory holding exactly one design and no documented convention for adding another. This lands the convention, the tooling that implements it, and the RFC-style template, so subsequent designs can be proposed without re-litigating layout.

## How this works

- Designs are named `YYYY-MM-DD-slug.md`, replacing the monotonic `NNNN-slug.md` scheme. A date needs no coordination between concurrent authors, and it is self-describing. The one remaining collision (same slug, same day) is caught by `just new-design` refusing to overwrite.
- The filename records when a design was *proposed*; git history records how *fresh* it is (`just design-age`). A hand-maintained date inside the document is still refused, because only that one can drift. Promotion stays a `status` flip, so the date never means "last touched".
- `category` accepts a list for designs spanning subsystems. Drawbacks survives promotion; only Unresolved questions is proposal-only, since the record of what was accepted is as useful after implementation as before.
- The old `[0-9][0-9][0-9][0-9]-*.md` glob in `design-doc-age.sh` would have matched date-prefixed names by accident, so the tightened glob is a correctness fix, not just prose.
- Generated-docs links live on `reference/README.md` as fully-qualified URLs. The design doc previously claimed `SUMMARY.md` accepts raw-URL sidebar entries; it does not, and a raw URL there fails the build. Full URLs resolve from local `mdbook serve` and forks, and `follow-web-links = false` already skips them, so no `linkcheck2` exclude is needed.
- The design doc is `active` while the site lands one page per PR, so it carries a rollout note and each PR in the stack ticks its own acceptance boxes.
- `AGENTS.md` drops its paragraph directing agents to a local authoring plugin: that tooling is not part of this repository.

## How this was tested

- `just book-build` (mdbook 0.5.3 + mermaid + linkcheck2) builds cleanly; `just ci-lint-markdown` and `shellcheck` pass.
- `just new-design <slug>` scaffolds a dated file and exits non-zero on a second run with the same slug.
- The frontmatter preprocessor strips the renamed design's and the template's YAML blocks; the rendered `<main>` opens on the H1.
