### PR TITLE
ci: derive the benchmark matrix from cargo metadata

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -20,6 +20,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Benchmark results are the point of the run, so do not discard a merged
   # commit's results just because a newer commit arrived.
+  queue: ${{ github.event_name == 'workflow_dispatch' && 'single' || 'max' }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: Benchmark
         env:
           BENCH: ${{ matrix.bench }}
-        run: ./scripts/run-just.sh ci-rust bench "$PROFILE_KEY" "$BENCH"
+        run: ./scripts/run-just.sh ci-rust-bench "$PROFILE_KEY" "$BENCH"
       - name: Upload benchmark results
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -4,36 +4,180 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      bench-filter:
+        description: >-
+          Optional regex matched against bench target names (e.g. `proofs`, or
+          `^(rlp|triehash)$`). Leave blank to run every bench target. A filter
+          that matches nothing fails the run.
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Benchmark results are the point of the run, so do not discard a merged
+  # commit's results just because a newer commit arrived.
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  # One value serving two purposes: the profile name understood by
+  # scripts/run-rust-ci.sh, and the Swatinem/rust-cache shared-key, so the
+  # warming job and the matrix legs cannot drift apart.
+  PROFILE_KEY: maxperf-ethhash-logger-test_utils
 
 jobs:
-  bench:
+  # Derives the bench matrix from cargo metadata rather than a hand-maintained
+  # list, so adding a `[[bench]]` target needs no change here.
+  discover:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      matrix: ${{ steps.list.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        with:
+          tool: just@1.46.0
+      # The script runs `cargo metadata`, so it needs a toolchain. It does not
+      # need rust-cache or `cargo fetch`: `--no-deps` reads only the workspace
+      # manifests, resolving nothing and touching neither registry nor network.
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2
+      - name: List bench targets
+        id: list
+        env:
+          BENCH_FILTER: ${{ inputs.bench-filter || '' }}
+        run: |
+          matrix="$(./scripts/run-just.sh ci-bench-matrix "$BENCH_FILTER")"
+          jq . <<<"$matrix"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  # Sole writer of the shared cache, and deliberately not a dependency of the
+  # matrix. rust-cache's SAVE_TARGETS is {lib, proc-macro}, so bench binaries
+  # and target/criterion are pruned before the tarball is written and each leg
+  # relinks its own binary no matter what this job does; gating on it would add
+  # its full build to the critical path to hand the legs nothing but the
+  # dependency rlibs they already restore from the cache. Running it alongside
+  # the matrix keeps the legs on a warm cache from the previous run while this
+  # one refreshes it for the next.
+  #
+  # Skipped on a filtered dispatch: `--workspace --benches` would build every
+  # target to support a subset, and a filtered run has no cache obligation.
+  build:
+    if: ${{ !inputs.bench-filter }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
-          shared-key: "maxperf-ethhash-logger-test_utils"
+          tool: just@1.46.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: ${{ env.PROFILE_KEY }}
           cache-all-crates: true
           cache-workspace-crates: true
       - name: Cargo Fetch (run `cargo generate-lockfile` if this fails)
         run: cargo fetch --locked --verbose
-      - name: Build
-        run: cargo build --frozen --profile maxperf --features ethhash,logger,test_utils --workspace --benches
-      - name: Run firewood crate hashop benchmark
-        run: cargo bench --frozen --profile maxperf --features ethhash,logger,test_utils -p firewood --bench hashops -- --noplot
-      - name: Run firewood crate defer_persist benchmark
-        run: cargo bench --frozen --profile maxperf --features ethhash,logger,test_utils -p firewood --bench defer_persist -- --noplot
-      - name: Run storage crate benchmarks
-        run: cargo bench --frozen --profile maxperf --features ethhash,logger -p firewood-storage --bench serializer -- --noplot
+      - name: Build benches
+        run: ./scripts/run-just.sh ci-rust build-benches "$PROFILE_KEY"
+
+  bench:
+    name: bench (${{ matrix.package }} / ${{ matrix.bench }})
+    needs: discover
+    strategy:
+      # do not cancel concurrent jobs if one fails for exhaustive failure reasons
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        with:
+          tool: just@1.46.0
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # @master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: "false"
+          shared-key: ${{ env.PROFILE_KEY }}
+      - name: Cargo Fetch (run `cargo generate-lockfile` if this fails)
+        run: cargo fetch --locked --verbose
+      - name: Benchmark
+        env:
+          BENCH: ${{ matrix.bench }}
+        run: ./scripts/run-just.sh ci-rust bench "$PROFILE_KEY" "$BENCH"
       - name: Upload benchmark results
         uses: actions/upload-artifact@v7
         with:
-          name: benchmark-results
+          # Artifacts are immutable since upload-artifact v4, so reusing one
+          # name across matrix legs fails the run. One name per leg.
+          name: benchmark-results-${{ matrix.package }}-${{ matrix.bench }}
           path: target/criterion
+          if-no-files-found: error
+          retention-days: 30
+
+  # Recombines the per-leg artifacts so `benchmark-results` remains a single
+  # download, as it was when the benches ran in one job.
+  merge-results:
+    needs: bench
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge benchmark results
+        uses: actions/upload-artifact/merge@v7
+        with:
+          name: benchmark-results
+          pattern: benchmark-results-*
+          # Criterion writes report/index.html for every run; a flat merge would
+          # resolve those collisions as last-writer-wins.
+          separate-directories: true
+          delete-merged: true
+          retention-days: 30
+
+  # A matrix with zero legs reports `skipped`, not `failure`, so aggregate the
+  # results explicitly rather than trusting the individual job statuses.
+  # `build` is the one job allowed to be skipped, because a filtered dispatch
+  # deliberately skips it; a skipped `bench` still fails the run.
+  benchmarks-required:
+    if: ${{ always() }}
+    needs:
+      - discover
+      - build
+      - bench
+      - merge-results
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail unless all required jobs succeeded
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          failed_jobs="$(
+            jq -r '
+              to_entries[]
+              | select(
+                  if .key == "build"
+                  then .value.result | IN("success", "skipped") | not
+                  else .value.result != "success"
+                  end
+                )
+              | .key
+            ' <<<"$NEEDS_JSON"
+          )"
+
+          if [[ -n "$failed_jobs" ]]; then
+            echo "Required jobs failed:"
+            printf '%s\n' "$failed_jobs"
+            exit 1
+          fi

--- a/justfile
+++ b/justfile
@@ -2,9 +2,13 @@
 default:
     ./scripts/run-just.sh --list
 
-# Run a Rust command with a named CI profile; only `bench` takes a trailing arg.
-ci-rust command profile *args:
-    ./scripts/run-rust-ci.sh "{{command}}" "{{profile}}" {{args}}
+# Run a Rust command with a named CI profile.
+ci-rust command profile:
+    ./scripts/run-rust-ci.sh "{{command}}" "{{profile}}"
+
+# Run one bench target by name with the CI profile.
+ci-rust-bench profile target:
+    ./scripts/run-rust-ci.sh bench "{{profile}}" "{{target}}"
 
 # Emit workspace bench targets as a GitHub Actions matrix (optional name regex).
 ci-bench-matrix filter="":

--- a/justfile
+++ b/justfile
@@ -2,9 +2,13 @@
 default:
     ./scripts/run-just.sh --list
 
-# Run a Rust command with a named CI profile.
-ci-rust command profile:
-    ./scripts/run-rust-ci.sh "{{command}}" "{{profile}}"
+# Run a Rust command with a named CI profile; only `bench` takes a trailing arg.
+ci-rust command profile *args:
+    ./scripts/run-rust-ci.sh "{{command}}" "{{profile}}" {{args}}
+
+# Emit workspace bench targets as a GitHub Actions matrix (optional name regex).
+ci-bench-matrix filter="":
+    ./scripts/list-bench-targets.sh "{{filter}}"
 
 # Check Rust formatting as CI does.
 ci-format:

--- a/scripts/list-bench-targets.sh
+++ b/scripts/list-bench-targets.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Emits the workspace's Criterion bench targets as a one-line JSON array, in the
+# shape GitHub Actions expects for `strategy.matrix.include`. This replaces a
+# hand-maintained list of `cargo bench` invocations, so a new `[[bench]]` target
+# is picked up without touching the workflow.
+#
+# Requires cargo and jq. Nothing else: because `--no-deps` skips dependency
+# resolution, this reads only the workspace manifests, so it runs with an empty
+# CARGO_HOME, with no registry, with no network, and without a prior
+# `cargo fetch`. It does not even need Cargo.lock to exist. `--frozen` is
+# therefore belt-and-braces rather than a check that anything is up to date;
+# it is here so that this stays offline if the invocation ever grows a form
+# that does resolve dependencies.
+#
+# Bench target names must be unique across the workspace, because the runner
+# selects a single target with `--workspace --bench <name>` (see the `bench`
+# command in run-rust-ci.sh for why it is not `-p <package>`). The uniqueness
+# assertion below is what makes that safe.
+#
+# The output is a single line: a multi-line value cannot be written to
+# $GITHUB_OUTPUT with a plain `echo ... >>`. Every value is a scalar, because
+# `${{ matrix.<key> }}` does not usefully stringify arrays or objects.
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/list-bench-targets.sh help
+  scripts/list-bench-targets.sh [filter]
+
+Emits a one-line JSON array of {"package", "bench"} objects for every bench
+target in the workspace, sorted by package then bench.
+
+Arguments:
+  filter   Optional regular expression matched against bench target names.
+           Matching nothing is an error, so a typo in a workflow input fails
+           instead of silently running no benchmarks.
+
+Examples:
+  scripts/list-bench-targets.sh
+  scripts/list-bench-targets.sh '^proofs$'
+  scripts/list-bench-targets.sh '^(rlp|triehash)$'
+EOF
+}
+
+if [[ $# -eq 1 && $1 == help ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -gt 1 ]]; then
+    usage >&2
+    exit 2
+fi
+
+filter=${1-}
+
+cargo metadata --format-version 1 --frozen --no-deps | jq -c --arg filter "$filter" '
+    # `.kind` is an array, so `.kind == "bench"` would silently match nothing.
+    [ .packages[] | .name as $package | .targets[]
+      | select(.kind | index("bench"))
+      | { package: $package, bench: .name }
+    ]
+    | sort_by(.package, .bench)
+    # Assert uniqueness before filtering: the runner resolves a bench name
+    # against the whole workspace regardless of which names the filter kept.
+    | [ .[].bench ] as $names
+    | if ($names | length) != ($names | unique | length) then
+          "error: bench target names must be unique across the workspace; duplicates: "
+          + ($names | group_by(.) | map(select(length > 1) | .[0]) | join(", "))
+          + "\n" | halt_error(1)
+      else . end
+    | if $filter == "" then . else map(select(.bench | test($filter))) end
+    | if length == 0 then
+          "error: no bench target matched filter \"\($filter)\"\n" | halt_error(1)
+      else . end
+'

--- a/scripts/run-rust-ci.sh
+++ b/scripts/run-rust-ci.sh
@@ -12,11 +12,14 @@ usage() {
 Usage:
   scripts/run-rust-ci.sh help
   scripts/run-rust-ci.sh <command> <profile>
+  scripts/run-rust-ci.sh bench <profile> <bench-target>
 
 Commands:
   help               Show this usage information
   check              Run cargo check with the CI profile
   build              Run cargo build with the CI profile
+  build-benches      Build every workspace bench target with the CI profile
+  bench              Run one bench target by name with the CI profile
   clippy             Run the pinned PR clippy toolchain with the CI profile
   clippy-nightly     Run the latest nightly clippy toolchain with the CI profile
   test               Run cargo-nextest with the CI profile
@@ -31,6 +34,10 @@ Profiles:
                       above the 1.94.0 workspace MSRV, because fwdctl's
                       launch feature pulls in the AWS SDK)
   maxperf-ethhash-logger
+  maxperf-ethhash-logger-test_utils (benchmarks; test_utils gates the internals
+                      several bench targets declare in required-features)
+
+Use scripts/list-bench-targets.sh to enumerate valid bench target names.
 EOF
 }
 
@@ -39,13 +46,23 @@ if [[ $# -eq 1 && $1 == help ]]; then
     exit 0
 fi
 
-if [[ $# -ne 2 ]]; then
+if [[ $# -lt 2 ]]; then
     usage >&2
     exit 2
 fi
 
 command=$1
 profile=$2
+shift 2
+
+# Only `bench` takes a trailing argument. Rejecting them elsewhere turns a typo
+# in a workflow or Just recipe into a failure instead of a silently ignored
+# argument.
+if [[ $command != bench && $# -ne 0 ]]; then
+    echo "error: Rust CI command '$command' does not accept extra arguments: $*" >&2
+    usage >&2
+    exit 2
+fi
 
 cargo_args=()
 nextest_args=()
@@ -68,6 +85,10 @@ case "$profile" in
         cargo_args=(--profile maxperf --features ethhash,logger)
         nextest_args=(--cargo-profile maxperf --features ethhash,logger)
         ;;
+    maxperf-ethhash-logger-test_utils)
+        cargo_args=(--profile maxperf --features ethhash,logger,test_utils)
+        nextest_args=(--cargo-profile maxperf --features ethhash,logger,test_utils)
+        ;;
     *)
         echo "error: unknown Rust CI profile '$profile'" >&2
         usage >&2
@@ -84,6 +105,30 @@ case "$command" in
         ;;
     build)
         cargo build --frozen ${cargo_args[@]+"${cargo_args[@]}"} --workspace --all-targets
+        ;;
+    build-benches)
+        cargo build --frozen ${cargo_args[@]+"${cargo_args[@]}"} --workspace --benches
+        ;;
+    bench)
+        if [[ $# -ne 1 ]]; then
+            echo "error: 'bench' requires exactly one bench target name" >&2
+            usage >&2
+            exit 2
+        fi
+        # `--workspace`, not `-p <package>`. Cargo resolves dependency features
+        # from the package selection, so narrowing to one package resolves a
+        # different feature set than `build-benches` does and recompiles behind
+        # an otherwise warm target directory. Workspace scoping also lets one
+        # feature string cover every member: a feature applies to whichever
+        # members declare it and is a no-op for the rest, whereas
+        # `-p firewood-triehash --features ethhash,...` is an error because that
+        # package declares no features at all.
+        #
+        # Selecting a single target by name requires bench names to be unique
+        # across the workspace; scripts/list-bench-targets.sh asserts that.
+        # Unlike the plural `--benches`, singular `--bench` fails loudly when a
+        # target's required-features are not enabled instead of skipping it.
+        cargo bench --frozen ${cargo_args[@]+"${cargo_args[@]}"} --workspace --bench "$1" -- --noplot
         ;;
     clippy)
         cargo +nightly-2026-07-05 clippy --locked ${cargo_args[@]+"${cargo_args[@]}"} --workspace --all-targets -- -D warnings


### PR DESCRIPTION
## Why this should be merged

`benchmarks.yaml` hand-enumerated three `cargo bench` steps. The workspace declares six bench targets, so `proposal_reconstruct`, `rlp`, and `triehash` had never run in CI. A hand-maintained list drifts silently — nothing fails when a new `[[bench]]` is added and never wired up. Deriving the list from `cargo metadata` closes that gap and lets the targets run in parallel.

## How this works

**`--workspace --bench <name>`, not `-p <package> --bench <name>`.** `-p firewood-triehash --features ethhash,logger,test_utils` is a hard error — that package declares no features at all. Workspace scoping applies each feature to whichever members declare it, so one feature string covers all six targets and no per-package feature computation is needed. It is also the cache-correct choice: Cargo resolves dependency features from the package selection, so `-p` resolves a narrower set than the `--workspace --benches` warming build and recompiles behind a warm tree. Measured under `maxperf`:

| scoping                             | units recompiled |
| ----------------------------------- | ---------------- |
| `--workspace --bench <name>`        | 0, every target  |
| `-p firewood` (first bench)         | 80               |
| `-p firewood-storage` (first bench) | 14               |
| `-p firewood-triehash`              | 28               |

Later benches in a package reuse the narrowed build, but each CI leg restores the cache cold and pays its package's first-invocation cost.

Name-only selection requires bench names to be unique workspace-wide, so `list-bench-targets.sh` asserts it rather than leaving a future duplicate to fail confusingly. Singular `--bench` also errors when a target's `required-features` are unmet, where the plural `--benches` glob silently skips it — the stricter behavior is what we want.

`list-bench-targets.sh` needs only cargo and jq. Because `--no-deps` reads just the workspace manifests, it runs with an empty `CARGO_HOME`, offline, and without `Cargo.lock`. `--frozen` therefore asserts nothing here; it is retained only so the invocation stays offline if it ever grows a form that does resolve dependencies.

**The cache-warming `build` job runs alongside the matrix rather than gating it.** `Swatinem/rust-cache`'s `SAVE_TARGETS` is `{lib, proc-macro}`, so bench binaries and `target/criterion` are pruned before the tarball is written; a leg restores the dependency rlibs and relinks its own binary whether or not `build` ran first. Gating bought the legs nothing while putting a full workspace build on the critical path — measured on CI, a 144s build step ahead of legs that each took 78–98s, roughly half of a 6m14s run. Ungated, `build` refreshes the cache for subsequent runs while the current run's legs proceed on the previous run's cache. It is skipped entirely on a filtered dispatch, where `--workspace --benches` would build all six targets to serve a subset and there is no cache obligation to meet. `benchmarks-required` accordingly tolerates a skipped `build` but still fails on a skipped `bench`, which is how an empty matrix surfaces.

Behavior changes:

- `serializer` and `proposal_reconstruct` now compile with `test_utils` at bench time. Every `cfg(feature = "test_utils")` site is additive — nothing is conditional inside an existing function body. The old Build step already compiled these targets with `test_utils` and the bench step then rebuilt them without it, so this removes a redundant compile rather than adding one.
- Six artifacts instead of one: `upload-artifact` has been immutable since v4, so a shared name across matrix legs fails the run. A merge job recombines them into `benchmark-results`. Nothing in the repo consumes that artifact — `track-performance.yml` reads a different file.
- `ci-rust` becomes variadic. Existing callers pass exactly two arguments and only `bench` takes a trailing one, so this is backward compatible, but extra arguments to other commands are now rejected rather than silently dropped.

## How this was tested

Exercised on CI as both a full sweep and a `bench-filter` subset, which is where the build/leg timings above come from and how the gating change was validated.

Locally, `build-benches` compiles all six targets under the new `maxperf-ethhash-logger-test_utils` profile, with freshness verified per target (table above), and `triehash`, `rlp` (73s), and `proposal_reconstruct` (85s) run end-to-end through `just ci-rust bench …`. `timeout-minutes` are headroom rather than tight bounds, since a cold leg is dominated by the fat-LTO build and not by any individual benchmark.

`list-bench-targets.sh` is covered for matrix shape and single-line output, filter hits, a filter matching nothing (`rc=1`), and the duplicate-name assertion (`rc=1`, exercised against synthetic metadata). The `benchmarks-required` aggregator is covered for all-green, filtered-with-`build`-skipped, `build` failure, empty matrix, leg failure, and `discover` failure. `actionlint`, `shellcheck`, and `markdownlint-cli2` are clean.

## Breaking Changes

CI and developer tooling only; no library, FFI, or CLI surface is affected.
