### PR TITLE
ci: run CI and local prepush checks through shared just recipes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,21 +27,18 @@ jobs:
       matrix:
         include:
           - profile-key: debug-no-default-features
-            profile-args: "--no-default-features"
           - profile-key: debug-no-features
-            profile-args: ""
           - profile-key: debug-no-features
-            profile-args: ""
             os: macos-26
           - profile-key: debug-ethhash-logger
-            profile-args: "--features ethhash,logger"
           - profile-key: debug-all-features
-            profile-args: "--all-features"
           - profile-key: maxperf-ethhash-logger
-            profile-args: "--profile maxperf --features ethhash,logger"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: stable
@@ -55,14 +52,17 @@ jobs:
       - name: Cargo Fetch (run `cargo generate-lockfile` if this fails)
         run: cargo fetch --locked --verbose
       - name: Check
-        run: cargo check --frozen ${{ matrix.profile-args }} --workspace --all-targets
+        run: ./scripts/run-just.sh ci-rust check ${{ matrix.profile-key }}
       - name: Build
-        run: cargo build --frozen ${{ matrix.profile-args }} --workspace --all-targets
+        run: ./scripts/run-just.sh ci-rust build ${{ matrix.profile-key }}
 
   no-rust-cache-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: stable
@@ -74,10 +74,10 @@ jobs:
           config: .github/check-license-headers.yaml
           strict: true
       - name: Format
-        run: cargo fmt -- --check
+        run: ./scripts/run-just.sh ci-format
       # Fails on TODO/FIXME markers lacking an owner or issue (see issue #1603).
       - name: Check TODO/FIXME annotations
-        run: ./scripts/check-todos.sh
+        run: ./scripts/run-just.sh ci-check-todos
 
   rust-lint-pr-comments:
     # caveat emptor: actions-rs/clippy-check can only write comments on pull requests
@@ -88,16 +88,11 @@ jobs:
       matrix:
         include:
           - profile-key: debug-no-default-features
-            profile-args: "--no-default-features"
           - profile-key: debug-no-features
-            profile-args: ""
           - profile-key: debug-no-features
-            profile-args: ""
             os: macos-26
           - profile-key: debug-ethhash-logger
-            profile-args: "--features ethhash,logger"
           - profile-key: debug-all-features
-            profile-args: "--all-features"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
@@ -122,21 +117,18 @@ jobs:
       matrix:
         include:
           - profile-key: debug-no-default-features
-            profile-args: "--no-default-features"
           - profile-key: debug-no-features
-            profile-args: ""
           - profile-key: debug-no-features
-            profile-args: ""
             os: macos-26
           - profile-key: debug-ethhash-logger
-            profile-args: "--features ethhash,logger"
           - profile-key: debug-all-features
-            profile-args: "--all-features"
           - profile-key: maxperf-ethhash-logger
-            profile-args: "--profile maxperf --features ethhash,logger"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: nightly-2026-07-05
@@ -146,7 +138,7 @@ jobs:
           save-if: "false"
           shared-key: ${{ matrix.profile-key }}
       - name: Clippy
-        run: cargo clippy --locked ${{ matrix.profile-args }} --workspace --all-targets -- -D warnings
+        run: ./scripts/run-just.sh ci-rust clippy ${{ matrix.profile-key }}
 
   test:
     needs: build
@@ -156,21 +148,18 @@ jobs:
       matrix:
         include:
           - profile-key: debug-no-default-features
-            profile-args: "--no-default-features"
           - profile-key: debug-no-features
-            profile-args: ""
           - profile-key: debug-no-features
-            profile-args: ""
             os: macos-26
           - profile-key: debug-ethhash-logger
-            profile-args: "--features ethhash,logger"
           - profile-key: debug-all-features
-            profile-args: "--all-features"
           - profile-key: maxperf-ethhash-logger
-            profile-args: "--cargo-profile maxperf --features ethhash,logger"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: stable
@@ -180,7 +169,7 @@ jobs:
           save-if: "false"
           shared-key: ${{ matrix.profile-key }}
       - name: Run tests with cargo-nextest
-        run: cargo nextest run --locked --profile ci --verbose ${{ matrix.profile-args }}
+        run: ./scripts/run-just.sh ci-rust test ${{ matrix.profile-key }}
 
   examples:
     needs: build
