### PR TITLE
Feat/unpadded nodes

### DIFF
--- a/fwdctl/src/check.rs
+++ b/fwdctl/src/check.rs
@@ -152,6 +152,10 @@ Leaf Area Stats:
     Leaf Area Distribution: {{leaf_area_counts}}
     Leaves that Can Fit Into Smaller Area (low_occupancy_leaf_area): {{low_occupancy_leaf_area_count}} ({{low_occupancy_leaf_area_percent}})
 
+Unpadded Stats:
+    Unpadded Node Count: {{unpadded_node_count}}
+    Unpadded Node Bytes: {{unpadded_node_bytes}}
+
 Free List Area Stats:
     Total Free List Area Count (free_list_area_count): {{total_free_list_area_count}}
     Total Free List Area Bytes (free_list_area_bytes): {{total_free_list_area_bytes}}
@@ -191,6 +195,9 @@ struct DBStatsReport {
     leaf_area_counts: String,
     low_occupancy_leaf_area_count: String,
     low_occupancy_leaf_area_percent: String,
+    // Unpadded stats
+    unpadded_node_count: String,
+    unpadded_node_bytes: String,
     // Free list area stats
     total_free_list_area_count: String,
     total_free_list_area_bytes: String,
@@ -285,6 +292,8 @@ fn print_stats_report(db_stats: DBStats) {
             db_stats.trie_stats.low_occupancy_leaf_area_count,
             total_leaf_area_count,
         ),
+        unpadded_node_count: format_u64(db_stats.trie_stats.unpadded_node_count),
+        unpadded_node_bytes: format_u64(db_stats.trie_stats.unpadded_node_bytes),
         total_free_list_area_count: format_u64(total_free_list_area_count),
         total_free_list_area_bytes: format_u64(total_free_list_area_bytes),
         free_list_area_counts: format_map(&db_stats.free_list_stats.area_counts),

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -49,11 +49,19 @@ fn is_valid_key(key: &Path) -> bool {
     key.0.len().is_multiple_of(2)
 }
 
+/// Returns Ok(()) if the area alignment is correct for the given format.
+///
+/// Unpadded nodes are not required to be aligned to area size boundaries.
+/// Padded nodes must be aligned to `MIN_AREA_SIZE`.
 #[expect(clippy::result_large_err)]
 const fn check_area_aligned(
     address: LinearAddress,
     parent: StoredAreaParent,
+    is_unpadded: bool,
 ) -> Result<(), CheckerError> {
+    if is_unpadded {
+        return Ok(());
+    }
     if !address.is_aligned() {
         return Err(CheckerError::AreaMisaligned { address, parent });
     }
@@ -112,10 +120,14 @@ pub struct TrieStats {
     pub low_occupancy_branch_area_count: u64,
     /// Leaves that can fit into a smaller area
     pub low_occupancy_leaf_area_count: u64,
-    /// The number of areas that span an extra page due to not being aligned
+    /// The number of padded areas that span an extra page due to not being aligned
     pub area_extra_unaligned_page: u64,
-    /// The number of nodes that span an extra page due to not being aligned
+    /// The number of padded nodes that span an extra page due to not being aligned
     pub node_extra_unaligned_page: u64,
+    /// Number of unpadded nodes
+    pub unpadded_node_count: u64,
+    /// Total bytes of unpadded nodes on disk (including prefix)
+    pub unpadded_node_bytes: u64,
 }
 
 impl Default for TrieStats {
@@ -133,6 +145,8 @@ impl Default for TrieStats {
             low_occupancy_leaf_area_count: 0,
             area_extra_unaligned_page: 0,
             node_extra_unaligned_page: 0,
+            unpadded_node_count: 0,
+            unpadded_node_bytes: 0,
         }
     }
 }
@@ -291,10 +305,6 @@ where
             has_peers,
         } = subtrie;
 
-        // check that address is aligned
-        check_area_aligned(subtrie_root_address, StoredAreaParent::TrieNode(parent))?;
-
-        // read the node from the disk - we avoid cache since we will never visit the same node twice
         let area_meta = self
             .area_index_and_size(subtrie_root_address)
             .map_err(|e| {
@@ -304,11 +314,12 @@ where
                 }]
             })?;
 
-        // TODO(galadd): will send a PR after  this to add proper unpadded handling here
-        // not included in this so that code changes won't be too large
-        // For now, all existing databases are padded
-        let area_index = area_meta.area_index.expect("padded node expected");
-        let area_size = area_meta.total_size;
+        // check alignment (skip for unpadded nodes)
+        check_area_aligned(
+            subtrie_root_address,
+            StoredAreaParent::TrieNode(parent),
+            area_meta.is_unpadded,
+        )?;
 
         let (node, node_bytes) = self
             .read_node_with_num_bytes_from_disk(subtrie_root_address)
@@ -319,11 +330,12 @@ where
                 }]
             })?;
 
