### PR TITLE
fix(fwdctl): escape JSON dump strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,6 +1905,7 @@ dependencies = [
  "hex",
  "humantime",
  "indicatif",
+ "json-escape",
  "log",
  "nonzero_ext",
  "num-format",
@@ -2930,6 +2931,15 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json-escape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6fd1644b881a0cb8030578c318e14840e543876e98f7bc9215270fd55ca5db"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/fwdctl/Cargo.toml
+++ b/fwdctl/Cargo.toml
@@ -39,6 +39,7 @@ humantime = "2.4.0"
 indicatif = "0.18.6"
 askama = "0.16.0"
 num-format = "0.4.4"
+json-escape = "0.3.1"
 aws-config = { version = "1.8", optional = true }
 aws-sdk-ec2 = { version = "1.237", default-features = false, features = ["default-https-client", "rt-tokio"], optional = true }
 aws-sdk-ssm = { version = "1.114", default-features = false, features = ["default-https-client", "rt-tokio"], optional = true }

--- a/fwdctl/src/dump.rs
+++ b/fwdctl/src/dump.rs
@@ -226,6 +226,10 @@ fn key_value_to_string(key: &[u8], value: &[u8], hex: bool) -> (String, String) 
     (key_str, value_str)
 }
 
+fn write_json_string<W: Write>(writer: &mut W, value: &str) -> Result<(), std::io::Error> {
+    write!(writer, "\"{}\"", json_escape::escape_str(value))
+}
+
 fn handle_next_key(next_key: KeyFromStream) {
     match next_key {
         Some(Ok((key, _))) => {
@@ -283,7 +287,10 @@ impl OutputHandler for JsonOutputHandler {
             self.writer.write_all(b",\n")?;
         }
 
-        write!(self.writer, r#"  "{key_str}": "{value_str}""#)?;
+        write!(self.writer, "  ")?;
+        write_json_string(&mut self.writer, &key_str)?;
+        write!(self.writer, ": ")?;
+        write_json_string(&mut self.writer, &value_str)?;
         Ok(())
     }
 

--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -465,6 +465,36 @@ fn test_slow_fwdctl_dump_with_csv_and_json() {
 }
 
 #[test]
+fn fwdctl_dump_json_escapes_special_characters() {
+    with_tmpdir(|db_path| {
+        create_db(db_path);
+
+        cargo_bin_cmd!()
+            .arg("insert")
+            .arg("--db")
+            .arg(db_path)
+            .args(["say\"hi\\", "line\n\t\u{1}"])
+            .assert()
+            .success();
+
+        cargo_bin_cmd!()
+            .arg("dump")
+            .arg("--db")
+            .arg(db_path)
+            .args(["--output-format", "json"])
+            .assert()
+            .success();
+
+        let contents = fs::read_to_string("dump.json").expect("Should read dump.json file");
+        assert_eq!(
+            contents,
+            "{\n  \"say\\\"hi\\\\\": \"line\\n\\t\\u0001\"\n}\n"
+        );
+        fs::remove_file("dump.json").expect("Should remove dump.json file");
+    });
+}
+
+#[test]
 fn fwdctl_dump_with_file_name() {
     with_tmpdir(|db_path| {
         create_db(db_path);


### PR DESCRIPTION
Fixes #2176

The JSON dump handler previously interpolated keys and values directly into quoted strings, producing invalid JSON when records contained quotes, backslashes, control characters, or newlines.

This adds a streaming JSON string escaper and covers the special-character cases with an integration test.

Validation:
- cargo fmt --all -- --check
- cargo test -p firewood-fwdctl --test cli
- cargo clippy -p firewood-fwdctl --all-targets -- -D warnings