@@ -188,21 +177,18 @@ jobs:
       matrix:
         include:
           - profile-key: debug-no-default-features
-            profile-args: "--no-default-features"
           - profile-key: debug-no-features
-            profile-args: ""
           - profile-key: debug-no-features
-            profile-args: ""
             os: macos-26
           - profile-key: debug-ethhash-logger
-            profile-args: "--features ethhash,logger"
           - profile-key: debug-all-features
-            profile-args: "--all-features"
           - profile-key: maxperf-ethhash-logger
-            profile-args: "--profile maxperf --features ethhash,logger"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: stable
@@ -211,15 +197,18 @@ jobs:
           save-if: "false"
           shared-key: ${{ matrix.profile-key }}
       - name: Run benchmark example
-        run: cargo run --locked ${{ matrix.profile-args }} --bin benchmark -- --number-of-batches 100 --batch-size 1000 create
+        run: ./scripts/run-just.sh ci-rust benchmark-example ${{ matrix.profile-key }}
       - name: Run insert example
-        run: cargo run --locked ${{ matrix.profile-args }} --example insert
+        run: ./scripts/run-just.sh ci-rust insert-example ${{ matrix.profile-key }}
 
   docs:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: stable
@@ -229,30 +218,18 @@ jobs:
           shared-key: "debug-no-features"
       - name: md check
         uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd # @v23.2.0
-        with:
-          globs: |
-            *.md
-            **/*.md
-            !CHANGELOG.md
-            !target/**
-            !.github/**
-            !.claude/**
       - name: doc generation
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --locked --document-private-items --no-deps
+        run: ./scripts/run-just.sh ci-docs
 
   ffi-check-go-generate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - name: Check `go generate` for changes
-        working-directory: ffi
-        run: |
-          go generate
-          if [[ -n $(git status --porcelain) ]]; then
-            echo "go generate resulted in changes to tracked files. Please commit these changes."
-            git --no-pager diff
-            exit 1
-          fi
+        run: ./scripts/run-just.sh ci-check-go-generate
 
   ffi:
     needs: [build, ffi-check-go-generate]
@@ -262,6 +239,9 @@ jobs:
         os: [ubuntu-latest, macos-26]
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: stable
@@ -271,7 +251,7 @@ jobs:
           shared-key: "debug-no-features"
       - name: Build Firewood FFI
         working-directory: ffi
-        run: cargo build --locked
+        run: ../scripts/run-just.sh ci-build-ffi firewood
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -280,11 +260,11 @@ jobs:
             ffi/go.sum
             ffi/tools/external/go.sum
       - name: Run golangci-lint
-        run: ./ffi/scripts/lint.sh
+        run: ./scripts/run-just.sh ci-lint-ffi
       - name: Test Go FFI bindings
         working-directory: ffi
         # cgocheck2 is expensive but provides complete pointer checks
-        run: GOEXPERIMENT=cgocheck2 TEST_FIREWOOD_HASH_MODE=firewood go test -race ./...
+        run: ../scripts/run-just.sh ci-test-ffi firewood
 
   # Replay recorded C-Chain execution logs against Firewood to catch changes that would break the C-Chain.
   replay-test:
@@ -341,6 +321,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: stable
@@ -349,7 +332,7 @@ jobs:
           save-if: "false"
           shared-key: "debug-ethhash-logger"
       - name: Build Firewood FFI (with ethhash)
-        run: cargo build --features ethhash,logger
+        run: ./scripts/run-just.sh ci-build-ffi ethhash
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -358,7 +341,7 @@ jobs:
       - name: Test Go FFI bindings
         working-directory: ffi
         # cgocheck2 is expensive but provides complete pointer checks
-        run: GOEXPERIMENT=cgocheck2 TEST_FIREWOOD_HASH_MODE=ethhash go test -race ./...
+        run: ../scripts/run-just.sh ci-test-ffi ethhash
       - name: Test Firewood <> Ethereum Differential Fuzz
         working-directory: ffi/tests/eth
         run: |
@@ -383,6 +366,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: stable
@@ -391,7 +377,7 @@ jobs:
           save-if: "false"
           shared-key: "debug-no-features"
       - name: Build Firewood FFI
-        run: cargo build -p firewood-ffi
+        run: ./scripts/run-just.sh ci-build-ffi firewood
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -420,6 +406,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: stable
@@ -430,7 +419,7 @@ jobs:
       - name: Install cargo-machete
         run: cargo install cargo-machete
       - name: Check for stale dependencies
-        run: cargo machete --with-metadata
+        run: ./scripts/run-just.sh ci-machete
 
   miri:
     name: miri (path::component slice casts)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
@@ -126,7 +126,7 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
@@ -157,7 +157,7 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
@@ -186,7 +186,7 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
@@ -225,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - name: Check `go generate` for changes
@@ -239,7 +239,7 @@ jobs:
         os: [ubuntu-latest, macos-26]
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
@@ -321,7 +321,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
@@ -366,7 +366,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
@@ -406,7 +406,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master

--- a/.github/workflows/lint-nightly.yaml
+++ b/.github/workflows/lint-nightly.yaml
@@ -12,21 +12,18 @@ jobs:
       matrix:
         include:
           - profile-key: debug-no-default-features
-            profile-args: "--no-default-features"
           - profile-key: debug-no-features
-            profile-args: ""
           - profile-key: debug-no-features
-            profile-args: ""
             os: macos-26
           - profile-key: debug-ethhash-logger
-            profile-args: "--features ethhash,logger"
           - profile-key: debug-all-features
-            profile-args: "--all-features"
           - profile-key: maxperf-ethhash-logger
-            profile-args: "--profile maxperf --features ethhash,logger"
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+        with:
+          tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: nightly
@@ -36,4 +33,4 @@ jobs:
           save-if: "false"
           shared-key: ${{ matrix.profile-key }}
       - name: Clippy
-        run: cargo clippy --locked ${{ matrix.profile-args }} --workspace --all-targets -- -D warnings
+        run: ./scripts/run-just.sh ci-rust clippy-nightly ${{ matrix.profile-key }}

--- a/.github/workflows/lint-nightly.yaml
+++ b/.github/workflows/lint-nightly.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # @v2 -> v2.85.7
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
           tool: just@1.46.0
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,13 @@
+{
+  // Defines which Markdown files linting includes and excludes, keeping local
+  // pre-push checks aligned with CI. Shared by `just ci-lint-markdown` and the
+  // GitHub Actions Markdown check.
+  "globs": [
+    "*.md",
+    "**/*.md",
+    "!CHANGELOG.md",
+    "!target/**",
+    "!.github/**",
+    "!.claude/**"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,40 +139,77 @@ of the change.
 
 ## PR Strategy
 
