### PR TITLE
docs: add the development container design

### DIFF
--- a/.devcontainer/features/firewood-tools/install.sh
+++ b/.devcontainer/features/firewood-tools/install.sh
@@ -38,8 +38,10 @@ rustup toolchain install nightly --profile minimal
 rustup component add clippy rustfmt rust-src rust-docs llvm-tools --toolchain nightly
 
 # 3. cargo-binstall (prebuilt) so the remaining tools install without compiling.
+#    Pin the installer to a release commit (v1.21.0) instead of the floating `main`
+#    branch, matching the repo convention of pinning third-party sources by commit SHA.
 curl -L --proto '=https' --tlsv1.2 -sSf \
-  https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+  https://raw.githubusercontent.com/cargo-bins/cargo-binstall/ead08b90bd7b2e6d81963fb9cf0b7239f66d5db4/install-from-binstall-release.sh | bash
 
 # 4. sccache, then wire it in as the global rustc wrapper.
 cargo binstall --no-confirm --locked sccache

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
 - [Designs](designs/README.md)
   - [On-disk format and addressing](designs/2024-08-13-on-disk-format-and-addressing.md)
   - [mdBook documentation site](designs/2026-06-17-mdbook-documentation-site.md)
+  - [Development container](designs/2026-06-22-devcontainer.md)
   - [Template](designs/template.md)
 
 # Integration

