### PR TITLE
ci: define required merge checks in code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,40 @@ env:
   RUST_BACKTRACE: full
 
 jobs:
+  # Keep this as the only CI status required by main's branch protection.
+  # To make another job merge-blocking, add its job key to this list. This
+  # keeps the required checks version-controlled instead of requiring a
+  # corresponding branch-protection update in the GitHub UI.
+  tests-required:
+    if: ${{ always() }}
+    needs:
+      - build
+      - no-rust-cache-lint
+      - rust-lint
+      - test
+      - examples
+      - docs
+      - ffi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless all required jobs succeeded
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failed_jobs="$(
+            jq -r '
+              to_entries[]
+              | select(.value.result != "success")
+              | .key
+            ' <<<"$NEEDS_JSON"
+          )"
+
+          if [[ -n "$failed_jobs" ]]; then
+            echo "Required jobs failed:"
+            printf '%s\n' "$failed_jobs"
+            exit 1
+          fi
+
   build:
     # To optimize cargo performance and caching throughout the CI pipeline, we use Swatinem/rust-cache
     # and set up an initial build job that writes the cache for a matrix of joint build profiles and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ guidelines for contributing to firewood.
 * [Quick Links](#quick-links)
 * [Testing](#testing)
 * [How to submit changes](#how-to-submit-changes)
+* [Required merge checks](#required-merge-checks)
 * [Signing your commits](#signing-your-commits)
 * [Code Review Process](#code-review-process)
 * [Labels](#labels)
@@ -39,6 +40,17 @@ Also, if you update any versions of packages, notably the MSRV (Minimum Supporte
 
 To create a PR, fork firewood, and use GitHub to create the PR. We typically prioritize reviews in the middle of the next work day,
 so you should expect a response during the week within 24 hours.
+
+## Required merge checks
+
+The `tests-required` job in [the CI workflow](.github/workflows/ci.yaml) is the
+single CI status required by the `main` branch protection. Its `needs` list is
+the version-controlled source of truth for merge-blocking CI jobs.
+
+When adding or removing a merge-blocking job, update the `tests-required.needs`
+list in the same pull request. No corresponding GitHub settings change is
+needed. The aggregate job uses `always()` and fails when any required job fails
+or is skipped, so dependency failures cannot accidentally allow a merge.
 
 ## Signing your commits
 


### PR DESCRIPTION
## Why this should be merged

#2178 changed the CI matrix-generated check names, which required a maintainer to update the repository’s merge rules manually before it could be merged. That process was tedious, error-prone, and created an unnecessary bottleneck even though the PR was already approved and its replacement checks were passing.

Required merge checks should be defined in version-controlled code so changes can be reviewed alongside the workflow changes that require them. This follows the same general approach used by AvalancheGo (ref: https://github.com/ava-labs/avalanchego/blob/9e14e9aa278e65c6caeaafb08ec202e720037134/.github/workflows/ci.yml#L26) and avoids requiring a maintainer to edit GitHub settings whenever CI jobs or matrix values change.

## How this works

This PR adds a single aggregate `tests-required` job. Instead of configuring branch protection with a collection of individual, matrix-generated check names, branch protection only needs to require `tests-required`. The aggregate job:

  - Depends on each merge-blocking CI job through its needs list.
  - Uses `always()` so it still runs when a dependency fails or is skipped.
  - Fails unless every listed dependency succeeds.

After the one-time branch-protection update, adding or removing a merge-blocking check only requires changing `tests-required.needs` in the CI workflow. The change can then be reviewed and merged like any other code change.

This initially expands the effective set of required passing jobs. The existing rules require 14 individual check contexts, while `tests-required` depends on all matrix variants across seven job groups - 28 underlying job executions in total. Branch protection sees only one stable required status, but every one of those underlying jobs must succeed for it to pass. This broader requirement preserves a strong merge gate while moving its definition into code. The dependency list can be trimmed in a follow-up if some matrix variants do not need to be merge-blocking.

## How this was tested

The new tests-required job is exercised by GitHub Actions on this PR. It runs after all jobs in its needs list complete and validates their reported results.

https://github.com/ava-labs/firewood/actions/runs/30950282102/job/92133177781?pr=2179

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