-Before submitting/updating a PR, run the following
+Before submitting or updating a PR, run the local pre-push checks:
 
 ```bash
-cargo fmt                                                               # Format code
-cargo nextest run --workspace --features ethhash,logger --all-targets   # Run tests
-cargo +nightly-2026-07-05 clippy --workspace --features ethhash,logger --all-targets                    # Linter
-cargo +nightly-2026-07-05 clippy --profile maxperf --features ethhash,logger --workspace --all-targets  # Linter (maxperf: debug-assertions off)
-cargo doc --no-deps                                                     # Ensure docs build
+just prepush
 ```
+
+This runs `just lint` followed by `just test`. These recipes use the same
+lower-level `ci-*` recipes as GitHub Actions, keeping the local and CI commands
+in sync. Run either phase separately while iterating:
+
+```bash
+just lint
+just test
+```
+
+If `just` is not installed, use `./scripts/run-just.sh prepush`. The wrapper
+uses `just` when available, falls back to Nix when available, and otherwise
+prints installation instructions.
+
+The complete set of Rust profile names and Cargo arguments, including
+Linux-only profiles, is defined in `scripts/run-rust-ci.sh`. The macOS-compatible
+Just recipes select the portable subset, while CI uses the full set. The
+Justfile and CI workflows should pass profile names instead of duplicating Cargo
+feature and profile arguments. When changing a CI Rust matrix, update the shared
+script and both callers as needed.
 
 All tests must pass, and there should be no clippy warnings.
 
 ### Slow Tests
 
