### PR TITLE
fix(storage): make the io-uring feature a portable no-op off Linux

### DIFF
--- a/.claude/skills/firewood-review/SKILL.md
+++ b/.claude/skills/firewood-review/SKILL.md
@@ -85,7 +85,7 @@ cargo fetch --locked
 # All subsequent cargo commands: add --frozen --target-dir target/review
 ```
 
-Use `uname -s` to determine which feature sets to test (e.g., skip `io-uring` features on macOS/Darwin).
+Every feature set below builds on both platforms. Note that `io-uring` is inert off Linux, so a green macOS `--all-features` run does not exercise `storage/src/linear/io_uring.rs`; only Linux compiles it.
 
 Use `--frozen` after the initial fetch to ensure we're not accidentally pulling new dependencies that aren't covered by the lockfile.
 
@@ -93,12 +93,12 @@ Use `--target-dir target/review` for ALL cargo commands to avoid conflicting wit
 
 Run `cargo clippy --workspace --all-targets` and `cargo nextest run --workspace --all-targets` for each feature set:
 
-| Feature flags               | macOS               | Linux |
-| --------------------------- | ------------------- | ----- |
-| (none)                      | ✓                   | ✓     |
-| `--no-default-features`     | ✓                   | ✓     |
-| `--features ethhash,logger` | ✓                   | ✓     |
-| `--all-features`            | ✗ (skip `io-uring`) | ✓     |
+| Feature flags               | macOS | Linux |
+| --------------------------- | ----- | ----- |
+| (none)                      | ✓     | ✓     |
+| `--no-default-features`     | ✓     | ✓     |
+| `--features ethhash,logger` | ✓     | ✓     |
+| `--all-features`            | ✓     | ✓     |
 
 If the PR adds any new Cargo feature, test with and without it across the applicable matrix rows.
 

--- a/.claude/skills/firewood-review/SKILL.md
+++ b/.claude/skills/firewood-review/SKILL.md
@@ -100,6 +100,8 @@ Run `cargo clippy --workspace --all-targets` and `cargo nextest run --workspace 
 | `--features ethhash,logger` | ✓     | ✓     |
 | `--all-features`            | ✓     | ✓     |
 
+`--all-features` requires rustc 1.94.1+, above the 1.94.0 workspace MSRV, because it enables `fwdctl`'s `launch` feature and its AWS SDK dependencies declare that floor. If `cargo` reports `rustc 1.94.0 is not supported by the following packages`, that is this constraint and not a defect in the PR under review.
+
 If the PR adds any new Cargo feature, test with and without it across the applicable matrix rows.
 
 **Header drift check:**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,15 +14,16 @@ See [`CODE_REVIEW.md`](../CODE_REVIEW.md) for the complete set of code review ch
 ## Cargo Feature Matrix
 
 The following feature combinations must all pass `cargo clippy` and `cargo nextest`
-before a PR is ready. Skip `--all-features` on macOS (it includes `io-uring` which
-requires Linux):
+before a PR is ready, on either platform. The `io-uring` feature is portable but
+inert off Linux, so `--all-features` builds everywhere — only Linux actually
+compiles the ring backend.
 
 | Feature flags               | macOS | Linux |
 | --------------------------- | ----- | ----- |
 | (none)                      | ✓     | ✓     |
 | `--no-default-features`     | ✓     | ✓     |
 | `--features ethhash,logger` | ✓     | ✓     |
-| `--all-features`            | ✗     | ✓     |
+| `--all-features`            | ✓     | ✓     |
 
 ## Commit and PR Conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,6 +25,10 @@ compiles the ring backend.
 | `--features ethhash,logger` | ✓     | ✓     |
 | `--all-features`            | ✓     | ✓     |
 
+`--all-features` requires rustc 1.94.1 or newer — above the 1.94.0 workspace MSRV
+— because it enables `fwdctl`'s `launch` feature, whose AWS SDK dependencies
+declare that floor. The other three rows build on 1.94.0.
+
 ## Commit and PR Conventions
 
 Commit messages and PR titles must follow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,12 +158,11 @@ If `just` is not installed, use `./scripts/run-just.sh prepush`. The wrapper
 uses `just` when available, falls back to Nix when available, and otherwise
 prints installation instructions.
 
