### PR TITLE
docs: add the AvalancheGo & EVM Integration landing page

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -21,7 +21,7 @@
 
 # Integration
 
-- [AvalancheGo & EVM Integration]()
+- [AvalancheGo & EVM Integration](integration/README.md)
 
 # Operations
 

--- a/docs/src/designs/2026-06-17-mdbook-documentation-site.md
+++ b/docs/src/designs/2026-06-17-mdbook-documentation-site.md
@@ -785,7 +785,7 @@ Distilled from the [`mdbooks.yaml` catalog](https://github.com/szabgab/mdbooks.c
 - [x] `scripts/design-doc-age.sh` (run via `just design-age`) lists each design by last
       git-commit date, oldest-first, from git history alone — never a filename's date
       prefix and never an in-doc date.
-- [ ] Sections with seed content (`concepts/`, `integration/`, `operations/`,
+- [x] Sections with seed content (`concepts/`, `integration/`, `operations/`,
       `reference/`) have authored landing pages and linked `SUMMARY.md` entries.
       Not-yet-written sub-pages are omitted from `SUMMARY.md` (added when their content
       lands) rather than shipped as empty `.md` files; no sub-page draft chapters ship

--- a/docs/src/integration/README.md
+++ b/docs/src/integration/README.md
@@ -1,0 +1,43 @@
+# AvalancheGo & EVM Integration
+
+Firewood exposes a Go API through its FFI layer, and downstream consumers (AvalancheGo
+and downstream projects) depend on a separately published Go module.
+
+## The Go API surface
+
+The in-repo `ffi/` directory ships a Go wrapper. Its public types map onto Firewood's
+Rust concepts — the Go names deliberately differ from the Rust ones:
+
+| Go type | Rust concept | Notes |
+| --- | --- | --- |
+| `Database` (`firewood.go`) | `Db` | the database handle; there is no Go type named `Db` |
+| `Proposal` (`proposal.go`) | `Proposal` | uncommitted batch atop a base root |
+| `Revision` (`revision.go`) | `DbView` | read-only view backed by a pinned revision (`DbView` is a Rust trait) |
+| `Reconstructed` (`reconstructed.go`) | reconstructed/archival view | state rebuilt from range proofs during state sync; freed by calling `Drop()` |
+| `Iterator` (`iterator.go`) | view iterator | streams key/value pairs; `Next` copies, `NextBorrowed` lends Rust memory |
+| `BatchOp` (`batch_op.go`) | `BatchOp` | a single `Put`/`Delete`/`PrefixDelete`; the unit of a write batch |
+| `RangeProof`, `ChangeProof`, `NextKeyRange` (`proofs.go`) | proof types | range/change proofs and key-range cursors for state sync |
+
+`New` constructs each type; the `With*` options tune it. The metrics and logging
+entry points (`Gatherer`, `LogConfig`, `StartMetrics`, `StartLogs`) wire up
+observability. The generated Go API reference is published as
+[Go API documentation (godoc) ↗](/firewood/ffi/) (resolves only on the deployed site).
+
+## How downstream consumers depend on Firewood
+
+AvalancheGo and downstream projects do **not** import the in-repo `ffi/` directory. They depend
+on the separately published Go module `github.com/ava-labs/firewood-go-ethhash/ffi`,
+pinned in their `go.mod` files. Firewood's crates are versioned independently, and that
+module tracks the `firewood-ffi` crate: the crate version is bumped by hand before a
+release (see the release process), and pushing the matching semver tag triggers CI to
+build the static libraries, copy the in-repo `ffi/` directory into the
+`ava-labs/firewood-go-ethhash` repository, and tag it there. See
+the build flow in [`ffi/README.md`](https://github.com/ava-labs/firewood/blob/main/ffi/README.md)
+(`cargo build` → `go tool cgo`) and the publish/version cadence in
+[the release process](../meta/release.md).
+
+> [!NOTE]
+> The Go module path in `firewood-go-ethhash` is rewritten by CI from the in-repo
+> path to `github.com/ava-labs/firewood-go-ethhash/ffi`. The tag format follows Go
+> module conventions: a `firewood-ffi` release `vX.Y.Z` is tagged as
+> `ffi/vX.Y.Z` in the `firewood-go-ethhash` repository.


### PR DESCRIPTION
## Why this should be merged

The integration story had a gap that reliably confuses newcomers: AvalancheGo does not import the `ffi/` directory in this repository. It depends on a separately published Go module, `github.com/ava-labs/firewood-go-ethhash/ffi`, and someone reading only this repository has no way to discover that. This page documents the relationship that is actually consumed downstream.

## How this works

Two parts. A table mapping the Go wrapper types onto their Rust concepts, because the names deliberately diverge and the divergence is not guessable — Go's `Database` is Rust's `Db` (there is no Go type named `Db`), and Go's `Revision` corresponds to the Rust `DbView` *trait*. Then the publish relationship: the `firewood-ffi` crate version is bumped by hand, and pushing the matching semver tag triggers CI to build the static libraries, copy `ffi/` into `ava-labs/firewood-go-ethhash`, and tag it there with a `ffi/` prefix so `go get` resolves it as a module version.

Every claim in the table was checked against the source rather than carried over on trust: all seven `ffi/*.go` files exist, all eleven named types are declared, `DbView` is a trait at `firewood/src/api.rs:335`, no Go type named `Db` exists, and the `ffi/` tag prefix is applied at `attach-static-libs.yaml:179`. Worth noting the workflow does *not* prefix pre-release versions such as `v1.1.1-beta`, since `go get` treats those as non-semantic tags — the page's claim is scoped to plain `vX.Y.Z` accordingly.

This is the last of the section landing pages, so it ticks the corresponding acceptance criterion in the mdBook documentation-site design. It links to the Meta section's release page for the publish cadence, which is why it lands after that section.

## How this was tested

- `just book-build` builds cleanly; the cross-link to `meta/release.md` resolves and the `/firewood/ffi/` link-out is correctly skipped by the linkcheck2 exclude.
- `markdownlint-cli2` reports no errors on the touched files.
