### PR TITLE
Migrate area_index_and_size to AreaMetadata

### DIFF
--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -295,14 +295,21 @@ where
         check_area_aligned(subtrie_root_address, StoredAreaParent::TrieNode(parent))?;
 
         // read the node from the disk - we avoid cache since we will never visit the same node twice
-        let (area_index, area_size) =
-            self.area_index_and_size(subtrie_root_address)
-                .map_err(|e| {
-                    vec![CheckerError::IO {
-                        error: e,
-                        parent: StoredAreaParent::TrieNode(parent),
-                    }]
-                })?;
+        let area_meta = self
+            .area_index_and_size(subtrie_root_address)
+            .map_err(|e| {
+                vec![CheckerError::IO {
+                    error: e,
+                    parent: StoredAreaParent::TrieNode(parent),
+                }]
+            })?;
+
+        // TODO(galadd): will send a PR after  this to add proper unpadded handling here
+        // not included in this so that code changes won't be too large
+        // For now, all existing databases are padded
+        let area_index = area_meta.area_index.expect("padded node expected");
+        let area_size = area_meta.total_size;
+
         let (node, node_bytes) = self
             .read_node_with_num_bytes_from_disk(subtrie_root_address)
             .map_err(|e| {
@@ -664,13 +671,22 @@ where
 
         // First attempt to read the valid stored areas from the leaked range
         loop {
-            let (area_index, area_size) = match self.read_leaked_area(current_addr) {
+            let area_meta = match self.read_leaked_area(current_addr) {
                 Ok(area_index_and_size) => area_index_and_size,
                 Err(e) => {
                     warn!("Error reading stored area at {current_addr}: {e}");
                     break;
                 }
             };
+
+            // TODO(galadd): will send a PR after  this to add proper unpadded handling here
+            // not included in this so that code changes won't be too large
+            // For now, all existing databases are padded
+            let Some(area_index) = area_meta.area_index else {
+                warn!("Unpadded node in leaked range at {current_addr}, cannot add to free list");
+                break;
+            };
+            let area_size = area_meta.total_size;
 
             let next_addr = current_addr
                 .advance(area_size)
@@ -745,12 +761,12 @@ mod test {
     use super::*;
     use crate::DeletedNodeTracking;
     use crate::linear::memory::MemStore;
-    use crate::nodestore::NodeStoreHeader;
     use crate::nodestore::alloc::FreeLists;
     use crate::nodestore::alloc::test_utils::{
         test_write_free_area, test_write_header, test_write_new_node, test_write_zeroed_area,
     };
     use crate::nodestore::primitives::area_size_iter;
+    use crate::nodestore::{AreaMetadata, NodeStoreHeader};
     use crate::{
         BranchNode, Child, Children, FreeListParent, ImmutableProposal, LeafNode, NodeStore, Path,
         PathComponent, area_index, hash_node,
@@ -1359,5 +1375,19 @@ mod test {
 
         assert_eq!(leaked_areas_offsets, expected_offsets);
         assert_eq!(leaked_area_size_indices, expected_indices);
+    }
+
+    #[test]
+    fn test_area_metadata() {
+        let idx = area_index!(5); // 256 bytes
+        let padded = AreaMetadata::padded(idx);
+        assert_eq!(padded.area_index, Some(idx));
+        assert_eq!(padded.total_size, 256);
+        assert!(!padded.is_unpadded);
+
+        let unpadded = AreaMetadata::unpadded(150);
+        assert_eq!(unpadded.area_index, None);
+        assert_eq!(unpadded.total_size, 150);
+        assert!(unpadded.is_unpadded);
     }
 }

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -304,10 +304,7 @@ where
                 }]
             })?;
 
-        // TODO(galadd): will send a PR after  this to add proper unpadded handling here
-        // not included in this so that code changes won't be too large
-        // For now, all existing databases are padded
-        let area_index = area_meta.area_index.expect("padded node expected");
+        let area_index = area_meta.area_index;
         let area_size = area_meta.total_size;
 
         let (node, node_bytes) = self
@@ -672,20 +669,14 @@ where
         // First attempt to read the valid stored areas from the leaked range
         loop {
             let area_meta = match self.read_leaked_area(current_addr) {
-                Ok(area_index_and_size) => area_index_and_size,
+                Ok(area_meta) => area_meta,
                 Err(e) => {
                     warn!("Error reading stored area at {current_addr}: {e}");
                     break;
                 }
             };
 
-            // TODO(galadd): will send a PR after  this to add proper unpadded handling here
-            // not included in this so that code changes won't be too large
-            // For now, all existing databases are padded
-            let Some(area_index) = area_meta.area_index else {
-                warn!("Unpadded node in leaked range at {current_addr}, cannot add to free list");
-                break;
-            };
+            let area_index = area_meta.area_index;
             let area_size = area_meta.total_size;
 
             let next_addr = current_addr
@@ -761,12 +752,12 @@ mod test {
     use super::*;
     use crate::DeletedNodeTracking;
     use crate::linear::memory::MemStore;
+    use crate::nodestore::NodeStoreHeader;
     use crate::nodestore::alloc::FreeLists;
     use crate::nodestore::alloc::test_utils::{
         test_write_free_area, test_write_header, test_write_new_node, test_write_zeroed_area,
     };
     use crate::nodestore::primitives::area_size_iter;
-    use crate::nodestore::{AreaMetadata, NodeStoreHeader};
     use crate::{
         BranchNode, Child, Children, FreeListParent, ImmutableProposal, LeafNode, NodeStore, Path,
         PathComponent, area_index, hash_node,
@@ -1375,19 +1366,5 @@ mod test {
 
         assert_eq!(leaked_areas_offsets, expected_offsets);
         assert_eq!(leaked_area_size_indices, expected_indices);
-    }
-
-    #[test]
-    fn test_area_metadata() {
-        let idx = area_index!(5); // 256 bytes
-        let padded = AreaMetadata::padded(idx);
-        assert_eq!(padded.area_index, Some(idx));
-        assert_eq!(padded.total_size, 256);
-        assert!(!padded.is_unpadded);
-
-        let unpadded = AreaMetadata::unpadded(150);
-        assert_eq!(unpadded.area_index, None);
-        assert_eq!(unpadded.total_size, 150);
-        assert!(unpadded.is_unpadded);
     }
 }

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -20,7 +20,6 @@
 //! - **`AreaType`** - 0xFF for free areas, otherwise node type data (1 byte)
 //! - **`NodeData`** - Serialized node content
 
-use super::area_index_and_size;
 use super::primitives::{AreaIndex, LinearAddress, index_name};
 use crate::linear::FileIoError;
 use crate::logger::trace;
@@ -254,7 +253,7 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
         self.storage.file_io_error(error, offset, context)
     }
 
-    /// Returns (index, `area_size`) for the stored area at `addr`.
+    /// Returns [`AreaMetadata`] for the stored area at `addr`.
     /// `index` is the index of `area_size` in the array of valid block sizes.
     ///
     /// # Errors
@@ -263,8 +262,8 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
     pub(crate) fn area_index_and_size(
         &self,
         addr: LinearAddress,
-    ) -> Result<(AreaIndex, u64), FileIoError> {
-        area_index_and_size(self.storage, addr)
+    ) -> Result<super::AreaMetadata, FileIoError> {
+        super::area_index_and_size(self.storage, addr)
     }
 
     /// Attempts to allocate from the free lists for `index`.
@@ -358,7 +357,10 @@ impl<S: WritableStorage> NodeAllocator<'_, S> {
         };
         debug_assert!(addr.is_aligned());
 
-        let (area_size_index, _) = self.area_index_and_size(addr)?;
+        let area_meta = self.area_index_and_size(addr)?;
+        let area_size_index = area_meta
+            .area_index
+            .expect("delete_node should only be called on padded nodes");
         trace!("Deleting node at {addr:?} of size {area_size_index}");
         firewood_counter!(DELETE_NODE, "index" => index_name(area_size_index)).increment(1);
         firewood_counter!(SPACE_FREED, "index" => index_name(area_size_index))

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -254,7 +254,6 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
     }
 
     /// Returns [`AreaMetadata`] for the stored area at `addr`.