--- a/docs/src/designs/2026-06-22-devcontainer.md
+++ b/docs/src/designs/2026-06-22-devcontainer.md
@@ -1,0 +1,152 @@
+---
+title: Development Container
+status: active
+category: tooling
+authors: [demosdemon]
+---
+
+# Development Container
+
+**Source:** `.devcontainer/`, `.github/workflows/devcontainer.yaml`
+
+## Overview
+
+Firewood's development container provides the Rust and Go toolchains, Nix, and the
+project's developer tooling. It is assembled declaratively from published
+[Dev Container features](https://containers.dev/features) plus one local feature —
+there is no `Dockerfile`. `devcontainer.json` layers features over the
+`mcr.microsoft.com/devcontainers/base:ubuntu26.04` base image (which provides the
+non-root `vscode` user, sudo, and common packages). Named Docker volumes persist
+developer authentication and shell history across container rebuilds.
+
+## Feature composition
+
+`devcontainer.json` composes these features, each pinned to its major version so
+patch and minor updates flow automatically while majors remain a deliberate bump:
+
+| Source | Provides |
+| --- | --- |
+| `mcr.microsoft.com/devcontainers/base:ubuntu26.04` (image) | base OS, non-root `vscode` user, sudo, common packages |
+| `github-cli:1` | `gh` |
+| `go:1` | Go toolchain (tracks `latest`) and `golangci-lint` |
+| `rust:1` (`profile: default`) | rustup + the stable toolchain with `clippy`, `rustfmt`, `rust-analyzer`, `rust-src` |
+| `nix:1` | Nix in daemon mode (`experimental-features = nix-command flakes`, `trusted-users = root vscode`) |
+| `node:1` | Node, required by the Claude Code feature |
+| `docker-in-docker:2` (`moby: false`) | Docker CE — Moby's `moby-cli` is not published for Ubuntu 26.04 |
+| `anthropics/devcontainer-features/claude-code:1` | the Claude Code CLI and its editor extension |
+| `./features/firewood-tools` (local) | build deps, sccache, cargo-nextest and other Cargo/Go tools, shell wiring (starship, sccache config, Claude Code symlink) — see [The local `firewood-tools` feature](#the-local-firewood-tools-feature) |
+
+Go tracks `latest` rather than a pinned version; `latest` always satisfies the Go
+floor in `ffi/go.mod`, which ends the manual version tracking that previously drifted.
+
+## The local `firewood-tools` feature
+
+`.devcontainer/features/firewood-tools/` is an in-repo feature that installs tooling
+with no maintained upstream equivalent. Its `devcontainer-feature.json` declares
+`installsAfter: [rust, go]` so it runs after those features during the image build.
+`install.sh` runs as root at build time and provides:
+
+- Build dependencies: `clang`, `cmake`, `libssl-dev`, `pkg-config`, `build-essential`,
+  `jq`, `shellcheck`.
+- Extra stable-toolchain components (`llvm-tools`, `rust-docs`) and a full `nightly`
+  toolchain.
+- `cargo-binstall`, then `sccache`, then sccache wiring written into
+  `/usr/local/cargo/config.toml`.
+- Cargo tools (via binstall): `ast-grep`, `cargo-edit`, `cargo-expand`,
+  `cargo-machete`, `cargo-msrv`, `cargo-nextest`, `git-cliff`, `just`, `ripgrep`,
+  `rustfilt`, `starship`.
+- Go tools (via `go install`): `dockerfmt`, `shfmt`.
+- Shell wiring: `starship` init, a persistent `HISTFILE`, and a symlink from
+  `~/.claude.json` to `~/.claude/user-claude.json` so Claude Code settings
+  land in the persistent volume.
+
+## Why there is no Dockerfile
+
+When `devcontainer.json` uses `build.dockerfile` together with `features`, the CLI
+builds the Dockerfile first and layers features on top — so anything that depends on
+`cargo`/`rustup` (cargo-binstall, sccache, the cargo tools, the nightly toolchain)
+cannot live in a Dockerfile, because it would run before the `rust` feature installs
+the toolchain. The local feature's `installsAfter: [rust, go]` orders that tooling
+after the toolchains within the feature layer, which is what makes the Dockerfile-less
+layout work. `installsAfter` only *orders* features that are already listed; it does
+not pull missing ones in, so `rust` and `go` stay explicitly listed in
+`devcontainer.json`.
+
+## Persistent state
+
+The named volumes below (suffixed `-${localEnv:USER}` for per-user isolation on
+shared hosts) start empty and fill on first use, so a one-time login survives rebuilds:
+
+| Volume target | Purpose |
+| --- | --- |
+| `/home/vscode/.cache/sccache` | sccache cache |
+| `/usr/local/cargo/registry`, `/usr/local/cargo/git` | cargo caches |
+| `/go/pkg` | Go module cache |
+| `/home/vscode/.config/gh` | `gh` authentication |
+| `/home/vscode/.claude` | Claude Code authentication, projects, and history |
+| `/home/vscode/.commandhistory` | shell history |
+
+Cargo and Go homes keep the features' defaults (`/usr/local/cargo`,
+`/usr/local/rustup`, `GOPATH=/go`); the cache volumes mount onto sub-paths so the
+features' PATH entries and tool proxies stay intact.
+
+## Build and runtime behavior
+
+- The container starts as the base image's `vscode` user.
+- Named volumes are created root-owned and mounted after the image build, so
+  `post-create.sh` (the `postCreateCommand`) `chown`s the volume targets to `vscode`
+  by username, then runs a verification smoke test (`rustup show`, `go version`,
+  `nix --version`, `sccache --show-stats`). The script is idempotent and safe to re-run on
+  rebuild.
+- `postStartCommand` runs `sccache --show-stats`.
+
+## Trade-offs and known interactions
+
+- **Rebuild required when upgrading** from the old Dockerfile-based container: an
+  editor reuses a container by its workspace-folder label, so the upgrade needs a
+  one-time "Rebuild Container" or the stale container fails with
+  `unable to find user vscode`.
+- The container user changes from the host `$USER` to `vscode`.
+- Go floats at `latest` rather than a pinned version.
+- Nix uses the upstream daemon-mode installer with `/nix` on a volume; the `ffi/`
+  flake is unchanged.
+- **IPv6 and `claude login`:** disabling IPv6 is not done by default (it is hard to
+  reverse). If `claude login` fails, `devcontainer.json` carries a commented
+  `--sysctl net.ipv6.conf.all.disable_ipv6=1` runArg to uncomment; see
+  [`.devcontainer/README.md`](https://github.com/ava-labs/firewood/blob/main/.devcontainer/README.md).
+
+## Security considerations
+
+This container is a developer convenience, not a hardened sandbox. Three properties
+are worth calling out:
+
+- **Privileged container.** The `docker-in-docker` feature runs the container
+  `--privileged`, which effectively grants root on the host's Docker. Do not use this
+  container to run untrusted code.
+- **Trusted Nix users.** The Nix install marks `root` and `vscode` as trusted users,
+  so anything running as `vscode` can reconfigure the Nix store and substituters. The
+  added risk is low, since `vscode` already has passwordless sudo in the base image.
+- **Tool installs are only partly pinned.** The `firewood-tools` feature bootstraps
+  `cargo-binstall` from a pinned installer commit, but the ~15 tools it then installs
+  via `cargo binstall`/`go install` float at their latest versions, so an upstream
+  compromise would land in the image. Pinning them is a possible follow-up.
+
+Per-user volume isolation is also incomplete. The volumes defined in
+`devcontainer.json` (the table above) are suffixed with `${localEnv:USER}`, but the
+volumes injected by the `nix` and `docker-in-docker` features — the Nix store and
+Docker's `/var/lib/docker` and `/var/lib/containerd` — are keyed by `${devcontainerId}`
+(derived from the workspace path, not the user). Two users who clone to the same path
+on a shared host still share those three volumes. This is accepted for now, not a
+guarantee.
+
+## Testing
+
+`.github/workflows/devcontainer.yaml` builds the container with the `devcontainers/ci`
+action on every `.devcontainer/**` change and smoke-tests the toolchains and
+feature-provided tools (`cargo +nightly`, `golangci-lint`, `shfmt`, `dockerfmt`,
+`starship`, `claude`, `shellcheck`, `jq`, and more). Because the action runs the full
+create lifecycle, `post-create.sh` is exercised in CI.
+
+## Related designs
+
+See [Design Documents](README.md) for the design workflow.

--- a/docs/src/designs/README.md
+++ b/docs/src/designs/README.md
@@ -31,6 +31,7 @@ location:
 | --- | --- | --- |
 | [On-disk format and addressing](2024-08-13-on-disk-format-and-addressing.md) | 2024-08-13 | active |
 | [mdBook documentation site](2026-06-17-mdbook-documentation-site.md) | 2026-06-17 | active |
+| [Development container](2026-06-22-devcontainer.md) | 2026-06-22 | active |
 
 ## Designs still to be written
 


### PR DESCRIPTION
## Why this should be merged

The dev container is the fastest path to a working Firewood build and the only one that is reproducible across machines, but nothing explained what it installs or why those choices were made. This documents the container as built, so a contributor can judge whether to use it and a maintainer can change it without re-deriving the intent.

## How this works

Filed as `2026-06-22-devcontainer.md` with `status: active`; content was checked against the shipped `.devcontainer/` files and `.github/workflows/devcontainer.yaml` rather than written from the design as originally imagined.

Also pins the `cargo-binstall` bootstrap script to the v1.21.0 release commit instead of fetching it from the floating `main` branch. Piping a moving branch tip into a shell during an image build makes the container non-reproducible and puts an upstream push in the path of every build; pinning by commit SHA matches how this repository handles other third-party sources. Verified the pinned SHA is the commit `cargo-bins/cargo-binstall` tags as `v1.21.0`.

Its "Related designs" section links only to the designs index for now. The reciprocal link to the Development Environment guide is added by the pull request that introduces that guide — the two documents reference each other, so whichever lands first cannot link forward without breaking the link checker.

## How this was tested

- `just book-build` builds cleanly with the new chapter linked from `SUMMARY.md`.
- `markdownlint-cli2` reports no errors on the touched Markdown; `shellcheck` is clean on the modified installer.