-If your PR modifies code that is tested by any test prefixed with `test_slow_`, you should also run the full test suite with the `ci` profile to ensure those tests pass:
+`just test` runs every portable Rust test profile with nextest's `ci` profile,
+so tests prefixed with `test_slow_` are included automatically. Targeted or
+default-profile test commands are useful during development, but do not replace
+`just test` before pushing.
+
+### Linux-only Checks
+
+The local `lint`, `test`, and `prepush` recipes are designed to run on macOS.
+They intentionally omit CI checks that require Linux:
+
+- The `debug-all-features` Rust profile enables `io-uring`.
+- Differential fuzz jobs use Linux-specific resource limits and tooling.
+
+GitHub Actions remains authoritative for these checks. To reproduce the
+all-features Rust checks, use a Linux development environment and run:
 
 ```bash
-cargo nextest run --workspace --features ethhash,logger --all-targets --profile ci
+just ci-rust clippy debug-all-features
+just ci-rust test debug-all-features
 ```
 
-The `ci` profile includes slow tests that are skipped in the default profile for faster local development.
+Do not add Linux-only commands to the macOS-compatible aggregate recipes.
+
+Two further CI checks have no local aggregate equivalent: the license-header
+check (a GitHub Action) and the `examples` job. The examples can be run
+manually with `just ci-rust benchmark-example <profile>` and
+`just ci-rust insert-example <profile>`.
 
 ### Markdown Linter
 
-If your PR touches any Markdown file, run the following:
+`just lint` and `just prepush` run the Markdown checks used by CI. To run only
+the repository-wide Markdown check, use:
 
 ```bash
-markdownlint-cli2 .
+just ci-lint-markdown
 ```
 
 If the linter fails, run the following to fix any lint errors:
 
 ```bash
-markdownlint-cli2 . --fix
+just fix-markdown
 ```
 
 If you don't have `markdownlint-cli2` available on your system, run the
@@ -212,7 +249,8 @@ Key dependencies are centrally managed in workspace `Cargo.toml`:
    blocks without documentation and strong justification. Unsafe code could be
    utilized in the `ffi` crate.
 
-2. **Testing**: Any changes should include appropriate tests. Run `cargo nextest run --release` to verify.
+2. **Testing**: Any changes should include appropriate tests. Run targeted tests
+   while iterating and `./scripts/run-just.sh prepush` before handoff.
 
 3. **Performance Context**: This is a database designed for blockchain state. Performance matters. Consider allocation patterns and hot paths.
 
@@ -220,7 +258,9 @@ Key dependencies are centrally managed in workspace `Cargo.toml`:
 
 5. **Feature Flags**: Be aware of `ethhash` feature flag when discussing Ethereum compatibility vs. default merkledb compatibility.
 
-6. **Documentation**: Public APIs should be well-documented. Run `cargo doc --no-deps` to check.
+6. **Documentation**: Public APIs should be well-documented. The documentation
+   check is included in `./scripts/run-just.sh lint`; run `./scripts/run-just.sh ci-docs` to invoke it
+   separately.
 
 7. **Workspace Awareness**: This is a multi-crate workspace. Changes may affect multiple crates. Check `Cargo.toml` for workspace structure.
 

--- a/justfile
+++ b/justfile
@@ -2,6 +2,119 @@
 default:
     ./scripts/run-just.sh --list
 
