### PR TITLE
test(fwdctl): scope dump output to a tmpdir instead of the shared CWD

### DIFF
--- a/fwdctl/tests/cli.rs
+++ b/fwdctl/tests/cli.rs
@@ -423,90 +423,111 @@ fn test_slow_fwdctl_dump_with_start_stop_and_max() {
 
 #[test]
 fn test_slow_fwdctl_dump_with_csv_and_json() {
-    with_tmpdir(|db_path| {
-        create_db(db_path);
-        insert_key_value(db_path, "a", "1");
-        insert_key_value(db_path, "b", "2");
-        insert_key_value(db_path, "c", "3");
+    with_tmpdir(|tmp_dir| {
+        let db_path = tmp_dir.join("db");
+        create_db(&db_path);
+        insert_key_value(&db_path, "a", "1");
+        insert_key_value(&db_path, "b", "2");
+        insert_key_value(&db_path, "c", "3");
 
         // Test output csv
+        let csv_file = tmp_dir.join("dump.csv");
         cargo_bin_cmd!()
             .arg("dump")
             .arg("--db")
-            .arg(db_path)
+            .arg(&db_path)
             .args(["--output-format"])
             .arg("csv")
+            .args(["--output-file-name"])
+            .arg(&csv_file)
             .assert()
             .success()
-            .stdout(predicate::str::contains("Dumping to dump.csv"));
+            .stdout(predicate::str::contains(format!(
+                "Dumping to {}",
+                csv_file.display()
+            )));
 
-        let contents = fs::read_to_string("dump.csv").expect("Should read dump.csv file");
+        let contents = fs::read_to_string(&csv_file).expect("Should read dump.csv file");
         assert_eq!(contents, "a,1\nb,2\nc,3\n");
-        fs::remove_file("dump.csv").expect("Should remove dump.csv file");
 
         // Test output json
+        let json_file = tmp_dir.join("dump.json");
         cargo_bin_cmd!()
             .arg("dump")
             .arg("--db")
-            .arg(db_path)
+            .arg(&db_path)
             .args(["--output-format"])
             .arg("json")
+            .args(["--output-file-name"])
+            .arg(&json_file)
             .assert()
             .success()
-            .stdout(predicate::str::contains("Dumping to dump.json"));
+            .stdout(predicate::str::contains(format!(
+                "Dumping to {}",
+                json_file.display()
+            )));
 
-        let contents = fs::read_to_string("dump.json").expect("Should read dump.json file");
+        let contents = fs::read_to_string(&json_file).expect("Should read dump.json file");
         assert_eq!(
             contents,
             "{\n  \"a\": \"1\",\n  \"b\": \"2\",\n  \"c\": \"3\"\n}\n"
         );
-        fs::remove_file("dump.json").expect("Should remove dump.json file");
     });
 }
 
 #[test]
 fn fwdctl_dump_json_escapes_special_characters() {
-    with_tmpdir(|db_path| {
-        create_db(db_path);
+    with_tmpdir(|tmp_dir| {
+        let db_path = tmp_dir.join("db");
+        create_db(&db_path);
 
         cargo_bin_cmd!()
             .arg("insert")
             .arg("--db")
-            .arg(db_path)
+            .arg(&db_path)
             .args(["say\"hi\\", "line\n\t\u{1}"])
             .assert()
             .success();
 
+        let json_file = tmp_dir.join("dump.json");
         cargo_bin_cmd!()
             .arg("dump")
             .arg("--db")
-            .arg(db_path)
+            .arg(&db_path)
             .args(["--output-format", "json"])
+            .args(["--output-file-name"])
+            .arg(&json_file)
             .assert()
             .success();
 
-        let contents = fs::read_to_string("dump.json").expect("Should read dump.json file");
+        let contents = fs::read_to_string(&json_file).expect("Should read dump.json file");
         assert_eq!(
             contents,
             "{\n  \"say\\\"hi\\\\\": \"line\\n\\t\\u0001\"\n}\n"
         );
-        fs::remove_file("dump.json").expect("Should remove dump.json file");
     });
 }
 
 #[test]
 fn fwdctl_dump_with_file_name() {
-    with_tmpdir(|db_path| {
-        create_db(db_path);
-        insert_key_value(db_path, "a", "1");
+    with_tmpdir(|tmp_dir| {
+        let db_path = tmp_dir.join("db");
+        create_db(&db_path);
+        insert_key_value(&db_path, "a", "1");
+
+        // `--output-file-name` is a base path; `dump` sets the extension from
+        // `--output-format`, so one base yields both `test.csv` and `test.json`.
+        let base = tmp_dir.join("test");
+        let csv_file = base.with_extension("csv");
+        let json_file = base.with_extension("json");
 
         // Test without output format
         cargo_bin_cmd!()
             .arg("dump")
             .arg("--db")
-            .arg(db_path)
+            .arg(&db_path)
             .args(["--output-file-name"])
-            .arg("test")
+            .arg(&base)
             .assert()
             .failure()
             .stderr(predicate::str::contains("--output-format"));
@@ -515,35 +536,39 @@ fn fwdctl_dump_with_file_name() {
         cargo_bin_cmd!()
             .arg("dump")
             .arg("--db")
-            .arg(db_path)
+            .arg(&db_path)
             .args(["--output-format"])
             .arg("csv")
             .args(["--output-file-name"])
-            .arg("test")
+            .arg(&base)
             .assert()
             .success()
-            .stdout(predicate::str::contains("Dumping to test.csv"));
+            .stdout(predicate::str::contains(format!(
+                "Dumping to {}",
+                csv_file.display()
+            )));
 
-        let contents = fs::read_to_string("test.csv").expect("Should read test.csv file");
+        let contents = fs::read_to_string(&csv_file).expect("Should read test.csv file");
         assert_eq!(contents, "a,1\n");
-        fs::remove_file("test.csv").expect("Should remove test.csv file");
 
         // Test output json
         cargo_bin_cmd!()
             .arg("dump")
             .arg("--db")
-            .arg(db_path)
+            .arg(&db_path)
             .args(["--output-format"])
             .arg("json")
             .args(["--output-file-name"])
-            .arg("test")
+            .arg(&base)
             .assert()
             .success()
-            .stdout(predicate::str::contains("Dumping to test.json"));
+            .stdout(predicate::str::contains(format!(
+                "Dumping to {}",
+                json_file.display()
+            )));
 
-        let contents = fs::read_to_string("test.json").expect("Should read test.json file");
+        let contents = fs::read_to_string(&json_file).expect("Should read test.json file");
         assert_eq!(contents, "{\n  \"a\": \"1\"\n}\n");
-        fs::remove_file("test.json").expect("Should remove test.json file");
     });
 }
 


### PR DESCRIPTION
## Why this should be merged

`main` is intermittently red at its tip. `test_slow_fwdctl_dump_with_csv_and_json` and
`fwdctl_dump_json_escapes_special_characters` both wrote, read, and deleted a **relative**
`dump.json`. Nextest gives each test its own process but not its own working directory, so
run concurrently one could overwrite the other's file between the write and the read, or
delete it before it was read. The observed failure asserted one test's expected JSON against
the other's payload — reading the neighbour's content is the signature of the collision.

`with_tmpdir` is the trap here. It looks like isolation but scopes only the **database**
path:

```rust
fn with_tmpdir(test: impl FnOnce(&Path)) {
    let tmpdir = tempfile::tempdir().unwrap();
    test(tmpdir.path());
}
```

Nothing in the file calls `set_current_dir`, so `dump`'s default output lands in the shared
test-process CWD and every test in the crate competes for one namespace.

It surfaces only under nextest's `ci` profile. `.config/nextest.toml` sets
`default-filter = "not test(test_slow) and not kind(bench)"`, so plain `cargo test` and
`cargo nextest run` never put the two tests in the same run and the collision cannot occur.
`just test` and `just prepush` use `ci`, where `default-filter = "all()"`.

## How this works

All three dump tests now pass `--output-file-name` a path inside their own tmpdir, matching
the pattern `test_slow_fwdctl_import_csv` already uses. `--output-file-name` is a `PathBuf`
and `dump` calls `set_extension` on it — which replaces rather than appends — so a full path
works unchanged.

The tests no longer share any filesystem path, so the race is gone **structurally** rather
than made less likely. That distinction matters: the failure never reproduced on demand
(it needs the two processes to interleave inside the write/read window), so a green loop
would not have been evidence of a fix.

The manual `remove_file` cleanup is gone with it — it existed only because the files were in
the CWD, and tmpdir teardown covers it now.

`fwdctl_dump_with_file_name` was **not** part of the collision: it uses `test.*` rather than
`dump.*`. It carried the identical defect, so it is fixed alongside — otherwise the
CWD-relative pattern survives as a template for the next test that copies it.

## How this was tested

`just prepush` passes: 718/718, 718/718, 763/763, 766/766, 763/763 across the Rust matrix
under the `ci` profile, plus fmt, five clippy configurations, docs, and markdown.

The full `firewood-fwdctl` suite passes 20/20 under the `ci` profile — the only profile that
runs both previously-colliding tests together — and the working directory stays clean
through a run.

## Provenance

`fwdctl_dump_json_escapes_special_characters` was added by 9e2e9723d
("fix(fwdctl): escape JSON dump strings", #2177). The `test_slow_` test it
collides with predates it. So the flake arrived with #2177 and has been intermittent since;
the CI signal is easy to misread as unrelated infrastructure noise.

Found while running `just prepush` on an unrelated branch that touches no fwdctl file.
