### PR TITLE
fix: add Owner tag to EC2 instances

### DIFF
--- a/fwdctl/README.launch.md
+++ b/fwdctl/README.launch.md
@@ -229,6 +229,7 @@ intentionally skipped so the node generates a fresh NodeID on first boot.
 ## Operational behavior
 
 - Managed instances are tagged with `ManagedBy=fwdctl`
+- Newly launched instances include `Owner=<AWS caller identity>`
 - Only managed instances are targeted by `launch list` and `launch kill`
 - `launch list` marks instances launched by your current AWS identity with `*`
 - `launch kill` requires explicit confirmation unless `-y`/`--yes` is provided.

--- a/fwdctl/src/launch/ec2_util.rs
+++ b/fwdctl/src/launch/ec2_util.rs
@@ -28,6 +28,8 @@ const UBUNTU_NOBLE_AMI_NAME_PATTERN: &str =
     "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-{arch}-server-*";
 /// Root EBS volume size (GiB) for launched benchmark instances.
 const ROOT_VOLUME_SIZE_GIB: i32 = 50;
+/// Tag key identifying the AWS caller responsible for the instance.
+const OWNER_TAG_KEY: &str = "Owner";
 /// Tag key used to identify instances managed by `fwdctl`.
 const MANAGED_BY_TAG_KEY: &str = "ManagedBy";
 /// Tag value used to identify instances managed by `fwdctl`.
@@ -135,6 +137,7 @@ pub async fn launch_instance(
     let instance_name = build_instance_name(opts);
     let username = get_aws_username().await;
     let tags = build_tags(opts, &instance_name, &username);
+    let owner_tag = Tag::builder().key(OWNER_TAG_KEY).value(&username).build();
     let root_device_name = ami_root_device_name(ec2, ami_id).await?;
 
     let root_volume = BlockDeviceMapping::builder()
@@ -161,6 +164,12 @@ pub async fn launch_instance(
                 .set_tags(Some(tags))
                 .build(),
         );
+    request = request.tag_specifications(
+        TagSpecification::builder()
+            .resource_type(ResourceType::Volume)
+            .set_tags(Some(vec![owner_tag]))
+            .build(),
+    );
 
     if let Some(key) = &opts.key_name {
         request = request.key_name(key);
@@ -175,7 +184,12 @@ pub async fn launch_instance(
     }
 
     info!("Requesting EC2 instance: {}", opts.instance_type);
-    let response = request.send().await?;
+    // EC2 applies TagSpecifications as part of RunInstances. If tagging is not
+    // authorized, the request fails instead of creating an unowned instance.
+    let response = request
+        .send()
+        .await
+        .map_err(|error| LaunchError::OwnerTag(super::format_aws_sdk_error(&error)))?;
 
     response
         .instances()
@@ -209,6 +223,7 @@ fn build_tags(opts: &DeployOptions, instance_name: &str, username: &str) -> Vec<
     let mut tags = vec![
         tag("Name", instance_name),
         tag("Component", "firewood"),
+        tag(OWNER_TAG_KEY, username),
         tag("ManagedBy", "fwdctl"),
         tag("LaunchedBy", username),
     ];

--- a/fwdctl/src/launch/ec2_util.rs
+++ b/fwdctl/src/launch/ec2_util.rs
@@ -163,13 +163,19 @@ pub async fn launch_instance(
                 .resource_type(ResourceType::Instance)
                 .set_tags(Some(tags))
                 .build(),
+        )
+        .tag_specifications(
+            TagSpecification::builder()
+                .resource_type(ResourceType::Volume)
+                .set_tags(Some(vec![owner_tag.clone()]))
+                .build(),
+        )
+        .tag_specifications(
+            TagSpecification::builder()
+                .resource_type(ResourceType::NetworkInterface)
+                .set_tags(Some(vec![owner_tag]))
+                .build(),
         );
-    request = request.tag_specifications(
-        TagSpecification::builder()
-            .resource_type(ResourceType::Volume)
-            .set_tags(Some(vec![owner_tag]))
-            .build(),
-    );
 
     if let Some(key) = &opts.key_name {
         request = request.key_name(key);

--- a/fwdctl/src/launch/ec2_util.rs
+++ b/fwdctl/src/launch/ec2_util.rs
@@ -137,7 +137,6 @@ pub async fn launch_instance(
     let instance_name = build_instance_name(opts);
     let username = get_aws_username().await;
     let tags = build_tags(opts, &instance_name, &username);
-    let owner_tag = Tag::builder().key(OWNER_TAG_KEY).value(&username).build();
     let root_device_name = ami_root_device_name(ec2, ami_id).await?;
 
     let root_volume = BlockDeviceMapping::builder()
@@ -161,19 +160,19 @@ pub async fn launch_instance(
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::Instance)
-                .set_tags(Some(tags))
+                .set_tags(Some(tags.clone()))
                 .build(),
         )
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::Volume)
-                .set_tags(Some(vec![owner_tag.clone()]))
+                .set_tags(Some(tags.clone()))
                 .build(),
         )
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::NetworkInterface)
-                .set_tags(Some(vec![owner_tag]))
+                .set_tags(Some(tags))
                 .build(),
         );
 

--- a/fwdctl/src/launch/mod.rs
+++ b/fwdctl/src/launch/mod.rs
@@ -22,6 +22,9 @@ pub enum LaunchError {
     #[error("EC2 operation failed: {0}")]
     Ec2(Box<aws_sdk_ec2::Error>),
 
+    #[error("EC2 launch failed; required launch tags, including Owner, were not applied: {0}")]
+    OwnerTag(String),
+
     #[error("SSM operation failed: {0}")]
     Ssm(Box<aws_sdk_ssm::Error>),
 
@@ -721,6 +724,7 @@ fn log_dry_run_plan(opts: &DeployOptions, ami_id: &str, user_data_size: usize, l
     info!("      tags:");
     info!("        ManagedBy=fwdctl");
     info!("        Component=firewood");
+    info!("        Owner={launched_by}");
     info!("        LaunchedBy={launched_by}");
     if let Some(tag) = &opts.custom_tag {
         info!("        CustomTag={tag}");


### PR DESCRIPTION
## Why this should be merged

Trying to launch an EC2 instance with `fwdctl launch deploy` fails because SecOps requires AWS resources (EC2 instances and EBS volumes, in this case) to have an `Owner` tag.

## How this works

Adds an `Owner` tag to resources deployed by `fwdctl launch deploy`.

## How this was tested

Ran `fwdctl launch deploy` and observed the benchmark run. Doing so off the `main` branch of Firewood currently fails.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
