### PR TITLE
docs: align the repository process docs with the site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,35 +11,49 @@ guidelines for contributing to firewood.
 * [How to submit changes](#how-to-submit-changes)
 * [Required merge checks](#required-merge-checks)
 * [Signing your commits](#signing-your-commits)
-* [Code Review Process](#code-review-process)
+* [Code review process](#code-review-process)
+* [How to report a bug](#how-to-report-a-bug)
+* [First time fixes for contributors](#first-time-fixes-for-contributors)
+* [How to request an enhancement](#how-to-request-an-enhancement)
 * [Labels](#labels)
+* [Style Guide / Coding Conventions](#style-guide--coding-conventions)
 * [Where can I ask for help?](#where-can-i-ask-for-help)
+* [Thank you](#thank-you)
 
 ## Quick Links
 
-* [Setting up docker](README.docker.md)
+* [Development container](.devcontainer/README.md)
 * [Auto-generated documentation](https://ava-labs.github.io/firewood/rustdoc/firewood/)
 * [Issue tracker](https://github.com/ava-labs/firewood/issues)
 
 ## Testing
 
-After submitting a PR, we'll run all the tests and verify your code meets our submission guidelines. To ensure it's more likely to pass these checks, you should run the following commands locally:
+CI runs all tests and verifies your code meets the submission guidelines. Run the following commands locally before opening a PR:
 
-    cargo fmt
-    cargo nextest run
-    cargo clippy
-    cargo doc --no-deps
+```sh
+cargo fmt
+cargo nextest run --workspace --features ethhash,logger --all-targets
+cargo +nightly-2026-07-05 clippy --workspace --features ethhash,logger --all-targets
+cargo +nightly-2026-07-05 clippy --profile maxperf --workspace --features ethhash,logger --all-targets
+cargo doc --no-deps
+```
 
 Resolve any warnings or errors before making your PR.
 
-Also, if you update any versions of packages, notably the MSRV (Minimum Supported Rust Version), you ought to update the nix ffi flake lock file to pin compatible versions of nix packages as well:
+Clippy runs on the pinned nightly toolchain (`nightly-2026-07-05`) that CI's
+required lint job uses, and the second invocation checks the `maxperf` profile
+(debug assertions off). Running clippy on stable can pass locally yet still fail
+the required CI check, which enforces lints stable does not.
 
-    ./scripts/run-just.sh update-ffi-flake
+Also, if you update any versions of packages, notably the MSRV (Minimum Supported Rust Version), update the nix ffi flake lock file to pin compatible versions of nix packages as well:
+
+```sh
+./scripts/run-just.sh update-ffi-flake
+```
 
 ## How to submit changes
 
-To create a PR, fork firewood, and use GitHub to create the PR. We typically prioritize reviews in the middle of the next work day,
-so you should expect a response during the week within 24 hours.
+To create a PR, fork firewood, and use GitHub to create the PR. Expect a response within one business day.
 
 ## Required merge checks
 
@@ -59,9 +73,11 @@ before you open one — GitHub should then show every commit as **Verified**.
 
 The quickest setup is signing with the SSH key you already push with:
 
-    git config --global gpg.format ssh
-    git config --global user.signingkey ~/.ssh/id_ed25519.pub
-    git config --global commit.gpgsign true
+```sh
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+```
 
 Then add that key to GitHub as a **Signing Key** under *Settings → SSH and GPG
 keys*. See GitHub's [signing commits][gh-signing] guide for full details,
@@ -69,38 +85,36 @@ including GPG keys and Windows/macOS setup.
 
 [gh-signing]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
 
-## Code Review Process
-
-Code review is a critical part of our development process. It ensures that our codebase remains maintainable, performant, and secure. This document outlines how we approach code reviews at Ava Labs, with responsibilities and expectations for both reviewers and authors.
+## Code review process
 
 ### For Reviewers
 
-Reviews should be completed or commented within one business day. We have a daily reminder for reviews that have not been reviewed that is posted in slack's #firewood channel.
+Reviews should be completed or commented within one business day.
 
 When reviewing code, your goal is to help the author improve the quality of the change and confirm that it meets our architectural and operational standards. GitHub provides three primary review options:
 
-#### ✅ Accept (Approve)
+#### Accept (Approve)
 
 Use this when the code is an improvement over the current state of the codebase.
 
 * It's okay to request minor changes in comments and still approve the pull request.
 * Perfection is not the goal — progress is. If the submitted code is better than what's in production, it's acceptable to approve even if small improvements remain. Consider adding a new issue or request adding a code TODO for larger changes.
 
-#### 💬 Comment (Comment Only)
+#### Comment (Comment Only)
 
 Use this when your review is incomplete, or you're not ready to approve or reject yet. You should use this if the code is too large to review in a limited amount of time (typically 30-60 minutes). You can also suggest how to break up this diff into a smaller diff.
 
 * This can be helpful for asking clarifying questions, suggesting optional improvements, or flagging issues you're unsure about.
 * This state signals that your review is in progress or advisory, not final.
 
-#### ❌ Reject (Request Changes)
+#### Reject (Request Changes)
 
 Use this when there are significant concerns with the code's correctness, architecture, design, or maintainability.
 
 * A "Reject" signals that the pull request must not be merged until the raised issues are addressed.
 * The author is expected to make substantial revisions and return the code for a second round of review by the same reviewer.
 
-#### Best Practices
+#### Best practices
 
 * Be respectful and constructive. Your comments should guide and empower the author, not discourage them.
 * Justify your feedback with principles, not preferences.
@@ -153,9 +167,9 @@ the GitHub UI.
 
 ## Style Guide / Coding Conventions
 
-We generally follow the same rules that `cargo fmt` and `cargo clippy` will report as warnings, with a few notable exceptions as documented in the associated Cargo.toml file.
+We generally follow the same rules that `cargo fmt` and `cargo clippy` will report as warnings, with a few notable exceptions as documented in the workspace `Cargo.toml` under `[workspace.lints.clippy]`.
 
-By default, we prohibit bare `unwrap` calls and index dereferencing, as there are usually better ways to write this code. In the case where you can't, please use `expect` with a message explaining why it would be a bug, which we currently allow. For more information on our motivation, please read this great article on unwrap: [Using unwrap() in Rust is Okay](https://blog.burntsushi.net/unwrap) by [Andrew Gallant](https://blog.burntsushi.net).
+By default, we prohibit bare `unwrap` calls and index dereferencing, as there are usually better ways to write this code. In the case where you can't, please use `expect` with a message explaining why it would be a bug, which we currently allow. For more information on our motivation, see [Using unwrap() in Rust is Okay](https://burntsushi.net/unwrap/) by [Andrew Gallant](https://burntsushi.net).
 
 ### Documenting wrappers, shims, and FFI adapters
 
@@ -183,16 +197,18 @@ Instead:
 In Rust, `rustdoc` renders `[Type::method]` as a clickable link, so referencing
 the canonical documentation is both DRY and convenient — prefer it:
 
-    /// Produce an `eth_getProof`-compatible proof against a reconstructed view
-    /// rather than a committed revision.
-    ///
-    /// See [`fwd_eth_get_proof`] for the proof format, arguments, return values,
-    /// and key-encoding requirements.
-    ///
-    /// # Safety
-    ///
-    /// As [`fwd_eth_get_proof`], except `reconstructed` must be a valid pointer to
-    /// a [`ReconstructedHandle`].
+```rust
+/// Produce an `eth_getProof`-compatible proof against a reconstructed view
+/// rather than a committed revision.
+///
+/// See [`fwd_eth_get_proof`] for the proof format, arguments, return values,
+/// and key-encoding requirements.
+///
+/// # Safety
+///
+/// As [`fwd_eth_get_proof`], except `reconstructed` must be a valid pointer to
+/// a [`ReconstructedHandle`].
+```
 
 In Go, doc links such as `[Revision.EthGetProof]` (available since Go 1.19) are
 clickable on pkg.go.dev and navigable via `gopls`, just as in Rust, so the same
@@ -204,8 +220,10 @@ principle and does not treat DRY as overriding, and the
 [Uber Go Style Guide][uber-go-style] is likewise a catalog of conventions that
 favor clarity and consistency:
 
-    // EthGetProof is [Revision.EthGetProof] evaluated against this reconstructed
-    // view. It returns [ErrDroppedReconstructed] if the view has been released.
+```go
+// EthGetProof is [Revision.EthGetProof] evaluated against this reconstructed
+// view. It returns [ErrDroppedReconstructed] if the view has been released.
+```
 
 [google-go-style]: https://google.github.io/styleguide/go/guide
 [uber-go-style]: https://github.com/uber-go/guide/blob/master/style.md
@@ -216,4 +234,4 @@ If you have questions or need help, please post them as issues in the [issue tra
 
 ## Thank you
 
-We'd like to extend a pre-emptive "thank you" for reading through this and submitting your first contribution!
+We'd like to extend a preemptive "thank you" for reading through this and submitting your first contribution!

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Firewood: Compaction-Less Database Optimized for Efficiently Storing Recent Merkleized Blockchain State
+# Firewood: compaction-less database optimized for efficiently storing recent Merkleized blockchain state
 
 ![Github Actions](https://github.com/ava-labs/firewood/actions/workflows/ci.yaml/badge.svg?branch=main)
 [![Ecosystem license](https://img.shields.io/badge/License-Ecosystem-blue.svg)](./LICENSE.md)
 
-> :warning: Firewood is beta-level software.
-> The Firewood API may change with little to no warning.
+> [!WARNING]
+> Firewood is beta-level software. Its API may change with little to no warning.
 
 Firewood is an embedded key-value store, optimized to store recent Merkleized blockchain
 state with minimal overhead. Most blockchains, including Avalanche's C-Chain and Ethereum, store their state in Merkle tries to support efficient generation and verification of state proofs.
@@ -17,7 +17,7 @@ to feed into the underlying database that is unaware of the data being stored.
 The convenient byproduct of this approach is that iteration is still fast (for serving state sync queries)
 but compaction is not required to maintain the index.
 Firewood was first conceived to provide a very fast storage layer for the EVM,
-but could be used on any blockchain that requires an authenticated state.
+but can be used on any blockchain that requires an authenticated state.
 
 By default, Firewood only attempts to store recent revisions on-disk and will actively clean up unused data when revisions expire.
 It keeps some configurable number of previous states in memory and on disk to power state sync and APIs
@@ -30,7 +30,7 @@ Firewood also supports archival mode via `RootStore`, which retains all historic
 
 Hashes are not used to determine where a node is stored on disk in the database file.
 Instead space for nodes may be allocated from the end of the file,
-or from space freed from expired revision. Free space management algorithmically resembles that of traditional heap memory management, with free lists used to track different-size spaces that can be reused.
+or from space freed from expired revision. Free space management resembles that of traditional heap memory management, with free lists used to track different-size spaces that can be reused.
 The root address of a node is simply the disk offset within the database file,
 and each branch node points to the disk offset of that other node.
 
@@ -65,7 +65,7 @@ as well as carefully managing the free list during the creation and expiration o
 - `Change Proof` - A proof that consists of a set of all changes between two
   revisions.
 - `Put` - An operation for a `Key`/`Value` pair. A put means "create if it doesn't
-  exist, or update it if it does. A put operation is how you add a `Value` for a
+  exist, or update it if it does". A put operation is how you add a `Value` for a
   specific `Key`.
 - `Delete` - An operation indicating that a `Key` should be removed from the trie.
 - `Batch Operation` - An operation of either `Put` or `Delete`.
@@ -86,13 +86,14 @@ as well as carefully managing the free list during the creation and expiration o
 
 ## Metrics
 
-Firewood provides comprehensive metrics for monitoring database performance, resource utilization, and operational characteristics. For detailed information about all available metrics, how to enable them, and how to interpret them, see [METRICS.md](METRICS.md).
+Firewood exposes metrics for monitoring database performance and resource utilization.
+See [METRICS.md](METRICS.md) for details.
 
 ## Development Environment
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ava-labs/firewood)
 
-The quickest way to get started is with the included devcontainer, which
+The simplest way to get started is with the included devcontainer, which
 provides a fully configured environment with all required tools pre-installed.
 
 **GitHub Codespaces** — click the badge above or go to
@@ -115,9 +116,9 @@ See [`.devcontainer/`](.devcontainer/) for the full configuration.
 In order to build firewood, the following dependencies must be installed:
 
 - `cargo` See [installation instructions](https://doc.rust-lang.org/cargo/getting-started/installation.html).
-- `make` See [download instructions](https://www.gnu.org/software/make/#download) or run `sudo apt install build-essential` on Linux.
+- **[just](https://github.com/casey/just)** — task runner (`just --list` shows available recipes). Optional; all commands can also be run with `cargo` directly.
 
-More detailed build instructions, including some scripts,
+More detailed build instructions, including benchmark environment setup scripts,
 can be found in the [benchmark setup scripts](benchmark/setup-scripts).
 
 If you want to build and test the ffi layer for another platform,
@@ -136,28 +137,32 @@ understands that an "account" is actually just a node in the storage tree at a s
 and computes the hash of the account trie as if it were an actual root.
 
 It is worth noting that the hash stored as a value inside the account root RLP is not used.
-During hash calculations, we know the hash of the children,
-and use that directly to modify the value in-place
+During hash calculations, the hashes of the children are already known
+and are used directly to modify the value in-place
 when hashing the node.
-See [replace\_hash](firewood/storage/src/hashers/ethhash.rs) for more details.
+See [replace\_list\_field](storage/src/rlp.rs) and the module documentation in
+[ethhash.rs](storage/src/hashers/ethhash.rs) for more details.
 
 ## Run
 
 Example(s) are in the [examples](firewood/examples) directory, that simulate real world
-use-cases. Try running the insert example via the command-line, via `cargo run --release
---example insert`.
+use-cases. Try running the insert example:
+
+```sh
+cargo run --release --example insert
+```
 
 For performance benchmarking — C-Chain re-execution, Rust criterion, and synthetic workloads — see [benchmark/README.md](benchmark/README.md).
 
 For maximum runtime performance at the cost of compile time,
-use `cargo run --maxperf` instead,
+use `cargo run --profile maxperf` instead,
 which enables maximum link time compiler optimizations.
 
 ## Logging
 
 If you want logging, enable the `logging` feature flag, and then set RUST\_LOG accordingly.
 See the documentation for [env\_logger](https://docs.rs/env_logger/latest/env_logger/) for specifics.
-We currently have very few logging statements, but this is useful for print-style debugging.
+Firewood currently emits very few log statements, but this is useful for print-style debugging.
 
 ## Release
 
@@ -175,8 +180,10 @@ Firewood comes with a CLI tool called `fwdctl` that enables one to create and in
 ## Test
 
 ```sh
-cargo nextest --release
+cargo nextest run --workspace --features ethhash,logger --all-targets
 ```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md#testing) for the full set of pre-PR checks.
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,11 @@
-# Releasing firewood
+# Releasing Firewood
 
-Releasing firewood is straightforward and can mostly be done in CI. Updating the
-Cargo.toml file is currently manual.
+Most of the release process runs in CI. Updating `Cargo.toml` is a manual step.
 
 Firewood is made up of several sub-projects in a workspace. Each project is in
 its own crate and has an independent version.
 
-## Workspace Dependencies
+## Prerequisites
 
 Ensure the following tools are installed before beginning:
 
@@ -25,11 +24,9 @@ branch 'release/v0.1.1' set up to track 'origin/main'.
 Switched to a new branch 'release/v0.1.1'
 ```
 
-If already on a new branch, ensure `HEAD` is the same as the remote's `main`.
-As the upstream repo changes, rebase the branch onto `main` so that the changes
-from `git cliff` follow the repository history in the correct linear order.
-
-On rebase, quickly redo the generative steps with `just`:
+If the release branch falls behind `origin/main` while in review, rebase it
+(not merge — `git cliff` requires a linear commit history for correct changelog
+ordering) and regenerate the release artifacts:
 
 ```shell
 just release-step-update-rust-dependencies && just release-step-refresh-changelog v0.1.1
@@ -42,21 +39,21 @@ just release-step-update-rust-dependencies && just release-step-refresh-changelo
 Optionally, the minimum supported rust version can be bumped. See
 <https://blog.rust-lang.org/releases/latest> for the latest version. Best
 effort 2 releases behind the current latest stable [^1]. However, Rust evolves
-fairly quickly and we occasionally want to take advantage of a new improvement
-before the stable release matures.
+fairly quickly, and a new improvement is occasionally worth adopting before the
+stable release matures.
 
 Updating the Rust MSRV requires edits in two places:
 
 - [clippy.toml]
   - Update the root `msrv` setting to indicate the set MSRV. This configures
     clippy to include newer lints that would otherwise be incorrect with a lower
-    MSRV; such as recommending newly stablized features that were unstable in
+    MSRV; such as recommending newly stabilized features that were unstable in
     the older release.
 - [Cargo.toml]
   - Update `workspace.package.rust-version` which will propagate through the
     other cargo packages that have `package.rust-version.workspace = true` set.
 
-[^1]: e.g., with 1.91 stable, 1.89 is the best effort MSRV
+[^1]: e.g., with 1.96 stable, 1.94 is the best effort MSRV
 
 ### Cargo Dependencies
 
@@ -100,7 +97,7 @@ bump signals non-breaking changes.
 
 ### Crates with public API guarantees
 
-| Crate | Public interface |
+| Component | Public interface |
 | ----- | ---------------- |
 | `firewood` | Rust API |
 | `firewood-storage` | Rust API |
@@ -108,15 +105,19 @@ bump signals non-breaking changes.
 | `firewood-go` (via `firewood-go-ethhash`) | Go module API |
 | `fwdctl` | CLI flags and config file format |
 
-Tag pull requests with the appropriate `breaking-change/<crate>` label when the
-change breaks the public interface. `git cliff` reads these labels via the GitHub
-API and marks affected entries in the CHANGELOG automatically.
+Tag pull requests with the `breaking-change` label when the change breaks the
+public interface. `git cliff` reads this label via the GitHub API and marks
+affected entries in the CHANGELOG automatically.
 
 ### Crates without public API guarantees
 
-`firewood-macros`, `firewood-benchmark`, `firewood-replay`, and `firewood-triehash`
-have no stability guarantees. `firewood-triehash` is a test helper pinned at its
-current version; do not bump it during workspace releases.
+`firewood-macros`, `firewood-metrics`, `firewood-benchmark`, `firewood-replay`, and
+`firewood-triehash` have no stability guarantees. `firewood-triehash` is a test helper
+pinned at its current version; do not bump it during workspace releases.
+`firewood-metrics` provides shared metrics utilities and has no independent stability
+guarantee (the metrics schema consumers rely on is covered by `firewood-ffi`, above).
+While the workspace patches `metrics` to a git fork, crates.io publishing is currently
+blocked: crates.io rejects the resulting non-registry dependency (see Publish, below).
 
 ### Determining whether a change is breaking
 
@@ -144,7 +145,7 @@ For semver breaking changes, all downstream packages require upgrading to the ne
 therefore, the next step is to bump the dependency declarations to the new version.
 Packages within the workspace that are used as libraries are also defined within
 the [`[workspace.dependencies]`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table)
-table. E.g.,:
+table. For example:
 
 ```toml
 [workspace.dependencies]
@@ -154,8 +155,7 @@ firewood = { path = "firewood", version = "0.1.1" }
 
 This allows packages within the workspace to inherit the dependency,
 including path, version, and workspace-level features by adding `workspace = true`
-to the dependency table (note: using `cargo add -p firewood-fwdctl firewood-metrics`
-would automatically add the dependency with `workspace = true`).
+to the dependency table.
 
 ```toml
 [dependencies]
@@ -169,8 +169,9 @@ firewood-storage = { workspace = true, features = ["io-uring"] }
 > `io-uring` needs no per-target dependency table. The feature is accepted on
 > every platform and only takes effect on Linux; see `storage/build.rs`.
 
-Thefefore, after updating the `workspace.package.version` value, we must update
-the dependency versions to match.
+Therefore, after updating each package's version in `[workspace.dependencies]`
+(and in the crate's own `Cargo.toml` if it sets `package.version` directly),
+update the matching dependency declarations to the new version.
 
 Run `cargo update` after editing the `Cargo.toml` files to ensure the lockfile
 is correct and reflects the new package versions.
@@ -191,7 +192,7 @@ just release-step-refresh-changelog v0.1.1
 ```
 
 Breaking changes are detected automatically from both conventional commit
-syntax (`feat!:`, `BREAKING CHANGE:` footer) and PR labels (`breaking-change/*`).
+syntax (`feat!:`, `BREAKING CHANGE:` footer) and PR labels (`breaking-change`).
 No manual edits to `CHANGELOG.md` are needed or expected.
 
 ## Commit
@@ -202,16 +203,16 @@ Commit the version bump and change log updates. Using the summary prefix:
 
 will cause `git-cliff` to omit the commit from the changelog. This is why
 substantive changes when upgrading dependencies should be in their own commit.
-If you do not use the prefix, there will be an egg-and-chicken problem as the
-commit message generated by GitHub includes the pull request as a suffix.
-Manually resolve this in the CHANGELOG if needed; otherwise, the CHANGELOG will
-have irrelevant changes on future releases.
+Without this prefix, `git cliff` includes the version-bump commit in the next
+release's changelog, producing a stale pull-request reference (the PR number
+did not exist when the commit was written). Manually correct the CHANGELOG if
+the prefix was omitted.
 
-## Review
+## Open and merge the release PR
 
-> ❗ Be sure to update the versions of all sub-projects before creating a new
-> release. Open a PR with the updated versions and merge it before continuing to
-> the next step.
+> [!IMPORTANT]
+> Update the versions of all relevant packages before opening this PR. After
+> the PR merges, continue to the tagging and publishing steps.
 
 ## Publish
 
@@ -228,7 +229,8 @@ git push origin v0.1.1
 
 ### What CI does automatically
 
-Pushing the tag triggers three automated jobs:
+Pushing the tag triggers two automated jobs (the crates.io publish is a separate
+step that runs later, when the draft release is published — see below):
 
 1. **Draft GitHub release** ([`.github/workflows/release.yaml`](.github/workflows/release.yaml)):
    Creates a draft release with auto-generated notes. Do not act yet — publish
@@ -241,7 +243,8 @@ Pushing the tag triggers three automated jobs:
 
 ### Publish the draft release (manual step)
 
-The crates.io workflow does **not** run until the GitHub release is published.
+> [!IMPORTANT]
+> The crates.io workflow does **not** run until the GitHub release is published.
 
 1. Go to <https://github.com/ava-labs/firewood/releases>.
 2. Find the draft (labelled **Draft**).
@@ -261,8 +264,6 @@ dependency order, automatically skipping:
   (crates.io rejects non-registry dependencies).
 
 ## Milestone
-
-> NOTE: this should be automated as well.
 
 Close the GitHub milestone for the version that was released. Be sure to create
 a new milestone for the next version if one does not already exist. Carry over


### PR DESCRIPTION
Final PR in the mdBook content stack. Corrects the three repository-root process docs that the book's Meta section links out to, so a reader following those links does not land on stale instructions.

## Why this should be merged

Several of these were actively wrong, not merely dated: the README's test command (`cargo nextest --release`) is not a valid nextest invocation and omits the feature flags the suite needs, `cargo run --maxperf` is not a cargo flag, and the ethhash pointer named a function and a path that do not exist. Each of them fails for anyone who copies it.

## How this works

README corrections, each verified against the tree rather than reasoned about:

- The test command becomes the one CI runs, with a pointer to CONTRIBUTING's full pre-PR check list.
- `cargo run --maxperf` becomes `cargo run --profile maxperf`.
- The ethhash pointer is repaired. The branch this stack came from had already caught that `replace_hash` and the `firewood/storage/...` path were both wrong, but its replacement was also wrong: `replace_list_field` is defined in `storage/src/rlp.rs`, not in `storage/src/hashers/ethhash.rs`, which only calls it. The link now points at the definition and, separately, at the ethhash module documentation that explains the in-place hash substitution.
- `make` is dropped from the prerequisites — there is no Makefile in the repository — and `just` is listed instead, marked optional since every recipe has a direct cargo equivalent.

RELEASE.md documents `firewood-metrics` and records why crates.io publishing is currently blocked (the workspace patches `metrics` to a git fork, and crates.io rejects the resulting non-registry dependency), so the next person to attempt a release finds the reason rather than rediscovering it. The rebase-not-merge requirement is stated with its cause: `git cliff` needs linear history to order changelog entries correctly.

CONTRIBUTING.md completes its table of contents and fences its code blocks.

## How this was tested

- `markdownlint-cli2` reports no errors on all three files.
- Every relative link in README.md was resolved against the working tree; all twelve targets exist.
- The test command and clippy toolchain were diffed against `ci.yaml` and `lint-nightly.yaml`; `firewood-metrics`, `storage/src/rlp.rs`, and the absence of a Makefile were each confirmed directly.