-    /// `index` is the index of `area_size` in the array of valid block sizes.
     ///
     /// # Errors
     ///
@@ -358,9 +357,7 @@ impl<S: WritableStorage> NodeAllocator<'_, S> {
         debug_assert!(addr.is_aligned());
 
         let area_meta = self.area_index_and_size(addr)?;
-        let area_size_index = area_meta
-            .area_index
-            .expect("delete_node should only be called on padded nodes");
+        let area_size_index = area_meta.area_index;
         trace!("Deleting node at {addr:?} of size {area_size_index}");
         firewood_counter!(DELETE_NODE, "index" => index_name(area_size_index)).increment(1);
         firewood_counter!(SPACE_FREED, "index" => index_name(area_size_index))

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -53,7 +53,9 @@ use crate::arc_swap_triomphe::TriompheArc;
 use crate::linear::{OffsetReader, ReadableNodeMode};
 use crate::logger::{debug, trace};
 use crate::node::branch::ReadSerializable as _;
+use crate::nodestore::primitives::{SENTINEL_UNPADDED, varint_encoded_size};
 use firewood_metrics::{firewood_counter, firewood_histogram};
+use integer_encoding::VarIntReader;
 use smallvec::SmallVec;
 use std::fmt::Debug;
 use std::io::{Error, ErrorKind};