+# Run a Rust command with a named CI profile.
+ci-rust command profile:
+    ./scripts/run-rust-ci.sh "{{command}}" "{{profile}}"
+
+# Check Rust formatting as CI does.
+ci-format:
+    cargo fmt -- --check
+
+# Check TODO/FIXME annotations as CI does.
+ci-check-todos:
+    ./scripts/check-todos.sh
+
+# Build Rust documentation with CI's warning policy.
+ci-docs:
+    RUSTDOCFLAGS="-D warnings" cargo doc --locked --document-private-items --no-deps
+
+# Lint the Markdown files selected by the shared markdownlint configuration.
+ci-lint-markdown:
+    markdownlint-cli2
+
+# Fix supported Markdown lint errors in the files selected by the shared config.
+fix-markdown:
+    markdownlint-cli2 --fix
+
+# Lint the Go FFI as CI does.
+ci-lint-ffi:
+    ./ffi/scripts/lint.sh
+
+# Check that `go generate` leaves the FFI sources unchanged, as CI does.
+ci-check-go-generate:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Compare repository status before and after so pre-existing local
+    # modifications do not count as failures.
+    before=$(git status --porcelain)
+    (cd ffi && go generate)
+    after=$(git status --porcelain)
+    if [[ "$before" != "$after" ]]; then
+        echo "error: go generate resulted in changes to tracked files. Please commit these changes." >&2
+        git --no-pager diff
+        exit 1
+    fi
+
+# Check for unused Rust dependencies as CI does.
+ci-machete:
+    cargo machete --with-metadata
+
+# Build the Go FFI's Rust library for a hash mode.
+ci-build-ffi hash_mode:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{hash_mode}}" in
+        firewood) features=() ;;
+        ethhash) features=(--features ethhash,logger) ;;
+        *) echo "error: unknown FFI hash mode '{{hash_mode}}'" >&2; exit 2 ;;
+    esac
+    # ${features[@]+…} guard: empty-array expansion errors under `set -u` on
+    # the stock macOS bash 3.2.
+    cargo build --locked -p firewood-ffi ${features[@]+"${features[@]}"}
+
+# Test the Go FFI against a Rust library built for a hash mode.
+ci-test-ffi hash_mode:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{hash_mode}}" in
+        firewood | ethhash) ;;
+        *) echo "error: unknown FFI hash mode '{{hash_mode}}'" >&2; exit 2 ;;
+    esac
+    cd ffi
+    GOEXPERIMENT=cgocheck2 TEST_FIREWOOD_HASH_MODE="{{hash_mode}}" go test -count=1 -race ./...
+
+# Test a Go compatibility suite against the corresponding FFI hash mode.
+ci-test-ffi-compat hash_mode:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{hash_mode}}" in
+        firewood) test_dir=ffi/tests/firewood ;;
+        ethhash) test_dir=ffi/tests/eth ;;
+        *) echo "error: unknown FFI hash mode '{{hash_mode}}'" >&2; exit 2 ;;
+    esac
+    cd "$test_dir"
+    go test -count=1 -race ./...
+
+# Run macOS-compatible CI lints (all-features/io-uring remains Linux-only).
+lint:
+    ./scripts/run-just.sh ci-format
+    ./scripts/run-just.sh ci-check-todos
+    ./scripts/run-just.sh ci-rust clippy debug-no-default-features
+    ./scripts/run-just.sh ci-rust clippy debug-no-features
+    ./scripts/run-just.sh ci-rust clippy debug-ethhash-logger
+    ./scripts/run-just.sh ci-rust clippy maxperf-ethhash-logger
+    ./scripts/run-just.sh ci-lint-markdown
+    ./scripts/run-just.sh ci-docs
+    ./scripts/run-just.sh ci-lint-ffi
+    ./scripts/run-just.sh ci-check-go-generate
+    ./scripts/run-just.sh ci-machete
+
+# Run macOS-compatible CI unit tests (all-features/fuzz remain Linux-only).
+test:
+    ./scripts/run-just.sh ci-rust test debug-no-default-features
+    ./scripts/run-just.sh ci-rust test debug-no-features
+    ./scripts/run-just.sh ci-rust test debug-ethhash-logger
+    ./scripts/run-just.sh ci-rust test maxperf-ethhash-logger
+    ./scripts/run-just.sh ci-build-ffi firewood
+    ./scripts/run-just.sh ci-test-ffi firewood
+    ./scripts/run-just.sh ci-test-ffi-compat firewood
+    ./scripts/run-just.sh ci-build-ffi ethhash
+    ./scripts/run-just.sh ci-test-ffi ethhash
+    ./scripts/run-just.sh ci-test-ffi-compat ethhash
+
+# Run every macOS-compatible pre-push check, with linting first.
+prepush: lint test
+
 # Regenerate proof wire serialization snapshots for both hash modes.
 #
 # Run this after any intentional change to the proof binary format (ser.rs,

