### PR TITLE
fix(proofs)!: bound the range-proof apply to the proven range

### DIFF
--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -58,7 +58,7 @@ typedef struct IteratorHandle IteratorHandle;
 typedef struct ProposalHandle ProposalHandle;
 
 /**
- * FFI context for for a parsed or generated range proof.
+ * FFI context for a parsed or generated range proof.
  */
 typedef struct RangeProofContext RangeProofContext;
 
@@ -815,7 +815,7 @@ typedef struct CreateRangeProofArgs {
   struct Maybe_BorrowedBytes start_key;
   /**
    * The end key of the range to prove. If `None`, the range ends at the end
-   * of the keyspace or until `max_length` items have been been included in
+   * of the keyspace or until `max_length` items have been included in
    * the proof.
    *
    * If provided, end key is inclusive if not truncated. Otherwise, the end
@@ -857,15 +857,9 @@ typedef struct VerifyRangeProofArgs {
    * The upper bound of the key range that the proof is expected to cover. If
    * `None`, the proof is expected to cover to the end of the keyspace.
    *
-   * This is an upper bound on what the proof *may* cover, not an assertion
-   * that it does. A responder may truncate its reply, in which case the
-   * proven range ends at the proof's own right edge instead. Verification
-   * accepts that as a valid partial result.
-   *
-   * The apply path writes over the **proven** range, so keys between the
-   * proven edge and this bound are left untouched rather than deleted. The
-   * caller owns the remainder: use `fwd_range_proof_find_next_key` to get the
-   * next range to request, and keep going until it reports nothing left.
+   * This is a ceiling, not an assertion: a proof carrying a key above this
+   * bound is invalid, but a truncated proof may prove less and anchor at
+   * its own right edge instead.
    */
   struct Maybe_BorrowedBytes end_key;
   /**
@@ -2964,7 +2958,7 @@ struct RangeProofResult fwd_range_proof_from_bytes(BorrowedBytes bytes);
  *
  * - [`ValueResult::NullHandlePointer`] if the caller provided a null pointer.
  * - [`ValueResult::Some`] containing the serialized bytes if successful.
- * - [`ValueResult::Err`] if the caller provided a null pointer.
+ * - [`ValueResult::Err`] containing an error message if serialization panicked.
  */
 struct ValueResult fwd_range_proof_to_bytes(const struct RangeProofContext *proof);
 

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -857,8 +857,15 @@ typedef struct VerifyRangeProofArgs {
    * The upper bound of the key range that the proof is expected to cover. If
    * `None`, the proof is expected to cover to the end of the keyspace.
    *
-   * This is ignored if the proof is truncated and does not cover the full,
-   * in which case the upper bound key is the final key in the key-value pairs.
+   * This is an upper bound on what the proof *may* cover, not an assertion
+   * that it does. A responder may truncate its reply, in which case the
+   * proven range ends at the proof's own right edge instead. Verification
+   * accepts that as a valid partial result.
+   *
+   * The apply path writes over the **proven** range, so keys between the
+   * proven edge and this bound are left untouched rather than deleted. The
+   * caller owns the remainder: use `fwd_range_proof_find_next_key` to get the
+   * next range to request, and keep going until it reports nothing left.
    */
   struct Maybe_BorrowedBytes end_key;
   /**

--- a/ffi/firewood_test.go
+++ b/ffi/firewood_test.go
@@ -271,6 +271,9 @@ func valForTest(i int) []byte {
 	return []byte("value" + strconv.Itoa(i))
 }
 
+// kvForTest returns num key/value pairs and a batch that writes them. The keys
+// (and their paired values) are sorted lexicographically, so keys[:n] is the
+// trie-order prefix of the whole set for any n.
 func kvForTest(num int) ([][]byte, [][]byte, []BatchOp) {
 	keys := make([][]byte, num)
 	vals := make([][]byte, num)

--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -113,9 +113,10 @@ type ChangeProof struct {
 	handle *C.ChangeProofContext
 }
 
-// NextKeyRange represents a range of keys to fetch from the database. The start
-// key is inclusive while the end key is exclusive. If the end key is Nothing,
-// the range is unbounded in that direction.
+// NextKeyRange represents a range of keys to fetch from the database,
+// `(startKey, endKey]`: the start key is exclusive because it has already been
+// synchronized, and the end key is inclusive. If the end key is Nothing, the
+// range is unbounded in that direction.
 type NextKeyRange struct {
 	startKey *ownedBytes
 	endKey   Maybe[*ownedBytes]
@@ -201,14 +202,12 @@ func (p *RangeProof) Verify(
 // call to [*Database.VerifyAndCommitRangeProof] will skip verification and commit the
 // prepared proposal.
 //
-// The prepared proposal only covers the range the proof actually proves,
-// which can be narrower than [endKey]: a responder is allowed to truncate
-// its reply, in which case the proof anchors at its own right edge instead
-// of the requested one. Keys beyond that proven edge are left untouched
-// rather than deleted. A sync-client caller must keep calling
-// [*RangeProof.FindNextKey] and requesting, verifying, and applying the
-// ranges it returns until it returns nil, to be sure the full [startKey,
-// endKey] span has actually been synchronized.
+// The proposal replaces state across the range the proof proves: any existing
+// key in that range that the proof does not carry is deleted. The range runs
+// from [startKey] to the proof's right edge, which is [endKey] when the
+// responder covered the whole request and a smaller key when it truncated.
+// Keys past that edge are left as they are; [*RangeProof.FindNextKey] reports
+// where to resume.
 //
 // Because this method prepares a proposal, the database must be kept alive
 // until the proof is committed or freed.
@@ -260,11 +259,8 @@ func (db *Database) VerifyRangeProof(
 // new root hash is returned. The resulting root hash may not equal the
 // provided root hash if the proof was truncated due to [maxLength].
 //
-// The commit only applies the range the proof actually proves, which can be
-// narrower than [endKey] when the responder truncated its reply; keys past
-// the proven edge are left untouched rather than deleted. The caller owns
-// the remainder: keep calling [*RangeProof.FindNextKey] and requesting,
-// verifying, and committing the ranges it returns until it returns nil.
+// The commit replaces state across the proven range on the same terms as
+// [*Database.VerifyRangeProof].
 func (db *Database) VerifyAndCommitRangeProof(
 	proof *RangeProof,
 	startKey, endKey Maybe[[]byte],
@@ -655,17 +651,18 @@ func (p *ChangeProof) setFreeFinalizer() {
 	runtime.SetFinalizer(p, (*ChangeProof).Free)
 }
 
-// StartKey returns the inclusive start key of this key range.
+// StartKey returns the exclusive start key of this key range: it has already
+// been synchronized, so the next request begins strictly after it.
 func (r *NextKeyRange) StartKey() []byte {
 	return r.startKey.CopiedBytes()
 }
 
-// HasEndKey returns true if this key range has an exclusive end key.
+// HasEndKey returns true if this key range has an inclusive end key.
 func (r *NextKeyRange) HasEndKey() bool {
 	return r.endKey != nil && r.endKey.HasValue()
 }
 
-// EndKey returns the exclusive end key of this key range if it exists or nil if
+// EndKey returns the inclusive end key of this key range if it exists or nil if
 // it does not.
 func (r *NextKeyRange) EndKey() []byte {
 	if r.HasEndKey() {

--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -201,6 +201,15 @@ func (p *RangeProof) Verify(
 // call to [*Database.VerifyAndCommitRangeProof] will skip verification and commit the
 // prepared proposal.
 //
+// The prepared proposal only covers the range the proof actually proves,
+// which can be narrower than [endKey]: a responder is allowed to truncate
+// its reply, in which case the proof anchors at its own right edge instead
+// of the requested one. Keys beyond that proven edge are left untouched
+// rather than deleted. A sync-client caller must keep calling
+// [*RangeProof.FindNextKey] and requesting, verifying, and applying the
+// ranges it returns until it returns nil, to be sure the full [startKey,
+// endKey] span has actually been synchronized.
+//
 // Because this method prepares a proposal, the database must be kept alive
 // until the proof is committed or freed.
 func (db *Database) VerifyRangeProof(
@@ -250,6 +259,12 @@ func (db *Database) VerifyRangeProof(
 // [rootHash]. If the proof is valid, it is committed to the database and the
 // new root hash is returned. The resulting root hash may not equal the
 // provided root hash if the proof was truncated due to [maxLength].
+//
+// The commit only applies the range the proof actually proves, which can be
+// narrower than [endKey] when the responder truncated its reply; keys past
+// the proven edge are left untouched rather than deleted. The caller owns
+// the remainder: keep calling [*RangeProof.FindNextKey] and requesting,
+// verifying, and committing the ranges it returns until it returns nil.
 func (db *Database) VerifyAndCommitRangeProof(
 	proof *RangeProof,
 	startKey, endKey Maybe[[]byte],

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -315,24 +315,13 @@ func TestRangeProofFindNextKey(t *testing.T) {
 	// Verify the proof
 	r.NoError(db.VerifyRangeProof(proof, nothing(), nothing(), root, rangeProofLenTruncated))
 
-	// This proof was taken from db's own current state and verified against
-	// itself, so db already held everything at `root` before any merge ran.
-	// Bounding the merge to the proven range (rather than the full requested
-	// range) means merging the truncated key-values changes nothing: they
-	// already match, and the untouched tail past the proven edge is left
-	// alone. The resulting proposal's root is therefore exactly `root`,
-	// which is the FFI short-circuit's signal that the receiver is fully
-	// caught up, so FindNextKey correctly returns nil — both here, before
-	// commit, and after commit below, since the committed proposal is the
-	// same already-matching one.
-	//
-	// This assertion previously read NotNil and only held because the
-	// pre-fix apply path merged over the caller's unbounded end_key instead
-	// of the proven edge, deleting the 90 keys past the proof's coverage and
-	// corrupting db's root away from `root`. That corruption is what kept
-	// this short-circuit from ever firing, so the assertion was passing for
-	// the wrong reason. If this goes back to NotNil, the apply path is
-	// deleting data outside the proven range again.
+	// The proof was taken from db's own state, so merging it over the proven
+	// range is a no-op and the proposal keeps `root`. That equality is the
+	// FFI's "already caught up" short-circuit, so there is nothing left to
+	// fetch — before commit here and after commit below. A NotNil here means
+	// the apply path deleted outside the proven range and moved the root.
+	// TestRangeProofFindNextKeyDivergentReceiver covers a receiver that is
+	// genuinely behind.
 	nextRange, err := proof.FindNextKey()
 	r.NoError(err)
 	r.Nil(nextRange)
@@ -345,19 +334,15 @@ func TestRangeProofFindNextKey(t *testing.T) {
 	r.Nil(nextRange)
 }
 
-// TestRangeProofFindNextKeyDivergentReceiver covers the case
-// TestRangeProofFindNextKey no longer can: a receiver genuinely behind the
-// proof's target root, rather than one self-proving state it already has.
-// A truncated proof applied to an empty target must report more to fetch.
+// TestRangeProofFindNextKeyDivergentReceiver applies a truncated proof to an
+// empty target: a receiver genuinely behind the proof's root must report more
+// to fetch.
 func TestRangeProofFindNextKeyDivergentReceiver(t *testing.T) {
 	r := require.New(t)
 
 	dbSource := newTestDatabase(t)
 	dbTarget := newTestDatabase(t)
 
-	// kvForTest sorts keys (and their paired vals) lexicographically, so
-	// keys[:rangeProofLenTruncated] are exactly the trie-order prefix the
-	// truncated proof below proves.
 	keys, vals, batch := kvForTest(100)
 	sourceRoot, err := dbSource.Update(batch)
 	r.NoError(err)
@@ -368,14 +353,9 @@ func TestRangeProofFindNextKeyDivergentReceiver(t *testing.T) {
 	_, err = dbTarget.VerifyAndCommitRangeProof(proof, nothing(), nothing(), sourceRoot, rangeProofLenTruncated)
 	r.NoError(err)
 
-	// Smoke check that the merge actually writes the proven prefix into a
-	// divergent target, not just that it avoids over-deleting (that guard is
-	// TestRangeProofTruncatedDoesNotDeleteBeyondProvenEdge). This does NOT
-	// exercise proven_end's bound at all: dbTarget starts empty, so its trie
-	// iterator is exhausted before merge.rs's bound check ever runs, and
-	// every key-value is applied unconditionally regardless of the bound's
-	// value — see TestRangeProofTruncatedDeletesStaleKeyWithinProvenEdge for
-	// a test that actually discriminates a too-tight proven_end.
+	// The proven prefix is written. Against an empty target this says nothing
+	// about where the bound falls — only the sibling tests named in
+	// TestRangeProofTruncatedDeletesStaleKeyWithinProvenEdge do.
 	for i := range rangeProofLenTruncated {
 		got, err := dbTarget.Get(keys[i])
 		r.NoError(err, "Get key %d", i)
@@ -1229,10 +1209,9 @@ func TestChangeProofMarshalWorksAfterVerify(t *testing.T) {
 	r.Equal(marshalledBefore, marshalledAfter)
 }
 
-// A truncated range proof proves only a prefix of the requested range. Applying
-// it must not delete local keys past the proven edge — they are covered by no
-// proof. Regression test for the apply path bounding its write to the proven
-// edge rather than the requested end_key.
+// A truncated range proof proves only a prefix of the requested range, so
+// applying it must leave local keys past the proven edge alone: no proof covers
+// them.
 func TestRangeProofTruncatedDoesNotDeleteBeyondProvenEdge(t *testing.T) {
 	r := require.New(t)
 
@@ -1255,10 +1234,8 @@ func TestRangeProofTruncatedDoesNotDeleteBeyondProvenEdge(t *testing.T) {
 	_, err = dbTarget.VerifyAndCommitRangeProof(proof, nothing(), nothing(), sourceRoot, rangeProofLenTruncated)
 	r.NoError(err)
 
-	// Source and target held the same data, and the proof covered a prefix of
-	// it, so every original key must survive. Before the fix the apply path
-	// replaced the whole keyspace with the truncated reply and deleted the
-	// tail.
+	// Source and target held the same data and the proof covered a prefix of
+	// it, so every original key must survive.
 	for i, key := range keys {
 		got, err := dbTarget.Get(key)
 		r.NoError(err, "Get key %d", i)
@@ -1266,21 +1243,16 @@ func TestRangeProofTruncatedDoesNotDeleteBeyondProvenEdge(t *testing.T) {
 	}
 }
 
-// A truncated range proof proves that, within the proven prefix, only the
-// key-values the proof carries exist — anything else there must be deleted.
-// This is the mirror of TestRangeProofTruncatedDoesNotDeleteBeyondProvenEdge:
-// that test guards against a bound looser than the proof justifies
-// (over-deletion past the proven edge); this one guards against a bound
-// tighter than the proof justifies (under-deletion within it). A too-tight
-// proven_end stops the merge's trie scan before it reaches the synthetic
-// stale key below, leaving it in place.
+// Within the proven prefix, a range proof proves that only the key-values it
+// carries exist, so anything else there must be deleted. This is the mirror of
+// TestRangeProofTruncatedDoesNotDeleteBeyondProvenEdge, which guards a bound
+// looser than the proof justifies; a bound tighter than it justifies stops the
+// merge's trie scan short and strands the synthetic stale key below.
 //
-// TestRangeProofFindNextKeyDivergentReceiver's positive-apply check cannot
-// catch this: merge.rs's bound only ever gates the trie-side scan
-// (MergeKeyValueIter::new's stop_after_key), never the key-value side, and an
-// empty target's trie iterator is exhausted before that scan even starts —
-// every key-value gets applied regardless of the bound's value. A stale local
-// key is the only way to observe the bound at all.
+// Only a stale local key can observe the bound: it gates the trie-side scan
+// alone, so against an empty target (as in
+// TestRangeProofFindNextKeyDivergentReceiver) every key-value is applied
+// whatever the bound is.
 func TestRangeProofTruncatedDeletesStaleKeyWithinProvenEdge(t *testing.T) {
 	r := require.New(t)
 
@@ -1295,12 +1267,9 @@ func TestRangeProofTruncatedDeletesStaleKeyWithinProvenEdge(t *testing.T) {
 	_, err = dbTarget.Update(batch)
 	r.NoError(err)
 
-	// A key present only in dbTarget: a proper extension of keys[0], which
-	// therefore sorts strictly after it, and — verified below rather than
-	// assumed, since kvForTest's lexicographic order need not match
-	// insertion order — strictly before the proven edge at
-	// keys[rangeProofLenTruncated-1]. It is absent from the proof's
-	// key-values, so a correctly-bounded merge must delete it.
+	// A key present only in dbTarget, and absent from the proof's key-values,
+	// so a correctly-bounded merge must delete it. The assertions pin it inside
+	// the proven range rather than assuming it.
 	staleKey := append(append([]byte{}, keys[0]...), 0)
 	r.Negative(bytes.Compare(keys[0], staleKey), "synthetic key must sort after keys[0]")
 	r.Negative(bytes.Compare(staleKey, keys[rangeProofLenTruncated-1]),

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -4,6 +4,7 @@
 package ffi
 
 import (
+	"bytes"
 	"encoding/hex"
 	"runtime"
 	"sync"
@@ -314,23 +315,80 @@ func TestRangeProofFindNextKey(t *testing.T) {
 	// Verify the proof
 	r.NoError(db.VerifyRangeProof(proof, nothing(), nothing(), root, rangeProofLenTruncated))
 
-	// Now FindNextKey should work
+	// This proof was taken from db's own current state and verified against
+	// itself, so db already held everything at `root` before any merge ran.
+	// Bounding the merge to the proven range (rather than the full requested
+	// range) means merging the truncated key-values changes nothing: they
+	// already match, and the untouched tail past the proven edge is left
+	// alone. The resulting proposal's root is therefore exactly `root`,
+	// which is the FFI short-circuit's signal that the receiver is fully
+	// caught up, so FindNextKey correctly returns nil — both here, before
+	// commit, and after commit below, since the committed proposal is the
+	// same already-matching one.
+	//
+	// This assertion previously read NotNil and only held because the
+	// pre-fix apply path merged over the caller's unbounded end_key instead
+	// of the proven edge, deleting the 90 keys past the proof's coverage and
+	// corrupting db's root away from `root`. That corruption is what kept
+	// this short-circuit from ever firing, so the assertion was passing for
+	// the wrong reason. If this goes back to NotNil, the apply path is
+	// deleting data outside the proven range again.
+	nextRange, err := proof.FindNextKey()
+	r.NoError(err)
+	r.Nil(nextRange)
+
+	_, err = db.VerifyAndCommitRangeProof(proof, nothing(), nothing(), root, rangeProofLenTruncated)
+	r.NoError(err)
+
+	nextRange, err = proof.FindNextKey()
+	r.NoError(err)
+	r.Nil(nextRange)
+}
+
+// TestRangeProofFindNextKeyDivergentReceiver covers the case
+// TestRangeProofFindNextKey no longer can: a receiver genuinely behind the
+// proof's target root, rather than one self-proving state it already has.
+// A truncated proof applied to an empty target must report more to fetch.
+func TestRangeProofFindNextKeyDivergentReceiver(t *testing.T) {
+	r := require.New(t)
+
+	dbSource := newTestDatabase(t)
+	dbTarget := newTestDatabase(t)
+
+	// kvForTest sorts keys (and their paired vals) lexicographically, so
+	// keys[:rangeProofLenTruncated] are exactly the trie-order prefix the
+	// truncated proof below proves.
+	keys, vals, batch := kvForTest(100)
+	sourceRoot, err := dbSource.Update(batch)
+	r.NoError(err)
+
+	// dbTarget starts empty, so it is materially behind sourceRoot.
+	proof := newVerifiedRangeProof(t, dbSource, sourceRoot, nothing(), nothing(), rangeProofLenTruncated)
+
+	_, err = dbTarget.VerifyAndCommitRangeProof(proof, nothing(), nothing(), sourceRoot, rangeProofLenTruncated)
+	r.NoError(err)
+
+	// Smoke check that the merge actually writes the proven prefix into a
+	// divergent target, not just that it avoids over-deleting (that guard is
+	// TestRangeProofTruncatedDoesNotDeleteBeyondProvenEdge). This does NOT
+	// exercise proven_end's bound at all: dbTarget starts empty, so its trie
+	// iterator is exhausted before merge.rs's bound check ever runs, and
+	// every key-value is applied unconditionally regardless of the bound's
+	// value — see TestRangeProofTruncatedDeletesStaleKeyWithinProvenEdge for
+	// a test that actually discriminates a too-tight proven_end.
+	for i := range rangeProofLenTruncated {
+		got, err := dbTarget.Get(keys[i])
+		r.NoError(err, "Get key %d", i)
+		r.Equal(vals[i], got, "key %d from the proven prefix was not applied", i)
+	}
+
+	// The truncated proof only proved a prefix, and dbTarget started with
+	// none of the data, so there is genuinely more to fetch.
 	nextRange, err := proof.FindNextKey()
 	r.NoError(err)
 	r.NotNil(nextRange)
 	startKey := nextRange.StartKey()
 	r.NotEmpty(startKey)
-	startKey = append([]byte{}, startKey...) // copy to new slice to avoid use-after-free
-	r.NoError(nextRange.Free())
-
-	_, err = db.VerifyAndCommitRangeProof(proof, nothing(), nothing(), root, rangeProofLenTruncated)
-	r.NoError(err)
-
-	// FindNextKey should still work after commit
-	nextRange, err = proof.FindNextKey()
-	r.NoError(err)
-	r.NotNil(nextRange)
-	r.Equal(nextRange.StartKey(), startKey)
 	r.NoError(nextRange.Free())
 }
 
@@ -1169,4 +1227,93 @@ func TestChangeProofMarshalWorksAfterVerify(t *testing.T) {
 	marshalledAfter, err := changeProof.MarshalBinary()
 	r.NoError(err)
 	r.Equal(marshalledBefore, marshalledAfter)
+}
+
+// A truncated range proof proves only a prefix of the requested range. Applying
+// it must not delete local keys past the proven edge — they are covered by no
+// proof. Regression test for the apply path bounding its write to the proven
+// edge rather than the requested end_key.
+func TestRangeProofTruncatedDoesNotDeleteBeyondProvenEdge(t *testing.T) {
+	r := require.New(t)
+
+	dbSource := newTestDatabase(t)
+	dbTarget := newTestDatabase(t)
+
+	keys, vals, batch := kvForTest(50)
+
+	sourceRoot, err := dbSource.Update(batch)
+	r.NoError(err)
+
+	// Seed the target with identical data, so it holds keys past the edge a
+	// truncated reply will prove. Nothing here should be deleted.
+	_, err = dbTarget.Update(batch)
+	r.NoError(err)
+
+	// Request the whole keyspace but cap the reply, forcing truncation.
+	proof := newVerifiedRangeProof(t, dbSource, sourceRoot, nothing(), nothing(), rangeProofLenTruncated)
+
+	_, err = dbTarget.VerifyAndCommitRangeProof(proof, nothing(), nothing(), sourceRoot, rangeProofLenTruncated)
+	r.NoError(err)
+
+	// Source and target held the same data, and the proof covered a prefix of
+	// it, so every original key must survive. Before the fix the apply path
+	// replaced the whole keyspace with the truncated reply and deleted the
+	// tail.
+	for i, key := range keys {
+		got, err := dbTarget.Get(key)
+		r.NoError(err, "Get key %d", i)
+		r.Equal(vals[i], got, "key %d was deleted or altered by a proof that never covered it", i)
+	}
+}
+
+// A truncated range proof proves that, within the proven prefix, only the
+// key-values the proof carries exist — anything else there must be deleted.
+// This is the mirror of TestRangeProofTruncatedDoesNotDeleteBeyondProvenEdge:
+// that test guards against a bound looser than the proof justifies
+// (over-deletion past the proven edge); this one guards against a bound
+// tighter than the proof justifies (under-deletion within it). A too-tight
+// proven_end stops the merge's trie scan before it reaches the synthetic
+// stale key below, leaving it in place.
+//
+// TestRangeProofFindNextKeyDivergentReceiver's positive-apply check cannot
+// catch this: merge.rs's bound only ever gates the trie-side scan
+// (MergeKeyValueIter::new's stop_after_key), never the key-value side, and an
+// empty target's trie iterator is exhausted before that scan even starts —
+// every key-value gets applied regardless of the bound's value. A stale local
+// key is the only way to observe the bound at all.
+func TestRangeProofTruncatedDeletesStaleKeyWithinProvenEdge(t *testing.T) {
+	r := require.New(t)
+
+	dbSource := newTestDatabase(t)
+	dbTarget := newTestDatabase(t)
+
+	keys, _, batch := kvForTest(50)
+
+	sourceRoot, err := dbSource.Update(batch)
+	r.NoError(err)
+
+	_, err = dbTarget.Update(batch)
+	r.NoError(err)
+
+	// A key present only in dbTarget: a proper extension of keys[0], which
+	// therefore sorts strictly after it, and — verified below rather than
+	// assumed, since kvForTest's lexicographic order need not match
+	// insertion order — strictly before the proven edge at
+	// keys[rangeProofLenTruncated-1]. It is absent from the proof's
+	// key-values, so a correctly-bounded merge must delete it.
+	staleKey := append(append([]byte{}, keys[0]...), 0)
+	r.Negative(bytes.Compare(keys[0], staleKey), "synthetic key must sort after keys[0]")
+	r.Negative(bytes.Compare(staleKey, keys[rangeProofLenTruncated-1]),
+		"synthetic key must sort inside the proven range")
+	_, err = dbTarget.Update([]BatchOp{Put(staleKey, []byte("stale"))})
+	r.NoError(err)
+
+	proof := newVerifiedRangeProof(t, dbSource, sourceRoot, nothing(), nothing(), rangeProofLenTruncated)
+
+	_, err = dbTarget.VerifyAndCommitRangeProof(proof, nothing(), nothing(), sourceRoot, rangeProofLenTruncated)
+	r.NoError(err)
+
+	got, err := dbTarget.Get(staleKey)
+	r.NoError(err)
+	r.Nil(got, "stale key inside the proven range should have been deleted")
 }

--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -26,7 +26,7 @@ pub struct CreateRangeProofArgs<'a> {
     /// The start key must be less than the end key if both are provided.
     pub start_key: Maybe<BorrowedBytes<'a>>,
     /// The end key of the range to prove. If `None`, the range ends at the end
-    /// of the keyspace or until `max_length` items have been been included in
+    /// of the keyspace or until `max_length` items have been included in
     /// the proof.
     ///
     /// If provided, end key is inclusive if not truncated. Otherwise, the end
@@ -58,15 +58,9 @@ pub struct VerifyRangeProofArgs<'a, 'db> {
     /// The upper bound of the key range that the proof is expected to cover. If
     /// `None`, the proof is expected to cover to the end of the keyspace.
     ///
-    /// This is an upper bound on what the proof *may* cover, not an assertion
-    /// that it does. A responder may truncate its reply, in which case the
-    /// proven range ends at the proof's own right edge instead. Verification
-    /// accepts that as a valid partial result.
-    ///
-    /// The apply path writes over the **proven** range, so keys between the
-    /// proven edge and this bound are left untouched rather than deleted. The
-    /// caller owns the remainder: use `fwd_range_proof_find_next_key` to get the
-    /// next range to request, and keep going until it reports nothing left.
+    /// This is a ceiling, not an assertion: a proof carrying a key above this
+    /// bound is invalid, but a truncated proof may prove less and anchor at
+    /// its own right edge instead.
     pub end_key: Maybe<BorrowedBytes<'a>>,
     /// The maximum number of key/value pairs that the proof is expected to cover.
     /// If the proof contains more items than this, it is considered invalid. If
@@ -74,7 +68,7 @@ pub struct VerifyRangeProofArgs<'a, 'db> {
     pub max_length: u32,
 }
 
-/// FFI context for for a parsed or generated range proof.
+/// FFI context for a parsed or generated range proof.
 #[derive(Debug)]
 pub struct RangeProofContext<'db> {
     proof: FrozenRangeProof,
@@ -151,19 +145,13 @@ impl<'db> RangeProofContext<'db> {
         Ok(())
     }
 
-    /// Returns the upper bound of the range the proof actually proves.
+    /// Returns the inclusive upper bound of the range the proof actually
+    /// proves, which may be narrower than the requested `end_key`. `None`
+    /// means proven to the end of the keyspace.
     ///
-    /// The responder may have truncated its reply, in which case
-    /// `(right_edge_key, end_key]` carries no proof — merging over the
-    /// caller's requested `end_key` instead of this bound would delete local
-    /// keys the proof never mentioned.
+    /// # Panics
     ///
-    /// `right_edge_key == None` legitimately means "proven to the end of the
-    /// keyspace", so this must not fall back to `None` when the verification
-    /// context is missing: that would authorise deleting the whole tail
-    /// instead of correctly reporting an unbounded proven range. A successful
-    /// [`Self::verify`] guarantees the context is populated, which is why
-    /// this asserts with `expect` rather than degrading to that default.
+    /// Panics unless [`Self::verify`] has succeeded first.
     fn proven_end(&self) -> Option<&[u8]> {
         self.verification
             .as_ref()
@@ -211,7 +199,7 @@ impl<'db> RangeProofContext<'db> {
     /// prepared, it is committed instead of preparing a new one.
     ///
     /// However, if the prepared proposal is no longer valid (e.g., the
-    /// database has changed since it was prepared), the proposal is discared
+    /// database has changed since it was prepared), the proposal is discarded
     /// and a just-in-time proposal is created and committed.
     ///
     /// After committing or if the proof has already been committed, the
@@ -266,7 +254,7 @@ impl<'db> RangeProofContext<'db> {
     /// Returns the next key range that should be fetched after processing this
     /// range proof, or [`None`] if there are no more keys to fetch.
     ///
-    /// The returned key range represents `(finalKey, endKey]` where finalKey is
+    /// The returned key range represents `(finalKey, endKey]` where `finalKey`
     /// is the last key known to be fully synchronized within the requested
     /// range. `finalKey` is exclusive, meaning it has already been processed.
     /// `endKey` is inclusive if provided during proof creation.
@@ -566,7 +554,7 @@ pub extern "C" fn fwd_range_proof_code_hash_iter<'a>(
 ///
 /// - [`ValueResult::NullHandlePointer`] if the caller provided a null pointer.
 /// - [`ValueResult::Some`] containing the serialized bytes if successful.
-/// - [`ValueResult::Err`] if the caller provided a null pointer.
+/// - [`ValueResult::Err`] containing an error message if serialization panicked.
 #[unsafe(no_mangle)]
 pub extern "C" fn fwd_range_proof_to_bytes(proof: Option<&RangeProofContext>) -> ValueResult {
     crate::invoke_with_handle(proof, |ctx| {

--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -58,8 +58,15 @@ pub struct VerifyRangeProofArgs<'a, 'db> {
     /// The upper bound of the key range that the proof is expected to cover. If
     /// `None`, the proof is expected to cover to the end of the keyspace.
     ///
-    /// This is ignored if the proof is truncated and does not cover the full,
-    /// in which case the upper bound key is the final key in the key-value pairs.
+    /// This is an upper bound on what the proof *may* cover, not an assertion
+    /// that it does. A responder may truncate its reply, in which case the
+    /// proven range ends at the proof's own right edge instead. Verification
+    /// accepts that as a valid partial result.
+    ///
+    /// The apply path writes over the **proven** range, so keys between the
+    /// proven edge and this bound are left untouched rather than deleted. The
+    /// caller owns the remainder: use `fwd_range_proof_find_next_key` to get the
+    /// next range to request, and keep going until it reports nothing left.
     pub end_key: Maybe<BorrowedBytes<'a>>,
     /// The maximum number of key/value pairs that the proof is expected to cover.
     /// If the proof contains more items than this, it is considered invalid. If
@@ -144,6 +151,27 @@ impl<'db> RangeProofContext<'db> {
         Ok(())
     }
 
+    /// Returns the upper bound of the range the proof actually proves.
+    ///
+    /// The responder may have truncated its reply, in which case
+    /// `(right_edge_key, end_key]` carries no proof — merging over the
+    /// caller's requested `end_key` instead of this bound would delete local
+    /// keys the proof never mentioned.
+    ///
+    /// `right_edge_key == None` legitimately means "proven to the end of the
+    /// keyspace", so this must not fall back to `None` when the verification
+    /// context is missing: that would authorise deleting the whole tail
+    /// instead of correctly reporting an unbounded proven range. A successful
+    /// [`Self::verify`] guarantees the context is populated, which is why
+    /// this asserts with `expect` rather than degrading to that default.
+    fn proven_end(&self) -> Option<&[u8]> {
+        self.verification
+            .as_ref()
+            .expect("verify() populates the verification context on success")
+            .right_edge_key
+            .as_deref()
+    }
+
     /// Verify the range proof and prepare a proposal against the given database
     /// without committing it.
     ///
@@ -169,7 +197,8 @@ impl<'db> RangeProofContext<'db> {
             return Ok(());
         }
 
-        let proposal = db.merge_key_value_range(start_key, end_key, self.proof.key_values())?;
+        let proven_end = self.proven_end();
+        let proposal = db.merge_key_value_range(start_key, proven_end, self.proof.key_values())?;
         self.proposal_state = Some(ProposalState::Proposed(proposal.handle));
 
         Ok(())
@@ -207,7 +236,8 @@ impl<'db> RangeProofContext<'db> {
             Some(ProposalState::Proposed(proposal)) => proposal,
             None => {
                 allow_rebase = false;
-                db.merge_key_value_range(start_key, end_key, self.proof.key_values())?
+                let proven_end = self.proven_end();
+                db.merge_key_value_range(start_key, proven_end, self.proof.key_values())?
                     .handle
             }
         };
@@ -217,8 +247,9 @@ impl<'db> RangeProofContext<'db> {
             && allow_rebase
         {
             // proposal is stale, try rebasing and committing again
+            let proven_end = self.proven_end();
             let proposal_handle = db
-                .merge_key_value_range(start_key, end_key, self.proof.key_values())?
+                .merge_key_value_range(start_key, proven_end, self.proof.key_values())?
                 .handle;
             proposal_handle.commit_proposal()
         } else {

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -410,8 +410,28 @@ impl<H: HashMode> Db<H> {
     /// the range that are not present in the provided key-values will be deleted,
     /// any duplicate keys will be overwritten, and any new keys will be inserted.
     ///
+    /// # Bounds must be proven, not requested
+    ///
+    /// When the key-values come from a verified range proof, `last_key` must be
+    /// the proof's **proven** right edge — [`ProvenRange::end`], surfaced as
+    /// [`RangeProofVerificationContext::right_edge_key`] — and not the bound the
+    /// caller requested. A truncated reply proves a narrower range than was
+    /// asked for, and the deletion above is unconditional: passing the requested
+    /// bound erases every local key in the uncovered span.
+    ///
+    /// If the proven edge is narrower than what was requested, the keys past it
+    /// are not yet proven, and this call leaves them untouched. Request the
+    /// next slice with [`find_next_key_after_range_proof`], verify it, and
+    /// merge it the same way; repeat until that call reports nothing left. The
+    /// next reply can be truncated again, so a single continuation is not
+    /// guaranteed to finish the job — plan for a loop, not one extra round trip.
+    ///
     /// Invariant: `key_values` must be sorted by key in ascending order; however,
     /// because debug assertions are disabled, this is not checked.
+    ///
+    /// [`ProvenRange::end`]: crate::ProvenRange::end
+    /// [`RangeProofVerificationContext::right_edge_key`]: crate::RangeProofVerificationContext::right_edge_key
+    /// [`find_next_key_after_range_proof`]: crate::find_next_key_after_range_proof
     pub fn merge_key_value_range(
         &self,
         first_key: Option<impl KeyType>,
@@ -432,6 +452,9 @@ impl<H: HashMode> Db<H> {
     /// the provided key-values from the iterator. I.e., any existing keys within
     /// the range that are not present in the provided key-values will be deleted,
     /// any duplicate keys will be overwritten, and any new keys will be inserted.
+    ///
+    /// See [`Db::merge_key_value_range`] for the proven-vs-requested bound obligation, which
+    /// applies identically here.
     ///
     /// Invariant: `key_values` must be sorted by key in ascending order; however,
     /// because debug assertions are disabled, this is not checked.

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -410,27 +410,18 @@ impl<H: HashMode> Db<H> {
     /// the range that are not present in the provided key-values will be deleted,
     /// any duplicate keys will be overwritten, and any new keys will be inserted.
     ///
-    /// # Bounds must be proven, not requested
-    ///
-    /// When the key-values come from a verified range proof, `last_key` must be
-    /// the proof's **proven** right edge — [`ProvenRange::end`], surfaced as
-    /// [`RangeProofVerificationContext::right_edge_key`] — and not the bound the
-    /// caller requested. A truncated reply proves a narrower range than was
-    /// asked for, and the deletion above is unconditional: passing the requested
-    /// bound erases every local key in the uncovered span.
-    ///
-    /// If the proven edge is narrower than what was requested, the keys past it
-    /// are not yet proven, and this call leaves them untouched. Request the
-    /// next slice with [`find_next_key_after_range_proof`], verify it, and
-    /// merge it the same way; repeat until that call reports nothing left. The
-    /// next reply can be truncated again, so a single continuation is not
-    /// guaranteed to finish the job — plan for a loop, not one extra round trip.
+    /// Because that deletion is unconditional, `last_key` must be a bound the
+    /// caller can justify. When the key-values come from a verified range
+    /// proof, that is the proof's proven right edge ([`ProvenRange::end`]) and
+    /// not the bound the caller requested: a truncated reply proves less than
+    /// was asked for, and merging to the requested bound erases every local key
+    /// in the span the proof never covered. Cover the remainder by iterating
+    /// [`find_next_key_after_range_proof`] — each reply can truncate again.
     ///
     /// Invariant: `key_values` must be sorted by key in ascending order; however,
     /// because debug assertions are disabled, this is not checked.
     ///
     /// [`ProvenRange::end`]: crate::ProvenRange::end
-    /// [`RangeProofVerificationContext::right_edge_key`]: crate::RangeProofVerificationContext::right_edge_key
     /// [`find_next_key_after_range_proof`]: crate::find_next_key_after_range_proof
     pub fn merge_key_value_range(
         &self,
@@ -453,8 +444,7 @@ impl<H: HashMode> Db<H> {
     /// the range that are not present in the provided key-values will be deleted,
     /// any duplicate keys will be overwritten, and any new keys will be inserted.
     ///
-    /// See [`Db::merge_key_value_range`] for the proven-vs-requested bound obligation, which
-    /// applies identically here.
+    /// See [`Db::merge_key_value_range`] for the obligation `last_key` carries.
     ///
     /// Invariant: `key_values` must be sorted by key in ascending order; however,
     /// because debug assertions are disabled, this is not checked.

--- a/firewood/src/lib.rs
+++ b/firewood/src/lib.rs
@@ -161,7 +161,7 @@ pub mod eth_proof;
 // Re-export commonly used proof types at the crate root for ergonomic access
 pub use eth_proof::account_code_hash;
 pub use eth_proof::{EthProof, EthStorageProof, eth_get_proof};
-pub use merkle::{Key, Value, verify_change_proof_root_hash, verify_range_proof};
+pub use merkle::{Key, ProvenRange, Value, verify_change_proof_root_hash, verify_range_proof};
 pub use proofs::{
     ChangeProof, ChangeProofVerificationContext, EmptyProofCollection, InvalidHeader, KeyRange,
     Proof, ProofCollection, ProofEdge, ProofError, ProofNode, ProofType, RangeProof,

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -242,18 +242,14 @@ impl RightBoundary<'_> {
     }
 }
 
-/// The key range a verified range proof actually proves.
+/// The inclusive key range a verified range proof actually proves, returned by
+/// [`verify_range_proof`]. `None` on either side means unbounded.
 ///
-/// Returned by [`verify_range_proof`]. `start` is always the caller's
-/// requested lower bound: anchored there by `verify_edge` when a start proof
-/// is present, and by the root-hash reconstruction otherwise. `end` is the
-/// upper bound the end proof anchors at, which may be **narrower** than the
-/// caller's requested bound when the responder truncated its reply. `None`
-/// on either side means unbounded.
-///
-/// A caller applying the proof must replace state over *this* range, not
-/// over the range it requested. Keys in `(end, requested_end]` are not
-/// covered by the proof, and deleting them is unproven data loss.
+/// `start` is always the caller's requested lower bound. `end` is the bound the
+/// end proof anchors at, which is **narrower** than the requested one when the
+/// responder truncated its reply. Callers that replace state from a proof must
+/// bound the write to this range — see
+/// [`Db::merge_key_value_range`](crate::db::Db::merge_key_value_range).
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 #[must_use]
@@ -888,11 +884,8 @@ fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Result<(), Proo
 /// key scenario (`test_dropped_trailing_key_accepted_as_partial_coverage`)
 /// is the canonical case, since the attacker shrunk it on purpose. This is
 /// a *valid* outcome, not a verification error: [`verify_range_proof`]
-/// reports the narrower bound via [`ProvenRange`], and the caller continues
-/// with [`find_next_key_after_range_proof`]. No data is hidden — at most
-/// one extra round trip is induced, and the attacker gains nothing.
-///
-/// [`find_next_key_after_range_proof`]: crate::find_next_key_after_range_proof
+/// reports the narrower bound via [`ProvenRange`]. No data is hidden — at
+/// most one extra round trip is induced, and the attacker gains nothing.
 ///
 /// # Why we still take `fallback_last`
 ///
@@ -982,20 +975,12 @@ fn right_edge<'a>(
 ///
 /// # Returns
 ///
-/// The [`ProvenRange`] the proof establishes. A successful return does
-/// **not** guarantee that the proof covered the caller's full requested
-/// range `[first_key, last_key]`: the proof generator may have truncated
-/// the response (e.g. hit a max-length limit), in which case `end` is
-/// **narrower** than `last_key`. This is a valid outcome of verification,
-/// not an error.
-///
-/// A caller that applies the proof must bound the write to the returned
-/// range; the span past it is unproven. Continue with
-/// [`find_next_key_after_range_proof`] to cover the remainder — the next
-/// reply can be truncated again, so plan for a loop, not one extra round
-/// trip.
-///
-/// [`find_next_key_after_range_proof`]: crate::find_next_key_after_range_proof
+/// The [`ProvenRange`] the proof establishes. Success does **not** mean the
+/// proof covered the requested `[first_key, last_key]`: a generator that
+/// truncated its response (e.g. hit a max-length limit) yields a `ProvenRange`
+/// whose `end` is narrower than `last_key`. That is a valid outcome of
+/// verification, not an error, and the returned range is what the caller may
+/// act on.
 ///
 /// # Node Hashing Algorithm
 ///

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -242,6 +242,55 @@ impl RightBoundary<'_> {
     }
 }
 
+/// The key range a verified range proof actually proves.
+///
+/// Returned by [`verify_range_proof`]. `start` is always the caller's
+/// requested lower bound: anchored there by `verify_edge` when a start proof
+/// is present, and by the root-hash reconstruction otherwise. `end` is the
+/// upper bound the end proof anchors at, which may be **narrower** than the
+/// caller's requested bound when the responder truncated its reply. `None`
+/// on either side means unbounded.
+///
+/// A caller applying the proof must replace state over *this* range, not
+/// over the range it requested. Keys in `(end, requested_end]` are not
+/// covered by the proof, and deleting them is unproven data loss.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+#[must_use]
+pub struct ProvenRange {
+    /// The proven inclusive lower bound. `None` means unbounded below.
+    pub start: Option<Box<[u8]>>,
+    /// The proven inclusive upper bound. `None` means unbounded above.
+    pub end: Option<Box<[u8]>>,
+}
+
+/// Reduce a [`RightBoundary`] to the inclusive upper bound the proof proves.
+///
+/// `InRange(b)` proves `[start, b]`, so `b` is the answer directly, and
+/// `InRange(None)` is unbounded. `OutOfRange(k)` proves `[start, k)` — `k`
+/// itself sits outside — so the inclusive answer is the caller's requested
+/// bound when it sorts below `k` (the whole request is covered), and
+/// otherwise `last_kv`, the largest key the proof positively reports.
+///
+/// That `OutOfRange` fallback is deliberately conservative. The span
+/// `(last_kv, k)` is genuinely proven empty, but expressing it as an
+/// *inclusive* bound needs the byte-string predecessor of `k`, which has no
+/// short representation. Under-reporting costs at most one extra round trip.
+/// Over-reporting would authorise unproven deletions.
+fn proven_right_edge(
+    boundary: &RightBoundary<'_>,
+    last_kv: Option<&[u8]>,
+    requested_end: Option<&[u8]>,
+) -> Option<Box<[u8]>> {
+    match boundary {
+        RightBoundary::InRange(bound) => bound.map(Box::from),
+        RightBoundary::OutOfRange(k) => match requested_end {
+            Some(end) if end < k.as_ref() => Some(Box::from(end)),
+            _ => last_kv.map(Box::from),
+        },
+    }
+}
+
 impl EdgeBoundary<'_> {
     fn boundary_key(&self) -> Option<&[u8]> {
         match self {
@@ -838,11 +887,12 @@ fn reject_odd_nibble_value_digests(proof_nodes: &[ProofNode]) -> Result<(), Proo
 /// strictly narrower than what the caller requested — the dropped-trailing-
 /// key scenario (`test_dropped_trailing_key_accepted_as_partial_coverage`)
 /// is the canonical case, since the attacker shrunk it on purpose. This is
-/// a *valid* outcome, not a verification error. The caller is expected to
-/// compare `key_values.last()` against their requested `last_key`; if the
-/// proven range is narrower, they re-request `(last_kv, last_key]`. No data
-/// is hidden — at most one extra round trip is induced, and the attacker
-/// gains nothing.
+/// a *valid* outcome, not a verification error: [`verify_range_proof`]
+/// reports the narrower bound via [`ProvenRange`], and the caller continues
+/// with [`find_next_key_after_range_proof`]. No data is hidden — at most
+/// one extra round trip is induced, and the attacker gains nothing.
+///
+/// [`find_next_key_after_range_proof`]: crate::find_next_key_after_range_proof
 ///
 /// # Why we still take `fallback_last`
 ///
@@ -930,21 +980,22 @@ fn right_edge<'a>(
 /// 5. **Root hash comparison**: Verify the reconstructed trie's root hash matches the
 ///    expected hash
 ///
-/// # Partial coverage
+/// # Returns
 ///
-/// A successful return does **not** guarantee that the proof covered the
-/// caller's full requested range `[first_key, last_key]`. The proof
-/// generator may have truncated the response (e.g. hit a max-length limit),
-/// in which case the proven range is `[first_key, key_values.last()]` with
-/// `key_values.last() < last_key`. This is a valid outcome of verification,
+/// The [`ProvenRange`] the proof establishes. A successful return does
+/// **not** guarantee that the proof covered the caller's full requested
+/// range `[first_key, last_key]`: the proof generator may have truncated
+/// the response (e.g. hit a max-length limit), in which case `end` is
+/// **narrower** than `last_key`. This is a valid outcome of verification,
 /// not an error.
 ///
-/// Callers who need the full requested range must compare
-/// `proof.key_values().last()` against their requested `last_key` after a
-/// successful verification. If the proven right edge is short, re-request
-/// `(key_values.last(), last_key]` and verify that next slice. Iterating
-/// this loop is the canonical way to assemble full-range coverage from
-/// truncated proofs.
+/// A caller that applies the proof must bound the write to the returned
+/// range; the span past it is unproven. Continue with
+/// [`find_next_key_after_range_proof`] to cover the remainder — the next
+/// reply can be truncated again, so plan for a loop, not one extra round
+/// trip.
+///
+/// [`find_next_key_after_range_proof`]: crate::find_next_key_after_range_proof
 ///
 /// # Node Hashing Algorithm
 ///
@@ -966,7 +1017,7 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     root_hash: &TrieHash,
     algorithm: NodeHashAlgorithm,
     proof: &RangeProof<impl KeyType, impl ValueType, H>,
-) -> Result<(), api::Error> {
+) -> Result<ProvenRange, api::Error> {
     // Reject a proof whose self-describing mode disagrees with the caller's
     // expectation before hashing it with that expected algorithm.
     if proof.hash_mode() != algorithm {
@@ -1110,6 +1161,13 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
         key_values,
     )?;
 
+    // Build the proven range before `right_boundary` is moved into the
+    // root-hash check below.
+    let proven = ProvenRange {
+        start: first_key_bytes.map(Box::from),
+        end: proven_right_edge(&right_boundary, last_kv_bytes, last_key_bytes),
+    };
+
     match algorithm {
         NodeHashAlgorithm::Ethereum => verify_range_proof_root_hash::<H, EthHash>(
             &all_proof_nodes,
@@ -1127,7 +1185,9 @@ pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
             right_boundary,
             root_hash,
         ),
-    }
+    }?;
+
+    Ok(proven)
 }
 
 /// Verifies that proof nodes with values within the range are included in `key_values`.

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -239,12 +239,12 @@ fn assert_range_proof_roundtrips(
     root_hash: &TrieHash,
     range_proof: &crate::api::FrozenRangeProof,
 ) {
-    verify_range_proof(first, last, root_hash, range_proof).unwrap();
+    let _ = verify_range_proof(first, last, root_hash, range_proof).unwrap();
 
     let mut serialized = Vec::new();
     range_proof.write_to_vec(&mut serialized);
     let deserialized = crate::api::FrozenRangeProof::from_slice(&serialized).unwrap();
-    verify_range_proof(first, last, root_hash, &deserialized).unwrap();
+    let _ = verify_range_proof(first, last, root_hash, &deserialized).unwrap();
 }
 
 /// The pieces a fold test needs from [`build_account_trie`].
@@ -495,7 +495,7 @@ fn test_range_proof_accounts_have_computed_storage_root() {
         .unwrap();
 
     // The range proof must verify against the committed root hash.
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(left_key.as_ref()),
         Some(right_key.as_ref()),
         &root_hash,
@@ -659,7 +659,7 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
         .collect();
 
     let range_proof = RangeProof::new(start_proof, end_proof, key_values);
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(left_key.as_ref()),
         Some(right_key.as_ref()),
         &root_hash,
@@ -719,7 +719,7 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
         .range_proof(Some(left_key.as_ref()), Some(right_key.as_ref()), None)
         .unwrap();
 
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(left_key.as_ref()),
         Some(right_key.as_ref()),
         &root_hash,

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -603,8 +603,8 @@ fn zero_storage_root_in_rlp(value: &[u8], replacement: &[u8; 32]) -> Vec<u8> {
 /// root hash, but stale zeros in the stored account values.
 ///
 /// Then generate a range proof and verify it still passes. The proof-time fix
-/// in `ProofNode::from()` should detect the zeros and recompute the correct
-/// storageRoot from the node's children.
+/// in `ProofNode::from_path_item` should detect the zeros and recompute the
+/// correct storageRoot from the node's children.
 #[test]
 fn test_range_proof_fixes_legacy_zeroed_storage_root() {
     use crate::RangeProof;

--- a/firewood/src/merkle/tests/ethhash.rs
+++ b/firewood/src/merkle/tests/ethhash.rs
@@ -3,7 +3,7 @@
 
 use crate::api::OptionalHashKeyExt;
 use crate::merkle::Merkle;
-use firewood_storage::{Committed, DefaultHashMode, DeletedNodeTracking, MemStore, NodeStore};
+use firewood_storage::{Committed, DeletedNodeTracking, MemStore, NodeStore};
 
 use super::*;
 use ethereum_types::H256;
@@ -11,6 +11,16 @@ use hash_db::Hasher;
 use plain_hasher::PlainHasher;
 use sha3::{Digest, Keccak256};
 use test_case::test_case;
+
+fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
+    first_key: Option<impl KeyType>,
+    last_key: Option<impl KeyType>,
+    root_hash: &TrieHash,
+    proof: &RangeProof<impl KeyType, impl ValueType, H>,
+) -> Result<(), Error> {
+    crate::merkle::verify_range_proof(first_key, last_key, root_hash, EthHash::ALGORITHM, proof)
+        .map(drop)
+}
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KeccakHasher;
@@ -239,12 +249,11 @@ fn assert_range_proof_roundtrips(
     root_hash: &TrieHash,
     range_proof: &crate::api::FrozenRangeProof,
 ) {
-    let _ = verify_range_proof(first, last, root_hash, range_proof).unwrap();
-
+    verify_range_proof(first, last, root_hash, range_proof).unwrap();
     let mut serialized = Vec::new();
     range_proof.write_to_vec(&mut serialized);
     let deserialized = crate::api::FrozenRangeProof::from_slice(&serialized).unwrap();
-    let _ = verify_range_proof(first, last, root_hash, &deserialized).unwrap();
+    verify_range_proof(first, last, root_hash, &deserialized).unwrap();
 }
 
 /// The pieces a fold test needs from [`build_account_trie`].
@@ -495,7 +504,7 @@ fn test_range_proof_accounts_have_computed_storage_root() {
         .unwrap();
 
     // The range proof must verify against the committed root hash.
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(left_key.as_ref()),
         Some(right_key.as_ref()),
         &root_hash,
@@ -659,7 +668,7 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
         .collect();
 
     let range_proof = RangeProof::new(start_proof, end_proof, key_values);
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(left_key.as_ref()),
         Some(right_key.as_ref()),
         &root_hash,
@@ -719,7 +728,7 @@ fn test_range_proof_fixes_legacy_zeroed_storage_root() {
         .range_proof(Some(left_key.as_ref()), Some(right_key.as_ref()), None)
         .unwrap();
 
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(left_key.as_ref()),
         Some(right_key.as_ref()),
         &root_hash,

--- a/firewood/src/merkle/tests/ethhash_fuzz.rs
+++ b/firewood/src/merkle/tests/ethhash_fuzz.rs
@@ -482,7 +482,7 @@ fn check_valid_range_proof(
         .unwrap_or_else(|e| panic!("range_proof should succeed ({locator}): {e}"));
     let range_proof = maybe_serialize_round_trip_range(rng, range_proof);
     // This fuzzer is ethhash-gated, so every proof it builds is Ethereum-mode.
-    verify_range_proof(first, last, root, NodeHashAlgorithm::Ethereum, &range_proof)
+    let _ = verify_range_proof(first, last, root, NodeHashAlgorithm::Ethereum, &range_proof)
         .unwrap_or_else(|e| panic!("valid range proof should verify ({locator}): {e}"));
     range_proof
 }

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -35,7 +35,7 @@ fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     last_key: Option<impl KeyType>,
     root_hash: &TrieHash,
     proof: &RangeProof<impl KeyType, impl ValueType, H>,
-) -> Result<ProvenRange, Error> {
+) -> Result<(), Error> {
     crate::merkle::verify_range_proof(
         first_key,
         last_key,
@@ -43,6 +43,7 @@ fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
         DefaultHashMode::ALGORITHM,
         proof,
     )
+    .map(drop)
 }
 
 // Returns n random key-value pairs.

--- a/firewood/src/merkle/tests/mod.rs
+++ b/firewood/src/merkle/tests/mod.rs
@@ -35,7 +35,7 @@ fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     last_key: Option<impl KeyType>,
     root_hash: &TrieHash,
     proof: &RangeProof<impl KeyType, impl ValueType, H>,
-) -> Result<(), Error> {
+) -> Result<ProvenRange, Error> {
     crate::merkle::verify_range_proof(
         first_key,
         last_key,

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -252,7 +252,7 @@ fn test_truncated_bounded_range_proof_round_trip() {
 
     // Verify with the *original* requested bounds — the only ones the caller
     // can provide. End_proof anchors at the last returned key, not `end`.
-    let _ = verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
+    verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
 }
 
 #[test]
@@ -271,7 +271,7 @@ fn test_full_range_proof_verifies_unbounded() {
     assert!(range_proof.start_proof().is_empty());
     assert!(range_proof.end_proof().is_empty());
 
-    let _ = verify_range_proof::<_>(
+    verify_range_proof(
         Option::<&[u8]>::None,
         Option::<&[u8]>::None,
         &root_hash,
@@ -306,7 +306,7 @@ fn test_terminal_strict_prefix_of_last_kv_verifies() {
     // Honest proof contains the three in-range keys.
     assert_eq!(range_proof.key_values().len(), 3);
 
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
@@ -360,10 +360,11 @@ fn test_dropped_trailing_key_accepted_as_partial_coverage() {
     // `[0x05, 0x10]`. It is *not* the verifier's job to enforce that the
     // proven range matches the requested range — partial coverage is a
     // valid outcome the caller is responsible for handling.
-    let proven = verify_range_proof(
+    let proven = crate::merkle::verify_range_proof(
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
+        DefaultHashMode::ALGORITHM,
         &tampered,
     )
     .unwrap();
@@ -418,10 +419,11 @@ fn test_tampered_in_range_value_rejected() {
         tampered_kvs.into_boxed_slice(),
     );
 
-    let result = verify_range_proof(
+    let result = crate::merkle::verify_range_proof(
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
+        DefaultHashMode::ALGORITHM,
         &tampered,
     );
     assert!(
@@ -451,7 +453,7 @@ fn test_divergent_terminal_past_last_kv() {
     assert_eq!(range_proof.key_values().len(), 1);
     assert_eq!(range_proof.key_values()[0].0.as_ref(), b"\x05");
 
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
@@ -485,7 +487,7 @@ fn test_divergent_terminal_before_first_kv() {
     assert_eq!(range_proof.key_values().len(), 1);
     assert_eq!(range_proof.key_values()[0].0.as_ref(), b"\x10");
 
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(b"\x07".as_slice()),
         Some(b"\x10".as_slice()),
         &root_hash,
@@ -518,7 +520,7 @@ fn test_range_proof() {
 
         let root_hash = merkle.nodestore().root_hash().unwrap();
 
-        let _ = verify_range_proof(
+        verify_range_proof(
             Some(items[start].0),
             Some(items[end - 1].0),
             &root_hash,
@@ -759,7 +761,7 @@ fn test_range_proof_with_non_existent_proof() {
 
         let root_hash = merkle.nodestore().root_hash().unwrap();
 
-        let _ = verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof).unwrap();
+        verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof).unwrap();
     }
 
     // Special case, two edge proofs for two edge key.
@@ -775,7 +777,7 @@ fn test_range_proof_with_non_existent_proof() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    let _ = verify_range_proof(Some(first), Some(last), &root_hash, &range_proof).unwrap();
+    verify_range_proof(Some(first), Some(last), &root_hash, &range_proof).unwrap();
 }
 
 #[test]
@@ -876,7 +878,7 @@ fn test_one_element_range_proof() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(items[start].0),
         Some(items[start].0),
         &root_hash,
@@ -893,7 +895,7 @@ fn test_one_element_range_proof() {
 
     let range_proof_2 = RangeProof::new(start_proof_2, end_proof_2, key_values_2.into());
 
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(&first),
         Some(items[start].0),
         &root_hash,
@@ -910,7 +912,7 @@ fn test_one_element_range_proof() {
 
     let range_proof_3 = RangeProof::new(start_proof_3, end_proof_3, key_values_3.into());
 
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(items[start].0),
         Some(&last),
         &root_hash,
@@ -926,7 +928,7 @@ fn test_one_element_range_proof() {
 
     let range_proof_4 = RangeProof::new(start_proof_4, end_proof_4, key_values_4.into());
 
-    let _ = verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof_4).unwrap();
+    verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof_4).unwrap();
 
     // Test the mini trie with only a single element.
     let key = rng.random::<[u8; 32]>();
@@ -943,7 +945,7 @@ fn test_one_element_range_proof() {
 
     let root_hash_mini = merkle_mini.nodestore().root_hash().unwrap();
 
-    let _ = verify_range_proof(Some(first), Some(&key), &root_hash_mini, &range_proof_5).unwrap();
+    verify_range_proof(Some(first), Some(&key), &root_hash_mini, &range_proof_5).unwrap();
 }
 
 #[test]
@@ -970,7 +972,7 @@ fn test_all_elements_proof() {
     let range_proof_2 =
         RangeProof::new(start_proof_2, end_proof_2, key_values_2.into_boxed_slice());
 
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(items[start].0),
         Some(items[end].0),
         &root_hash,
@@ -989,7 +991,7 @@ fn test_all_elements_proof() {
     let range_proof_3 =
         RangeProof::new(start_proof_3, end_proof_3, key_values_3.into_boxed_slice());
 
-    let _ = verify_range_proof(Some(first), Some(last), &root_hash, &range_proof_3).unwrap();
+    verify_range_proof(Some(first), Some(last), &root_hash, &range_proof_3).unwrap();
 }
 
 #[test]
@@ -1010,7 +1012,7 @@ fn test_empty_range_proof() {
     let key_values: KeyValuePairs = Vec::new();
     let range_proof = RangeProof::new(proof.clone(), proof, key_values.into_boxed_slice());
 
-    let _ = verify_range_proof(Some(&first), Some(&first), &root_hash, &range_proof).unwrap();
+    verify_range_proof(Some(&first), Some(&first), &root_hash, &range_proof).unwrap();
 }
 
 #[test]
@@ -1139,8 +1141,7 @@ fn test_single_side_range_proof() {
 
             let root_hash = merkle.nodestore().root_hash().unwrap();
 
-            let _ = verify_range_proof(Some(start), Some(items[case].0), &root_hash, &range_proof)
-                .unwrap();
+            verify_range_proof(Some(start), Some(items[case].0), &root_hash, &range_proof).unwrap();
         }
     }
 }
@@ -1175,8 +1176,7 @@ fn test_reverse_single_side_range_proof() {
 
             let root_hash = merkle.nodestore().root_hash().unwrap();
 
-            let _ = verify_range_proof(Some(items[case].0), Some(end), &root_hash, &range_proof)
-                .unwrap();
+            verify_range_proof(Some(items[case].0), Some(end), &root_hash, &range_proof).unwrap();
         }
     }
 }
@@ -1208,7 +1208,7 @@ fn test_both_sides_range_proof() {
 
         let root_hash = merkle.nodestore().root_hash().unwrap();
 
-        let _ = verify_range_proof(Some(start), Some(end), &root_hash, &range_proof).unwrap();
+        verify_range_proof(Some(start), Some(end), &root_hash, &range_proof).unwrap();
     }
 }
 
@@ -1332,7 +1332,7 @@ fn test_range_proof_keys_with_shared_prefix() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    let _ = verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
+    verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
 }
 
 #[test]
@@ -1373,7 +1373,7 @@ fn test_bloated_range_proof() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    let _ = verify_range_proof(Some(&target.0), Some(&target.0), &root_hash, &range_proof).unwrap();
+    verify_range_proof(Some(&target.0), Some(&target.0), &root_hash, &range_proof).unwrap();
 }
 
 #[test]
@@ -1554,7 +1554,7 @@ fn test_range_proof_fuzz() {
                 let range_proof = merkle
                     .range_proof(Some(items[start].0), Some(items[end].0), None)
                     .unwrap();
-                let _ = verify_range_proof(
+                verify_range_proof(
                     Some(items[start].0),
                     Some(items[end].0),
                     &root_hash,
@@ -1573,9 +1573,8 @@ fn test_range_proof_fuzz() {
                 let range_proof = merkle
                     .range_proof(Some(&first), Some(items[end].0), None)
                     .unwrap();
-                let _ =
-                    verify_range_proof(Some(&first), Some(items[end].0), &root_hash, &range_proof)
-                        .unwrap();
+                verify_range_proof(Some(&first), Some(items[end].0), &root_hash, &range_proof)
+                    .unwrap();
             }
             // Right edge is non-existent
             2 => {
@@ -1590,9 +1589,8 @@ fn test_range_proof_fuzz() {
                 let range_proof = merkle
                     .range_proof(Some(items[start].0), Some(&last), None)
                     .unwrap();
-                let _ =
-                    verify_range_proof(Some(items[start].0), Some(&last), &root_hash, &range_proof)
-                        .unwrap();
+                verify_range_proof(Some(items[start].0), Some(&last), &root_hash, &range_proof)
+                    .unwrap();
             }
             // Both edges are non-existent
             3 => {
@@ -1608,8 +1606,7 @@ fn test_range_proof_fuzz() {
                     continue;
                 }
                 let range_proof = merkle.range_proof(Some(&first), Some(&last), None).unwrap();
-                let _ = verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof)
-                    .unwrap();
+                verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof).unwrap();
             }
             // Single element
             4 => {
@@ -1617,7 +1614,7 @@ fn test_range_proof_fuzz() {
                 let range_proof = merkle
                     .range_proof(Some(items[idx].0), Some(items[idx].0), None)
                     .unwrap();
-                let _ = verify_range_proof(
+                verify_range_proof(
                     Some(items[idx].0),
                     Some(items[idx].0),
                     &root_hash,
@@ -2017,7 +2014,7 @@ fn test_range_proof_with_limit() {
 
     // The end proof should anchor at items[2] (last returned), not items[9].
     // Verify the truncated proof against the last returned key.
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(&items[0].0),
         Some(&items[2].0),
         &root_hash,
@@ -2031,7 +2028,7 @@ fn test_range_proof_with_limit() {
         .unwrap();
     assert_eq!(full_proof.key_values().len(), 10);
 
-    let _ = verify_range_proof(
+    verify_range_proof(
         Some(&items[0].0),
         Some(&items[9].0),
         &root_hash,
@@ -2120,7 +2117,7 @@ fn test_right_edge_boundary_prefix_of_terminal() {
     );
     // End proof should only have 2 proof nodes.
     assert_eq!(proof.end_proof().len(), 2);
-    let _ = verify_range_proof(None::<&[u8]>, Some(b"\x20"), &root_hash, &proof).unwrap();
+    verify_range_proof(None::<&[u8]>, Some(b"\x20"), &root_hash, &proof).unwrap();
 }
 
 /// Regression test: range proof verification must handle `ValueDigest::Hash`
@@ -2169,7 +2166,7 @@ fn test_range_proof_with_hashed_value() {
     );
 
     // This must pass — the Hash digest matches the branch value.
-    let _ = verify_range_proof(Some(b"\x10"), Some(b"\x30"), &root_hash, &deserialized).unwrap();
+    verify_range_proof(Some(b"\x10"), Some(b"\x30"), &root_hash, &deserialized).unwrap();
 }
 
 /// Regression test: empty range proof with a Hash digest at an out-of-range
@@ -2201,7 +2198,7 @@ fn test_empty_range_proof_with_hashed_value() {
     let deserialized = crate::api::FrozenRangeProof::from_slice(&serialized).unwrap();
 
     // This must pass — the Hash proof node is out of range.
-    let _ = verify_range_proof(Some(b"\x30"), Some(b"\x40"), &root_hash, &deserialized).unwrap();
+    verify_range_proof(Some(b"\x30"), Some(b"\x40"), &root_hash, &deserialized).unwrap();
 }
 
 /// Multi-level trie with hashed values at multiple branch depths.
@@ -2260,7 +2257,7 @@ fn test_multi_level_range_proof_with_hashed_values() {
     // This exercises:
     // - "abc" out-of-range: Hash fallback in compute_root_hash_with_proofs
     // - "abcdef" in-range: Hash fast path in reconcile_branch_proof_node
-    let _ = verify_range_proof(Some(b"abc123"), Some(b"\xff"), &root_hash, &deserialized).unwrap();
+    verify_range_proof(Some(b"abc123"), Some(b"\xff"), &root_hash, &deserialized).unwrap();
 }
 
 #[test]

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE.md for licensing terms.
 
+use super::verify_range_proof;
 use super::*;
 use crate::RangeProof;
 use firewood_storage::U4;
@@ -220,12 +221,7 @@ fn test_missing_key_proof() {
         assert_eq!(proof.len(), 1);
 
         proof
-            .verify(
-                key,
-                None::<&[u8]>,
-                &root_hash,
-                firewood_storage::DefaultHashMode::ALGORITHM,
-            )
+            .verify(key, None::<&[u8]>, &root_hash, DefaultHashMode::ALGORITHM)
             .unwrap();
     }
 }
@@ -256,7 +252,7 @@ fn test_truncated_bounded_range_proof_round_trip() {
 
     // Verify with the *original* requested bounds — the only ones the caller
     // can provide. End_proof anchors at the last returned key, not `end`.
-    verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
+    let _ = verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
 }
 
 #[test]
@@ -275,7 +271,7 @@ fn test_full_range_proof_verifies_unbounded() {
     assert!(range_proof.start_proof().is_empty());
     assert!(range_proof.end_proof().is_empty());
 
-    verify_range_proof::<_>(
+    let _ = verify_range_proof::<_>(
         Option::<&[u8]>::None,
         Option::<&[u8]>::None,
         &root_hash,
@@ -310,7 +306,7 @@ fn test_terminal_strict_prefix_of_last_kv_verifies() {
     // Honest proof contains the three in-range keys.
     assert_eq!(range_proof.key_values().len(), 3);
 
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
@@ -364,7 +360,7 @@ fn test_dropped_trailing_key_accepted_as_partial_coverage() {
     // `[0x05, 0x10]`. It is *not* the verifier's job to enforce that the
     // proven range matches the requested range — partial coverage is a
     // valid outcome the caller is responsible for handling.
-    verify_range_proof(
+    let proven = verify_range_proof(
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
@@ -372,9 +368,14 @@ fn test_dropped_trailing_key_accepted_as_partial_coverage() {
     )
     .unwrap();
 
-    // The caller's `last_kv < requested_last` check is what flags partial
-    // coverage and should drive a follow-up request.
-    assert!(tampered.key_values().last().unwrap().0.as_ref() < b"\x10\x30".as_slice());
+    // The verifier now *reports* the partial coverage rather than leaving
+    // the caller to re-derive it: the proven upper bound is `0x10`, not the
+    // requested `0x10\x30`. A caller that replaces state over the requested
+    // bound would delete `0x10\x10` on the strength of a proof that stops
+    // at `0x10`.
+    assert_eq!(proven.start.as_deref(), Some(b"\x05".as_slice()));
+    assert_eq!(proven.end.as_deref(), Some(b"\x10".as_slice()));
+    assert!(proven.end.as_deref().unwrap() < b"\x10\x30".as_slice());
 }
 
 #[test]
@@ -450,7 +451,7 @@ fn test_divergent_terminal_past_last_kv() {
     assert_eq!(range_proof.key_values().len(), 1);
     assert_eq!(range_proof.key_values()[0].0.as_ref(), b"\x05");
 
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(b"\x05".as_slice()),
         Some(b"\x10\x30".as_slice()),
         &root_hash,
@@ -484,7 +485,7 @@ fn test_divergent_terminal_before_first_kv() {
     assert_eq!(range_proof.key_values().len(), 1);
     assert_eq!(range_proof.key_values()[0].0.as_ref(), b"\x10");
 
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(b"\x07".as_slice()),
         Some(b"\x10".as_slice()),
         &root_hash,
@@ -517,7 +518,7 @@ fn test_range_proof() {
 
         let root_hash = merkle.nodestore().root_hash().unwrap();
 
-        verify_range_proof(
+        let _ = verify_range_proof(
             Some(items[start].0),
             Some(items[end - 1].0),
             &root_hash,
@@ -758,7 +759,7 @@ fn test_range_proof_with_non_existent_proof() {
 
         let root_hash = merkle.nodestore().root_hash().unwrap();
 
-        verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof).unwrap();
+        let _ = verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof).unwrap();
     }
 
     // Special case, two edge proofs for two edge key.
@@ -774,7 +775,7 @@ fn test_range_proof_with_non_existent_proof() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    verify_range_proof(Some(first), Some(last), &root_hash, &range_proof).unwrap();
+    let _ = verify_range_proof(Some(first), Some(last), &root_hash, &range_proof).unwrap();
 }
 
 #[test]
@@ -875,7 +876,7 @@ fn test_one_element_range_proof() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(items[start].0),
         Some(items[start].0),
         &root_hash,
@@ -892,7 +893,7 @@ fn test_one_element_range_proof() {
 
     let range_proof_2 = RangeProof::new(start_proof_2, end_proof_2, key_values_2.into());
 
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(&first),
         Some(items[start].0),
         &root_hash,
@@ -909,7 +910,7 @@ fn test_one_element_range_proof() {
 
     let range_proof_3 = RangeProof::new(start_proof_3, end_proof_3, key_values_3.into());
 
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(items[start].0),
         Some(&last),
         &root_hash,
@@ -925,7 +926,7 @@ fn test_one_element_range_proof() {
 
     let range_proof_4 = RangeProof::new(start_proof_4, end_proof_4, key_values_4.into());
 
-    verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof_4).unwrap();
+    let _ = verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof_4).unwrap();
 
     // Test the mini trie with only a single element.
     let key = rng.random::<[u8; 32]>();
@@ -942,7 +943,7 @@ fn test_one_element_range_proof() {
 
     let root_hash_mini = merkle_mini.nodestore().root_hash().unwrap();
 
-    verify_range_proof(Some(first), Some(&key), &root_hash_mini, &range_proof_5).unwrap();
+    let _ = verify_range_proof(Some(first), Some(&key), &root_hash_mini, &range_proof_5).unwrap();
 }
 
 #[test]
@@ -969,7 +970,7 @@ fn test_all_elements_proof() {
     let range_proof_2 =
         RangeProof::new(start_proof_2, end_proof_2, key_values_2.into_boxed_slice());
 
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(items[start].0),
         Some(items[end].0),
         &root_hash,
@@ -988,7 +989,7 @@ fn test_all_elements_proof() {
     let range_proof_3 =
         RangeProof::new(start_proof_3, end_proof_3, key_values_3.into_boxed_slice());
 
-    verify_range_proof(Some(first), Some(last), &root_hash, &range_proof_3).unwrap();
+    let _ = verify_range_proof(Some(first), Some(last), &root_hash, &range_proof_3).unwrap();
 }
 
 #[test]
@@ -1009,7 +1010,7 @@ fn test_empty_range_proof() {
     let key_values: KeyValuePairs = Vec::new();
     let range_proof = RangeProof::new(proof.clone(), proof, key_values.into_boxed_slice());
 
-    verify_range_proof(Some(&first), Some(&first), &root_hash, &range_proof).unwrap();
+    let _ = verify_range_proof(Some(&first), Some(&first), &root_hash, &range_proof).unwrap();
 }
 
 #[test]
@@ -1138,7 +1139,8 @@ fn test_single_side_range_proof() {
 
             let root_hash = merkle.nodestore().root_hash().unwrap();
 
-            verify_range_proof(Some(start), Some(items[case].0), &root_hash, &range_proof).unwrap();
+            let _ = verify_range_proof(Some(start), Some(items[case].0), &root_hash, &range_proof)
+                .unwrap();
         }
     }
 }
@@ -1173,7 +1175,8 @@ fn test_reverse_single_side_range_proof() {
 
             let root_hash = merkle.nodestore().root_hash().unwrap();
 
-            verify_range_proof(Some(items[case].0), Some(end), &root_hash, &range_proof).unwrap();
+            let _ = verify_range_proof(Some(items[case].0), Some(end), &root_hash, &range_proof)
+                .unwrap();
         }
     }
 }
@@ -1205,7 +1208,7 @@ fn test_both_sides_range_proof() {
 
         let root_hash = merkle.nodestore().root_hash().unwrap();
 
-        verify_range_proof(Some(start), Some(end), &root_hash, &range_proof).unwrap();
+        let _ = verify_range_proof(Some(start), Some(end), &root_hash, &range_proof).unwrap();
     }
 }
 
@@ -1329,7 +1332,7 @@ fn test_range_proof_keys_with_shared_prefix() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
+    let _ = verify_range_proof(Some(&start), Some(&end), &root_hash, &range_proof).unwrap();
 }
 
 #[test]
@@ -1370,7 +1373,7 @@ fn test_bloated_range_proof() {
 
     let root_hash = merkle.nodestore().root_hash().unwrap();
 
-    verify_range_proof(Some(&target.0), Some(&target.0), &root_hash, &range_proof).unwrap();
+    let _ = verify_range_proof(Some(&target.0), Some(&target.0), &root_hash, &range_proof).unwrap();
 }
 
 #[test]
@@ -1551,7 +1554,7 @@ fn test_range_proof_fuzz() {
                 let range_proof = merkle
                     .range_proof(Some(items[start].0), Some(items[end].0), None)
                     .unwrap();
-                verify_range_proof(
+                let _ = verify_range_proof(
                     Some(items[start].0),
                     Some(items[end].0),
                     &root_hash,
@@ -1570,8 +1573,9 @@ fn test_range_proof_fuzz() {
                 let range_proof = merkle
                     .range_proof(Some(&first), Some(items[end].0), None)
                     .unwrap();
-                verify_range_proof(Some(&first), Some(items[end].0), &root_hash, &range_proof)
-                    .unwrap();
+                let _ =
+                    verify_range_proof(Some(&first), Some(items[end].0), &root_hash, &range_proof)
+                        .unwrap();
             }
             // Right edge is non-existent
             2 => {
@@ -1586,8 +1590,9 @@ fn test_range_proof_fuzz() {
                 let range_proof = merkle
                     .range_proof(Some(items[start].0), Some(&last), None)
                     .unwrap();
-                verify_range_proof(Some(items[start].0), Some(&last), &root_hash, &range_proof)
-                    .unwrap();
+                let _ =
+                    verify_range_proof(Some(items[start].0), Some(&last), &root_hash, &range_proof)
+                        .unwrap();
             }
             // Both edges are non-existent
             3 => {
@@ -1603,7 +1608,8 @@ fn test_range_proof_fuzz() {
                     continue;
                 }
                 let range_proof = merkle.range_proof(Some(&first), Some(&last), None).unwrap();
-                verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof).unwrap();
+                let _ = verify_range_proof(Some(&first), Some(&last), &root_hash, &range_proof)
+                    .unwrap();
             }
             // Single element
             4 => {
@@ -1611,7 +1617,7 @@ fn test_range_proof_fuzz() {
                 let range_proof = merkle
                     .range_proof(Some(items[idx].0), Some(items[idx].0), None)
                     .unwrap();
-                verify_range_proof(
+                let _ = verify_range_proof(
                     Some(items[idx].0),
                     Some(items[idx].0),
                     &root_hash,
@@ -2011,7 +2017,7 @@ fn test_range_proof_with_limit() {
 
     // The end proof should anchor at items[2] (last returned), not items[9].
     // Verify the truncated proof against the last returned key.
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(&items[0].0),
         Some(&items[2].0),
         &root_hash,
@@ -2025,7 +2031,7 @@ fn test_range_proof_with_limit() {
         .unwrap();
     assert_eq!(full_proof.key_values().len(), 10);
 
-    verify_range_proof(
+    let _ = verify_range_proof(
         Some(&items[0].0),
         Some(&items[9].0),
         &root_hash,
@@ -2117,7 +2123,7 @@ fn test_right_edge_boundary_prefix_of_terminal() {
     );
     // End proof should only have 2 proof nodes.
     assert_eq!(proof.end_proof().len(), 2);
-    verify_range_proof(None::<&[u8]>, Some(b"\x20"), &root_hash, &proof).unwrap();
+    let _ = verify_range_proof(None::<&[u8]>, Some(b"\x20"), &root_hash, &proof).unwrap();
 }
 
 /// Regression test: range proof verification must handle `ValueDigest::Hash`
@@ -2136,8 +2142,6 @@ fn test_right_edge_boundary_prefix_of_terminal() {
 #[cfg(not(feature = "ethhash"))]
 #[test]
 fn test_range_proof_with_hashed_value() {
-    use firewood_storage::NodeHashAlgorithm;
-
     // Value >= 32 bytes triggers ValueDigest::Hash in merkledb mode
     let big_value = vec![0xab_u8; 32];
     let merkle = init_merkle([
@@ -2168,14 +2172,7 @@ fn test_range_proof_with_hashed_value() {
     );
 
     // This must pass — the Hash digest matches the branch value.
-    crate::merkle::verify_range_proof(
-        Some(b"\x10"),
-        Some(b"\x30"),
-        &root_hash,
-        NodeHashAlgorithm::MerkleDB,
-        &deserialized,
-    )
-    .unwrap();
+    let _ = verify_range_proof(Some(b"\x10"), Some(b"\x30"), &root_hash, &deserialized).unwrap();
 }
 
 /// Regression test: empty range proof with a Hash digest at an out-of-range
@@ -2186,8 +2183,6 @@ fn test_range_proof_with_hashed_value() {
 #[cfg(not(feature = "ethhash"))]
 #[test]
 fn test_empty_range_proof_with_hashed_value() {
-    use firewood_storage::NodeHashAlgorithm;
-
     // \x10 has a large value (>= 32 bytes), \x10\x20 makes \x10 a branch.
     // Range is past all keys — empty key-value list.
     let big_value = vec![0xab_u8; 32];
@@ -2209,14 +2204,7 @@ fn test_empty_range_proof_with_hashed_value() {
     let deserialized = crate::api::FrozenRangeProof::from_slice(&serialized).unwrap();
 
     // This must pass — the Hash proof node is out of range.
-    crate::merkle::verify_range_proof(
-        Some(b"\x30"),
-        Some(b"\x40"),
-        &root_hash,
-        NodeHashAlgorithm::MerkleDB,
-        &deserialized,
-    )
-    .unwrap();
+    let _ = verify_range_proof(Some(b"\x30"), Some(b"\x40"), &root_hash, &deserialized).unwrap();
 }
 
 /// Multi-level trie with hashed values at multiple branch depths.
@@ -2237,8 +2225,6 @@ fn test_empty_range_proof_with_hashed_value() {
 #[cfg(not(feature = "ethhash"))]
 #[test]
 fn test_multi_level_range_proof_with_hashed_values() {
-    use firewood_storage::NodeHashAlgorithm;
-
     let merkle = init_merkle([
         (b"abc" as &[u8], [0; 64].as_slice()),
         (b"abc123", [1; 64].as_slice()),
@@ -2277,12 +2263,119 @@ fn test_multi_level_range_proof_with_hashed_values() {
     // This exercises:
     // - "abc" out-of-range: Hash fallback in compute_root_hash_with_proofs
     // - "abcdef" in-range: Hash fast path in reconcile_branch_proof_node
-    crate::merkle::verify_range_proof(
-        Some(b"abc123"),
-        Some(b"\xff"),
-        &root_hash,
-        NodeHashAlgorithm::MerkleDB,
-        &deserialized,
+    let _ = verify_range_proof(Some(b"abc123"), Some(b"\xff"), &root_hash, &deserialized).unwrap();
+}
+
+#[test]
+fn test_proven_right_edge() {
+    use crate::merkle::{ProvenRange, RightBoundary, proven_right_edge};
+    use std::borrow::Cow;
+
+    // InRange(Some) — the end proof anchors at a real key, so that key is
+    // the inclusive proven bound. This is the truncated-reply shape.
+    assert_eq!(
+        proven_right_edge(
+            &RightBoundary::InRange(Some(b"\x10")),
+            Some(b"\x10"),
+            Some(b"\x10\x30")
+        ),
+        Some(Box::from(b"\x10".as_slice()))
+    );
+
+    // InRange(None) — an unbounded request stays unbounded.
+    assert_eq!(
+        proven_right_edge(&RightBoundary::InRange(None), Some(b"\x10"), None),
+        None
+    );
+
+    // OutOfRange with the requested bound below the terminal: the request is
+    // fully covered, so the requested bound is proven.
+    assert_eq!(
+        proven_right_edge(
+            &RightBoundary::OutOfRange(Cow::Borrowed(b"\x10\x50")),
+            Some(b"\x10\x10"),
+            Some(b"\x10\x30")
+        ),
+        Some(Box::from(b"\x10\x30".as_slice()))
+    );
+
+    // OutOfRange with the requested bound exactly equal to the terminal: the
+    // guard is `end < k`, strictly, so equality does not count as covered.
+    // This strictness is load-bearing: with `<=` here, a `requested_end`
+    // exactly equal to the end-proof terminal would report as proven a key
+    // that provably *exists* in the source trie and was withheld —
+    // authorizing its local deletion.
+    assert_eq!(
+        proven_right_edge(
+            &RightBoundary::OutOfRange(Cow::Borrowed(b"\x10\x50")),
+            Some(b"\x10\x10"),
+            Some(b"\x10\x50")
+        ),
+        Some(Box::from(b"\x10\x10".as_slice()))
+    );
+
+    // OutOfRange with the requested bound at or above the terminal: fall back
+    // to last_kv rather than claim the unrepresentable predecessor of the
+    // terminal. Conservative on purpose.
+    assert_eq!(
+        proven_right_edge(
+            &RightBoundary::OutOfRange(Cow::Borrowed(b"\x10\x50")),
+            Some(b"\x10\x10"),
+            Some(b"\x99")
+        ),
+        Some(Box::from(b"\x10\x10".as_slice()))
+    );
+
+    // OutOfRange with no requested bound: same conservative fallback.
+    assert_eq!(
+        proven_right_edge(
+            &RightBoundary::OutOfRange(Cow::Borrowed(b"\x10\x50")),
+            Some(b"\x10\x10"),
+            None
+        ),
+        Some(Box::from(b"\x10\x10".as_slice()))
+    );
+
+    // The type is constructible and comparable — pins the field names.
+    let pr = ProvenRange {
+        start: Some(Box::from(b"\x05".as_slice())),
+        end: Some(Box::from(b"\x10".as_slice())),
+    };
+    assert_eq!(pr.start.as_deref(), Some(b"\x05".as_slice()));
+    assert_eq!(pr.end.as_deref(), Some(b"\x10".as_slice()));
+}
+
+#[test]
+fn test_verification_context_reports_truncated_right_edge() {
+    use crate::verify_range_proof_structure;
+    use std::num::NonZeroUsize;
+
+    let items: &[(&[u8], &[u8])] = &[
+        (b"\x05", b"a"),
+        (b"\x10", b"b"),
+        (b"\x20", b"c"),
+        (b"\x30", b"d"),
+    ];
+    let merkle = init_merkle(items.iter().copied());
+    let root_hash = merkle.nodestore().root_hash().unwrap();
+
+    // Ask for the whole keyspace but cap the reply at two pairs, so the
+    // responder truncates and the proof anchors at its own last key.
+    let limit = NonZeroUsize::new(2).unwrap();
+    let proof = merkle.range_proof(None, None, Some(limit)).unwrap();
+    assert_eq!(proof.key_values().len(), 2);
+
+    let ctx = verify_range_proof_structure(
+        &proof,
+        root_hash,
+        None,
+        None,
+        DefaultHashMode::ALGORITHM,
+        Some(limit),
     )
     .unwrap();
+
+    // The request was unbounded, but only `[.., 0x10]` is proven.
+    assert_eq!(ctx.end_key, None);
+    assert_eq!(ctx.right_edge_key.as_deref(), Some(b"\x10".as_slice()));
 }

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -2041,18 +2041,15 @@ fn test_range_proof_with_limit() {
 }
 
 #[test]
-// Demonstrates that verify_range_proof does not verify that proof node values
-// match the corresponding values in key_values. A malicious prover can supply
-// correct proof nodes (with the real value) but incorrect key_values at an
-// intermediate proof-path position. Reconciliation silently overwrites the
-// wrong value with the proof's correct one, the hash check passes, and the
-// caller trusts the wrong key_values.
+// A malicious prover can supply correct proof nodes (carrying the real value)
+// alongside incorrect key_values at an intermediate proof-path position.
+// Verification rejects this with `ProofNodeValueMismatch` rather than letting
+// reconciliation overwrite the tampered value and pass the hash check.
 //
 // Trie: ("b", "v1"), ("ba", "v2"), ("bc", "v3")
 // Range: ["a", "bc"]
-// The end proof for "bc" traverses the "b" node (which carries "v1").
-// We change "b"'s value in key_values to "WRONG" — verification should fail
-// but currently passes.
+// The end proof for "bc" traverses the "b" node (which carries "v1"), and "b"'s
+// value in key_values is changed to "WRONG".
 fn test_bad_range_proof_value_mismatch_on_proof_path() {
     let items = [("b", "v1"), ("ba", "v2"), ("bc", "v3")];
     let merkle = init_merkle(items);

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -74,16 +74,30 @@ pub type KeyRange = (Box<[u8]>, Option<Box<[u8]>>);
 /// Stored so that downstream logic (root hash verification, `find_next_key`)
 /// can reference the original verification parameters without re-validating.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct RangeProofVerificationContext {
     /// The expected root hash of the trie.
     pub root: HashKey,
     /// The lower bound of the verified key range, if any.
     pub start_key: Option<Box<[u8]>>,
-    /// The upper bound of the verified key range, if any.
+    /// The upper bound the caller **requested**, if any.
     pub end_key: Option<Box<[u8]>>,
     /// The maximum number of key/value pairs the proof was permitted to
     /// contain. `None` means no limit.
     pub max_length: Option<NonZeroUsize>,
+    /// The actual right edge of the **proven** range, inclusive. Equals
+    /// `end_key` when the responder covered the whole request, and a smaller
+    /// key when the reply was truncated. `None` means unbounded above.
+    ///
+    /// Mirrors [`ChangeProofVerificationContext::right_edge_key`].
+    ///
+    /// A caller applying the proof must bound the write to this key rather
+    /// than to `end_key`: the span `(right_edge_key, end_key]` carries no
+    /// proof, so replacing state across it deletes local keys that were
+    /// never covered.
+    ///
+    /// [`ChangeProofVerificationContext::right_edge_key`]: crate::ChangeProofVerificationContext::right_edge_key
+    pub right_edge_key: Option<Box<[u8]>>,
 }
 
 /// Verify structural properties of a range proof and produce a
@@ -121,13 +135,14 @@ pub fn verify_range_proof_structure(
         ));
     }
 
-    verify_range_proof(start_key, end_key, &root, algorithm, proof)?;
+    let proven = verify_range_proof(start_key, end_key, &root, algorithm, proof)?;
 
     Ok(RangeProofVerificationContext {
         root,
         start_key: start_key.map(Box::from),
         end_key: end_key.map(Box::from),
         max_length,
+        right_edge_key: proven.end,
     })
 }
 

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -85,17 +85,15 @@ pub struct RangeProofVerificationContext {
     /// The maximum number of key/value pairs the proof was permitted to
     /// contain. `None` means no limit.
     pub max_length: Option<NonZeroUsize>,
-    /// The actual right edge of the **proven** range, inclusive. Equals
-    /// `end_key` when the responder covered the whole request, and a smaller
-    /// key when the reply was truncated. `None` means unbounded above.
+    /// The inclusive right edge of the **proven** range — [`ProvenRange::end`]
+    /// as returned by verification. Equals `end_key` when the responder covered
+    /// the whole request, a smaller key when the reply was truncated, and
+    /// `None` when unbounded above. Callers applying the proof must bound the
+    /// write to this key, not to `end_key`.
     ///
     /// Mirrors [`ChangeProofVerificationContext::right_edge_key`].
     ///
-    /// A caller applying the proof must bound the write to this key rather
-    /// than to `end_key`: the span `(right_edge_key, end_key]` carries no
-    /// proof, so replacing state across it deletes local keys that were
-    /// never covered.
-    ///
+    /// [`ProvenRange::end`]: crate::ProvenRange::end
     /// [`ChangeProofVerificationContext::right_edge_key`]: crate::ChangeProofVerificationContext::right_edge_key
     pub right_edge_key: Option<Box<[u8]>>,
 }
@@ -207,8 +205,9 @@ pub struct RangeProof<K, V, H> {
     /// The hash algorithm this proof was constructed or parsed with. For proofs
     /// built in this binary it is the compile default; for proofs parsed via
     /// [`FrozenRangeProof::from_slice`](crate::api::FrozenRangeProof::from_slice)
-    /// it is resolved from the self-describing header byte.
-    /// [`ProofError::HashModeMismatch`]).
+    /// it is resolved from the self-describing header byte. A mismatch against
+    /// the algorithm a verifier expects is rejected with
+    /// [`ProofError::HashModeMismatch`].
     hash_mode: NodeHashAlgorithm,
 }
 


### PR DESCRIPTION
## Why this should be merged

`Db::merge_key_value_range` is a total replacement: any key in its bounds that
is absent from the supplied key-values is deleted. The FFI apply path passed it
the caller's **requested** `end_key`, while verification only ever anchored at
the proof's own right edge. A truncated reply therefore deleted every local key
in `(proven_edge, end_key]` on the strength of a proof that never covered it.

#1970 established truncated coverage as a valid outcome rather than a
verification error, on the rationale that *"the caller is expected to compare
`key_values.last()` against their requested `last_key`."* Sound — but firewood's
own apply path is that caller, and it wasn't comparing. Verification had no way
to tell it what was proven: `verify_range_proof` computed the right edge, used
it, and returned `()`.

Forward-only sync never populates the affected window, which is why this stayed
latent. Repair, patch, and re-sync do.

## Notes for review

**The load-bearing invariant is `proven_end >= last_kv`, on every branch of
`proven_right_edge`.** That is what makes three otherwise-alarming things safe:
`MergeKeyValueIter` cannot over-apply despite the hardcoded `None` on its
key-values side; `find_next_key_after_range_proof`, resuming at
`key_values.last()`, cannot open a gap; and a bound that is too tight cannot
silently drop proven data.

Both failure directions are tested, and each test was verified to fail without
its fix. The under-deletion side — a bound *tighter* than justified — has no
natural trigger, so it is mutation-tested: force `proven_end()` artificially
tight and confirm the stale key survives.

## Behavior change

**`FindNextKey` can now return `nil` where it previously returned a range.** A
receiver that is genuinely caught up now reaches the target root, so the
existing "already at target" short-circuit fires where it structurally could not
before — the unbounded merge used to corrupt local state and mask it. A Go sync
driver that treats `nil` as unexpected will behave differently.

`TestRangeProofFindNextKey`'s assertion flips from "more to fetch" to `nil` for
that reason: it previously passed *because of* the bug.

Separately, `NextKeyRange` and its accessors documented the fetch range as
`[start, end)` when the implementation returns `(start, end]`. No code changes,
but a Go client that trusted those docs re-requests a key it already holds, or
skips one.

## Deliberately out of scope

`find_next_key_after_range_proof` still resumes from `key_values.last()` and
keeps its stale `TODO(#352)`. It is safe as-is: because `proven_end >= last_kv`,
resuming there re-requests a span already written and already proven — overlap,
never a gap. Worst case is one redundant round trip.

## Breaking Changes

`firewood`:

- `verify_range_proof` returns `ProvenRange` instead of `()`. External callers
  binding `Ok(())` must change. `ProvenRange` is `#[must_use]`, so discarding the
  proven bound — the defect this fixes — is now a compile error rather than
  silent data loss.
- `RangeProofVerificationContext` gains `right_edge_key` and becomes
  `#[non_exhaustive]`.

`firewood-ffi` / `firewood-go`: no signature changes, but a truncated proof
writes a narrower range than before, and `FindNextKey` may return `nil` where it
previously returned a range — see above.
