### PR TITLE
docs: add the Meta section

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -33,4 +33,6 @@
 
 # Meta
 
-- [About These Docs]()
+- [About These Docs](meta/README.md)
+  - [How these docs work](meta/documentation.md)
+  - [Release process](meta/release.md)

--- a/docs/src/designs/2026-06-17-mdbook-documentation-site.md
+++ b/docs/src/designs/2026-06-17-mdbook-documentation-site.md
@@ -794,7 +794,7 @@ Distilled from the [`mdbooks.yaml` catalog](https://github.com/szabgab/mdbooks.c
       (`Database`/`Proposal`/`Revision`, mapping to the Rust `Db`/`Proposal`/`DbView`)
       and the `firewood-go-ethhash` publish relationship that AvalancheGo actually
       consumes.
-- [ ] A `meta/` section exists with an **authored** `documentation.md` (how the docs
+- [x] A `meta/` section exists with an **authored** `documentation.md` (how the docs
       work: tooling, layout, build/serve, authoring, design workflow) and thin
       repository-function pages (`release.md` plus link-out pointers to CONTRIBUTING /
       CODE_REVIEW); the process-doc link-outs are in `meta/`, not `reference/`.

--- a/docs/src/meta/README.md
+++ b/docs/src/meta/README.md
@@ -1,0 +1,7 @@
+# About These Docs
+
+This section documents the repository's processes and the documentation system
+itself.
+
+- [How these docs work](documentation.md)
+- [Release process](release.md)

--- a/docs/src/meta/documentation.md
+++ b/docs/src/meta/documentation.md
@@ -1,0 +1,38 @@
+# How These Docs Work
+
+This site is an [mdBook](https://rust-lang.github.io/mdBook/) rooted at `docs/`
+(`docs/book.toml`, `docs/src/`).
+
+## Toolchain
+
+- `mdbook` builds the book.
+- `mdbook-mermaid` renders Mermaid diagrams; its JS assets are generated at build time
+  by `just book-assets` and are git-ignored.
+- Callouts use mdBook's native alert syntax (`> [!NOTE]`, `> [!WARNING]`, …) — no
+  preprocessor required.
+- `mdbook-linkcheck2` runs as a backend during `mdbook build` and validates internal
+  links (`follow-web-links = false`).
+- The in-repo `frontmatter-strip` preprocessor removes each design doc's YAML
+  frontmatter before rendering (it needs `jq` on `PATH`; no binary to install).
+
+## Build and serve
+
+- `just book-serve` — serve locally with live reload.
+- `just book-build` — build and run the link checker. This mirrors the book-build and
+  link-check part of CI, not the full site assembly (rustdoc, Go docs, benchmark merge)
+  the Pages workflow also runs.
+
+Install the toolchain as described in
+[Development Environment](../getting-started/dev-environment.md).
+
+## Adding or editing a page
+
+1. Add or edit a Markdown file under `docs/src/`.
+2. Add it to `docs/src/SUMMARY.md` — a linked entry for real content, or a draft
+   chapter (`- [Title]()`) for a page not yet written.
+3. Run `just book-build` to validate, then open a pull request.
+
+## Designs
+
+The [Design Documents](../designs/README.md) section describes how to propose and
+promote designs, including the `just new-design` scaffolder.

--- a/docs/src/meta/release.md
+++ b/docs/src/meta/release.md
@@ -1,0 +1,15 @@
+# Release Process
+
+Firewood's release process is documented in
+[`RELEASE.md`](https://github.com/ava-labs/firewood/blob/main/RELEASE.md). It covers
+semver tagging, publishing the Rust workspace crates to crates.io, and triggering the
+CI pipeline that builds the static library, copies `ffi/` into the
+`ava-labs/firewood-go-ethhash` repository, and tags the resulting Go module.
+
+## Related repository processes
+
+- [Contributing](https://github.com/ava-labs/firewood/blob/main/CONTRIBUTING.md) —
+  testing requirements, PR workflow, and coding conventions
+- [Code review](https://github.com/ava-labs/firewood/blob/main/CODE_REVIEW.md) —
+  the Firewood-specific review checklist: Rust safety, lint suppression, and
+  FFI/unsafe code


### PR DESCRIPTION
## Why this should be merged

The documentation system had no page explaining itself: which preprocessors run, why the link checker is a renderer backend rather than a command, and what to do to add a page. A contributor's first documentation change should not require reverse-engineering `book.toml`. This also gives the book a home for repository-process pages, keeping process link-outs out of Reference, which is reserved for generated artifacts.

## How this works

Three pages. `documentation.md` is the authored one: the toolchain, the build and serve recipes, and the add-a-page workflow. Two details are called out because they are the ones that bite — `mdbook-linkcheck2` is a renderer backend that runs as part of `mdbook build` with no separate command to invoke, and the in-repo frontmatter preprocessor needs `jq` on `PATH`.

`release.md` is deliberately thin, pointing at `RELEASE.md`, `CONTRIBUTING.md`, and `CODE_REVIEW.md` rather than restating them; those live next to what they govern and a copy here would drift. It does summarize the one thing not obvious from any single file: that publishing spans two repositories, with a `firewood-ffi` tag triggering CI to build static libraries, copy `ffi/` into `ava-labs/firewood-go-ethhash`, and tag it there.

Lands before the Integration page, which links to `release.md` for exactly that publish cadence. Ticks the corresponding acceptance criterion in the mdBook documentation-site design.

## How this was tested

- `just book-build` builds cleanly; the cross-links to the designs index and the Development Environment guide both resolve.
- `markdownlint-cli2` reports no errors on the touched Markdown.
- Confirmed `CODE_REVIEW.md`, `CONTRIBUTING.md`, and `RELEASE.md` exist at the linked paths.
