### PR TITLE
fix(merkle): test both range bounds in the reconcile guards

### DIFF
--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -32,6 +32,22 @@ pub(crate) struct CollapseRange<'a> {
     pub(crate) end: Option<&'a [u8]>,
 }
 
+impl CollapseRange<'_> {
+    /// Whether a node at nibble path `node` sits inside the range.
+    ///
+    /// Both reconcile loops in [`verify_change_proof_root_hash`] and
+    /// [`Merkle::collapse_strip`]'s value check ask this same question: a node's
+    /// position is in range or it is not, regardless of which proof carried it.
+    /// Testing only the near bound would judge a divergent terminal beyond the
+    /// far bound as in-range, and report its legitimately differing value as
+    /// `UnexpectedValue`.
+    ///
+    /// [`verify_change_proof_root_hash`]: crate::merkle::verify_change_proof_root_hash
+    pub(crate) fn contains(&self, node: &[u8]) -> bool {
+        node >= self.start && self.end.is_none_or(|end| node <= end)
+    }
+}
+
 /// Where the hash step should get a boundary terminal's on-path child.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum BoundaryChildSource {
@@ -440,9 +456,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
         // An in-range value belongs to an in-range key and must be kept so it
         // is validated against the batch. Dropping it lets a forged or omitted
         // in-range op whose key is a prefix of the boundary slip through.