-The complete set of Rust profile names and Cargo arguments, including
-Linux-only profiles, is defined in `scripts/run-rust-ci.sh`. The macOS-compatible
-Just recipes select the portable subset, while CI uses the full set. The
-Justfile and CI workflows should pass profile names instead of duplicating Cargo
-feature and profile arguments. When changing a CI Rust matrix, update the shared
-script and both callers as needed.
+The complete set of Rust profile names and Cargo arguments is defined in
+`scripts/run-rust-ci.sh`. Every profile there is portable to macOS, so the Just
+recipes and CI run the same set. The Justfile and CI workflows should pass
+profile names instead of duplicating Cargo feature and profile arguments. When
+changing a CI Rust matrix, update the shared script and both callers as needed.
 
 All tests must pass, and there should be no clippy warnings.
 
@@ -177,18 +176,17 @@ default-profile test commands are useful during development, but do not replace
 ### Linux-only Checks
 
 The local `lint`, `test`, and `prepush` recipes are designed to run on macOS.
-They intentionally omit CI checks that require Linux:
+They intentionally omit CI checks that require Linux: the differential fuzz jobs,
+which use Linux-specific resource limits and tooling. GitHub Actions remains
+authoritative for those.
 
-- The `debug-all-features` Rust profile enables `io-uring`.
-- Differential fuzz jobs use Linux-specific resource limits and tooling.
-
-GitHub Actions remains authoritative for these checks. To reproduce the
-all-features Rust checks, use a Linux development environment and run:
-
-```bash
-just ci-rust clippy debug-all-features
-just ci-rust test debug-all-features
-```
+`--all-features` is *not* in that category. The `io-uring` feature is accepted on
+every platform but only takes effect on Linux, where `storage/build.rs` sets the
+`cfg(io_uring)` alias that gates the ring backend; elsewhere the feature is inert
+and the standard I/O path is used. So `debug-all-features` runs in `just lint`
+and `just test` like any other profile. Note this means the ring code itself is
+compiled only by the Linux CI jobs — a macOS-green `--all-features` run does not
+prove `storage/src/linear/io_uring.rs` builds.
 
 Do not add Linux-only commands to the macOS-compatible aggregate recipes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ and EVM-compatible blockchains that store state in Merkle tries.
 
 **Key Characteristics:**
 
