### PR TITLE
docs: add the Concepts & Architecture landing page

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,7 +9,7 @@
 
 # Concepts
 
-- [Concepts & Architecture]()
+- [Concepts & Architecture](concepts/README.md)
 
 # Design Documents
 

--- a/docs/src/concepts/README.md
+++ b/docs/src/concepts/README.md
@@ -1,0 +1,37 @@
+# Concepts & Architecture
+
+Firewood uses the Merkle trie directly as its on-disk index. New roots are created
+per revision; superseded nodes are tracked in a future-delete log and their space
+returns to free lists once no live revision references them.
+
+![Firewood architecture](../assets/architecture.svg)
+
+## Terminology
+
+- **Revision** — a historical, point-in-time state of the trie, including all
+  key/value pairs and nodes at that point.
+- **View** — a read-only interface into a `Revision`, `Proposal`, or reconstructed
+  state.
+- **Node** — a portion of the trie; nodes link to other nodes and/or hold key/value
+  pairs.
+- **Future-delete log (FDL)** — the per-revision record of nodes superseded by a
+  commit; their on-disk space is not freed until the revision that produced them
+  expires.
+- **Free list** — a set of size-classed lists tracking freed on-disk space so later
+  allocations can reuse it.
+- **Hash / Root Hash** — the Merkle hash of a node; the root hash is the hash of a
+  revision's root node.
+- **Key / Value** — the byte arrays a trie indexes; a zero-length value is valid.
+- **Proof types** — a *key proof* attests a key exists in a revision; a *range proof*
+  bounds a key range with two key proofs plus the pairs between them; a *change proof*
+  is the set of changes between two revisions.
+- **Batch / Batch Operation** — a `Put` or `Delete` is a batch operation; an ordered
+  set of them is a batch.
+- **Proposal** — a base root hash plus a batch, not yet committed. A proposal is
+  required to commit.
+- **Reconstructed** — a base historical state plus a batch applied in memory;
+  read-only and not committable.
+- **Commit** — applying one or more proposals to the most recent revision.
+
+For the on-disk representation that implements these concepts, see
+[On-disk format and addressing](../designs/2024-08-13-on-disk-format-and-addressing.md).


### PR DESCRIPTION
## Why this should be merged

Firewood's vocabulary is unusual enough that the rest of the documentation is hard to read without it — "revision", "view", "proposal", and "reconstructed" all have precise meanings here that do not match their everyday senses, and the FDL and free lists have no everyday sense at all. This gives every later page one place to point at.

## How this works

Promotes the terminology and architecture prose that lived in the repository README into a book page, alongside the architecture diagram already committed under `docs/src/assets/`. The page ends by handing off to the on-disk format design for the representation that implements these concepts, so the conceptual page stays conceptual rather than drifting into storage detail.

Two terms are defined more sharply than the README had them: a zero-length value is valid and distinct from an absent key, and a "reconstructed" view is read-only and not committable — both are easy to get wrong from the type names alone.

## How this was tested

- `just book-build` builds cleanly; the cross-link to the on-disk format design and the diagram reference both resolve under linkcheck2.
- `markdownlint-cli2` reports no errors on the touched files.
