### PR TITLE
refactor(db): let revision manager own consistency checks

### DIFF
--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -218,9 +218,7 @@ impl Db {
 
     /// Check the database for consistency
     pub fn check(&self, opt: CheckOpt) -> CheckerReport {
-        let latest_rev_nodestore = self.manager.current_revision();
-        let header = self.manager.locked_header();
-        latest_rev_nodestore.check(&header, opt)
+        self.manager.check(opt)
     }
 
     /// Create a proposal with a specified parent. A proposal is created in parallel if `use_parallel`

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -7,7 +7,7 @@
 )]
 
 use nonzero_ext::nonzero;
-use parking_lot::{Mutex, MutexGuard, RwLock};
+use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, VecDeque};
 use std::io;
 use std::num::{NonZero, NonZeroU64};
@@ -27,9 +27,9 @@ use firewood_metrics::{GaugeExt, firewood_counter, firewood_gauge, firewood_hist
 pub use firewood_storage::CacheReadStrategy;
 use firewood_storage::RootStore;
 use firewood_storage::{
-    BranchNode, Committed, CommittedId, DeletedNodeTracking, FileBacked, FileIoError,
-    HashedNodeReader, ImmutableProposal, Mutable, MutableKind, NodeHashAlgorithm, NodeStore,
-    NodeStoreHeader, Propose, Recon, TrieHash,
+    BranchNode, CheckOpt, CheckerReport, Committed, CommittedId, DeletedNodeTracking, FileBacked,
+    FileIoError, HashedNodeReader, ImmutableProposal, Mutable, MutableKind, NodeHashAlgorithm,
+    NodeStore, NodeStoreHeader, Propose, Recon, TrieHash,
 };
 
 pub(crate) const DB_FILE_NAME: &str = "firewood.db";
@@ -581,6 +581,12 @@ impl RevisionManager {
         self.current_revision().root_hash()
     }
 
+    pub(crate) fn check(&self, opt: CheckOpt) -> CheckerReport {
+        let current_revision = self.current_revision();
+        let header = self.persist_worker.locked_header();
+        current_revision.check(&header, opt)
+    }
+
     pub fn current_revision(&self) -> CommittedRevision {
         // BLOCKING: read lock on `in_memory_revisions`. Called on every propose() and
         // merge_key_value_range(); blocks while a commit() holds the write lock (steps 1-5).
@@ -592,17 +598,6 @@ impl RevisionManager {
             .back()
             .expect("there is always one revision")
             .clone()
-    }
-
-    /// Acquires a lock on the header and returns a guard.
-    ///
-    /// # Blocking
-    ///
-    /// This contends with the background `PersistLoop`, which holds the header lock for the
-    /// entire duration of a `persist_to_disk` or `reap` call (both of which do disk I/O).
-    /// Callers (e.g. `Db::check`) may stall until the current persistence cycle finishes.
-    pub(crate) fn locked_header(&self) -> MutexGuard<'_, NodeStoreHeader> {
-        self.persist_worker.locked_header()
     }
 
     /// Gets or creates a threadpool associated with the revision manager.

--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -569,7 +569,7 @@ impl PersistLoop {
     fn persist_to_disk(&self, revision: &CommittedRevision) -> Result<(), PersistError> {
         // BLOCKING: mutex lock on the shared `NodeStoreHeader`. Held for the entire duration of
         // the disk flush (serializes all node writes + header write). Any concurrent caller of
-        // `RevisionManager::locked_header()` (e.g. `Db::check`) will stall until this returns.
+        // `RevisionManager::check` will stall until this returns.
         // Under heavy I/O this can take tens to hundreds of milliseconds.
         let mut header = self.shared.header.lock();
         revision.persist(&mut header).map_err(|e| {
@@ -583,7 +583,7 @@ impl PersistLoop {
         // BLOCKING: same header mutex as `persist_to_disk`. Held while writing all freed-node
         // metadata back to the free-list in storage. Contends with any `persist_to_disk` that
         // might be running concurrently (they cannot — both run in the single background thread —
-        // but the lock also blocks external `locked_header()` callers).
+        // but the lock also blocks `RevisionManager::check`).
         nodestore
             .reap_deleted(&mut self.shared.header.lock())
             .map_err(|e| {


### PR DESCRIPTION
## Why this should be merged

While working on #1754, I noticed that `Db::check()` mostly relegates to `RevisionManager::check()` - by moving the actual logic of `check()` to the `RevisionManager` (getting latest revision and the header file), we can remove the `locked_header()` method from the `RevisionManager` type.

## How this works

Simple refactor

## How this was tested

CI

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