-        // check if the node fits in the area, equal is not allowed due to 1-byte area size index
-        if node_bytes > area_size {
+        // For padded nodes, verify node fits within area
+        // For unpadded nodes, node_bytes should equal total_size (no padding)
+        if !area_meta.is_unpadded && node_bytes > area_meta.total_size {
             return Err(vec![CheckerError::NodeLargerThanArea {
                 area_start: subtrie_root_address,
-                area_size,
+                area_size: area_meta.total_size,
                 node_bytes,
                 parent,
             }]);
@@ -360,7 +372,7 @@ where
         // check that the area is within bounds and does not intersect with other areas and mark it as visiteds
         visited.insert_area(
             subtrie_root_address,
-            area_size,
+            area_meta.total_size,
             StoredAreaParent::TrieNode(parent),
         )?;
 
@@ -380,21 +392,29 @@ where
                     .saturating_add(key_bytes as u64)
                     .saturating_add(value_bytes as u64);
             }
-            // collect the number of areas that requires reading an extra page due to not being aligned
-            if extra_read_pages(subtrie_root_address, area_size)
-                .expect("impossible since we checked in visited.insert_area()")
-                > 0
-            {
-                trie_stats.area_extra_unaligned_page =
-                    trie_stats.area_extra_unaligned_page.saturating_add(1);
-            }
-            // collect the number of nodes that requires reading an extra page due to not being aligned
-            if extra_read_pages(subtrie_root_address, node_bytes)
-                .expect("impossible since we checked in visited.insert_area()")
-                > 0
-            {
-                trie_stats.node_extra_unaligned_page =
-                    trie_stats.node_extra_unaligned_page.saturating_add(1);
+
+            if area_meta.is_unpadded {
+                // Unpadded node stats
+                trie_stats.unpadded_node_count = trie_stats.unpadded_node_count.saturating_add(1);
+                trie_stats.unpadded_node_bytes =
+                    trie_stats.unpadded_node_bytes.saturating_add(node_bytes);
+            } else {
+                // collect the number of areas that requires reading an extra page due to not being aligned
+                if extra_read_pages(subtrie_root_address, area_meta.total_size)
+                    .expect("impossible since we checked in visited.insert_area()")
+                    > 0
+                {
+                    trie_stats.area_extra_unaligned_page =
+                        trie_stats.area_extra_unaligned_page.saturating_add(1);
+                }
+                // collect the number of nodes that requires reading an extra page due to not being aligned
+                if extra_read_pages(subtrie_root_address, node_bytes)
+                    .expect("impossible since we checked in visited.insert_area()")
+                    > 0
+                {
+                    trie_stats.node_extra_unaligned_page =
+                        trie_stats.node_extra_unaligned_page.saturating_add(1);
+                }
             }
         }
 
@@ -404,7 +424,16 @@ where
             Node::Branch(branch) => {
                 let persist_info = branch.persist_info();
                 let num_children = persist_info.count();
-                {
+
+                if area_meta.is_unpadded {
+                    // Unpadded branch: just track bytes
+                    trie_stats.branch_bytes = trie_stats.branch_bytes.saturating_add(node_bytes);
+                } else {
+                    let area_index = area_meta
+                        .area_index
+                        .expect("padded node must have area_index");
+                    let area_size = area_meta.total_size;
+
                     // update the branch area count
                     let branch_area_count = trie_stats
                         .branch_area_counts
@@ -420,13 +449,14 @@ where
                         trie_stats.low_occupancy_branch_area_count =
                             trie_stats.low_occupancy_branch_area_count.saturating_add(1);
                     }
-                    // collect the branching factor distribution
-                    let branching_factor_count = trie_stats
-                        .branching_factors
-                        .entry(num_children)
-                        .or_insert(0);
-                    *branching_factor_count = branching_factor_count.saturating_add(1);
                 }
+
+                // collect the branching factor distribution
+                let branching_factor_count = trie_stats
+                    .branching_factors
+                    .entry(num_children)
+                    .or_insert(0);
+                *branching_factor_count = branching_factor_count.saturating_add(1);
 
                 // this is an internal node, traverse the children
                 for (nibble, (address, hash)) in persist_info
@@ -457,21 +487,32 @@ where
                 }
             }
             Node::Leaf(_) => {
-                // update the leaf area count
-                let leaf_area_count = trie_stats
+                if area_meta.is_unpadded {
+                    // Unpadded leaf: just track bytes
+                    trie_stats.leaf_bytes = trie_stats.leaf_bytes.saturating_add(node_bytes);
+                } else {
+                    let area_index = area_meta
+                        .area_index
+                        .expect("padded node must have area_index");
+                    let area_size = area_meta.total_size;
+
+                    // update the leaf area count
+                    let leaf_area_count = trie_stats
                  .leaf_area_counts
                  .get_mut(&area_size)
                  .expect("area size is initialized when trie_stats is created and we checked that node_bytes <= area_size");
-                *leaf_area_count = leaf_area_count.saturating_add(1);
-                // collect the leaf bytes
-                trie_stats.leaf_bytes = trie_stats.leaf_bytes.saturating_add(node_bytes);
-                // collect low occupancy area count, add 1 for the area size index byte
-                let smallest_area_index = AreaIndex::from_size(node_bytes)
-                    .expect("impossible since we checked that node_bytes <= area_size");
-                if smallest_area_index < area_index {
-                    trie_stats.low_occupancy_leaf_area_count =
-                        trie_stats.low_occupancy_leaf_area_count.saturating_add(1);
+                    *leaf_area_count = leaf_area_count.saturating_add(1);
+                    // collect the leaf bytes
+                    trie_stats.leaf_bytes = trie_stats.leaf_bytes.saturating_add(node_bytes);
+                    // collect low occupancy area count, add 1 for the area size index byte
+                    let smallest_area_index = AreaIndex::from_size(node_bytes)
+                        .expect("impossible since we checked that node_bytes <= area_size");
+                    if smallest_area_index < area_index {
+                        trie_stats.low_occupancy_leaf_area_count =
+                            trie_stats.low_occupancy_leaf_area_count.saturating_add(1);
+                    }
                 }
+
                 // collect the depth distribution
                 let depth_count = trie_stats.depths.entry(depth).or_insert(0);
                 *depth_count = depth_count.saturating_add(1);
@@ -516,7 +557,7 @@ where
             };
 
             // check that the area is aligned
-            if let Err(e) = check_area_aligned(addr, StoredAreaParent::FreeList(parent)) {
+            if let Err(e) = check_area_aligned(addr, StoredAreaParent::FreeList(parent), false) {
                 errors.push(e);
                 free_list_iter.move_to_next_free_list();
                 continue;
@@ -679,14 +720,13 @@ where
                 }
             };
 
-            // TODO(galadd): will send a PR after  this to add proper unpadded handling here
-            // not included in this so that code changes won't be too large
-            // For now, all existing databases are padded
-            let Some(area_index) = area_meta.area_index else {
-                warn!("Unpadded node in leaked range at {current_addr}, cannot add to free list");
+            // Unpadded nodes can't be added to free lists (wrong size class)
+            let (area_index, area_size) = if let Some(idx) = area_meta.area_index {
+                (idx, area_meta.total_size)
+            } else {
+                warn!("Unpadded node at {current_addr} in leaked range, cannot add to free list");
                 break;
             };
-            let area_size = area_meta.total_size;
 
             let next_addr = current_addr
                 .advance(area_size)
@@ -870,6 +910,8 @@ mod test {
             low_occupancy_leaf_area_count: 0,
             area_extra_unaligned_page: 0,
             node_extra_unaligned_page: 0,
+            unpadded_node_count: 0,
+            unpadded_node_bytes: 0,
         };
 
         TestTrie {

--- a/storage/src/checker/mod.rs
+++ b/storage/src/checker/mod.rs
@@ -295,14 +295,21 @@ where
         check_area_aligned(subtrie_root_address, StoredAreaParent::TrieNode(parent))?;
 
         // read the node from the disk - we avoid cache since we will never visit the same node twice
-        let (area_index, area_size) =
-            self.area_index_and_size(subtrie_root_address)
-                .map_err(|e| {
-                    vec![CheckerError::IO {
-                        error: e,
-                        parent: StoredAreaParent::TrieNode(parent),
-                    }]
-                })?;
+        let area_meta = self
+            .area_index_and_size(subtrie_root_address)
+            .map_err(|e| {
+                vec![CheckerError::IO {
+                    error: e,
+                    parent: StoredAreaParent::TrieNode(parent),
+                }]
+            })?;
+
+        // TODO(galadd): will send a PR after  this to add proper unpadded handling here
+        // not included in this so that code changes won't be too large
+        // For now, all existing databases are padded
+        let area_index = area_meta.area_index.expect("padded node expected");
+        let area_size = area_meta.total_size;
+
         let (node, node_bytes) = self
             .read_node_with_num_bytes_from_disk(subtrie_root_address)
             .map_err(|e| {
@@ -664,13 +671,22 @@ where
 
         // First attempt to read the valid stored areas from the leaked range
         loop {
-            let (area_index, area_size) = match self.read_leaked_area(current_addr) {
+            let area_meta = match self.read_leaked_area(current_addr) {
                 Ok(area_index_and_size) => area_index_and_size,
                 Err(e) => {
                     warn!("Error reading stored area at {current_addr}: {e}");
                     break;
                 }
             };
+
+            // TODO(galadd): will send a PR after  this to add proper unpadded handling here
+            // not included in this so that code changes won't be too large
+            // For now, all existing databases are padded
+            let Some(area_index) = area_meta.area_index else {
+                warn!("Unpadded node in leaked range at {current_addr}, cannot add to free list");
+                break;
+            };
+            let area_size = area_meta.total_size;
 
             let next_addr = current_addr
                 .advance(area_size)
@@ -745,12 +761,12 @@ mod test {
     use super::*;
     use crate::DeletedNodeTracking;
     use crate::linear::memory::MemStore;
-    use crate::nodestore::NodeStoreHeader;
     use crate::nodestore::alloc::FreeLists;
     use crate::nodestore::alloc::test_utils::{
         test_write_free_area, test_write_header, test_write_new_node, test_write_zeroed_area,
     };
     use crate::nodestore::primitives::area_size_iter;
+    use crate::nodestore::{AreaMetadata, NodeStoreHeader};
     use crate::{
         BranchNode, Child, Children, FreeListParent, ImmutableProposal, LeafNode, NodeStore, Path,
         PathComponent, area_index, hash_node,
@@ -1359,5 +1375,19 @@ mod test {
 
         assert_eq!(leaked_areas_offsets, expected_offsets);
         assert_eq!(leaked_area_size_indices, expected_indices);
+    }
+
+    #[test]
+    fn test_area_metadata() {
+        let idx = area_index!(5); // 256 bytes
+        let padded = AreaMetadata::padded(idx);
+        assert_eq!(padded.area_index, Some(idx));
+        assert_eq!(padded.total_size, 256);
+        assert!(!padded.is_unpadded);
+
+        let unpadded = AreaMetadata::unpadded(150);
+        assert_eq!(unpadded.area_index, None);
+        assert_eq!(unpadded.total_size, 150);
+        assert!(unpadded.is_unpadded);
     }
 }

--- a/storage/src/node/mod.rs
+++ b/storage/src/node/mod.rs
@@ -197,51 +197,15 @@ impl Node {
         }
     }
 
-    /// Given a [Node], returns a set of bytes to write to storage
-    /// The format is as follows:
+    /// Encodes the node payload without any storage-specific prefix.
     ///
-    /// For a branch:
-    ///  - Byte 0:
-    ///   - Bit 0: always 0
-    ///   - Bit 1: indicates if the branch has a value
-    ///   - Bits 2-5: the number of children
-    ///   - Bits 6-7: 0: empty `partial_path`, 1: 1 nibble, 2: 2 nibbles, 3: length is encoded in the next byte
-    ///
-    /// The remaining bytes are in the following order:
-    ///   - The partial path, possibly preceeded by the length if it is longer than 3 nibbles (varint encoded)
-    ///   - The number of children, if the branch factor is 256
-    ///   - The children. If the number of children == [`BranchNode::MAX_CHILDREN`], then the children are just
-    ///     addresses with hashes. Otherwise, they are offset, address, hash tuples.
-    ///
-    /// For a leaf:
-    ///  - Byte 0:
-    ///    - Bit 0: always 1
-    ///    - Bits 1-7: the length of the partial path. If the partial path is longer than 126 nibbles, this is set to
-    ///      126 and the length is encoded in the next byte.
-    ///
-    /// The remaining bytes are in the following order:
-    ///    - The partial path, possibly preceeded by the length if it is longer than 126 nibbles (varint encoded)
-    ///    - The value, always preceeded by the length, varint encoded
-    ///
-    /// Note that this means the first byte cannot be 255, which would be a leaf with 127 nibbles. We save this extra
-    /// value to mark this as a freed area.
-    ///
-    /// The first byte of the encoding is the area size index, which is calculated from the total
-    /// size of the encoded node. This method returns the `AreaIndex` for the encoded node.
-    ///
-    /// TODO(rkuris): We could pack two bytes of the partial path into one and handle the odd byte length
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the encoded size exceeds the maximum area size.
-    pub fn as_bytes<T>(&self, encoded: &mut T) -> Result<AreaIndex, Error>
+    /// This writes the node's intrinsic encoding beginning with the node-type byte,
+    /// but does not write the leading area index used by padded storage or any
+    /// archive-mode framing.
+    pub fn encode_body<T>(&self, encoded: &mut T)
     where
-        T: ExtendableBytes + AsRef<[u8]> + std::ops::IndexMut<usize, Output = u8>,
+        T: ExtendableBytes,
     {
-        // Push placeholder for area size index (will be updated later)
-        let area_size_index_position = encoded.as_ref().len();
-        encoded.push(0);
-
         match self {
             Node::Branch(b) => {
                 let child_iter = b.children.iter_present();
@@ -320,6 +284,53 @@ impl Node {
                 encoded.extend_from_slice(&l.value);
             }
         }
+    }
+
+    /// Given a [Node], returns a set of bytes to write to storage
+    /// The format is as follows:
+    ///
+    /// For a branch:
+    ///  - Byte 0:
+    ///   - Bit 0: always 0
+    ///   - Bit 1: indicates if the branch has a value
+    ///   - Bits 2-5: the number of children
+    ///   - Bits 6-7: 0: empty `partial_path`, 1: 1 nibble, 2: 2 nibbles, 3: length is encoded in the next byte
+    ///
+    /// The remaining bytes are in the following order:
+    ///   - The partial path, possibly preceeded by the length if it is longer than 3 nibbles (varint encoded)
+    ///   - The number of children, if the branch factor is 256
+    ///   - The children. If the number of children == [`BranchNode::MAX_CHILDREN`], then the children are just
+    ///     addresses with hashes. Otherwise, they are offset, address, hash tuples.
+    ///
+    /// For a leaf:
+    ///  - Byte 0:
+    ///    - Bit 0: always 1
+    ///    - Bits 1-7: the length of the partial path. If the partial path is longer than 126 nibbles, this is set to
+    ///      126 and the length is encoded in the next byte.
+    ///
+    /// The remaining bytes are in the following order:
+    ///    - The partial path, possibly preceeded by the length if it is longer than 126 nibbles (varint encoded)
+    ///    - The value, always preceeded by the length, varint encoded
+    ///
+    /// Note that this means the first byte cannot be 255, which would be a leaf with 127 nibbles. We save this extra
+    /// value to mark this as a freed area.
+    ///
+    /// The first byte of the encoding is the area size index, which is calculated from the total
+    /// size of the encoded node. This method returns the `AreaIndex` for the encoded node.
+    ///
+    /// TODO(rkuris): We could pack two bytes of the partial path into one and handle the odd byte length
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the encoded size exceeds the maximum area size.
+    pub fn as_bytes<T>(&self, encoded: &mut T) -> Result<AreaIndex, Error>
+    where
+        T: ExtendableBytes + AsRef<[u8]> + std::ops::IndexMut<usize, Output = u8>,
+    {
+        // Push placeholder for area size index (will be updated later)
+        let area_size_index_position = encoded.as_ref().len();
+        encoded.push(0);
+        self.encode_body(encoded);
 
         // Calculate the area index from the encoded length (subtract position to get just this node's size)
         let node_size = encoded

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -20,7 +20,6 @@
 //! - **`AreaType`** - 0xFF for free areas, otherwise node type data (1 byte)
 //! - **`NodeData`** - Serialized node content
 
-use super::area_index_and_size;
 use super::primitives::{AreaIndex, LinearAddress, index_name};
 use crate::linear::FileIoError;
 use crate::logger::trace;
@@ -254,7 +253,7 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
         self.storage.file_io_error(error, offset, context)
     }
 
-    /// Returns (index, `area_size`) for the stored area at `addr`.
+    /// Returns [`AreaMetadata`] for the stored area at `addr`.
     /// `index` is the index of `area_size` in the array of valid block sizes.
     ///
     /// # Errors
@@ -263,8 +262,8 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
     pub(crate) fn area_index_and_size(
         &self,
         addr: LinearAddress,
-    ) -> Result<(AreaIndex, u64), FileIoError> {
-        area_index_and_size(self.storage, addr)
+    ) -> Result<super::AreaMetadata, FileIoError> {
+        super::area_index_and_size(self.storage, addr)
     }
 
     /// Attempts to allocate from the free lists for `index`.
@@ -358,7 +357,10 @@ impl<S: WritableStorage> NodeAllocator<'_, S> {
         };
         debug_assert!(addr.is_aligned());
 
-        let (area_size_index, _) = self.area_index_and_size(addr)?;
+        let area_meta = self.area_index_and_size(addr)?;
+        let area_size_index = area_meta
+            .area_index
+            .expect("delete_node should only be called on padded nodes");
         trace!("Deleting node at {addr:?} of size {area_size_index}");
         firewood_counter!(DELETE_NODE, "index" => index_name(area_size_index)).increment(1);
         firewood_counter!(SPACE_FREED, "index" => index_name(area_size_index))

--- a/storage/src/nodestore/alloc.rs
+++ b/storage/src/nodestore/alloc.rs
@@ -34,7 +34,9 @@ use std::iter::FusedIterator;
 use std::mem::size_of;
 use std::ops::{Index, IndexMut};
 
-use crate::{FreeListParent, MaybePersistedNode, ReadableStorage, WritableStorage};
+use crate::{
+    DeletedNodeTracking, FreeListParent, MaybePersistedNode, ReadableStorage, WritableStorage,
+};
 
 /// Returns the maximum size needed to encode a `VarInt`.
 const fn var_int_max_size<VI>() -> usize {
@@ -236,11 +238,26 @@ use super::NodeStore;
 pub struct NodeAllocator<'a, S> {
     storage: &'a S,
     header: &'a mut NodeStoreHeader,
+    deleted_node_tracking: DeletedNodeTracking,
 }
 
 impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
-    pub const fn new(storage: &'a S, header: &'a mut NodeStoreHeader) -> Self {
-        Self { storage, header }
+    pub const fn new(
+        storage: &'a S,
+        header: &'a mut NodeStoreHeader,
+        deleted_node_tracking: DeletedNodeTracking,
+    ) -> Self {
+        Self {
+            storage,
+            header,
+            deleted_node_tracking,
+        }
+    }
+
+    /// Returns `true` if this allocator should write unpadded nodes.
+    #[must_use]
+    pub const fn is_unpadded_mode(&self) -> bool {
+        !self.deleted_node_tracking.is_enabled()
     }
 
     /// Helper to convert an `io::Error` to a `FileIoError` with context.
@@ -313,7 +330,12 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
 
     /// Returns an address that can be used to store the given `node` and updates
     /// `self.header` to reflect the allocation. Doesn't actually write the node to storage.
-    /// Also returns the index of the free list the node was allocated from.
+    ///
+    /// For padded nodes (`is_unpadded == false`): allocates from free list or end,
+    /// returns `Some(AreaIndex)`.
+    ///
+    /// For unpadded nodes (`is_unpadded == true`): allocates exact size from end,
+    /// returns `None` for area index.
     ///
     /// # Errors
     ///
@@ -321,7 +343,19 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
     pub(crate) fn allocate_node(
         &mut self,
         node: &[u8],
-    ) -> Result<(LinearAddress, AreaIndex), FileIoError> {
+        is_unpadded: bool,
+    ) -> Result<(LinearAddress, Option<AreaIndex>), FileIoError> {
+        if is_unpadded {
+            // Allocate exact size from end
+            let size = node.len() as u64;
+            let addr = LinearAddress::new(self.header.size()).expect("node store size can't be 0");
+            self.header
+                .set_size(self.header.size().saturating_add(size));
+            trace!("Allocating unpadded from end: addr: {addr:?}, size: {size}");
+
+            firewood_counter!(NODES_ALLOCATED, "type" => "unpadded").increment(1);
+            return Ok((addr, None));
+        }
         let stored_area_size = node.len() as u64;
         let area_index = AreaIndex::from_size(stored_area_size).map_err(|e| {
             self.storage
@@ -340,13 +374,19 @@ impl<'a, S: ReadableStorage> NodeAllocator<'a, S> {
         let waste = area_index.size().saturating_sub(stored_area_size);
         firewood_counter!(BYTES_WASTED, "index" => index_name(area_index)).increment(waste);
 
-        Ok((addr, area_index))
+        Ok((addr, Some(area_index)))
     }
 }
 
 impl<S: WritableStorage> NodeAllocator<'_, S> {
     /// Deletes the `Node` and updates the header of the allocator.
     /// Nodes that are not persisted are just dropped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on an unpadded node. This should never happen
+    /// because `DeletedNodeTracking::Disabled` prevents `reap_deleted`
+    /// from being called.
     ///
     /// # Errors
     ///
@@ -358,6 +398,13 @@ impl<S: WritableStorage> NodeAllocator<'_, S> {
         debug_assert!(addr.is_aligned());
 
         let area_meta = self.area_index_and_size(addr)?;
+
+        assert!(
+            !area_meta.is_unpadded,
+            "delete_node called on unpadded node at {addr}. \
+             This should never happen when DeletedNodeTracking::Disabled is set correctly."
+        );
+
         let area_size_index = area_meta
             .area_index
             .expect("delete_node should only be called on padded nodes");

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -1598,7 +1598,8 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
         self.storage
             .invalidate_cached_nodes(self.kind.deleted.iter());
         trace!("There are {} nodes to reap", self.kind.deleted.len());
-        let mut allocator = NodeAllocator::new(self.storage.as_ref(), header);
+        let mut allocator =
+            NodeAllocator::new(self.storage.as_ref(), header, self.deleted_node_tracking);
         for node in take(&mut self.kind.deleted) {
             allocator.delete_node(node)?;
         }

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -53,7 +53,9 @@ use crate::arc_swap_triomphe::TriompheArc;
 use crate::linear::{OffsetReader, ReadableNodeMode};
 use crate::logger::{debug, trace};
 use crate::node::branch::ReadSerializable as _;
+use crate::nodestore::primitives::{SENTINEL_UNPADDED, varint_encoded_size};
 use firewood_metrics::{firewood_counter, firewood_histogram};
+use integer_encoding::VarIntReader;
 use smallvec::SmallVec;
 use std::fmt::Debug;
 use std::io::{Error, ErrorKind};
@@ -1323,31 +1325,95 @@ impl<T: HashedNodeReader> HashedNodeReader for &T {
     }
 }
 
-// TODO(rkuris): return only the index since we can easily get the size from the index
-fn area_index_and_size<S: ReadableStorage>(
+/// Metadata about a stored area on disk.
+///
+/// Disambiguates between padded nodes (with a valid [`AreaIndex`]),
+/// unpadded nodes (archive mode, with [`SENTINEL_UNPADDED`] prefix),
+/// and free areas
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AreaMetadata {
+    /// The area size index, if this is a padded node or free area.
+    /// `None` for unpadded archive-mode nodes.
+    pub area_index: Option<AreaIndex>,
+    /// The total size of this area on disk, including any prefix bytes.
+    pub total_size: u64,
+    /// Whether the node is unpadded.
+    pub is_unpadded: bool,
+}
+
+impl AreaMetadata {
+    /// Create metadata for a padded area (normal mode node or free area).
+    #[must_use]
+    pub const fn padded(index: AreaIndex) -> Self {
+        Self {
+            area_index: Some(index),
+            total_size: index.size(),
+            is_unpadded: false,
+        }
+    }
+
+    /// Create metadata for an unpadded area (archive mode node).
+    #[must_use]
+    pub const fn unpadded(total_size: u64) -> Self {
+        Self {
+            area_index: None,
+            total_size,
+            is_unpadded: true,
+        }
+    }
+}
+
+/// Reads area metadata from the first byte(s) at `addr`.
+///
+/// Handles both padded and unpadded formats:
+/// - First byte 0-22: padded, size from `AREA_SIZES[index]`
+/// - First byte 0xFF: unpadded, size from following varint + prefix
+///
+/// # Errors
+///
+/// Returns a [`FileIoError`] if the area cannot be read or the format is invalid.
+pub(crate) fn area_index_and_size<S: ReadableStorage>(
     storage: &S,
     addr: LinearAddress,
-) -> Result<(AreaIndex, u64), FileIoError> {
-    let mut area_stream = storage.stream_from(addr.get())?;
+) -> Result<AreaMetadata, FileIoError> {
+    let mut stream = storage.stream_from(addr.get())?;
 
-    let index: AreaIndex = AreaIndex::new(area_stream.read_byte().map_err(|e| {
+    let first_byte = stream.read_byte().map_err(|e| {
         storage.file_io_error(
             Error::new(ErrorKind::InvalidData, e),
             addr.get(),
             Some("area_index_and_size".to_owned()),
         )
-    })?)
-    .ok_or_else(|| {
-        storage.file_io_error(
-            Error::new(ErrorKind::InvalidData, "invalid area index"),
-            addr.get(),
-            Some("area_index_and_size".to_owned()),
-        )
     })?;
 
-    let size = index.size();
+    if first_byte == SENTINEL_UNPADDED {
+        // Unpadded node: read varint length
+        let node_len = stream.read_varint::<u64>().map_err(|e| {
+            storage.file_io_error(
+                Error::new(ErrorKind::InvalidData, e),
+                addr.get(),
+                Some("area_index_and_size: unpadded length".to_owned()),
+            )
+        })?;
 
-    Ok((index, size))
+        #[expect(clippy::arithmetic_side_effects)]
+        let prefix_len = 1_u64 + varint_encoded_size(node_len) as u64;
+
+        #[expect(clippy::arithmetic_side_effects)]
+        let total_size = prefix_len + node_len;
+
+        Ok(AreaMetadata::unpadded(total_size))
+    } else {
+        // Padded node or free area
+        let index = AreaIndex::new(first_byte).ok_or_else(|| {
+            storage.file_io_error(
+                Error::new(ErrorKind::InvalidData, "invalid area index byte"),
+                addr.get(),
+                Some("area_index_and_size".to_owned()),
+            )
+        })?;
+        Ok(AreaMetadata::padded(index))
+    }
 }
 
 impl<T, S: ReadableStorage> NodeStore<T, S> {
@@ -1383,49 +1449,115 @@ impl<T, S: ReadableStorage> NodeStore<T, S> {
         Ok(node)
     }
 
+    /// Reads a node from disk, returning the node and its total on-disk size.
+    ///
+    /// Handles both padded and unpadded formats:
+    /// - Padded: `[AreaIndex][node_data][padding]`
+    /// - Unpadded: `[0xFF][varint length][node_data]`
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`FileIoError`] if the node cannot be read.
     pub(crate) fn read_node_with_num_bytes_from_disk(
         &self,
         addr: LinearAddress,
     ) -> Result<(SharedNode, u64), FileIoError> {
-        debug_assert!(addr.is_aligned());
+        let mut stream = self.storage.stream_from(addr.get())?;
 
-        // saturating because there is no way we can be reading at u64::MAX
-        // and this will fail very soon afterwards
-        let actual_addr = addr.get().saturating_add(1); // skip the length byte
+        let first_byte = stream.read_byte().map_err(|e| {
+            self.storage.file_io_error(
+                Error::new(ErrorKind::InvalidData, e),
+                addr.get(),
+                Some("read_node_with_num_bytes_from_disk".to_owned()),
+            )
+        })?;
 
-        let _span = fastrace::local::LocalSpan::enter_with_local_parent("read_and_deserialize");
+        if first_byte == SENTINEL_UNPADDED {
+            // Unpadded format: [0xFF][varint length][node_data]
+            let node_len = stream.read_varint::<usize>().map_err(|e| {
+                self.storage.file_io_error(
+                    Error::new(ErrorKind::InvalidData, e),
+                    addr.get(),
+                    Some("read_node_with_num_bytes_from_disk: unpadded length".to_owned()),
+                )
+            })?;
 
-        let mut area_stream = self.storage.stream_from(actual_addr)?;
-        let offset_before = area_stream.offset();
-        let node: SharedNode = Node::from_reader(&mut area_stream)
-            .map_err(|e| {
-                self.storage
-                    .file_io_error(e, actual_addr, Some("read_node_from_disk".to_owned()))
-            })?
-            .into();
-        let length = area_stream
-            .offset()
-            .checked_sub(offset_before)
-            .ok_or_else(|| {
+            #[expect(clippy::arithmetic_side_effects)]
+            let prefix_len = 1 + varint_encoded_size(node_len as u64);
+            let offset_before = stream.offset();
+
+            let _span = fastrace::local::LocalSpan::enter_with_local_parent("read_and_deserialize");
+            let node: SharedNode = Node::from_reader(&mut stream)
+                .map_err(|e| {
+                    self.storage.file_io_error(
+                        e,
+                        addr.get(),
+                        Some("read_node_with_num_bytes_from_disk".to_owned()),
+                    )
+                })?
+                .into();
+
+            let bytes_read = stream.offset().checked_sub(offset_before).ok_or_else(|| {
                 self.storage.file_io_error(
                     Error::other("Reader offset went backwards"),
-                    actual_addr,
+                    addr.get(),
                     Some("read_node_with_num_bytes_from_disk".to_owned()),
                 )
             })?;
-        Ok((node, length.saturating_add(1))) // add 1 for the area size index byte
+
+            if bytes_read != node_len as u64 {
+                return Err(self.storage.file_io_error(
+                    Error::new(ErrorKind::InvalidData, format!("Unpadded node length mismatch: header says {node_len}, read {bytes_read}")), addr.get(), Some("read_node_with_num_bytes_from_disk".to_owned())));
+            }
+
+            let total_size = prefix_len
+                .checked_add(node_len)
+                .expect("encoded node size overflow");
+
+            Ok((node, total_size as u64))
+        } else {
+            // Padded format: [AreaIndex][node_data][padding]
+            let _area_index = AreaIndex::new(first_byte).ok_or_else(|| {
+                self.storage.file_io_error(
+                    Error::new(ErrorKind::InvalidData, "invalid area index byte"),
+                    addr.get(),
+                    Some("read_node_with_num_bytes".to_owned()),
+                )
+            })?;
+
+            let _span = fastrace::local::LocalSpan::enter_with_local_parent("read_and_deserialize");
+            let offset_before = stream.offset();
+            let node: SharedNode = Node::from_reader(&mut stream)
+                .map_err(|e| {
+                    self.storage.file_io_error(
+                        e,
+                        addr.get(),
+                        Some("read_node_with_num_bytes_from".to_owned()),
+                    )
+                })?
+                .into();
+
+            let node_bytes = stream.offset().checked_sub(offset_before).ok_or_else(|| {
+                self.storage.file_io_error(
+                    Error::other("Reader offset went backwards"),
+                    addr.get(),
+                    Some("read_node_with_num_bytes_from_disk".to_owned()),
+                )
+            })?;
+
+            Ok((node, node_bytes.saturating_add(1)))
+        }
     }
 
-    /// Returns (index, `area_size`) for the stored area at `addr`.
-    /// `index` is the index of `area_size` in the array of valid block sizes.
+    /// Returns [`AreaMetadata`] for the stored area at `addr`.
     ///
     /// # Errors
     ///
     /// Returns a [`FileIoError`] if the area cannot be read.
-    pub fn area_index_and_size(
+    pub(crate) fn area_index_and_size(
         &self,
         addr: LinearAddress,
-    ) -> Result<(AreaIndex, u64), FileIoError> {
+    ) -> Result<AreaMetadata, FileIoError> {
         area_index_and_size(self.storage.as_ref(), addr)
     }
 }
@@ -1483,18 +1615,23 @@ impl<T, S: ReadableStorage> NodeStore<T, S>
 where
     NodeStore<T, S>: NodeReader,
 {
-    // Find the area index and size of the stored area at the given address if the area is valid.
-    // TODO(#2050): there should be a way to read stored area directly instead of try reading as a free area then as a node
+    /// Find the area metadata for the stored area at the given address.
+    ///
+    /// Tries to interpret the area as a free area first, then as a node.
+    /// Returns [`AreaMetadata`] describing the area's format and size.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`FileIoError`] if the area cannot be read
     pub(crate) fn read_leaked_area(
         &self,
         address: LinearAddress,
-    ) -> Result<(AreaIndex, u64), FileIoError> {
+    ) -> Result<AreaMetadata, FileIoError> {
         if alloc::FreeArea::from_storage(self.storage.as_ref(), address).is_err() {
             self.read_node(address)?;
         }
 
-        let area_index_and_size = self.area_index_and_size(address)?;
-        Ok(area_index_and_size)
+        self.area_index_and_size(address)
     }
 }
 

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -31,6 +31,8 @@ use bumpalo::Bump;
 use std::iter::FusedIterator;
 
 use crate::linear::FileIoError;
+use crate::node::ExtendableBytes;
+use crate::nodestore::primitives::SENTINEL_UNPADDED;
 use firewood_metrics::{GaugeExt, firewood_gauge, firewood_histogram};
 use std::time::Instant;
 
@@ -158,6 +160,9 @@ impl<N: NodeReader + RootReader> Iterator for UnPersistedNodeIterator<'_, N> {
 
 /// Helper function to serialize a node into a bump allocator and allocate storage for it
 ///
+/// For padded mode (normal): writes `[AreaIndex][node_data][padding]` using `as_bytes()`.
+/// For unpadded mode (archive): writes `[0xFF][varint length][node_data]`.
+///
 /// # Errors
 ///
 /// Returns a [`FileIoError`] if the node cannot be allocated in storage.
@@ -166,14 +171,38 @@ fn serialize_node_to_bump<'a>(
     shared_node: &crate::SharedNode,
     node_allocator: &mut NodeAllocator<'_, impl WritableStorage>,
 ) -> Result<(&'a [u8], crate::LinearAddress, usize), FileIoError> {
-    let mut bytes = bumpalo::collections::Vec::new_in(bump);
-    let area_size_index = shared_node
-        .as_bytes(&mut bytes)
-        .map_err(|e| node_allocator.io_error(e, 0, Some("allocate_node".to_owned())))?;
-    let (persisted_address, _) = node_allocator.allocate_node(bytes.as_slice())?;
-    bytes.shrink_to_fit();
-    let slice = bytes.into_bump_slice();
-    Ok((slice, persisted_address, area_size_index.size() as usize))
+    let is_unpadded = node_allocator.is_unpadded_mode();
+
+    if is_unpadded {
+        let mut node_body = bumpalo::collections::Vec::new_in(bump);
+        shared_node.as_ref().encode_body(&mut node_body);
+        let node_len = node_body.len();
+
+        // Build the full unpadded format: [0xFF][varint][data]
+        let mut output = bumpalo::collections::Vec::with_capacity_in(
+            node_len.saturating_add(11), // 1 for sentinel, 10 for max varint, node_len for data
+            bump,
+        );
+        output.push(SENTINEL_UNPADDED);
+        output.extend_var_int(node_len as u64);
+        output.extend_from_slice(&node_body);
+
+        let total_len = output.len();
+
+        let (persisted_address, _) = node_allocator.allocate_node(&output, true)?;
+
+        let slice = output.into_bump_slice();
+        Ok((slice, persisted_address, total_len))
+    } else {
+        let mut bytes = bumpalo::collections::Vec::new_in(bump);
+        let area_size_index = shared_node
+            .as_bytes(&mut bytes)
+            .map_err(|e| node_allocator.io_error(e, 0, Some("allocate_node".to_owned())))?;
+        let (persisted_address, _) = node_allocator.allocate_node(bytes.as_slice(), false)?;
+        bytes.shrink_to_fit();
+        let slice = bytes.into_bump_slice();
+        Ok((slice, persisted_address, area_size_index.size() as usize))
+    }
 }
 
 impl<S: WritableStorage> NodeStore<Committed, S> {
@@ -186,7 +215,8 @@ impl<S: WritableStorage> NodeStore<Committed, S> {
     fn flush_nodes(&self, header: &mut NodeStoreHeader) -> Result<(), FileIoError> {
         let flush_start = Instant::now();
 
-        let mut node_allocator = NodeAllocator::new(self.storage.as_ref(), header);
+        let mut node_allocator =
+            NodeAllocator::new(self.storage.as_ref(), header, self.deleted_node_tracking);
         let mut bump = Bump::with_capacity(super::INITIAL_BUMP_SIZE);
 
         self.process_unpersisted_nodes(&mut bump, &mut node_allocator, super::INITIAL_BUMP_SIZE)?;
@@ -586,5 +616,33 @@ mod tests {
             .unwrap();
         assert_eq!(*child2_node.partial_path(), Path::from(&[4, 5, 6]));
         assert_eq!(child2_node.value(), Some(&b"value2"[..]));
+    }
+
+    #[test]
+    fn test_unpadded_round_trip() {
+        use crate::linear::memory::MemStore;
+
+        // Create a store with deletion tracking disabled (archive mode)
+        let mem_store = MemStore::default().into();
+        let mut header = NodeStoreHeader::new(NodeHashAlgorithm::compile_option());
+        let base = NodeStore::new_empty_committed(mem_store, DeletedNodeTracking::Disabled);
+
+        // Create a proposal with nodes
+        let mut proposal = NodeStore::new(&base).unwrap();
+        proposal
+            .root_mut()
+            .replace(create_leaf(&[1, 2, 3], b"value"));
+
+        // Convert to immutable proposal (this hashes and assigns addresses)
+        let immutable: NodeStore<Arc<ImmutableProposal>, _> = proposal.try_into().unwrap();
+
+        // Commit
+        let committed = immutable.as_committed();
+        committed.persist(&mut header).unwrap();
+
+        // Verify we can read the root back
+        let root = committed.root_node().expect("root should exist");
+        assert_eq!(*root.partial_path(), Path::from(&[1, 2, 3]));
+        assert_eq!(root.value(), Some(&b"value"[..]));
     }
 }

--- a/storage/src/nodestore/primitives.rs
+++ b/storage/src/nodestore/primitives.rs
@@ -21,6 +21,33 @@ use std::num::NonZeroU64;
 // See build.rs for how this is generated
 include!(concat!(env!("OUT_DIR"), "/area_sizes.rs"));
 
+/// Sentinel byte indicating an unpadded, non-freeable node.
+///
+/// Used as the first byte on disk instead of an [`AreaIndex`] when
+/// [`DeletedNodeTracking::Disabled`] (archive mode). Nodes with this
+/// sentinel can never be freed because their size is not aligned to any
+/// area size class.
+///
+/// Value 0xFF is chosen because:
+/// - Valid [`AreaIndex`] values are 0-22, so no collision
+/// - Free areas use 0xFF as the *second* byte (after a valid `AreaIndex`),
+///   so the format `[valid_index][0xFF]` for free areas is distinct from
+///   `[0xFF][...]` for unpadded nodes
+pub const SENTINEL_UNPADDED: u8 = 0xFF;
+
+/// Returns the number of bytes needed to encode a `u64` as a varint.
+#[inline]
+#[must_use]
+pub const fn varint_encoded_size(value: u64) -> usize {
+    if value == 0 {
+        return 1;
+    }
+
+    #[expect(clippy::arithmetic_side_effects)]
+    let bits_needed = 64u32 - value.leading_zeros();
+    (bits_needed as usize).saturating_add(6) / 7
+}
+
 /// Returns an iterator over all valid area sizes.
 // TODO(rkuris): return a named iterator
 pub(crate) fn area_size_iter() -> impl DoubleEndedIterator<Item = (AreaIndex, u64)> {
@@ -327,5 +354,32 @@ mod tests {
     fn test_area_index_try_from_usize_out_of_bounds() {
         assert!(AreaIndex::try_from(AreaIndex::NUM_AREA_SIZES).is_err());
         assert!(AreaIndex::try_from(usize::MAX).is_err());
+    }
+
+    #[test]
+    fn test_varint_encoded_size() {
+        // Single byte: 0-127
+        assert_eq!(varint_encoded_size(0), 1);
+        assert_eq!(varint_encoded_size(1), 1);
+        assert_eq!(varint_encoded_size(127), 1);
+
+        // Two bytes: 128-16383
+        assert_eq!(varint_encoded_size(128), 2);
+        assert_eq!(varint_encoded_size(16383), 2);
+
+        // Three bytes: 16384-2097151
+        assert_eq!(varint_encoded_size(16384), 3);
+
+        // Max u64: 10 bytes
+        assert_eq!(varint_encoded_size(u64::MAX), 10);
+    }
+
+    #[test]
+    fn test_sentinel_value() {
+        assert_eq!(SENTINEL_UNPADDED, 0xFF);
+        // Verify it doesn't collide with any valid AreaIndex
+        for i in 0..=AreaIndex::MAX.get() {
+            assert_ne!(i, SENTINEL_UNPADDED);
+        }
     }
 }


### PR DESCRIPTION
## Why this should be merged

Closes #2151. 

Requires #2173 to be merged.

When DeletedNodeTracking::Disabled (archive mode), nodes are now written without padding—saving significant space for branch nodes that don't fill their area size class.

## How this works

**Writer:** `NodeAllocator` now accepts a `deleted_node_tracking` field. When disabled, serialize_node_to_bump() writes nodes in compact format: `[0xFF][varint length][node data].` The allocator bumps the header size by exact bytes instead of area size. A panic in delete_node() provides defense in depth if this path is ever reached.

**Checker:** Updated to skip alignment checks for unpadded nodes (they're not aligned to area boundaries). Added unpadded_node_count and unpadded_node_bytes to TrieStats. The fwdctl check report now shows an "Unpadded (Archive Mode)" section.

**Leaked area handling:** Unpadded nodes in leaked ranges are skipped with a warning—they can't be added to free lists since they don't match any area size class.

## How this was tested

- Added test_unpadded_round_trip: creates archive mode DB, writes nodes, reads them back
- All existing tests pass (normal mode unchanged)
- Manual testing: fwdctl check on archive DB shows unpadded stats

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