@@ -1323,31 +1325,95 @@ impl<T: HashedNodeReader> HashedNodeReader for &T {
     }
 }
 
-// TODO(rkuris): return only the index since we can easily get the size from the index
-fn area_index_and_size<S: ReadableStorage>(
+/// Metadata about a stored area on disk.
+///
+/// Disambiguates between padded nodes (with a valid [`AreaIndex`]),
+/// unpadded nodes (archive mode, with [`SENTINEL_UNPADDED`] prefix),
+/// and free areas
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AreaMetadata {
+    /// The area size index, if this is a padded node or free area.
+    /// `None` for unpadded archive-mode nodes.
+    pub area_index: Option<AreaIndex>,
+    /// The total size of this area on disk, including any prefix bytes.
+    pub total_size: u64,
+    /// Whether the node is unpadded.
+    pub is_unpadded: bool,
+}
+
+impl AreaMetadata {
+    /// Create metadata for a padded area (normal mode node or free area).
+    #[must_use]
+    pub const fn padded(index: AreaIndex) -> Self {
+        Self {
+            area_index: Some(index),
+            total_size: index.size(),
+            is_unpadded: false,
+        }
+    }
+
+    /// Create metadata for an unpadded area (archive mode node).
+    #[must_use]
+    pub const fn unpadded(total_size: u64) -> Self {
+        Self {
+            area_index: None,
+            total_size,
+            is_unpadded: true,
+        }
+    }
+}
+
+/// Reads area metadata from the first byte(s) at `addr`.
+///
+/// Handles both padded and unpadded formats:
+/// - First byte 0-22: padded, size from `AREA_SIZES[index]`
+/// - First byte 0xFF: unpadded, size from following varint + prefix
+///
+/// # Errors
+///
+/// Returns a [`FileIoError`] if the area cannot be read or the format is invalid.
+pub(crate) fn area_index_and_size<S: ReadableStorage>(
     storage: &S,
     addr: LinearAddress,
-) -> Result<(AreaIndex, u64), FileIoError> {
-    let mut area_stream = storage.stream_from(addr.get())?;
+) -> Result<AreaMetadata, FileIoError> {
+    let mut stream = storage.stream_from(addr.get())?;
 
-    let index: AreaIndex = AreaIndex::new(area_stream.read_byte().map_err(|e| {
+    let first_byte = stream.read_byte().map_err(|e| {
         storage.file_io_error(
             Error::new(ErrorKind::InvalidData, e),
             addr.get(),
             Some("area_index_and_size".to_owned()),
         )
-    })?)
-    .ok_or_else(|| {
-        storage.file_io_error(
-            Error::new(ErrorKind::InvalidData, "invalid area index"),
-            addr.get(),
-            Some("area_index_and_size".to_owned()),
-        )
     })?;
 
-    let size = index.size();
+    if first_byte == SENTINEL_UNPADDED {
+        // Unpadded node: read varint length
+        let node_len = stream.read_varint::<u64>().map_err(|e| {
+            storage.file_io_error(
+                Error::new(ErrorKind::InvalidData, e),
+                addr.get(),
+                Some("area_index_and_size: unpadded length".to_owned()),
+            )
+        })?;
 
-    Ok((index, size))
+        #[expect(clippy::arithmetic_side_effects)]
+        let prefix_len = 1_u64 + varint_encoded_size(node_len) as u64;
+
+        #[expect(clippy::arithmetic_side_effects)]
+        let total_size = prefix_len + node_len;
+
+        Ok(AreaMetadata::unpadded(total_size))
+    } else {
+        // Padded node or free area
+        let index = AreaIndex::new(first_byte).ok_or_else(|| {
+            storage.file_io_error(
+                Error::new(ErrorKind::InvalidData, "invalid area index byte"),
+                addr.get(),
+                Some("area_index_and_size".to_owned()),
+            )
+        })?;
+        Ok(AreaMetadata::padded(index))
+    }
 }
 
 impl<T, S: ReadableStorage> NodeStore<T, S> {
@@ -1383,49 +1449,115 @@ impl<T, S: ReadableStorage> NodeStore<T, S> {
         Ok(node)
     }
 
+    /// Reads a node from disk, returning the node and its total on-disk size.
+    ///
+    /// Handles both padded and unpadded formats:
+    /// - Padded: `[AreaIndex][node_data][padding]`
+    /// - Unpadded: `[0xFF][varint length][node_data]`
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`FileIoError`] if the node cannot be read.
     pub(crate) fn read_node_with_num_bytes_from_disk(
         &self,
         addr: LinearAddress,
     ) -> Result<(SharedNode, u64), FileIoError> {
-        debug_assert!(addr.is_aligned());
+        let mut stream = self.storage.stream_from(addr.get())?;
 
-        // saturating because there is no way we can be reading at u64::MAX
-        // and this will fail very soon afterwards
-        let actual_addr = addr.get().saturating_add(1); // skip the length byte
+        let first_byte = stream.read_byte().map_err(|e| {
+            self.storage.file_io_error(
+                Error::new(ErrorKind::InvalidData, e),
+                addr.get(),
+                Some("read_node_with_num_bytes_from_disk".to_owned()),
+            )
+        })?;
 
-        let _span = fastrace::local::LocalSpan::enter_with_local_parent("read_and_deserialize");
+        if first_byte == SENTINEL_UNPADDED {
+            // Unpadded format: [0xFF][varint length][node_data]
+            let node_len = stream.read_varint::<usize>().map_err(|e| {
+                self.storage.file_io_error(
+                    Error::new(ErrorKind::InvalidData, e),
+                    addr.get(),
+                    Some("read_node_with_num_bytes_from_disk: unpadded length".to_owned()),
+                )
+            })?;
 
-        let mut area_stream = self.storage.stream_from(actual_addr)?;
-        let offset_before = area_stream.offset();
-        let node: SharedNode = Node::from_reader(&mut area_stream)
-            .map_err(|e| {
-                self.storage
-                    .file_io_error(e, actual_addr, Some("read_node_from_disk".to_owned()))
-            })?
-            .into();
-        let length = area_stream
-            .offset()
-            .checked_sub(offset_before)
-            .ok_or_else(|| {
+            #[expect(clippy::arithmetic_side_effects)]
+            let prefix_len = 1 + varint_encoded_size(node_len as u64);
+            let offset_before = stream.offset();
+
+            let _span = fastrace::local::LocalSpan::enter_with_local_parent("read_and_deserialize");
+            let node: SharedNode = Node::from_reader(&mut stream)
+                .map_err(|e| {
+                    self.storage.file_io_error(
+                        e,
+                        addr.get(),
+                        Some("read_node_with_num_bytes_from_disk".to_owned()),
+                    )
+                })?
+                .into();
+
+            let bytes_read = stream.offset().checked_sub(offset_before).ok_or_else(|| {
                 self.storage.file_io_error(
                     Error::other("Reader offset went backwards"),
-                    actual_addr,
+                    addr.get(),
                     Some("read_node_with_num_bytes_from_disk".to_owned()),
                 )
             })?;
-        Ok((node, length.saturating_add(1))) // add 1 for the area size index byte
+
+            if bytes_read != node_len as u64 {
+                return Err(self.storage.file_io_error(
+                    Error::new(ErrorKind::InvalidData, format!("Unpadded node length mismatch: header says {node_len}, read {bytes_read}")), addr.get(), Some("read_node_with_num_bytes_from_disk".to_owned())));
+            }
+
+            let total_size = prefix_len
+                .checked_add(node_len)
+                .expect("encoded node size overflow");
+
+            Ok((node, total_size as u64))
+        } else {
+            // Padded format: [AreaIndex][node_data][padding]
+            let _area_index = AreaIndex::new(first_byte).ok_or_else(|| {
+                self.storage.file_io_error(
+                    Error::new(ErrorKind::InvalidData, "invalid area index byte"),
+                    addr.get(),
+                    Some("read_node_with_num_bytes".to_owned()),
+                )
+            })?;
+
+            let _span = fastrace::local::LocalSpan::enter_with_local_parent("read_and_deserialize");
+            let offset_before = stream.offset();
+            let node: SharedNode = Node::from_reader(&mut stream)
+                .map_err(|e| {
+                    self.storage.file_io_error(
+                        e,
+                        addr.get(),
+                        Some("read_node_with_num_bytes_from".to_owned()),
+                    )
+                })?
+                .into();
+
+            let node_bytes = stream.offset().checked_sub(offset_before).ok_or_else(|| {
+                self.storage.file_io_error(
+                    Error::other("Reader offset went backwards"),
+                    addr.get(),
+                    Some("read_node_with_num_bytes_from_disk".to_owned()),
+                )
+            })?;
+
+            Ok((node, node_bytes.saturating_add(1)))
+        }
     }
 
-    /// Returns (index, `area_size`) for the stored area at `addr`.
-    /// `index` is the index of `area_size` in the array of valid block sizes.
+    /// Returns [`AreaMetadata`] for the stored area at `addr`.
     ///
     /// # Errors
     ///
     /// Returns a [`FileIoError`] if the area cannot be read.
-    pub fn area_index_and_size(
+    pub(crate) fn area_index_and_size(
         &self,
         addr: LinearAddress,
-    ) -> Result<(AreaIndex, u64), FileIoError> {
+    ) -> Result<AreaMetadata, FileIoError> {
         area_index_and_size(self.storage.as_ref(), addr)
     }
 }
@@ -1483,18 +1615,23 @@ impl<T, S: ReadableStorage> NodeStore<T, S>
 where
     NodeStore<T, S>: NodeReader,
 {
-    // Find the area index and size of the stored area at the given address if the area is valid.
-    // TODO(#2050): there should be a way to read stored area directly instead of try reading as a free area then as a node
+    /// Find the area metadata for the stored area at the given address.
+    ///
+    /// Tries to interpret the area as a free area first, then as a node.
+    /// Returns [`AreaMetadata`] describing the area's format and size.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`FileIoError`] if the area cannot be read
     pub(crate) fn read_leaked_area(
         &self,
         address: LinearAddress,
-    ) -> Result<(AreaIndex, u64), FileIoError> {
+    ) -> Result<AreaMetadata, FileIoError> {
         if alloc::FreeArea::from_storage(self.storage.as_ref(), address).is_err() {
             self.read_node(address)?;
         }
 
-        let area_index_and_size = self.area_index_and_size(address)?;
-        Ok(area_index_and_size)
+        self.area_index_and_size(address)
     }
 }
 

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -53,9 +53,7 @@ use crate::arc_swap_triomphe::TriompheArc;
 use crate::linear::{OffsetReader, ReadableNodeMode};
 use crate::logger::{debug, trace};
 use crate::node::branch::ReadSerializable as _;
-use crate::nodestore::primitives::{SENTINEL_UNPADDED, varint_encoded_size};
 use firewood_metrics::{firewood_counter, firewood_histogram};
-use integer_encoding::VarIntReader;
 use smallvec::SmallVec;
 use std::fmt::Debug;
 use std::io::{Error, ErrorKind};
@@ -1326,48 +1324,23 @@ impl<T: HashedNodeReader> HashedNodeReader for &T {
 }
 
 /// Metadata about a stored area on disk.
-///
-/// Disambiguates between padded nodes (with a valid [`AreaIndex`]),
-/// unpadded nodes (archive mode, with [`SENTINEL_UNPADDED`] prefix),
-/// and free areas
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct AreaMetadata {
-    /// The area size index, if this is a padded node or free area.
-    /// `None` for unpadded archive-mode nodes.
-    pub area_index: Option<AreaIndex>,
-    /// The total size of this area on disk, including any prefix bytes.
+    pub area_index: AreaIndex,
     pub total_size: u64,
-    /// Whether the node is unpadded.
-    pub is_unpadded: bool,
 }
 
 impl AreaMetadata {
-    /// Create metadata for a padded area (normal mode node or free area).
+    /// Create metadata for an area
     #[must_use]
-    pub const fn padded(index: AreaIndex) -> Self {
+    pub const fn new(area_index: AreaIndex) -> Self {
         Self {
-            area_index: Some(index),
-            total_size: index.size(),
-            is_unpadded: false,
-        }
-    }
-
-    /// Create metadata for an unpadded area (archive mode node).
-    #[must_use]
-    pub const fn unpadded(total_size: u64) -> Self {
-        Self {
-            area_index: None,
-            total_size,
-            is_unpadded: true,
+            area_index,
+            total_size: area_index.size(),
         }
     }
 }
 
-/// Reads area metadata from the first byte(s) at `addr`.
-///
-/// Handles both padded and unpadded formats:
-/// - First byte 0-22: padded, size from `AREA_SIZES[index]`
-/// - First byte 0xFF: unpadded, size from following varint + prefix
+/// Reads area metadata at `addr`.
 ///
 /// # Errors
 ///
@@ -1378,42 +1351,22 @@ pub(crate) fn area_index_and_size<S: ReadableStorage>(
 ) -> Result<AreaMetadata, FileIoError> {
     let mut stream = storage.stream_from(addr.get())?;
 
-    let first_byte = stream.read_byte().map_err(|e| {
+    let index = AreaIndex::new(stream.read_byte().map_err(|e| {
         storage.file_io_error(
             Error::new(ErrorKind::InvalidData, e),
             addr.get(),
             Some("area_index_and_size".to_owned()),
         )
+    })?)
+    .ok_or_else(|| {
+        storage.file_io_error(
+            Error::new(ErrorKind::InvalidData, "invalid area index"),
+            addr.get(),
+            Some("area_index_and_size".to_owned()),
+        )
     })?;
 
-    if first_byte == SENTINEL_UNPADDED {
-        // Unpadded node: read varint length
-        let node_len = stream.read_varint::<u64>().map_err(|e| {
-            storage.file_io_error(
-                Error::new(ErrorKind::InvalidData, e),
-                addr.get(),
-                Some("area_index_and_size: unpadded length".to_owned()),
-            )
-        })?;
-
-        #[expect(clippy::arithmetic_side_effects)]
-        let prefix_len = 1_u64 + varint_encoded_size(node_len) as u64;
-
-        #[expect(clippy::arithmetic_side_effects)]
-        let total_size = prefix_len + node_len;
-
-        Ok(AreaMetadata::unpadded(total_size))
-    } else {
-        // Padded node or free area
-        let index = AreaIndex::new(first_byte).ok_or_else(|| {
-            storage.file_io_error(
-                Error::new(ErrorKind::InvalidData, "invalid area index byte"),
-                addr.get(),
-                Some("area_index_and_size".to_owned()),
-            )
-        })?;
-        Ok(AreaMetadata::padded(index))
-    }
+    Ok(AreaMetadata::new(index))
 }
 
 impl<T, S: ReadableStorage> NodeStore<T, S> {
@@ -1449,104 +1402,37 @@ impl<T, S: ReadableStorage> NodeStore<T, S> {
         Ok(node)
     }
 
-    /// Reads a node from disk, returning the node and its total on-disk size.
-    ///
-    /// Handles both padded and unpadded formats:
-    /// - Padded: `[AreaIndex][node_data][padding]`
-    /// - Unpadded: `[0xFF][varint length][node_data]`
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`FileIoError`] if the node cannot be read.
     pub(crate) fn read_node_with_num_bytes_from_disk(
         &self,
         addr: LinearAddress,
     ) -> Result<(SharedNode, u64), FileIoError> {
-        let mut stream = self.storage.stream_from(addr.get())?;
+        debug_assert!(addr.is_aligned());
 
-        let first_byte = stream.read_byte().map_err(|e| {
-            self.storage.file_io_error(
-                Error::new(ErrorKind::InvalidData, e),
-                addr.get(),
-                Some("read_node_with_num_bytes_from_disk".to_owned()),
-            )
-        })?;
+        // saturating because there is no way we can be reading at u64::MAX
+        // and this will fail very soon afterwards
+        let actual_addr = addr.get().saturating_add(1); // skip the length byte
 
-        if first_byte == SENTINEL_UNPADDED {
-            // Unpadded format: [0xFF][varint length][node_data]
-            let node_len = stream.read_varint::<usize>().map_err(|e| {
-                self.storage.file_io_error(
-                    Error::new(ErrorKind::InvalidData, e),
-                    addr.get(),
-                    Some("read_node_with_num_bytes_from_disk: unpadded length".to_owned()),
-                )
-            })?;
+        let _span = fastrace::local::LocalSpan::enter_with_local_parent("read_and_deserialize");
 
-            #[expect(clippy::arithmetic_side_effects)]
-            let prefix_len = 1 + varint_encoded_size(node_len as u64);
-            let offset_before = stream.offset();
-
-            let _span = fastrace::local::LocalSpan::enter_with_local_parent("read_and_deserialize");
-            let node: SharedNode = Node::from_reader(&mut stream)
-                .map_err(|e| {
-                    self.storage.file_io_error(
-                        e,
-                        addr.get(),
-                        Some("read_node_with_num_bytes_from_disk".to_owned()),
-                    )
-                })?
-                .into();
-
-            let bytes_read = stream.offset().checked_sub(offset_before).ok_or_else(|| {
+        let mut area_stream = self.storage.stream_from(actual_addr)?;
+        let offset_before = area_stream.offset();
+        let node: SharedNode = Node::from_reader(&mut area_stream)
+            .map_err(|e| {
+                self.storage
+                    .file_io_error(e, actual_addr, Some("read_node_from_disk".to_owned()))
+            })?
+            .into();
+        let length = area_stream
+            .offset()
+            .checked_sub(offset_before)
+            .ok_or_else(|| {
                 self.storage.file_io_error(
                     Error::other("Reader offset went backwards"),
-                    addr.get(),
+                    actual_addr,
                     Some("read_node_with_num_bytes_from_disk".to_owned()),
                 )
             })?;
-
-            if bytes_read != node_len as u64 {
-                return Err(self.storage.file_io_error(
-                    Error::new(ErrorKind::InvalidData, format!("Unpadded node length mismatch: header says {node_len}, read {bytes_read}")), addr.get(), Some("read_node_with_num_bytes_from_disk".to_owned())));
-            }
-
-            let total_size = prefix_len
-                .checked_add(node_len)
-                .expect("encoded node size overflow");
-
-            Ok((node, total_size as u64))
-        } else {
-            // Padded format: [AreaIndex][node_data][padding]
-            let _area_index = AreaIndex::new(first_byte).ok_or_else(|| {
-                self.storage.file_io_error(
-                    Error::new(ErrorKind::InvalidData, "invalid area index byte"),
-                    addr.get(),
-                    Some("read_node_with_num_bytes".to_owned()),
-                )
-            })?;
-
-            let _span = fastrace::local::LocalSpan::enter_with_local_parent("read_and_deserialize");
-            let offset_before = stream.offset();
-            let node: SharedNode = Node::from_reader(&mut stream)
-                .map_err(|e| {
-                    self.storage.file_io_error(
-                        e,
-                        addr.get(),
-                        Some("read_node_with_num_bytes_from".to_owned()),
-                    )
-                })?
-                .into();
-
-            let node_bytes = stream.offset().checked_sub(offset_before).ok_or_else(|| {
-                self.storage.file_io_error(
-                    Error::other("Reader offset went backwards"),
-                    addr.get(),
-                    Some("read_node_with_num_bytes_from_disk".to_owned()),
-                )
-            })?;
-
-            Ok((node, node_bytes.saturating_add(1)))
-        }
+        Ok((node, length.saturating_add(1))) // add 1 for the area size index byte
     }
 
     /// Returns [`AreaMetadata`] for the stored area at `addr`.
@@ -1615,14 +1501,9 @@ impl<T, S: ReadableStorage> NodeStore<T, S>
 where
     NodeStore<T, S>: NodeReader,
 {
-    /// Find the area metadata for the stored area at the given address.
-    ///
-    /// Tries to interpret the area as a free area first, then as a node.
-    /// Returns [`AreaMetadata`] describing the area's format and size.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`FileIoError`] if the area cannot be read
+    // Find the area metadata for the stored area at the given address.
+    //
+    // TODO(#2050): there should be a way to read stored area directly instead of try reading as a free area then as a node
     pub(crate) fn read_leaked_area(
         &self,
         address: LinearAddress,

--- a/storage/src/nodestore/primitives.rs
+++ b/storage/src/nodestore/primitives.rs
@@ -21,6 +21,33 @@ use std::num::NonZeroU64;
 // See build.rs for how this is generated
 include!(concat!(env!("OUT_DIR"), "/area_sizes.rs"));
 
+/// Sentinel byte indicating an unpadded, non-freeable node.
+///
+/// Used as the first byte on disk instead of an [`AreaIndex`] when
+/// [`DeletedNodeTracking::Disabled`] (archive mode). Nodes with this
+/// sentinel can never be freed because their size is not aligned to any
+/// area size class.
+///
+/// Value 0xFF is chosen because:
+/// - Valid [`AreaIndex`] values are 0-22, so no collision
+/// - Free areas use 0xFF as the *second* byte (after a valid `AreaIndex`),
+///   so the format `[valid_index][0xFF]` for free areas is distinct from
+///   `[0xFF][...]` for unpadded nodes
+pub const SENTINEL_UNPADDED: u8 = 0xFF;
+
+/// Returns the number of bytes needed to encode a `u64` as a varint.
+#[inline]
+#[must_use]
+pub const fn varint_encoded_size(value: u64) -> usize {
+    if value == 0 {
+        return 1;
+    }
+
+    #[expect(clippy::arithmetic_side_effects)]
+    let bits_needed = 64u32 - value.leading_zeros();
+    (bits_needed as usize).saturating_add(6) / 7
+}
+
 /// Returns an iterator over all valid area sizes.
 // TODO(rkuris): return a named iterator
 pub(crate) fn area_size_iter() -> impl DoubleEndedIterator<Item = (AreaIndex, u64)> {
@@ -327,5 +354,32 @@ mod tests {
     fn test_area_index_try_from_usize_out_of_bounds() {
         assert!(AreaIndex::try_from(AreaIndex::NUM_AREA_SIZES).is_err());
         assert!(AreaIndex::try_from(usize::MAX).is_err());
+    }
+
+    #[test]
+    fn test_varint_encoded_size() {
+        // Single byte: 0-127
+        assert_eq!(varint_encoded_size(0), 1);
+        assert_eq!(varint_encoded_size(1), 1);
+        assert_eq!(varint_encoded_size(127), 1);
+
+        // Two bytes: 128-16383
+        assert_eq!(varint_encoded_size(128), 2);
+        assert_eq!(varint_encoded_size(16383), 2);
+
+        // Three bytes: 16384-2097151
+        assert_eq!(varint_encoded_size(16384), 3);
+
+        // Max u64: 10 bytes
+        assert_eq!(varint_encoded_size(u64::MAX), 10);
+    }
+
+    #[test]
+    fn test_sentinel_value() {
+        assert_eq!(SENTINEL_UNPADDED, 0xFF);
+        // Verify it doesn't collide with any valid AreaIndex
+        for i in 0..=AreaIndex::MAX.get() {
+            assert_ne!(i, SENTINEL_UNPADDED);
+        }
     }
 }

--- a/storage/src/nodestore/primitives.rs
+++ b/storage/src/nodestore/primitives.rs
@@ -21,33 +21,6 @@ use std::num::NonZeroU64;
 // See build.rs for how this is generated
 include!(concat!(env!("OUT_DIR"), "/area_sizes.rs"));
 
-/// Sentinel byte indicating an unpadded, non-freeable node.
-///
-/// Used as the first byte on disk instead of an [`AreaIndex`] when
-/// [`DeletedNodeTracking::Disabled`] (archive mode). Nodes with this
-/// sentinel can never be freed because their size is not aligned to any
-/// area size class.
-///
-/// Value 0xFF is chosen because:
-/// - Valid [`AreaIndex`] values are 0-22, so no collision
-/// - Free areas use 0xFF as the *second* byte (after a valid `AreaIndex`),
-///   so the format `[valid_index][0xFF]` for free areas is distinct from
-///   `[0xFF][...]` for unpadded nodes
-pub const SENTINEL_UNPADDED: u8 = 0xFF;
-
-/// Returns the number of bytes needed to encode a `u64` as a varint.
-#[inline]
-#[must_use]
-pub const fn varint_encoded_size(value: u64) -> usize {
-    if value == 0 {
-        return 1;
-    }
-
-    #[expect(clippy::arithmetic_side_effects)]
-    let bits_needed = 64u32 - value.leading_zeros();
-    (bits_needed as usize).saturating_add(6) / 7
-}
-
 /// Returns an iterator over all valid area sizes.
 // TODO(rkuris): return a named iterator
 pub(crate) fn area_size_iter() -> impl DoubleEndedIterator<Item = (AreaIndex, u64)> {
@@ -354,32 +327,5 @@ mod tests {
     fn test_area_index_try_from_usize_out_of_bounds() {
         assert!(AreaIndex::try_from(AreaIndex::NUM_AREA_SIZES).is_err());
         assert!(AreaIndex::try_from(usize::MAX).is_err());
-    }
-
-    #[test]
-    fn test_varint_encoded_size() {
-        // Single byte: 0-127
-        assert_eq!(varint_encoded_size(0), 1);
-        assert_eq!(varint_encoded_size(1), 1);
-        assert_eq!(varint_encoded_size(127), 1);
-
-        // Two bytes: 128-16383
-        assert_eq!(varint_encoded_size(128), 2);
-        assert_eq!(varint_encoded_size(16383), 2);
-
-        // Three bytes: 16384-2097151
-        assert_eq!(varint_encoded_size(16384), 3);
-
-        // Max u64: 10 bytes
-        assert_eq!(varint_encoded_size(u64::MAX), 10);
-    }
-
-    #[test]
-    fn test_sentinel_value() {
-        assert_eq!(SENTINEL_UNPADDED, 0xFF);
-        // Verify it doesn't collide with any valid AreaIndex
-        for i in 0..=AreaIndex::MAX.get() {
-            assert_ne!(i, SENTINEL_UNPADDED);
-        }
     }
 }


### PR DESCRIPTION
## Why this should be merged

Foundation for #2151. Adds reader support for unpadded node format without changing any existing behavior.

## How this works

Nodes on disk currently start with an AreaIndex byte (0-22) indicating their padded size class. This PR adds support for a SENTINEL_UNPADDED byte (0xFF) that indicates an unpadded node followed by a varint length prefix. The area_index_and_size() function and node readers now handle both formats.

Since no existing code writes the sentinel byte, all current databases continue to work unchanged through the padded code path.

## How this was tested

-  Added unit tests for varint_encoded_size() and SENTINEL_UNPADDED collision check
-  Added unit test for AreaMetadata struct
-  All existing tests pass (no behavior change)

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