-- Written in Rust (edition 2024, MSRV 1.94.0)
+- Written in Rust (edition 2024, MSRV 1.94.0 — but see
+  [Toolchain Floor for `--all-features`](#toolchain-floor-for---all-features))
 - Beta-level software with evolving API
 - Compaction-less database that directly stores trie nodes on-disk
 - Not built on generic KV stores (LevelDB/RocksDB)
@@ -165,6 +166,33 @@ profile names instead of duplicating Cargo feature and profile arguments. When
 changing a CI Rust matrix, update the shared script and both callers as needed.
 
 All tests must pass, and there should be no clippy warnings.
+
+### Toolchain Floor for `--all-features`
+
+The workspace declares `rust-version = "1.94.0"`, and that is accurate for the
+default build, `--no-default-features`, and `--features ethhash,logger`.
+`--all-features` needs **1.94.1**.
+
+`--all-features` turns on `fwdctl`'s `launch` feature, which pulls in the AWS SDK
+(`aws-config`, `aws-sdk-ec2`, `aws-sdk-ssm`, `aws-sdk-sts`, and their
+`aws-smithy-*` dependencies). Every one of those crates declares
+`rust-version = "1.94.1"`. Cargo refuses the build before compiling anything:
+
+```text
+error: rustc 1.94.0 is not supported by the following packages:
+  aws-config@1.9.0 requires rustc 1.94.1
+  ...
+```
+
+This is unrelated to the platform gating described under
+[Linux-only Checks](#linux-only-checks) — it applies equally on macOS and Linux.
+
+On exactly 1.94.0, either use a newer toolchain for `debug-all-features` (any
+1.94.1+ release works, and CI is well ahead of the floor), or downgrade the AWS
+crates as the error suggests. The workspace `rust-version` is deliberately left at
+1.94.0 so the floor reflects what the shipped library crates need rather than what
+an optional `fwdctl` feature needs; bumping it to 1.94.1 is the alternative if the
+split proves confusing in practice.
 
 ### Slow Tests
 

--- a/METRICS.md
+++ b/METRICS.md
@@ -177,7 +177,7 @@ High tail latencies indicate write–read contention between concurrent commits 
 | ---------------------------------- | ------- | ------ | ------------------------- |
 | `firewood_rootstore_lookups_total` | counter | —      | Root-store fetch attempts |
 
-#### io_uring (only when `io-uring` feature is enabled)
+#### io_uring (only on Linux with the `io-uring` feature enabled)
 
 | Metric                                          | Type    | Labels | Description                                      |
 | ----------------------------------------------- | ------- | ------ | ------------------------------------------------ |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -161,13 +161,13 @@ would automatically add the dependency with `workspace = true`).
 [dependencies]
 firewood-macros.workspace = true
 
-# more complex example
-[target.'cfg(target_os = "linux")'.dependencies]
+# inherit path and version from the workspace while adding a feature
 firewood-storage = { workspace = true, features = ["io-uring"] }
-
-[target.'cfg(not(target_os = "linux"))'.dependencies]
-firewood-storage.workspace = true
 ```
+
+> [!NOTE]
+> `io-uring` needs no per-target dependency table. The feature is accepted on
+> every platform and only takes effect on Linux; see `storage/build.rs`.
 
 Thefefore, after updating the `workspace.package.version` value, we must update
 the dependency versions to match.

--- a/justfile
+++ b/justfile
@@ -85,13 +85,14 @@ ci-test-ffi-compat hash_mode:
     cd "$test_dir"
     go test -count=1 -race ./...
 
-# Run macOS-compatible CI lints (all-features/io-uring remains Linux-only).
+# Run macOS-compatible CI lints.
 lint:
     ./scripts/run-just.sh ci-format
     ./scripts/run-just.sh ci-check-todos
     ./scripts/run-just.sh ci-rust clippy debug-no-default-features
     ./scripts/run-just.sh ci-rust clippy debug-no-features
     ./scripts/run-just.sh ci-rust clippy debug-ethhash-logger
+    ./scripts/run-just.sh ci-rust clippy debug-all-features
     ./scripts/run-just.sh ci-rust clippy maxperf-ethhash-logger
     ./scripts/run-just.sh ci-lint-markdown
     ./scripts/run-just.sh ci-docs
@@ -99,11 +100,12 @@ lint:
     ./scripts/run-just.sh ci-check-go-generate
     ./scripts/run-just.sh ci-machete
 
-# Run macOS-compatible CI unit tests (all-features/fuzz remain Linux-only).
+# Run macOS-compatible CI unit tests (differential fuzzing remains Linux-only).
 test:
     ./scripts/run-just.sh ci-rust test debug-no-default-features
     ./scripts/run-just.sh ci-rust test debug-no-features
     ./scripts/run-just.sh ci-rust test debug-ethhash-logger
+    ./scripts/run-just.sh ci-rust test debug-all-features
     ./scripts/run-just.sh ci-rust test maxperf-ethhash-logger
     ./scripts/run-just.sh ci-build-ffi firewood
     ./scripts/run-just.sh ci-test-ffi firewood

--- a/scripts/run-rust-ci.sh
+++ b/scripts/run-rust-ci.sh
@@ -27,7 +27,9 @@ Profiles:
   debug-no-default-features
   debug-no-features (default features)
   debug-ethhash-logger
-  debug-all-features (io-uring is active on Linux only)
+  debug-all-features (io-uring is active on Linux only; needs rustc 1.94.1+,
+                      above the 1.94.0 workspace MSRV, because fwdctl's
+                      launch feature pulls in the AWS SDK)
   maxperf-ethhash-logger
 EOF
 }

--- a/scripts/run-rust-ci.sh
+++ b/scripts/run-rust-ci.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 # This is the single source of truth for the Cargo arguments behind the full CI
-# matrix, including Linux-only profiles such as debug-all-features. GitHub
-# Actions uses the full set; the local Just aggregators pass only the profile
-# names that are portable to macOS.
+# matrix. Every profile here is portable to macOS, so GitHub Actions and the
+# local Just aggregators pass the same set. Checks that genuinely require Linux
+# (differential fuzzing) live in the workflows, not here.
 
 usage() {
     cat <<'EOF'
@@ -27,7 +27,7 @@ Profiles:
   debug-no-default-features
   debug-no-features (default features)
   debug-ethhash-logger
-  debug-all-features (Linux-only; enables io-uring)
+  debug-all-features (io-uring is active on Linux only)
   maxperf-ethhash-logger
 EOF
 }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -45,7 +45,6 @@ parking_lot.workspace = true
 triomphe = "0.1.16"
 weak-table = "0.3.2"
 # Optional dependencies
-io-uring = { version = "0.7.13", optional = true }
 log = { version = "0.4.33", optional = true }
 sha3 = "0.12.0"
 bumpalo = { version = "3.20.3", features = ["collections", "std"] }
@@ -67,6 +66,12 @@ test-case.workspace = true
 [build-dependencies]
 bytemuck.workspace = true
 sha2.workspace = true
+
+# The io-uring crate only builds on Linux, so the dependency is declared per
+# target. The `io-uring` feature itself stays portable and is a no-op elsewhere;
+# see build.rs for the `cfg(io_uring)` alias that gates the code on both.
+[target.'cfg(target_os = "linux")'.dependencies]
+io-uring = { version = "0.7.13", optional = true }
 
 [features]
 logger = ["log"]

--- a/storage/build.rs
+++ b/storage/build.rs
@@ -3,6 +3,9 @@
 
 //! Build script for `firewood-storage`.
 //!
+//! Emits the `io_uring` cfg that gates the io-uring backend; see
+//! [`emit_io_uring_cfg`].
+//!
 //! Generates `$OUT_DIR/area_sizes.rs`, which is `include!`d by
 //! `src/nodestore/primitives.rs`. The generated file contains:
 //!
@@ -68,10 +71,34 @@ area_sizes![
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    emit_io_uring_cfg();
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
     let dest_path = std::path::Path::new(&out_dir).join("area_sizes.rs");
     let contents = generate_area_sizes_rs().expect("Failed to generate area_sizes.rs");
     std::fs::write(dest_path, contents).expect("Failed to write area_sizes.rs");
+}
+
+/// Emits the `io_uring` cfg when the `io-uring` feature is enabled *and* the
+/// build target is Linux.
+///
+/// The `io-uring` crate only builds on Linux, so the dependency is declared
+/// under `[target.'cfg(target_os = "linux")'.dependencies]`. The Cargo feature
+/// itself stays portable and silently selects the standard I/O path elsewhere,
+/// which keeps `--all-features` usable on every host. Source code branches on
+/// `cfg(io_uring)` rather than `cfg(feature = "io-uring")` so that this policy
+/// is stated in exactly one place.
+fn emit_io_uring_cfg() {
+    // Emitted unconditionally so that the `unexpected_cfgs` lint recognizes the
+    // cfg in the configurations where it is not set.
+    println!("cargo::rustc-check-cfg=cfg(io_uring)");
+
+    // `CARGO_CFG_TARGET_OS` rather than `cfg!(target_os = …)`: the latter
+    // describes the host that compiled this build script, not the target the
+    // crate is being built for.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS not set");
+    if std::env::var_os("CARGO_FEATURE_IO_URING").is_some() && target_os == "linux" {
+        println!("cargo::rustc-cfg=io_uring");
+    }
 }
 
 /// Generates the contents of `area_sizes.rs`.

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -45,7 +45,7 @@ use super::{FileIoError, OffsetReader, ReadableStorage, WritableStorage};
 /// Reads and writes go through positioned (`pread`/`pwrite`) syscalls, so they
 /// share no file cursor and take no per-handle lock; the caches absorb most
 /// reads so that the hot path rarely touches disk. The only serialization
-/// points are the two cache mutexes and, on the `io-uring` path, the ring's
+/// points are the two cache mutexes and, on the io-uring path, the ring's
 /// internal lock.
 #[derive(Debug)]
 pub struct FileBacked {
@@ -79,9 +79,12 @@ pub struct FileBacked {
     /// `io_uring` instance, not the descriptor — `fd` is passed by `RawFd` into
     /// each `write_batch` call.
     ///
+    /// Present only under `cfg(io_uring)`, that is on Linux with the `io-uring`
+    /// feature enabled.
+    ///
     /// Declared before `fd` so that it is dropped first (struct fields are
     /// dropped in declaration order).
-    #[cfg(feature = "io-uring")]
+    #[cfg(io_uring)]
     ring: super::io_uring::IoUringProxy,
     /// The open file handle backing this storage, wrapped so that the advisory
     /// lock taken by [`Self::lock`] is released when the handle is dropped.
@@ -125,7 +128,7 @@ impl FileBacked {
                 context: Some("file open".to_owned()),
             })?;
 
-        #[cfg(feature = "io-uring")]
+        #[cfg(io_uring)]
         let ring = super::io_uring::IoUringProxy::new().map_err(|err| FileIoError {
             inner: err,
             filename: Some(path.clone()),
@@ -139,7 +142,7 @@ impl FileBacked {
             cache_read_strategy,
             filename: path,
             node_hash_algorithm,
-            #[cfg(feature = "io-uring")]
+            #[cfg(io_uring)]
             ring,
             fd: UnlockOnDrop(fd),
         })
@@ -237,7 +240,10 @@ impl WritableStorage for FileBacked {
             .map_err(|e| self.file_io_error(e, offset, Some("write".to_owned())))
     }
 
-    #[cfg(feature = "io-uring")]
+    /// Overrides the serial [`WritableStorage::write_batch`] default with a
+    /// single batched ring submission. Compiled in only under `cfg(io_uring)`;
+    /// otherwise the trait default applies.
+    #[cfg(io_uring)]
     fn write_batch<'a, I: IntoIterator<Item = (u64, &'a [u8])> + Clone>(
         &self,
         writes: I,

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -16,9 +16,24 @@ use std::path::PathBuf;
 
 use crate::{CacheReadStrategy, LinearAddress, MaybePersistedNode, SharedNode};
 pub(super) mod filebacked;
-#[cfg(feature = "io-uring")]
+/// Batched-write backend built on Linux `io_uring`.
+///
+/// Gated on `cfg(io_uring)`, which `build.rs` sets only when the `io-uring`
+/// feature is enabled *and* the target is Linux. The `io-uring` crate does not
+/// build on other targets, so the feature is accepted but inert there and
+/// [`FileBacked`](filebacked::FileBacked) falls back to the serial
+/// [`WritableStorage::write_batch`] default.
+#[cfg(io_uring)]
 mod io_uring;
 pub mod memory;
+
+/// Pins the `cfg(io_uring)` policy that `build.rs` implements.
+///
+/// A regression that stopped emitting the cfg would silently fall back to the
+/// serial write path on Linux without failing anything — the ring has no unit
+/// tests of its own. Conversely, emitting it off Linux would fail to compile
+/// with a confusing missing-crate error. This catches both at build time.
+const _: () = assert!(cfg!(io_uring) == (cfg!(feature = "io-uring") && cfg!(target_os = "linux")));
 
 /// An error that occurs when reading or writing to a [`ReadableStorage`] or [`WritableStorage`]
 ///
@@ -213,9 +228,14 @@ pub trait WritableStorage: ReadableStorage {
     /// Write a batch of objects to the storage.
     ///
     /// Implementations may provide a more efficient way to write multiple
-    /// objects at once.
+    /// objects at once. This default writes each object in turn via
+    /// [`Self::write`]; under `cfg(io_uring)`,
+    /// [`FileBacked`](filebacked::FileBacked) overrides it with a single ring
+    /// submission.
     ///
     /// The iterator is expected to be cheap to clone without copying the data.
+    /// The [`Clone`] bound exists for the io-uring override, which re-walks the
+    /// batch when retrying entries.
     fn write_batch<'a, I: IntoIterator<Item = (u64, &'a [u8])> + Clone>(
         &self,
         writes: I,

--- a/storage/src/nodestore/persist.rs
+++ b/storage/src/nodestore/persist.rs
@@ -8,24 +8,26 @@
 //!
 //! ## I/O Backend Support
 //!
-//! This module supports multiple I/O backends through conditional compilation:
+//! This module contains no conditional compilation of its own. It batches node
+//! writes and hands them to [`WritableStorage::write_batch`], and the backend is
+//! chosen by whichever implementation of that method is compiled in:
 //!
-//! - **Standard I/O** - `#[cfg(not(feature = "io-uring"))]` - Uses standard file operations
-//! - **io-uring** - `#[cfg(feature = "io-uring")]` - Uses Linux io-uring for async I/O
+//! - **Standard I/O** — the trait's default `write_batch`, which issues one
+//!   positioned write per node.
+//! - **io-uring** — an override on
+//!   [`FileBacked`](crate::linear::filebacked::FileBacked) that submits the
+//!   whole batch to a ring, reducing syscall overhead on high-throughput
+//!   workloads.
 //!
-//! This feature flag is automatically enabled when running on Linux, and disabled for all other platforms.
-//!
-//! The io-uring implementation provides:
-//! - Asynchronous batch operations
-//! - Reduced system call overhead
-//! - Better performance for high-throughput workloads
+//! The io-uring override is compiled in only under `cfg(io_uring)`, which
+//! requires both the `io-uring` feature and a Linux target. The feature is not
+//! enabled by default on any platform.
 //!
 //! ## Performance Considerations
 //!
 //! - Nodes are written in batches to minimize I/O overhead
 //! - Metrics are collected for flush operation timing
 //! - Memory-efficient serialization with pre-allocated buffers
-//! - Ring buffer management for io-uring operations
 
 use bumpalo::Bump;
 use std::iter::FusedIterator;


### PR DESCRIPTION
## Why this should be merged

`--all-features` could not be run on macOS: the `io-uring` feature pulled in the `io-uring` crate unconditionally, and that crate has no `target_os` gate of its own — `src/sys/mod.rs` dispatches purely on `target_arch`, so on Apple Silicon it selects the `aarch64` bindings and then fails against Linux-only `libc` items. There is no upstream fix to wait for.

The cost had spread past the build: `debug-all-features` was excluded from `just lint` and `just test`, and four documents told humans and agents to skip `--all-features` on macOS, so nothing run locally exercised that configuration.

## How this works

The Cargo feature stays portable and declarable everywhere; a new `cfg(io_uring)` alias emitted by `storage/build.rs` gates the code on the feature _and_ a Linux target.

The non-obvious constraint is that the two halves cannot be separated. Target-gating the dependency alone would make things _worse_: `cfg(feature = "io-uring")` still evaluates true on macOS, so the existing sites would reference a crate no longer in the graph.

`Cargo.lock` is unchanged by design — it records dependencies target-agnostically, and CI runs `--frozen`/`--locked`.

## How this was tested

`just lint` and `just test` pass in full on macOS, now including `debug-all-features` (765/765). Verified in a `rust:1.96-bookworm` container that `--all-features` still compiles `io-uring v0.7.13`, so the ring is not silently disabled — and that substituting a `build.rs` which omits the cfg fails with `error[E0080]`, confirming the new `const` guard is not decorative.

## Follow-ups

- macOS is **not** added to the `debug-all-features` CI matrices, so that configuration is enforced only by local `just prepush`. Adding `os: macos-26` to five entries in `ci.yaml` would make CI authoritative, at the cost of CI minutes per PR.
- A green macOS `--all-features` run does not prove `storage/src/linear/io_uring.rs` compiles — only the Linux jobs build it. Called out in `AGENTS.md` and the review skill so the new checkmark is not over-read.

## Breaking Changes

None. The feature keeps its name and its Linux behavior, and stays off by default everywhere. Downstream consumers who split the dependency by target to work around this can now enable `io-uring` unconditionally.
