### PR TITLE
docs: add the Operations & Benchmarking landing page

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -25,7 +25,7 @@
 
 # Operations
 
-- [Operations & Benchmarking]()
+- [Operations & Benchmarking](operations/README.md)
 
 # Reference
 

--- a/docs/src/operations/README.md
+++ b/docs/src/operations/README.md
@@ -1,0 +1,20 @@
+# Operations & Benchmarking
+
+This section covers running and measuring Firewood.
+
+## `fwdctl`
+
+`fwdctl` is the command-line tool for operating on a Firewood database. See its
+[README](https://github.com/ava-labs/firewood/blob/main/fwdctl/README.md) for the
+available commands.
+
+## Benchmarking
+
+Firewood tracks performance with a C-Chain reexecution benchmark and synthetic
+workloads:
+
+- [C-Chain reexecution benchmark](https://github.com/ava-labs/firewood/blob/main/benchmark/docs/cchain-reexecution.md)
+- [Synthetic workloads](https://github.com/ava-labs/firewood/blob/main/benchmark/docs/synthetic-workloads.md)
+
+Live benchmark dashboards are published at [`/bench/` ↗](/firewood/bench/) (resolves
+only on the deployed site).


### PR DESCRIPTION
## Why this should be merged

Firewood's operational surface — the `fwdctl` CLI and the two benchmark suites — was discoverable only by finding the right directory in the repository. This gives the book a page that names all three and points at them.

## How this works

A thin landing page by design: `fwdctl` and the benchmark suites already have maintained documentation next to the code they describe, so this links out to it rather than restating it where a copy would drift. All three targets were confirmed present at the paths linked.

The live dashboards are a site-absolute `/firewood/bench/` link, which resolves only on the deployed GitHub Pages site; the page says so, and the path is covered by the link checker's exclude list. Deeper sub-pages are omitted from `SUMMARY.md` rather than shipped as empty stubs, per the documentation-site design.

## How this was tested

- `just book-build` builds cleanly, with the `/firewood/bench/` link-out correctly skipped by the linkcheck2 exclude.
- `markdownlint-cli2` reports no errors on the touched files.