-        let out_of_range = range.is_none_or(|CollapseRange { start, end }| {
-            acc_prefix < start || end.is_some_and(|end| acc_prefix > end)
-        });
+        let out_of_range = range.is_none_or(|range| !range.contains(acc_prefix));
         if out_of_range {
             branch.value = None;
         }

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -339,8 +339,7 @@ impl<S: ReadableStorage> Merkle<NodeStore<Mutable<Propose>, S>> {
 
         let child_node = child.as_shared_node(&self.nodestore)?;
         let pfx = build_child_prefix(acc_prefix, nibble.0.as_u8(), &child_node);
-        let key_in_range =
-            pfx.as_ref() >= range.start && range.end.is_none_or(|end| pfx.as_ref() <= end);
+        let key_in_range = range.contains(pfx.as_ref());
 
         let Some(branch) = child_node.as_branch() else {
             return Ok(key_in_range);

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -1283,31 +1283,50 @@ pub fn verify_change_proof_root_hash(
     // values outside the range). Overwrite with the proof's value so the
     // hash computation uses end_root's value.
     //
-    // Out-of-range nodes include:
-    //  - proper prefixes of start_key (ancestors on the path)
-    //  - divergent nodes whose key is NOT a prefix of start_key (these
-    //    appear in exclusion proofs when start_key doesn't exist)
+    // A start proof can carry these out-of-range nodes:
+    //  - proper prefixes of start_key (ancestors on the path), which sort
+    //    before it
+    //  - divergent nodes that sort before start_key, which appear when no node
+    //    sits at start_key itself
+    //  - nodes that sort after the right edge, reachable when the end trie
+    //    holds no key in the range
     //
-    // Only nodes whose key exactly equals start_key are in-range; value
-    // mismatches there are real errors.
+    // A divergent terminal that overshoots to the nearest existing key after
+    // start_key is in range, and a value mismatch there is a real error.
     let start_key_nibbles: Vec<u8> = verification
         .start_key
         .as_deref()
         .map(|k| NibblesIterator::new(k).collect())
         .unwrap_or_default();
 
+    // `None` is an unbounded right edge (+∞). Keeping it distinct from an empty
+    // slice matters: an empty slice sorts as the minimum key, which would mark
+    // every key out of range at the upper bound.
+    let end_key_nibbles: Option<Vec<u8>> = verification
+        .right_edge_key
+        .as_deref()
+        .map(|k| NibblesIterator::new(k).collect());
+
+    // Whether a boundary proof node sits inside the proven range. Both loops
+    // below ask the same question — a node's position is in range or it is not,
+    // regardless of which proof carried it. Testing only the near bound would
+    // judge a divergent terminal beyond the far bound as in-range and report
+    // its legitimately differing value as `UnexpectedValue`.
+    let in_proven_range = |node_nibbles: &[u8]| {
+        node_nibbles >= start_key_nibbles.as_slice()
+            && end_key_nibbles
+                .as_deref()
+                .is_none_or(|end| node_nibbles <= end)
+    };
+
     for proof_node in start_nodes {
         proving_merkle.reconcile_branch_proof_node(proof_node, |pn, _branch_value| {
             let node_nibbles: Vec<u8> = pn.key.iter().map(|c| c.as_u8()).collect();
-            // A start proof node is in-range if its key >= start_key. This
-            // covers both inclusion proofs (key == start_key) and exclusion
-            // proofs where the terminal node overshoots start_key to the
-            // nearest existing key. Reaching this guard at an in-range
-            // position is always a real error: the proposal already holds the
-            // correct value, so the only way the proof node and branch
-            // disagree is tampering — e.g. a dropped in-range `Put` whose
-            // boundary proof still carries the omitted key's hash.
-            if node_nibbles >= start_key_nibbles {
+            // Reaching this guard in range is always a real error: the proposal
+            // already holds the correct value, so the only way the proof node
+            // and branch disagree is tampering — e.g. a dropped in-range `Put`
+            // whose boundary proof still carries the omitted key's hash.
+            if in_proven_range(&node_nibbles) {
                 Err(ProofError::UnexpectedValue)
             } else {
                 match &pn.value_digest {
@@ -1322,25 +1341,14 @@ pub fn verify_change_proof_root_hash(
     // Same treatment for end proof nodes: ancestors and divergent nodes
     // of the right boundary may have out-of-range values that differ
     // from the proposal.
-    // `None` is an unbounded right edge (+∞). Keeping it distinct from an empty
-    // slice matters: an empty slice sorts as the minimum key, which would mark
-    // every key out of range at the upper bound.
-    let end_key_nibbles: Option<Vec<u8>> = verification
-        .right_edge_key
-        .as_deref()
-        .map(|k| NibblesIterator::new(k).collect());
-
     for proof_node in end_nodes {
         proving_merkle.reconcile_branch_proof_node(proof_node, |pn, _branch_value| {
             let node_nibbles: Vec<u8> = pn.key.iter().map(|c| c.as_u8()).collect();
-            // Symmetric to the start proof: an end proof node is in-range
-            // if its key <= end_key (covers exclusion proofs where the
-            // terminal undershoots to the nearest existing key). An unbounded
-            // right edge (+∞) puts every node in range.
-            if end_key_nibbles
-                .as_ref()
-                .is_none_or(|end| node_nibbles <= *end)
-            {
+            // Symmetric to the start proof. An exclusion proof's terminal can
+            // undershoot to the nearest existing key, so at an out-of-range
+            // position the proposal's branch value legitimately differs from the
+            // proof's, and the proof's is adopted.
+            if in_proven_range(&node_nibbles) {
                 Err(ProofError::UnexpectedValue)
             } else {
                 match &pn.value_digest {
@@ -1718,6 +1726,12 @@ impl<T: HashedNodeReader> Merkle<T> {
     ///
     /// * `api::Error::InvalidRange` - If `start_key` > `end_key` when both are provided.
     ///   This ensures the range bounds are logically consistent.
+    ///
+    /// * `api::Error::ProofError(ProofError::Empty)` - If the end revision has no
+    ///   root, i.e. every key in the database was deleted. `prove` yields no nodes
+    ///   for a rootless trie, so no boundary proof can be produced and a change
+    ///   proof onto an empty trie is not expressible. Deleting every key in a
+    ///   bounded *range* is fine as long as some key survives elsewhere.
     ///
     /// * `api::Error` - Various other errors can occur during proof generation, such as:
     ///   - I/O errors when reading nodes from storage

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -1221,18 +1221,6 @@ fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
     Ok(())
 }
 
-/// Whether a boundary proof node at `node` sits inside the proven range
-/// `[start, end]`, in nibbles. An empty `start` is −∞ and a `None` `end` is +∞.
-///
-/// Both reconcile loops in [`verify_change_proof_root_hash`] ask this same
-/// question: a node's position is in range or it is not, regardless of which
-/// proof carried it. Testing only the near bound would judge a divergent
-/// terminal beyond the far bound as in-range, and report its legitimately
-/// differing value as `UnexpectedValue`.
-fn in_proven_range(node: &[u8], start: &[u8], end: Option<&[u8]>) -> bool {
-    node >= start && end.is_none_or(|end| node <= end)
-}
-
 /// Verify that the proposal (`start_root` + `batch_ops`) is consistent with
 /// `end_root` within the proven range (phase 3 of change proof verification).
 ///
@@ -1328,6 +1316,11 @@ pub fn verify_change_proof_root_hash(
         .as_deref()
         .map(|k| NibblesIterator::new(k).collect());
 
+    let range = CollapseRange {
+        start: start_key_nibbles.as_slice(),
+        end: end_key_nibbles.as_deref(),
+    };
+
     for proof_node in start_nodes {
         proving_merkle.reconcile_branch_proof_node(proof_node, |pn, _branch_value| {
             let node_nibbles: Vec<u8> = pn.key.iter().map(|c| c.as_u8()).collect();
@@ -1335,11 +1328,7 @@ pub fn verify_change_proof_root_hash(
             // already holds the correct value, so the only way the proof node
             // and branch disagree is tampering — e.g. a dropped in-range `Put`
             // whose boundary proof still carries the omitted key's hash.
-            if in_proven_range(
-                &node_nibbles,
-                &start_key_nibbles,
-                end_key_nibbles.as_deref(),
-            ) {
+            if range.contains(&node_nibbles) {
                 Err(ProofError::UnexpectedValue)
             } else {
                 match &pn.value_digest {
@@ -1361,11 +1350,7 @@ pub fn verify_change_proof_root_hash(
             // undershoot to the nearest existing key, so at an out-of-range
             // position the proposal's branch value legitimately differs from the
             // proof's, and the proof's is adopted.
-            if in_proven_range(
-                &node_nibbles,
-                &start_key_nibbles,
-                end_key_nibbles.as_deref(),
-            ) {
+            if range.contains(&node_nibbles) {
                 Err(ProofError::UnexpectedValue)
             } else {
                 match &pn.value_digest {
@@ -1394,10 +1379,6 @@ pub fn verify_change_proof_root_hash(
     // Out-of-range children are stripped. Stripping an off-path child that
     // holds an in-range key indicates tampered operations and triggers
     // rejection.
-    let range = CollapseRange {
-        start: start_key_nibbles.as_slice(),
-        end: end_key_nibbles.as_deref(),
-    };
     for [parent, child] in start_nodes.array_windows() {
         proving_merkle.collapse_branch_to_path(&parent.key, &child.key, Some(range))?;
     }

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -1292,31 +1292,50 @@ pub fn verify_change_proof_root_hash(
     // values outside the range). Overwrite with the proof's value so the
     // hash computation uses end_root's value.
     //
-    // Out-of-range nodes include:
-    //  - proper prefixes of start_key (ancestors on the path)
-    //  - divergent nodes whose key is NOT a prefix of start_key (these
-    //    appear in exclusion proofs when start_key doesn't exist)
+    // A start proof can carry these out-of-range nodes:
+    //  - proper prefixes of start_key (ancestors on the path), which sort
+    //    before it
+    //  - divergent nodes that sort before start_key, which appear when no node
+    //    sits at start_key itself
+    //  - nodes that sort after the right edge, reachable when the end trie
+    //    holds no key in the range
     //
-    // Only nodes whose key exactly equals start_key are in-range; value
-    // mismatches there are real errors.
+    // A divergent terminal that overshoots to the nearest existing key after
+    // start_key is in range, and a value mismatch there is a real error.
     let start_key_nibbles: Vec<u8> = verification
         .start_key
         .as_deref()
         .map(|k| NibblesIterator::new(k).collect())
         .unwrap_or_default();
 
+    // `None` is an unbounded right edge (+∞). Keeping it distinct from an empty
+    // slice matters: an empty slice sorts as the minimum key, which would mark
+    // every key out of range at the upper bound.
+    let end_key_nibbles: Option<Vec<u8>> = verification
+        .right_edge_key
+        .as_deref()
+        .map(|k| NibblesIterator::new(k).collect());
+
+    // Whether a boundary proof node sits inside the proven range. Both loops
+    // below ask the same question — a node's position is in range or it is not,
+    // regardless of which proof carried it. Testing only the near bound would
+    // judge a divergent terminal beyond the far bound as in-range and report
+    // its legitimately differing value as `UnexpectedValue`.
+    let in_proven_range = |node_nibbles: &[u8]| {
+        node_nibbles >= start_key_nibbles.as_slice()
+            && end_key_nibbles
+                .as_deref()
+                .is_none_or(|end| node_nibbles <= end)
+    };
+
     for proof_node in start_nodes {
         proving_merkle.reconcile_branch_proof_node(proof_node, |pn, _branch_value| {
             let node_nibbles: Vec<u8> = pn.key.iter().map(|c| c.as_u8()).collect();
-            // A start proof node is in-range if its key >= start_key. This
-            // covers both inclusion proofs (key == start_key) and exclusion
-            // proofs where the terminal node overshoots start_key to the
-            // nearest existing key. Reaching this guard at an in-range
-            // position is always a real error: the proposal already holds the
-            // correct value, so the only way the proof node and branch
-            // disagree is tampering — e.g. a dropped in-range `Put` whose
-            // boundary proof still carries the omitted key's hash.
-            if node_nibbles >= start_key_nibbles {
+            // Reaching this guard in range is always a real error: the proposal
+            // already holds the correct value, so the only way the proof node
+            // and branch disagree is tampering — e.g. a dropped in-range `Put`
+            // whose boundary proof still carries the omitted key's hash.
+            if in_proven_range(&node_nibbles) {
                 Err(ProofError::UnexpectedValue)
             } else {
                 match &pn.value_digest {
@@ -1331,25 +1350,14 @@ pub fn verify_change_proof_root_hash(
     // Same treatment for end proof nodes: ancestors and divergent nodes
     // of the right boundary may have out-of-range values that differ
     // from the proposal.
-    // `None` is an unbounded right edge (+∞). Keeping it distinct from an empty
-    // slice matters: an empty slice sorts as the minimum key, which would mark
-    // every key out of range at the upper bound.
-    let end_key_nibbles: Option<Vec<u8>> = verification
-        .right_edge_key
-        .as_deref()
-        .map(|k| NibblesIterator::new(k).collect());
-
     for proof_node in end_nodes {
         proving_merkle.reconcile_branch_proof_node(proof_node, |pn, _branch_value| {
             let node_nibbles: Vec<u8> = pn.key.iter().map(|c| c.as_u8()).collect();
-            // Symmetric to the start proof: an end proof node is in-range
-            // if its key <= end_key (covers exclusion proofs where the
-            // terminal undershoots to the nearest existing key). An unbounded
-            // right edge (+∞) puts every node in range.
-            if end_key_nibbles
-                .as_ref()
-                .is_none_or(|end| node_nibbles <= *end)
-            {
+            // Symmetric to the start proof. An exclusion proof's terminal can
+            // undershoot to the nearest existing key, so at an out-of-range
+            // position the proposal's branch value legitimately differs from the
+            // proof's, and the proof's is adopted.
+            if in_proven_range(&node_nibbles) {
                 Err(ProofError::UnexpectedValue)
             } else {
                 match &pn.value_digest {
@@ -1721,6 +1729,12 @@ impl<T: HashedNodeReader> Merkle<T> {
     ///
     /// * `api::Error::InvalidRange` - If `start_key` > `end_key` when both are provided.
     ///   This ensures the range bounds are logically consistent.
+    ///
+    /// * `api::Error::ProofError(ProofError::Empty)` - If the end revision has no
+    ///   root, i.e. every key in the database was deleted. `prove` yields no nodes
+    ///   for a rootless trie, so no boundary proof can be produced and a change
+    ///   proof onto an empty trie is not expressible. Deleting every key in a
+    ///   bounded *range* is fine as long as some key survives elsewhere.
     ///
     /// * `api::Error` - Various other errors can occur during proof generation, such as:
     ///   - I/O errors when reading nodes from storage

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -1221,6 +1221,18 @@ fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
     Ok(())
 }
 
+/// Whether a boundary proof node at `node` sits inside the proven range
+/// `[start, end]`, in nibbles. An empty `start` is −∞ and a `None` `end` is +∞.
+///
+/// Both reconcile loops in [`verify_change_proof_root_hash`] ask this same
+/// question: a node's position is in range or it is not, regardless of which
+/// proof carried it. Testing only the near bound would judge a divergent
+/// terminal beyond the far bound as in-range, and report its legitimately
+/// differing value as `UnexpectedValue`.
+fn in_proven_range(node: &[u8], start: &[u8], end: Option<&[u8]>) -> bool {
+    node >= start && end.is_none_or(|end| node <= end)
+}
+
 /// Verify that the proposal (`start_root` + `batch_ops`) is consistent with
 /// `end_root` within the proven range (phase 3 of change proof verification).
 ///
@@ -1316,18 +1328,6 @@ pub fn verify_change_proof_root_hash(
         .as_deref()
         .map(|k| NibblesIterator::new(k).collect());
 
-    // Whether a boundary proof node sits inside the proven range. Both loops
-    // below ask the same question — a node's position is in range or it is not,
-    // regardless of which proof carried it. Testing only the near bound would
-    // judge a divergent terminal beyond the far bound as in-range and report
-    // its legitimately differing value as `UnexpectedValue`.
-    let in_proven_range = |node_nibbles: &[u8]| {
-        node_nibbles >= start_key_nibbles.as_slice()
-            && end_key_nibbles
-                .as_deref()
-                .is_none_or(|end| node_nibbles <= end)
-    };
-
     for proof_node in start_nodes {
         proving_merkle.reconcile_branch_proof_node(proof_node, |pn, _branch_value| {
             let node_nibbles: Vec<u8> = pn.key.iter().map(|c| c.as_u8()).collect();
@@ -1335,7 +1335,11 @@ pub fn verify_change_proof_root_hash(
             // already holds the correct value, so the only way the proof node
             // and branch disagree is tampering — e.g. a dropped in-range `Put`
             // whose boundary proof still carries the omitted key's hash.
-            if in_proven_range(&node_nibbles) {
+            if in_proven_range(
+                &node_nibbles,
+                &start_key_nibbles,
+                end_key_nibbles.as_deref(),
+            ) {
                 Err(ProofError::UnexpectedValue)
             } else {
                 match &pn.value_digest {
@@ -1357,7 +1361,11 @@ pub fn verify_change_proof_root_hash(
             // undershoot to the nearest existing key, so at an out-of-range
             // position the proposal's branch value legitimately differs from the
             // proof's, and the proof's is adopted.
-            if in_proven_range(&node_nibbles) {
+            if in_proven_range(
+                &node_nibbles,
+                &start_key_nibbles,
+                end_key_nibbles.as_deref(),
+            ) {
                 Err(ProofError::UnexpectedValue)
             } else {
                 match &pn.value_digest {

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -1212,6 +1212,18 @@ fn verify_range_proof_root_hash<H: ProofCollection<Node = ProofNode>>(
     Ok(())
 }
 
+/// Whether a boundary proof node at `node` sits inside the proven range
+/// `[start, end]`, in nibbles. An empty `start` is −∞ and a `None` `end` is +∞.
+///
+/// Both reconcile loops in [`verify_change_proof_root_hash`] ask this same
+/// question: a node's position is in range or it is not, regardless of which
+/// proof carried it. Testing only the near bound would judge a divergent
+/// terminal beyond the far bound as in-range, and report its legitimately
+/// differing value as `UnexpectedValue`.
+fn in_proven_range(node: &[u8], start: &[u8], end: Option<&[u8]>) -> bool {
+    node >= start && end.is_none_or(|end| node <= end)
+}
+
 /// Verify that the proposal (`start_root` + `batch_ops`) is consistent with
 /// `end_root` within the proven range (phase 3 of change proof verification).
 ///
@@ -1307,18 +1319,6 @@ pub fn verify_change_proof_root_hash(
         .as_deref()
         .map(|k| NibblesIterator::new(k).collect());
 
-    // Whether a boundary proof node sits inside the proven range. Both loops
-    // below ask the same question — a node's position is in range or it is not,
-    // regardless of which proof carried it. Testing only the near bound would
-    // judge a divergent terminal beyond the far bound as in-range and report
-    // its legitimately differing value as `UnexpectedValue`.
-    let in_proven_range = |node_nibbles: &[u8]| {
-        node_nibbles >= start_key_nibbles.as_slice()
-            && end_key_nibbles
-                .as_deref()
-                .is_none_or(|end| node_nibbles <= end)
-    };
-
     for proof_node in start_nodes {
         proving_merkle.reconcile_branch_proof_node(proof_node, |pn, _branch_value| {
             let node_nibbles: Vec<u8> = pn.key.iter().map(|c| c.as_u8()).collect();
@@ -1326,7 +1326,11 @@ pub fn verify_change_proof_root_hash(
             // already holds the correct value, so the only way the proof node
             // and branch disagree is tampering — e.g. a dropped in-range `Put`
             // whose boundary proof still carries the omitted key's hash.
-            if in_proven_range(&node_nibbles) {
+            if in_proven_range(
+                &node_nibbles,
+                &start_key_nibbles,
+                end_key_nibbles.as_deref(),
+            ) {
                 Err(ProofError::UnexpectedValue)
             } else {
                 match &pn.value_digest {
@@ -1348,7 +1352,11 @@ pub fn verify_change_proof_root_hash(
             // undershoot to the nearest existing key, so at an out-of-range
             // position the proposal's branch value legitimately differs from the
             // proof's, and the proof's is adopted.
-            if in_proven_range(&node_nibbles) {
+            if in_proven_range(
+                &node_nibbles,
+                &start_key_nibbles,
+                end_key_nibbles.as_deref(),
+            ) {
                 Err(ProofError::UnexpectedValue)
             } else {
                 match &pn.value_digest {

--- a/firewood/src/merkle/tests/change/regression.rs
+++ b/firewood/src/merkle/tests/change/regression.rs
@@ -30,6 +30,10 @@
 //!   where the deleted key extends the bound.
 //! - `test_out_of_range_delete_below_start_bound_verifies`: start bound, where
 //!   the bound extends the deleted key.
+//!
+//! Completeness — a reconcile guard must test both bounds, not one (#2154):
+//! - `test_all_deleted_range_with_survivor_above_end_bound_verifies`: every
+//!   in-range key is deleted and the sole survivor sorts above the end bound.
 
 use super::*;
 use crate::{ChangeProof, Proof};
@@ -426,5 +430,62 @@ fn test_split_start_boundary_child_omitted_in_range_delete_is_rejected() {
         "a split boundary child must be recomputed from the proposal. The start \
          boundary's child holds the in-range 0xd490 as well as the out-of-range \
          0xd410, so it cannot be taken from the proof"
+    );
+}
+
+/// A bounded change proof must verify when every in-range key was deleted and
+/// the sole surviving key sorts above the end bound.
+///
+/// start trie: `{ 0x10, 0x56, 0x5601, 0xf1 }`
+/// end trie:   `{ 0x5601 }`  (all others deleted, `0x5601` rewritten)
+/// range:      `[0x1000, 0x56]`
+///
+/// `0x10` sorts below `0x1000` (a shorter key comes first), so only `Delete
+/// 0x56` is in range. `0x5601` sorts above the bound `0x56` and is therefore out
+/// of range, but it is the end trie's only key, so it appears as a valued node
+/// in the start proof. A reconcile guard testing only `>= start_key` judges it
+/// in-range and reports its value as `UnexpectedValue`, rejecting an honest
+/// proof. Nothing here needs a limit or truncation.
+///
+/// The `Put` rewriting `0x5601` is load-bearing: `reconcile_branch_proof_node`
+/// short-circuits when the proof node's value already equals the branch's, so
+/// without a value change the guard is never reached and this test passes even
+/// with the defect present.
+#[test]
+fn test_all_deleted_range_with_survivor_above_end_bound_verifies() {
+    let (db, _dir) = setup_db![
+        (b"\x10".as_slice(), b"a".as_slice()),
+        (b"\x56".as_slice(), b"b".as_slice()),
+        (b"\x56\x01".as_slice(), b"c".as_slice()),
+        (b"\xf1".as_slice(), b"d".as_slice())
+    ];
+    let (start_root, end_root) = commit_batch(
+        &db,
+        vec![
+            BatchOp::Delete { key: b"\x10" },
+            BatchOp::Delete { key: b"\x56" },
+            BatchOp::Put {
+                key: b"\x56\x01",
+                value: b"c2",
+            },
+            BatchOp::Delete { key: b"\xf1" },
+        ],
+    );
+
+    let (sk, ek) = (b"\x10\x00".as_slice(), b"\x56".as_slice());
+    let proof = db
+        .change_proof(
+            start_root.clone(),
+            end_root.clone(),
+            Some(sk),
+            Some(ek),
+            None,
+        )
+        .unwrap();
+    assert_eq!(proof.batch_ops().len(), 1);
+    verify(&db, &proof, &start_root, &end_root, Some(sk), Some(ek)).expect(
+        "honest change proof over [0x1000, 0x56] must verify. The surviving \
+         0x5601 sorts above the end bound, so it is out of range and its value \
+         must not be reported as UnexpectedValue",
     );
 }

--- a/firewood/src/merkle/tests/change/regression.rs
+++ b/firewood/src/merkle/tests/change/regression.rs
@@ -30,6 +30,10 @@
 //!   where the deleted key extends the bound.
 //! - `test_out_of_range_delete_below_start_bound_verifies`: start bound, where
 //!   the bound extends the deleted key.
+//!
+//! Completeness — a reconcile guard must test both bounds, not one (#2154):
+//! - `test_all_deleted_range_with_survivor_above_end_bound_verifies`: every
+//!   in-range key is deleted and the sole survivor sorts above the end bound.
 
 use super::*;
 use crate::{ChangeProof, Proof};
@@ -426,5 +430,62 @@ fn test_split_start_boundary_child_omitted_in_range_delete_is_rejected() {
          though the start boundary child also holds the out-of-range 0xd410. The \
          in-range key remains in the proposal and its subtree must be recomputed, \
          not taken from the start proof"
+    );
+}
+
+/// A bounded change proof must verify when every in-range key was deleted and
+/// the sole surviving key sorts above the end bound.
+///
+/// start trie: `{ 0x10, 0x56, 0x5601, 0xf1 }`
+/// end trie:   `{ 0x5601 }`  (all others deleted, `0x5601` rewritten)
+/// range:      `[0x1000, 0x56]`
+///
+/// `0x10` sorts below `0x1000` (a shorter key comes first), so only `Delete
+/// 0x56` is in range. `0x5601` sorts above the bound `0x56` and is therefore out
+/// of range, but it is the end trie's only key, so it appears as a valued node
+/// in the start proof. A reconcile guard testing only `>= start_key` judges it
+/// in-range and reports its value as `UnexpectedValue`, rejecting an honest
+/// proof. Nothing here needs a limit or truncation.
+///
+/// The `Put` rewriting `0x5601` is load-bearing: `reconcile_branch_proof_node`
+/// short-circuits when the proof node's value already equals the branch's, so
+/// without a value change the guard is never reached and this test passes even
+/// with the defect present.
+#[test]
+fn test_all_deleted_range_with_survivor_above_end_bound_verifies() {
+    let (db, _dir) = setup_db![
+        (b"\x10".as_slice(), b"a".as_slice()),
+        (b"\x56".as_slice(), b"b".as_slice()),
+        (b"\x56\x01".as_slice(), b"c".as_slice()),
+        (b"\xf1".as_slice(), b"d".as_slice())
+    ];
+    let (start_root, end_root) = commit_batch(
+        &db,
+        vec![
+            BatchOp::Delete { key: b"\x10" },
+            BatchOp::Delete { key: b"\x56" },
+            BatchOp::Put {
+                key: b"\x56\x01",
+                value: b"c2",
+            },
+            BatchOp::Delete { key: b"\xf1" },
+        ],
+    );
+
+    let (sk, ek) = (b"\x10\x00".as_slice(), b"\x56".as_slice());
+    let proof = db
+        .change_proof(
+            start_root.clone(),
+            end_root.clone(),
+            Some(sk),
+            Some(ek),
+            None,
+        )
+        .unwrap();
+    assert_eq!(proof.batch_ops().len(), 1);
+    verify(&db, &proof, &start_root, &end_root, Some(sk), Some(ek)).expect(
+        "honest change proof over [0x1000, 0x56] must verify. The surviving \
+         0x5601 sorts above the end bound, so it is out of range and its value \
+         must not be reported as UnexpectedValue",
     );
 }

--- a/firewood/src/merkle/tests/change/regression.rs
+++ b/firewood/src/merkle/tests/change/regression.rs
@@ -2,8 +2,8 @@
 // See the file LICENSE.md for licensing terms.
 
 //! Deterministic regression tests for change-proof verification at range
-//! boundaries, where a boundary key shares a trie-descent path with a
-//! neighbouring key.
+//! boundaries, where the verifier must decide whether a boundary proof node
+//! falls inside the proven range.
 //!
 //! Soundness — a tampered, forged, or omitted op must be rejected:
 //! - `test_tampered_right_edge_delete_to_put_is_rejected` (#2091): in a
@@ -31,9 +31,12 @@
 //! - `test_out_of_range_delete_below_start_bound_verifies`: start bound, where
 //!   the bound extends the deleted key.
 //!
-//! Completeness — a reconcile guard must test both bounds, not one (#2154):
+//! Completeness — a reconcile guard must test both bounds, not one (#2154,
+//! #2145):
 //! - `test_all_deleted_range_with_survivor_above_end_bound_verifies`: every
 //!   in-range key is deleted and the sole survivor sorts above the end bound.
+//! - `test_key_empty_range_verifies`: the range contains no keys in either
+//!   revision, so the start proof's exclusion terminal sorts past the end bound.
 
 use super::*;
 use crate::{ChangeProof, Proof};
@@ -487,5 +490,47 @@ fn test_all_deleted_range_with_survivor_above_end_bound_verifies() {
         "honest change proof over [0x1000, 0x56] must verify. The surviving \
          0x5601 sorts above the end bound, so it is out of range and its value \
          must not be reported as UnexpectedValue",
+    );
+}
+
+/// A change proof over a range that contains no keys in either revision must
+/// verify (#2145). The start trie holds `0x20` and the end trie holds `0xe0`, so
+/// the range `[0x60, 0xb0]` is empty on both sides and the proof correctly
+/// claims nothing changed within it.
+///
+/// Both boundary proofs are generated from the end trie, so the start proof is
+/// an exclusion proof whose terminal is the nearest end-trie key at or after
+/// `0x60` — that is `0xe0`, which sorts after the end bound. A guard testing
+/// only `>= start_key` treats that terminal as in-range and reports its value as
+/// `UnexpectedValue`, rejecting an honest proof.
+#[test]
+fn test_key_empty_range_verifies() {
+    let (db, _dir) = setup_db![(b"\x20".as_slice(), b"\x01".as_slice())];
+    let (start_root, end_root) = commit_batch(
+        &db,
+        vec![
+            BatchOp::Delete { key: b"\x20" },
+            BatchOp::Put {
+                key: b"\xe0",
+                value: b"\x01",
+            },
+        ],
+    );
+
+    let (sk, ek) = (b"\x60".as_slice(), b"\xb0".as_slice());
+    let proof = db
+        .change_proof(
+            start_root.clone(),
+            end_root.clone(),
+            Some(sk),
+            Some(ek),
+            None,
+        )
+        .unwrap();
+    assert!(proof.batch_ops().is_empty());
+    verify(&db, &proof, &start_root, &end_root, Some(sk), Some(ek)).expect(
+        "honest change proof over the key-empty range [0x60, 0xb0] must verify. \
+         The start proof's exclusion terminal 0xe0 sorts after the end bound, so \
+         it is out of range and its value must not be reported as UnexpectedValue",
     );
 }

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -972,12 +972,13 @@ fn test_get_branch_from_nibbles_mut() {
     assert!(leaf.is_none());
 }
 
-/// `in_proven_range` decides which boundary proof nodes the reconcile loops in
-/// `verify_change_proof_root_hash` treat as in-range. Its bound conventions are
-/// easy to get wrong, so pin them directly: both bounds are inclusive, an empty
-/// `start` is −∞, and a `None` `end` is +∞. `None` is distinct from `Some(&[])`,
-/// which is the empty key itself — conflating the two put every key out of
-/// range at the upper bound.
+/// `CollapseRange::contains` decides which boundary proof nodes the reconcile
+/// loops in `verify_change_proof_root_hash` treat as in-range, and which branch
+/// values `collapse_strip` clears. Its bound conventions are easy to get wrong,
+/// so pin them directly: both bounds are inclusive, an empty `start` is −∞, and
+/// a `None` `end` is +∞. `None` is distinct from `Some(&[])`, which is the empty
+/// key itself — conflating the two put every key out of range at the upper
+/// bound.
 #[test_case(&[3], &[3], Some(&[7]), true ; "start bound is inclusive")]
 #[test_case(&[7], &[3], Some(&[7]), true ; "end bound is inclusive")]
 #[test_case(&[2], &[3], Some(&[7]), false ; "before start")]
@@ -985,6 +986,6 @@ fn test_get_branch_from_nibbles_mut() {
 #[test_case(&[7, 0], &[3], Some(&[7]), false ; "longer key extending the end bound sorts after it")]
 #[test_case(&[9, 9], &[3], None, true ; "None end is positive infinity")]
 #[test_case(&[0], &[], Some(&[]), false ; "Some(empty) is the empty key, not positive infinity")]
-fn test_in_proven_range_bounds(node: &[u8], start: &[u8], end: Option<&[u8]>, expected: bool) {
-    assert_eq!(in_proven_range(node, start, end), expected);
+fn test_collapse_range_contains(node: &[u8], start: &[u8], end: Option<&[u8]>, expected: bool) {
+    assert_eq!(CollapseRange { start, end }.contains(node), expected);
 }

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -970,3 +970,37 @@ fn test_get_branch_from_nibbles_mut() {
     );
     assert!(leaf.is_none());
 }
+
+/// `in_proven_range` decides which boundary proof nodes the reconcile loops in
+/// `verify_change_proof_root_hash` treat as in-range. Its bound conventions are
+/// easy to get wrong, so pin them directly: both bounds are inclusive, an empty
+/// `start` is −∞, and a `None` `end` is +∞. `None` is distinct from `Some(&[])`,
+/// which is the empty key itself — conflating the two put every key out of
+/// range at the upper bound.
+#[test]
+fn test_in_proven_range_bounds() {
+    fn check(node: &[u8], start: &[u8], end: Option<&[u8]>, expected: bool) {
+        assert_eq!(
+            in_proven_range(node, start, end),
+            expected,
+            "node={node:?} start={start:?} end={end:?}"
+        );
+    }
+
+    check(&[5], &[3], Some(&[7]), true);
+    // Both bounds are inclusive.
+    check(&[3], &[3], Some(&[7]), true);
+    check(&[7], &[3], Some(&[7]), true);
+    check(&[2], &[3], Some(&[7]), false);
+    check(&[8], &[3], Some(&[7]), false);
+    // A longer key extending the bound sorts after it.
+    check(&[7, 0], &[3], Some(&[7]), false);
+    // An empty start is -inf.
+    check(&[0], &[], Some(&[7]), true);
+    // A None end is +inf.
+    check(&[9, 9], &[3], None, true);
+    check(&[], &[], None, true);
+    // Some(&[]) is the empty key, not +inf.
+    check(&[], &[], Some(&[]), true);
+    check(&[0], &[], Some(&[]), false);
+}

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -23,6 +23,7 @@ use firewood_storage::{
     Children, Committed, DeletedNodeTracking, MemStore, Mutable, NodeHashAlgorithm, NodeStore,
     NodeStoreHeader, PathComponent, Propose, RootReader, TrieHash, ValueDigest,
 };
+use test_case::test_case;
 
 // Returns n random key-value pairs.
 fn generate_random_kvs(rng: &firewood_storage::SeededRng, n: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
@@ -952,30 +953,13 @@ fn test_get_branch_from_nibbles_mut() {
 /// `start` is −∞, and a `None` `end` is +∞. `None` is distinct from `Some(&[])`,
 /// which is the empty key itself — conflating the two put every key out of
 /// range at the upper bound.
-#[test]
-fn test_in_proven_range_bounds() {
-    fn check(node: &[u8], start: &[u8], end: Option<&[u8]>, expected: bool) {
-        assert_eq!(
-            in_proven_range(node, start, end),
-            expected,
-            "node={node:?} start={start:?} end={end:?}"
-        );
-    }
-
-    check(&[5], &[3], Some(&[7]), true);
-    // Both bounds are inclusive.
-    check(&[3], &[3], Some(&[7]), true);
-    check(&[7], &[3], Some(&[7]), true);
-    check(&[2], &[3], Some(&[7]), false);
-    check(&[8], &[3], Some(&[7]), false);
-    // A longer key extending the bound sorts after it.
-    check(&[7, 0], &[3], Some(&[7]), false);
-    // An empty start is -inf.
-    check(&[0], &[], Some(&[7]), true);
-    // A None end is +inf.
-    check(&[9, 9], &[3], None, true);
-    check(&[], &[], None, true);
-    // Some(&[]) is the empty key, not +inf.
-    check(&[], &[], Some(&[]), true);
-    check(&[0], &[], Some(&[]), false);
+#[test_case(&[3], &[3], Some(&[7]), true ; "start bound is inclusive")]
+#[test_case(&[7], &[3], Some(&[7]), true ; "end bound is inclusive")]
+#[test_case(&[2], &[3], Some(&[7]), false ; "before start")]
+#[test_case(&[8], &[3], Some(&[7]), false ; "after end")]
+#[test_case(&[7, 0], &[3], Some(&[7]), false ; "longer key extending the end bound sorts after it")]
+#[test_case(&[9, 9], &[3], None, true ; "None end is positive infinity")]
+#[test_case(&[0], &[], Some(&[]), false ; "Some(empty) is the empty key, not positive infinity")]
+fn test_in_proven_range_bounds(node: &[u8], start: &[u8], end: Option<&[u8]>, expected: bool) {
+    assert_eq!(in_proven_range(node, start, end), expected);
 }

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -945,3 +945,37 @@ fn test_get_branch_from_nibbles_mut() {
     );
     assert!(leaf.is_none());
 }
+
+/// `in_proven_range` decides which boundary proof nodes the reconcile loops in
+/// `verify_change_proof_root_hash` treat as in-range. Its bound conventions are
+/// easy to get wrong, so pin them directly: both bounds are inclusive, an empty
+/// `start` is −∞, and a `None` `end` is +∞. `None` is distinct from `Some(&[])`,
+/// which is the empty key itself — conflating the two put every key out of
+/// range at the upper bound.
+#[test]
+fn test_in_proven_range_bounds() {
+    fn check(node: &[u8], start: &[u8], end: Option<&[u8]>, expected: bool) {
+        assert_eq!(
+            in_proven_range(node, start, end),
+            expected,
+            "node={node:?} start={start:?} end={end:?}"
+        );
+    }
+
+    check(&[5], &[3], Some(&[7]), true);
+    // Both bounds are inclusive.
+    check(&[3], &[3], Some(&[7]), true);
+    check(&[7], &[3], Some(&[7]), true);
+    check(&[2], &[3], Some(&[7]), false);
+    check(&[8], &[3], Some(&[7]), false);
+    // A longer key extending the bound sorts after it.
+    check(&[7, 0], &[3], Some(&[7]), false);
+    // An empty start is -inf.
+    check(&[0], &[], Some(&[7]), true);
+    // A None end is +inf.
+    check(&[9, 9], &[3], None, true);
+    check(&[], &[], None, true);
+    // Some(&[]) is the empty key, not +inf.
+    check(&[], &[], Some(&[]), true);
+    check(&[0], &[], Some(&[]), false);
+}

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -29,6 +29,7 @@ use firewood_storage::{
     NodeHashAlgorithm, NodeStore, NodeStoreHeader, PathComponent, Propose, RootReader, TrieHash,
     ValueDigest,
 };
+use test_case::test_case;
 
 /// Test wrapper around [`crate::merkle::verify_range_proof`] that supplies the
 /// compile-default hash mode as the expected `algorithm` (the mode every proof
@@ -977,30 +978,13 @@ fn test_get_branch_from_nibbles_mut() {
 /// `start` is −∞, and a `None` `end` is +∞. `None` is distinct from `Some(&[])`,
 /// which is the empty key itself — conflating the two put every key out of
 /// range at the upper bound.
-#[test]
-fn test_in_proven_range_bounds() {
-    fn check(node: &[u8], start: &[u8], end: Option<&[u8]>, expected: bool) {
-        assert_eq!(
-            in_proven_range(node, start, end),
-            expected,
-            "node={node:?} start={start:?} end={end:?}"
-        );
-    }
-
-    check(&[5], &[3], Some(&[7]), true);
-    // Both bounds are inclusive.
-    check(&[3], &[3], Some(&[7]), true);
-    check(&[7], &[3], Some(&[7]), true);
-    check(&[2], &[3], Some(&[7]), false);
-    check(&[8], &[3], Some(&[7]), false);
-    // A longer key extending the bound sorts after it.
-    check(&[7, 0], &[3], Some(&[7]), false);
-    // An empty start is -inf.
-    check(&[0], &[], Some(&[7]), true);
-    // A None end is +inf.
-    check(&[9, 9], &[3], None, true);
-    check(&[], &[], None, true);
-    // Some(&[]) is the empty key, not +inf.
-    check(&[], &[], Some(&[]), true);
-    check(&[0], &[], Some(&[]), false);
+#[test_case(&[3], &[3], Some(&[7]), true ; "start bound is inclusive")]
+#[test_case(&[7], &[3], Some(&[7]), true ; "end bound is inclusive")]
+#[test_case(&[2], &[3], Some(&[7]), false ; "before start")]
+#[test_case(&[8], &[3], Some(&[7]), false ; "after end")]
+#[test_case(&[7, 0], &[3], Some(&[7]), false ; "longer key extending the end bound sorts after it")]
+#[test_case(&[9, 9], &[3], None, true ; "None end is positive infinity")]
+#[test_case(&[0], &[], Some(&[]), false ; "Some(empty) is the empty key, not positive infinity")]
+fn test_in_proven_range_bounds(node: &[u8], start: &[u8], end: Option<&[u8]>, expected: bool) {
+    assert_eq!(in_proven_range(node, start, end), expected);
 }

--- a/firewood/src/proofs/mod.rs
+++ b/firewood/src/proofs/mod.rs
@@ -208,11 +208,12 @@
 //! so the hash computation reflects `end_root`.
 //!
 //! For exclusion proofs, the terminal proof node may overshoot the
-//! boundary key to the nearest existing key. Such nodes are in-range
-//! (>= `requested_start_key` for start proofs, <= `requested_end_key`
-//! for end proofs) and
-//! value conflicts there are real errors — the proposal already has
-//! the correct value from the batch_ops.
+//! boundary key to the nearest existing key. Such a node is in-range only
+//! when it lies within both bounds, `[requested_start_key,
+//! right_edge_key]`, and a value conflict there is a real error — the
+//! proposal already has the correct value from the batch_ops. Testing one
+//! bound alone would judge a terminal beyond the far bound as in-range,
+//! and report its legitimately differing value as an error.
 //!
 //! ### Step 3 — Branch collapsing
 //!


### PR DESCRIPTION
## Why this should be merged

Fixes #2154 and #2145.

Issue #2154 comes from the two reconcile loops in `verify_change_proof_root_hash`. Each loop decides whether a boundary proof node falls inside the proven range, but each one checked only a single bound. The start-proof loop tested `node_nibbles >= start_key_nibbles`. The end-proof loop tested `node_nibbles <= end_key_nibbles`.

So a node can fall outside the range on the side its own loop does not check, and still be treated as in-range. The verifier then compares that node's value against the proposal, finds a difference, and returns `UnexpectedValue`. The proof is honest, but it gets rejected.

To hit this, delete every key inside a bounded range and leave one surviving key that sorts after the end bound. The start proof must still include that survivor, since it is the only key left in the end trie. The survivor sits past the right edge, so it is out of range, but the start-proof loop has no upper bound and accepts it as in-range. No limit or truncation is involved. A sync that hits this case stalls, and the client cannot work around it.

Issue #2145 has the same cause and is fixed by the same change. Both boundary proofs are generated from the end trie, so for a range containing no keys the start proof is an exclusion proof whose terminal is the nearest end-trie key at or after `start_key`. That terminal can sort past the end bound, and the start-proof loop again treats it as in-range.

## How this works

`end_key_nibbles` and the `CollapseRange` built from it are now computed before the start-proof loop, instead of after both loops. Both loops then call one shared predicate, `CollapseRange::contains`, which checks both bounds. `child_in_range` and `collapse_strip` already ran the same comparison inline, so they now call it too, leaving one copy in the codebase instead of three.

One predicate is enough because both loops ask the same question. Whether a node sits inside the range depends on where the node is, not on which proof carried it. The old code had two conditions that were meant to be symmetric, and they were not.

`CollapseRange::contains` is stricter than the two one-sided checks it replaces, so more boundary nodes now take their value from the proof instead of raising `UnexpectedValue`. That is safe because no batch operation can sit at such a position. `verify_change_proof_structure` rejects a proof whose first operation sorts below `start_key`, or whose last sorts above `end_key`, and requires the operations to be strictly increasing. Every branch of `compute_right_edge_key` returns a right edge at or above the last operation's key. So every operation key falls inside `[start_key, right_edge_key]`, and a position the predicate excludes has no operation on it. An operation there would have raised the right edge to cover it.

The value taken from the proof is still checked. `verify_change_proof_structure` verifies each boundary proof against `end_root`, which chains every proof node's hash to the root. `verify_change_proof_root_hash` then recomputes that node's hash from the proving trie. Neither step can admit a value `end_root` does not have. No in-range node changes behaviour.

It also corrects documentation that had drifted:

- `proofs/mod.rs` still described the one-bound rule in the algorithm spec. It also said `requested_end_key` where the code uses `right_edge_key`. Those two differ when a proof is truncated, and `verify_change_proof_root_hash` points readers at this spec.
- The start-loop comment listed "divergent nodes whose key is NOT a prefix of `start_key`" as out-of-range. That is wrong. Such a node often sorts after `start_key`, which puts it in range, and the check below the comment exists to catch exactly that case.
- The end-loop comment described the mismatch backwards. The proof node's value is always `end_root`'s. It is the proposal's value that differs.
- Added a `# Errors` bullet for `ProofError::Empty`, returned when the end revision has no root because every key in the database was deleted.

## How this was tested

`test_all_deleted_range_with_survivor_above_end_bound_verifies` covers the case above. With the fix reverted it fails with `ProofError(UnexpectedValue)`. With the fix applied it passes.

The `Put` that rewrites `0x5601` in that test is required, and a comment now says so. Without a value change, `reconcile_branch_proof_node` returns early and never reaches the check, so the test would pass even with the bug present.

`test_key_empty_range_verifies` covers #2145, using the fixture from that issue: start trie `{0x20}`, end trie `{0xe0}`, range `[0x60, 0xb0]`. It also fails with `ProofError(UnexpectedValue)` when the fix is reverted.

`test_collapse_range_contains` pins the bound conventions as seven `test_case` entries.

`test_crafted_forged_value_detected` and `test_crafted_tampered_start_key_value_detected` both pass, and both fail if `CollapseRange::contains` is made to return false for bounded ranges. That confirms the verifier still rejects a tampered value inside a bounded range. Dropping the lower-bound comparison fails tests across `account`, `edge_cases`, and `empty`. Dropping the upper-bound comparison reinstates the original bug, which the new regression test catches. Because the predicate is now shared, either experiment also changes which branch values `collapse_strip` clears.

Full workspace matrix, all with `--all-targets`. nextest passes with no features, with `--no-default-features`, with `ethhash,logger`, and on the `ci` profile including every `test_slow_*` test. Clippy is clean on `nightly-2026-07-05` for those three feature rows plus `maxperf`. `cargo fmt --check` and `cargo doc --no-deps` are clean, and `ffi/firewood.h` did not change.

## Breaking Changes

None. The API is unchanged. Verification behaviour changes as intended: honest proofs that were rejected with `UnexpectedValue` at an out-of-range boundary node now verify.   