### PR TITLE
feat(fwdctl): accept hex and Ethereum key inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,6 +1913,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha3",
  "tempfile",
  "thiserror",
  "tokio",

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -32,6 +32,7 @@ firewood-storage.workspace = true
 hex.workspace = true
 log.workspace = true
 nonzero_ext.workspace = true
+sha3 = { version = "0.12.0", optional = true }
 # Regular dependencies
 csv = "1.4.0"
 humantime = "2.4.0"
@@ -53,7 +54,7 @@ thiserror = { version = "2.0", optional = true }
 tokio = { version = "1.52", features = ["rt-multi-thread", "sync", "time"], optional = true }
 
 [features]
-ethhash = ["firewood/ethhash"]
+ethhash = ["dep:sha3", "firewood/ethhash"]
 logger = ["firewood/logger"]
 launch = [
     "dep:aws-config",

--- a/fwdctl/README.md
+++ b/fwdctl/README.md
@@ -58,6 +58,9 @@ $ fwdctl create firewood
 ```sh
 # Get the value associated with a key in the database, if it exists.
 fwdctl get KEY
+
+# Use raw bytes instead of UTF-8 text.
+fwdctl get --key-hex 0xdeadbeef
 ```
 
 * fwdctl insert KEY VALUE
@@ -65,6 +68,12 @@ fwdctl get KEY
 ```sh
 # Insert a key/value pair into the database.
 fwdctl insert KEY VALUE
+
+# In an ethhash build, hash an account and storage slot into one trie key.
+cargo run -p firewood-fwdctl --features ethhash -- insert --node-hash-algorithm ethereum \
+  --account 0x1111111111111111111111111111111111111111 \
+  --storage-key 0x2222222222222222222222222222222222222222222222222222222222222222 \
+  VALUE
 ```
 
 * fwdctl delete KEY
@@ -73,3 +82,9 @@ fwdctl insert KEY VALUE
 # Delete a key from the database, along with the associated value.
 fwdctl delete KEY
 ```
+
+The `get`, `insert`, and `delete` commands accept a text `KEY`, `--key-hex`,
+or `--account` with an optional `--storage-key`. Account inputs must be 20
+bytes and storage keys must be 32 bytes. In an `ethhash` build, an account is
+stored under `keccak256(account)`, and a storage entry is stored under
+`keccak256(account) || keccak256(storage_key)`.

--- a/fwdctl/src/delete.rs
+++ b/fwdctl/src/delete.rs
@@ -5,20 +5,28 @@ use clap::Args;
 use firewood::api::{self, Db as _, Proposal as _};
 use firewood::db::{BatchOp, Db, DbConfig};
 
-use crate::DatabasePath;
+use crate::{DatabasePath, key};
 
 #[derive(Debug, Args)]
 pub struct Options {
     #[command(flatten)]
     pub database: DatabasePath,
 
-    /// The key to delete
-    #[arg(required = true, value_name = "KEY", help = "Key to delete")]
-    pub key: String,
+    #[command(flatten)]
+    pub key: key::Options,
+
+    #[arg(value_name = "KEY", num_args = 0..=1)]
+    pub args: Vec<String>,
 }
 
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("deleting key {opts:?}");
+    let raw_key = opts.key.raw_key(&opts.args, "delete")?;
+    let key = opts
+        .key
+        .resolve(raw_key, opts.database.node_hash_algorithm)?;
+    let key_display = opts.key.display(raw_key, &key);
+
     let cfg = DbConfig::builder()
         .node_hash_algorithm(opts.database.node_hash_algorithm.into())
         .create_if_missing(false)
@@ -26,12 +34,10 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
 
     let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
 
-    let batch: Vec<BatchOp<String, String>> = vec![BatchOp::Delete {
-        key: opts.key.clone(),
-    }];
+    let batch: Vec<BatchOp<Box<[u8]>, Vec<u8>>> = vec![BatchOp::Delete { key }];
     let proposal = db.propose(batch)?;
     proposal.commit()?;
 
-    println!("key {} deleted successfully", opts.key);
+    println!("key {key_display} deleted successfully");
     db.close()
 }

--- a/fwdctl/src/get.rs
+++ b/fwdctl/src/get.rs
@@ -6,20 +6,27 @@ use clap::Args;
 use firewood::api::{self, Db as _, DbView as _};
 use firewood::db::{Db, DbConfig};
 
-use crate::DatabasePath;
+use crate::{DatabasePath, key};
 
 #[derive(Debug, Args)]
 pub struct Options {
     #[command(flatten)]
     pub database: DatabasePath,
 
-    /// The key to get the value for
-    #[arg(required = true, value_name = "KEY", help = "Key to get")]
-    pub key: String,
+    #[command(flatten)]
+    pub key: key::Options,
+
+    #[arg(value_name = "KEY", num_args = 0..=1)]
+    pub args: Vec<String>,
 }
 
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("get key value pair {opts:?}");
+    let raw_key = opts.key.raw_key(&opts.args, "get")?;
+    let key = opts
+        .key
+        .resolve(raw_key, opts.database.node_hash_algorithm)?;
+
     let cfg = DbConfig::builder()
         .node_hash_algorithm(opts.database.node_hash_algorithm.into())
         .create_if_missing(false)
@@ -36,13 +43,13 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
 
     let rev = db.revision(hash)?;
 
-    match rev.val(opts.key.as_bytes()) {
+    match rev.val(&key) {
         Ok(Some(val)) => {
             let s = String::from_utf8_lossy(val.as_ref());
             println!("{s:?}");
         }
         Ok(None) => {
-            eprintln!("Key '{}' not found", opts.key);
+            eprintln!("Key '{}' not found", opts.key.display(raw_key, &key));
         }
         Err(e) => return Err(e),
     }

--- a/fwdctl/src/insert.rs
+++ b/fwdctl/src/insert.rs
@@ -5,24 +5,29 @@ use clap::Args;
 use firewood::api::{self, Db as _, Proposal as _};
 use firewood::db::{BatchOp, Db, DbConfig};
 
-use crate::DatabasePath;
+use crate::{DatabasePath, key};
 
 #[derive(Debug, Args)]
 pub struct Options {
     #[command(flatten)]
     pub database: DatabasePath,
 
-    /// The key to insert
-    #[arg(required = true, value_name = "KEY", help = "Key to insert")]
-    pub key: String,
+    #[command(flatten)]
+    pub key: key::Options,
 
-    /// The value to insert
-    #[arg(required = true, value_name = "VALUE", help = "Value to insert")]
-    pub value: String,
+    /// KEY VALUE for text keys, or only VALUE when a key selector is used.
+    #[arg(value_names = ["KEY", "VALUE"], num_args = 0..=2)]
+    pub args: Vec<String>,
 }
 
 pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
     log::debug!("inserting key value pair {opts:?}");
+    let (raw_key, value) = opts.key.insert_args(&opts.args)?;
+    let key = opts
+        .key
+        .resolve(raw_key, opts.database.node_hash_algorithm)?;
+    let key_display = opts.key.display(raw_key, &key);
+
     let cfg = DbConfig::builder()
         .node_hash_algorithm(opts.database.node_hash_algorithm.into())
         .create_if_missing(false)
@@ -30,13 +35,13 @@ pub(super) fn run(opts: &Options) -> Result<(), api::Error> {
 
     let db = Db::new(opts.database.dbpath.clone(), cfg.build())?;
 
-    let batch: Vec<BatchOp<Vec<u8>, Vec<u8>>> = vec![BatchOp::Put {
-        key: opts.key.clone().into(),
-        value: opts.value.bytes().collect(),
+    let batch: Vec<BatchOp<Box<[u8]>, Vec<u8>>> = vec![BatchOp::Put {
+        key,
+        value: value.bytes().collect(),
     }];
     let proposal = db.propose(batch)?;
     proposal.commit()?;
 
-    println!("{}", opts.key);
+    println!("{key_display}");
     db.close()
 }

--- a/fwdctl/src/key.rs
+++ b/fwdctl/src/key.rs
@@ -1,0 +1,261 @@
+// Copyright (C) 2023, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE.md for licensing terms.
+
+use clap::Args;
+use std::io::{Error, ErrorKind};
+
+use crate::NodeHashAlgorithm;
+
+/// Selects a database key from text, raw hex, or Ethereum account inputs.
+#[derive(Debug, Args, Clone)]
+pub struct Options {
+    /// The key bytes in hexadecimal form. An optional 0x prefix is accepted.
+    #[arg(
+        long = "key-hex",
+        value_name = "KEY_HEX",
+        conflicts_with_all = ["account", "storage_key"]
+    )]
+    pub key_hex: Option<String>,
+
+    /// An Ethereum account address (20 bytes in hexadecimal form).
+    #[arg(long, value_name = "ACCOUNT", conflicts_with = "key_hex")]
+    pub account: Option<String>,
+
+    /// An Ethereum storage slot (32 bytes in hexadecimal form), combined with --account.
+    #[arg(long, value_name = "STORAGE_KEY", requires = "account")]
+    pub storage_key: Option<String>,
+}
+
+impl Options {
+    /// Whether one of the non-text key selectors was provided.
+    pub fn has_selector(&self) -> bool {
+        self.key_hex.is_some() || self.account.is_some() || self.storage_key.is_some()
+    }
+
+    /// Pick a single command key argument, or let the selector flags provide it.
+    pub fn raw_key<'a>(&self, args: &'a [String], command: &str) -> Result<Option<&'a str>, Error> {
+        if self.has_selector() {
+            if !args.is_empty() {
+                return Err(invalid(format!(
+                    "a key selector cannot be combined with a text KEY for {command}"
+                )));
+            }
+            Ok(None)
+        } else if args.len() == 1 {
+            Ok(Some(args[0].as_str()))
+        } else {
+            Err(invalid(format!("{command} requires a KEY argument")))
+        }
+    }
+
+    /// Pick the key and value arguments for `insert`.
+    pub fn insert_args<'a>(&self, args: &'a [String]) -> Result<(Option<&'a str>, &'a str), Error> {
+        if self.has_selector() {
+            if args.len() == 1 {
+                Ok((None, &args[0]))
+            } else {
+                Err(invalid(
+                    "a key selector requires exactly one VALUE argument",
+                ))
+            }
+        } else if args.len() == 2 {
+            Ok((Some(args[0].as_str()), &args[1]))
+        } else {
+            Err(invalid("insert requires KEY and VALUE arguments"))
+        }
+    }
+
+    /// Resolve the selected input into the bytes used by Firewood.
+    pub fn resolve(
+        &self,
+        raw_key: Option<&str>,
+        hash_algorithm: NodeHashAlgorithm,
+    ) -> Result<Box<[u8]>, Error> {
+        match (raw_key, &self.key_hex, &self.account, &self.storage_key) {
+            (Some(key), None, None, None) => Ok(key.as_bytes().into()),
+            (None, Some(key_hex), None, None) => decode_hex(key_hex, "key"),
+            (None, None, Some(account), storage_key) => {
+                resolve_ethereum_key(account, storage_key.as_deref(), hash_algorithm)
+            }
+            (None, None, None, Some(_)) => Err(invalid("--storage-key requires --account")),
+            _ => Err(invalid("provide exactly one key input")),
+        }
+    }
+
+    /// Return a human-readable representation for command output.
+    pub fn display(&self, raw_key: Option<&str>, resolved: &[u8]) -> String {
+        raw_key.map_or_else(|| format!("0x{}", hex::encode(resolved)), str::to_owned)
+    }
+}
+
+fn decode_hex(value: &str, name: &str) -> Result<Box<[u8]>, Error> {
+    let value = value.strip_prefix("0x").unwrap_or(value);
+    hex::decode(value)
+        .map(Vec::into_boxed_slice)
+        .map_err(|error| invalid(format!("invalid {name} hex: {error}")))
+}
+
+fn decode_fixed(value: &str, name: &str, expected: usize) -> Result<Box<[u8]>, Error> {
+    let decoded = decode_hex(value, name)?;
+    if decoded.len() != expected {
+        return Err(invalid(format!(
+            "{name} must be {expected} bytes, got {}",
+            decoded.len()
+        )));
+    }
+    Ok(decoded)
+}
+
+#[cfg(feature = "ethhash")]
+fn resolve_ethereum_key(
+    account: &str,
+    storage_key: Option<&str>,
+    hash_algorithm: NodeHashAlgorithm,
+) -> Result<Box<[u8]>, Error> {
+    use sha3::{Digest, Keccak256};
+
+    if hash_algorithm != NodeHashAlgorithm::Ethereum {
+        return Err(invalid(
+            "--account and --storage-key require --node-hash-algorithm ethereum",
+        ));
+    }
+
+    let account = decode_fixed(account, "account", 20)?;
+    let account_hash = Keccak256::digest(&account);
+    let Some(storage_key) = storage_key else {
+        return Ok(account_hash.to_vec().into_boxed_slice());
+    };
+
+    let storage_key = decode_fixed(storage_key, "storage key", 32)?;
+    let storage_hash = Keccak256::digest(&storage_key);
+    Ok(account_hash
+        .iter()
+        .chain(storage_hash.iter())
+        .copied()
+        .collect::<Vec<_>>()
+        .into_boxed_slice())
+}
+
+#[cfg(not(feature = "ethhash"))]
+fn resolve_ethereum_key(
+    _account: &str,
+    _storage_key: Option<&str>,
+    _hash_algorithm: NodeHashAlgorithm,
+) -> Result<Box<[u8]>, Error> {
+    Err(invalid(
+        "--account and --storage-key require fwdctl built with the ethhash feature",
+    ))
+}
+
+fn invalid(message: impl Into<String>) -> Error {
+    Error::new(ErrorKind::InvalidInput, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Options;
+    use crate::NodeHashAlgorithm;
+
+    #[test]
+    fn resolves_text_and_hex_keys() {
+        let text = Options {
+            key_hex: None,
+            account: None,
+            storage_key: None,
+        };
+        assert_eq!(
+            &*text
+                .resolve(Some("hello"), NodeHashAlgorithm::MerkleDB)
+                .unwrap(),
+            b"hello"
+        );
+
+        let hex = Options {
+            key_hex: Some("0x00ff".into()),
+            account: None,
+            storage_key: None,
+        };
+        assert_eq!(
+            &*hex.resolve(None, NodeHashAlgorithm::MerkleDB).unwrap(),
+            &[0, 255]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_hex_and_combinations() {
+        let invalid_hex = Options {
+            key_hex: Some("not-hex".into()),
+            account: None,
+            storage_key: None,
+        };
+        assert!(
+            invalid_hex
+                .resolve(None, NodeHashAlgorithm::MerkleDB)
+                .is_err()
+        );
+
+        let missing = Options {
+            key_hex: None,
+            account: None,
+            storage_key: None,
+        };
+        assert!(missing.resolve(None, NodeHashAlgorithm::MerkleDB).is_err());
+    }
+
+    #[test]
+    fn separates_legacy_and_selector_arguments() {
+        let text = Options {
+            key_hex: None,
+            account: None,
+            storage_key: None,
+        };
+        let args = vec!["key".into(), "value".into()];
+        assert_eq!(text.insert_args(&args).unwrap(), (Some("key"), "value"));
+        assert_eq!(text.raw_key(&args[..1], "get").unwrap(), Some("key"));
+
+        let hex = Options {
+            key_hex: Some("00".into()),
+            account: None,
+            storage_key: None,
+        };
+        let value = vec!["value".into()];
+        assert_eq!(hex.insert_args(&value).unwrap(), (None, "value"));
+        assert_eq!(hex.raw_key(&[], "get").unwrap(), None);
+    }
+
+    #[cfg(feature = "ethhash")]
+    #[test]
+    fn resolves_ethereum_account_and_storage_keys() {
+        let account = Options {
+            key_hex: None,
+            account: Some("11".repeat(20)),
+            storage_key: Some("22".repeat(32)),
+        };
+        let key = account.resolve(None, NodeHashAlgorithm::Ethereum).unwrap();
+        assert_eq!(key.len(), 64);
+
+        let account_only = Options {
+            key_hex: None,
+            account: Some("11".repeat(20)),
+            storage_key: None,
+        };
+        assert_eq!(
+            account_only
+                .resolve(None, NodeHashAlgorithm::Ethereum)
+                .unwrap()
+                .len(),
+            32
+        );
+    }
+
+    #[cfg(feature = "ethhash")]
+    #[test]
+    fn rejects_wrong_ethereum_lengths() {
+        let account = Options {
+            key_hex: None,
+            account: Some("11".repeat(19)),
+            storage_key: None,
+        };
+        assert!(account.resolve(None, NodeHashAlgorithm::Ethereum).is_err());
+    }
+}

--- a/fwdctl/src/main.rs
+++ b/fwdctl/src/main.rs
@@ -16,6 +16,7 @@ pub mod get;
 pub mod graph;
 pub mod import;
 pub mod insert;
+pub mod key;
 #[cfg(feature = "launch")]
 pub mod launch;
 pub mod replay;

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -89,6 +89,40 @@ fn fwdctl_get_successful() {
 }
 
 #[test]
+fn fwdctl_hex_key_round_trip() {
+    with_tmpdir(|db_path| {
+        create_db(db_path);
+
+        cargo_bin_cmd!()
+            .arg("insert")
+            .args(["--key-hex", "0x00ff", "binary-value"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("0x00ff"));
+
+        cargo_bin_cmd!()
+            .arg("get")
+            .args(["--key-hex", "0x00ff"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("binary-value"));
+
+        cargo_bin_cmd!()
+            .arg("delete")
+            .args(["--key-hex", "0x00ff"])
+            .arg("--db")
+            .arg(db_path)
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("0x00ff"));
+    });
+}
+
+#[test]
 fn fwdctl_delete_successful() {
     with_tmpdir(|db_path| {
         create_db(db_path);


### PR DESCRIPTION
Closes #1000

## Summary

- add one shared key selector for `fwdctl get`, `insert`, and `delete`
- accept UTF-8 keys as before, raw hex keys with an optional `0x` prefix, and Ethereum account/storage inputs
- hash 20-byte accounts and 32-byte storage slots with Keccak256, composing storage keys as `keccak256(account) || keccak256(storage_key)`
- validate selector combinations and exact Ethereum input lengths before opening the database
- add CLI round-trip coverage for a binary key and document the new forms

## Validation

- `cargo fmt --check` passes
- `git diff --check` passes
- focused Rust tests were attempted with and without `ethhash`; this Windows checkout cannot compile the existing storage crate because it imports `std::os::unix::fs::FileExt`
- no diagnostics were emitted for the changed `fwdctl` files

The legacy `insert KEY VALUE`, `get KEY`, and `delete KEY` forms remain supported. The change is limited to the CLI key boundary and its tests. The commit is unsigned because this environment has no configured signing key; I can amend if the repository requires a specific signing setup.