--- a/scripts/run-rust-ci.sh
+++ b/scripts/run-rust-ci.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This is the single source of truth for the Cargo arguments behind the full CI
+# matrix, including Linux-only profiles such as debug-all-features. GitHub
+# Actions uses the full set; the local Just aggregators pass only the profile
+# names that are portable to macOS.
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/run-rust-ci.sh help
+  scripts/run-rust-ci.sh <command> <profile>
+
+Commands:
+  help               Show this usage information
+  check              Run cargo check with the CI profile
+  build              Run cargo build with the CI profile
+  clippy             Run the pinned PR clippy toolchain with the CI profile
+  clippy-nightly     Run the latest nightly clippy toolchain with the CI profile
+  test               Run cargo-nextest with the CI profile
+  benchmark-example  Run the benchmark example exercised by CI
+  insert-example     Run the insert example exercised by CI
+
+Profiles:
+  debug-no-default-features
+  debug-no-features (default features)
+  debug-ethhash-logger
+  debug-all-features (Linux-only; enables io-uring)
+  maxperf-ethhash-logger
+EOF
+}
+
+if [[ $# -eq 1 && $1 == help ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+    usage >&2
+    exit 2
+fi
+
+command=$1
+profile=$2
+
+cargo_args=()
+nextest_args=()
+case "$profile" in
+    debug-no-default-features)
+        cargo_args=(--no-default-features)
+        nextest_args=(--no-default-features)
+        ;;
+    debug-no-features)
+        ;;
+    debug-ethhash-logger)
+        cargo_args=(--features ethhash,logger)
+        nextest_args=(--features ethhash,logger)
+        ;;
+    debug-all-features)
+        cargo_args=(--all-features)
+        nextest_args=(--all-features)
+        ;;
+    maxperf-ethhash-logger)
+        cargo_args=(--profile maxperf --features ethhash,logger)
+        nextest_args=(--cargo-profile maxperf --features ethhash,logger)
+        ;;
+    *)
+        echo "error: unknown Rust CI profile '$profile'" >&2
+        usage >&2
+        exit 2
+        ;;
+esac
+
+# Expanding an empty array with "${arr[@]}" is an unbound-variable error
+# under `set -u` on bash < 4.4 (macOS ships 3.2), so expansion sites use
+# ${arr[@]+"${arr[@]}"} instead.
+case "$command" in
+    check)
+        cargo check --frozen ${cargo_args[@]+"${cargo_args[@]}"} --workspace --all-targets
+        ;;
+    build)
+        cargo build --frozen ${cargo_args[@]+"${cargo_args[@]}"} --workspace --all-targets
+        ;;
+    clippy)
+        cargo +nightly-2026-07-05 clippy --locked ${cargo_args[@]+"${cargo_args[@]}"} --workspace --all-targets -- -D warnings
+        ;;
+    clippy-nightly)
+        cargo +nightly clippy --locked ${cargo_args[@]+"${cargo_args[@]}"} --workspace --all-targets -- -D warnings
+        ;;
+    test)
+        cargo nextest run --locked --profile ci --verbose ${nextest_args[@]+"${nextest_args[@]}"}
+        ;;
+    benchmark-example)
+        cargo run --locked ${cargo_args[@]+"${cargo_args[@]}"} --bin benchmark -- --number-of-batches 100 --batch-size 1000 create
+        ;;
+    insert-example)
+        cargo run --locked ${cargo_args[@]+"${cargo_args[@]}"} --example insert
+        ;;
+    *)
+        echo "error: unknown Rust CI command '$command'" >&2
+        usage >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Why this should be merged

When working with coding agents, especially when building a stack of PRs, a lint or test failure in the base PR causes every PR above it to fail as well. The author then has to fix the base PR and rebase the rest of the stack, creating avoidable work and slowing developer velocity.

We should run as many checks as practical locally before pushing code. CI should be the final gate before merging into `main`, rather than the first place routine lint or unit-test failures are discovered. Although the existing CI jobs are individually reproducible, there was no simple way to run the same collection of checks locally. CI runs many commands across several jobs, making it easy for developers and coding agents to miss a check before pushing.

## How this works

This PR provides a small Justfile API shared by developers, coding agents, and CI:

  - `just lint` runs the macOS-compatible linting and documentation checks.
  - `just test` runs the macOS-compatible unit and FFI test suites.
  - `just prepush` runs both phases in the expected order (on my local macbook, this took ~6.5 minutes to run)

The lower-level `ci-*` recipes are also used by GitHub Actions. Named Rust profiles and their Cargo arguments are defined in one shared script, avoiding duplicated command arguments between the Justfile and CI workflows.

`AGENTS.md` now directs developers and coding agents to these commands before pushing. This gives both groups a consistent, simple interface for reproducing as much of CI as possible locally.

Checks that require a Linux environment, such as the `io-uring` all-features profile and differential fuzz jobs, remain CI-only.

## How this was tested

CI + ran `just` commands locally.

> Note: for this PR to be merged, the `main` branch protection rules will need to be modified to account for the new CI jobs. For example, `rust-lint (debug-ethhash-logger, --features ethhash,logger)` is now just `rust-lint (debug-ethhash-logger)` now that `profile-args` have been removed.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
