### PR TITLE
refactor(proofs)!: privatize verification-context fields

### DIFF
--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -116,10 +116,10 @@ impl<'db> RangeProofContext<'db> {
         max_length: Option<NonZeroUsize>,
     ) -> Result<(), api::Error> {
         if let Some(ref ctx) = self.verification {
-            if ctx.root == root
-                && ctx.start_key.as_deref() == start_key
-                && ctx.end_key.as_deref() == end_key
-                && ctx.max_length == max_length
+            if *ctx.root() == root
+                && ctx.start_key() == start_key
+                && ctx.end_key() == end_key
+                && ctx.max_length() == max_length
             {
                 // already verified with the same context
                 return Ok(());
@@ -156,8 +156,7 @@ impl<'db> RangeProofContext<'db> {
         self.verification
             .as_ref()
             .expect("verify() populates the verification context on success")
-            .right_edge_key
-            .as_deref()
+            .right_edge_key()
     }
 
     /// Verify the range proof and prepare a proposal against the given database
@@ -277,7 +276,7 @@ impl<'db> RangeProofContext<'db> {
             Some(ProposalState::Proposed(ref proposal)) => Ok(proposal.root_hash()),
             None => Err(api::Error::ProofError(ProofError::Unverified)),
         }?;
-        if root_hash.as_ref() == Some(&verification.root) {
+        if root_hash.as_ref() == Some(verification.root()) {
             return Ok(None);
         }
 

--- a/ffi/src/proofs/range.rs
+++ b/ffi/src/proofs/range.rs
@@ -256,12 +256,14 @@ impl<'db> RangeProofContext<'db> {
     /// The returned key range represents `(finalKey, endKey]` where `finalKey`
     /// is the last key known to be fully synchronized within the requested
     /// range. `finalKey` is exclusive, meaning it has already been processed.
-    /// `endKey` is inclusive if provided during proof creation.
+    /// `endKey` is inclusive if provided when verifying the proof, i.e. the
+    /// `end_key` of [`VerifyRangeProofArgs`], which need not match the
+    /// `end_key` the proof was created with.
     ///
-    /// Because the proof includes hash information about the state of the
-    /// database outside of the range of key-value pairs included in the proof,
-    /// we are able to inspect the database and provide a more accurate value
-    /// for `finalKey` than simply the last key in the set of key-value pairs.
+    /// The proof carries hash information about the state outside the range of
+    /// key-value pairs it includes, so `finalKey` could in principle be
+    /// tightened beyond the last key in those pairs. That is not yet
+    /// implemented (tracked in #352); today `finalKey` is simply that last key.
     fn find_next_key(&mut self) -> Result<Option<KeyRange>, api::Error> {
         let verification = self
             .verification

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -488,8 +488,8 @@ fn compute_outside_children<'a>(
 /// recomputed, and fails the root-hash check. Returns the union of the left
 /// and right boundary masks keyed by node path.
 ///
-/// `range` must be the nibble expansion of `verification`'s `start_key` and
-/// `right_edge_key`.
+/// `range` must be the nibble expansion of `verification.start_key()` and
+/// `verification.right_edge_key()`.
 fn change_outside_children<S: ReadableStorage, H: HashMode>(
     proof: &FrozenChangeProof,
     verification: &ChangeProofVerificationContext,
@@ -1358,9 +1358,9 @@ fn verify_range_proof_root_hash<P: ProofCollection<Node = ProofNode>, H: HashMod
 /// # Ordering
 ///
 /// `verification` must come from `verify_change_proof_structure` for this same
-/// `proof`. Its `start_key` and `right_edge_key` define the proven range used by
-/// the collapse and reconciliation steps, so a hand-built context — or one
-/// produced for a different proof — makes those steps judge the wrong range.
+/// `proof`. Its `start_key()` and `right_edge_key()` define the proven range
+/// used by the collapse and reconciliation steps, so a hand-built context — or
+/// one produced for a different proof — makes those steps judge the wrong range.
 ///
 /// Marking a boundary terminal's on-path child outside takes that child's hash
 /// from the proof, which is safe only if the proof has no hash there. This

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -496,10 +496,8 @@ fn change_outside_children<S: ReadableStorage, H: HashMode>(
     proving_merkle: &Merkle<NodeStore<Mutable<Propose>, S, H>>,
     range: CollapseRange<'_>,
 ) -> Result<HashMap<PathBuf, ChildMask>, api::Error> {
-    let start_boundary = EdgeBoundary::Left(verification.start_key.as_deref());
-    let end_boundary = EdgeBoundary::Right(RightBoundary::InRange(
-        verification.right_edge_key.as_deref(),
-    ));
+    let start_boundary = EdgeBoundary::Left(verification.start_key());
+    let end_boundary = EdgeBoundary::Right(RightBoundary::InRange(verification.right_edge_key()));
     let start_proof = proof.start_proof();
     let end_proof = proof.end_proof();
 
@@ -1382,7 +1380,7 @@ pub fn verify_change_proof_root_hash<H: HashMode>(
     // end_root. Also covers the degenerate case of an empty diff.
     if start_nodes.is_empty() && end_nodes.is_empty() {
         let computed = api::DbView::root_hash(proposal).unwrap_or_else(HashKey::empty);
-        if computed != verification.end_root {
+        if computed != *verification.end_root() {
             return Err(api::Error::ProofError(ProofError::EndRootMismatch));
         }
         return Ok(());
@@ -1416,16 +1414,14 @@ pub fn verify_change_proof_root_hash<H: HashMode>(
     // A divergent terminal that overshoots to the nearest existing key after
     // start_key is in range, and a value mismatch there is a real error.
     let start_key_nibbles: Vec<u8> = verification
-        .start_key
-        .as_deref()
+        .start_key()
         .map(|k| NibblesIterator::new(k).collect())
         .unwrap_or_default();
     // `None` is an unbounded right edge (+∞). Keeping it distinct from an empty
     // slice matters: an empty slice sorts as the minimum key, which would mark
     // every key out of range at the upper bound.
     let end_key_nibbles: Option<Vec<u8>> = verification
-        .right_edge_key
-        .as_deref()
+        .right_edge_key()
         .map(|k| NibblesIterator::new(k).collect());
 
     let range = CollapseRange {
@@ -1537,7 +1533,7 @@ pub fn verify_change_proof_root_hash<H: HashMode>(
         proving_merkle.nodestore(),
     )?;
 
-    if computed != verification.end_root {
+    if computed != *verification.end_root() {
         return Err(api::Error::ProofError(ProofError::EndRootMismatch));
     }
 

--- a/firewood/src/merkle/tests/change/attack.rs
+++ b/firewood/src/merkle/tests/change/attack.rs
@@ -404,12 +404,12 @@ fn test_crafted_conflicting_proof_nodes_rejected() {
     );
 
     // Skip structural validation (the modified hash chain won't pass).
-    let ctx = ChangeProofVerificationContext {
-        end_root: root2,
-        start_key: Some(b"\x10".to_vec().into()),
-        end_key: Some(b"\x20".to_vec().into()),
-        right_edge_key: Some(b"\x20".to_vec().into()),
-    };
+    let ctx = ChangeProofVerificationContext::for_test(
+        root2,
+        Some(b"\x10".to_vec().into()),
+        Some(b"\x20".to_vec().into()),
+        Some(b"\x20".to_vec().into()),
+    );
 
     let parent = db.revision(root1).unwrap();
     let proposal = db.apply_change_proof_to_parent(&crafted, &*parent).unwrap();
@@ -456,12 +456,8 @@ fn test_crafted_value_at_odd_nibble_length_rejected() {
     );
 
     // Skip structural validation (injected value breaks the hash chain).
-    let ctx = ChangeProofVerificationContext {
-        end_root: root2,
-        start_key: Some(b"\x10".to_vec().into()),
-        end_key: None,
-        right_edge_key: None,
-    };
+    let ctx =
+        ChangeProofVerificationContext::for_test(root2, Some(b"\x10".to_vec().into()), None, None);
 
     let parent = db.revision(root1).unwrap();
     let proposal = db.apply_change_proof_to_parent(&crafted, &*parent).unwrap();
@@ -539,12 +535,12 @@ fn test_crafted_divergence_at_depth_zero() {
         .apply_change_proof_to_parent(&crafted, &*parent)
         .unwrap();
 
-    let verification = ChangeProofVerificationContext {
-        end_root: root2,
-        start_key: Some(b"\x10".to_vec().into()),
-        end_key: Some(b"\xa1".to_vec().into()),
-        right_edge_key: Some(b"\xa1".to_vec().into()),
-    };
+    let verification = ChangeProofVerificationContext::for_test(
+        root2,
+        Some(b"\x10".to_vec().into()),
+        Some(b"\xa1".to_vec().into()),
+        Some(b"\xa1".to_vec().into()),
+    );
 
     let err = verify_change_proof_root_hash(&crafted, &verification, &proposal).unwrap_err();
     assert!(

--- a/firewood/src/merkle/tests/change/edge_cases.rs
+++ b/firewood/src/merkle/tests/change/edge_cases.rs
@@ -837,7 +837,7 @@ fn test_truncation_narrows_to_the_last_op(
         "fixture must end in the expected op kind"
     );
     assert_eq!(
-        ctx.right_edge_key.as_deref(),
+        ctx.right_edge_key(),
         Some(expected_edge),
         "the range must narrow to the last operation's key"
     );
@@ -887,7 +887,7 @@ fn test_truncation_classification_under_a_prefix_key(
         .unwrap();
     let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x20"), limit).unwrap();
 
-    assert_eq!(ctx.right_edge_key.as_deref(), expected_edge);
+    assert_eq!(ctx.right_edge_key(), expected_edge);
 }
 
 /// A proof covering its whole requested range keeps its full proven range when the
@@ -937,8 +937,8 @@ fn test_prefix_bound_does_not_narrow_a_complete_proof() {
 
     let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\x10\x20"), None).unwrap();
     assert_eq!(
-        ctx.right_edge_key.as_deref(),
-        ctx.end_key.as_deref(),
+        ctx.right_edge_key(),
+        ctx.end_key(),
         "a complete proof keeps the range it was asked for"
     );
 
@@ -980,13 +980,13 @@ fn test_a_terminal_at_the_last_operation_narrows_the_range() {
 
     let ctx = verify_change_proof_structure(&proof, root2, None, Some(b"\xff"), None).unwrap();
     assert_eq!(
-        ctx.right_edge_key.as_deref(),
+        ctx.right_edge_key(),
         Some(&b"\x10"[..]),
         "the terminal-valued node narrows the range to the last op's key"
     );
     assert_ne!(
-        ctx.right_edge_key.as_deref(),
-        ctx.end_key.as_deref(),
+        ctx.right_edge_key(),
+        ctx.end_key(),
         "the narrowed edge sits below the requested bound"
     );
     verify_and_check(&target, &proof, &ctx, root1).unwrap();
@@ -1125,13 +1125,13 @@ fn test_stopping_short_on_a_delete_is_accepted_over_the_narrowed_range() {
     )
     .unwrap();
     assert_eq!(
-        ctx.right_edge_key.as_deref(),
+        ctx.right_edge_key(),
         Some(&b"\x20"[..]),
         "the proven range narrows to the trailing removal's key"
     );
     assert_ne!(
-        ctx.right_edge_key.as_deref(),
-        ctx.end_key.as_deref(),
+        ctx.right_edge_key(),
+        ctx.end_key(),
         "the narrowed edge sits below the requested bound"
     );
     verify_and_check(&f.target, &f.proof, &ctx, f.start_root).unwrap();
@@ -1155,7 +1155,7 @@ fn test_stopping_short_below_a_surviving_key_is_accepted() {
     )
     .unwrap();
     assert_eq!(
-        ctx.right_edge_key.as_deref(),
+        ctx.right_edge_key(),
         Some(&b"\x20"[..]),
         "the proven range narrows to the trailing removal's key"
     );
@@ -1249,7 +1249,7 @@ fn test_an_unrelated_end_proof_does_not_narrow() {
         // and the proof must still be rejected.
         Ok(ctx) => {
             assert_eq!(
-                ctx.right_edge_key.as_deref(),
+                ctx.right_edge_key(),
                 Some(&b"\xff"[..]),
                 "an end proof that cannot be anchored at the last operation keeps the wide range"
             );

--- a/firewood/src/merkle/tests/ethhash_fuzz.rs
+++ b/firewood/src/merkle/tests/ethhash_fuzz.rs
@@ -808,7 +808,7 @@ fn check_truncated_change_proof(
     .unwrap_or_else(|e| {
         panic!("honest truncated proof must verify structurally ({locator}, limit={limit}): {e}")
     });
-    let right_edge = ctx.right_edge_key.clone();
+    let right_edge = ctx.right_edge_key();
     let parent = db.revision(start_root.clone()).unwrap();
     let proposal = db
         .apply_change_proof_to_parent(&proof, &*parent)
@@ -819,7 +819,7 @@ fn check_truncated_change_proof(
 
     // Every op must lie at or below the proven right edge. Narrowing must never
     // claim a smaller range than the operations the proof carries.
-    if let Some(edge) = right_edge.as_deref() {
+    if let Some(edge) = right_edge {
         for op in proof.batch_ops() {
             assert!(
                 op.key().as_ref() <= edge,

--- a/firewood/src/merkle/tests/range.rs
+++ b/firewood/src/merkle/tests/range.rs
@@ -2370,6 +2370,6 @@ fn test_verification_context_reports_truncated_right_edge() {
     .unwrap();
 
     // The request was unbounded, but only `[.., 0x10]` is proven.
-    assert_eq!(ctx.end_key, None);
-    assert_eq!(ctx.right_edge_key.as_deref(), Some(b"\x10".as_slice()));
+    assert_eq!(ctx.end_key(), None);
+    assert_eq!(ctx.right_edge_key(), Some(b"\x10".as_slice()));
 }

--- a/firewood/src/proofs/change.rs
+++ b/firewood/src/proofs/change.rs
@@ -196,7 +196,6 @@ where
 /// Constructible only by [`verify_change_proof_structure`]; fields are private
 /// so a context cannot be forged or altered after verification.
 #[derive(Debug)]
-#[non_exhaustive]
 pub struct ChangeProofVerificationContext {
     end_root: HashKey,
     start_key: Option<Box<[u8]>>,

--- a/firewood/src/proofs/change.rs
+++ b/firewood/src/proofs/change.rs
@@ -190,11 +190,13 @@ where
 // ── Change proof verification ──────────────────────────────────────────────
 
 /// Verification context captured after structural validation of a change proof.
-/// Stored so that downstream logic (root hash verification, `find_next_key`) can
-/// reference the original verification parameters without re-validating.
+/// Stored so that downstream logic (root hash verification,
+/// [`find_next_key_after_change_proof`]) can reference the original
+/// verification parameters without re-validating.
 ///
-/// Constructible only by [`verify_change_proof_structure`]; fields are private
-/// so a context cannot be forged or altered after verification.
+/// Outside of test builds, constructible only by
+/// [`verify_change_proof_structure`]; fields are private so a context cannot be
+/// forged or altered after verification.
 #[derive(Debug)]
 pub struct ChangeProofVerificationContext {
     end_root: HashKey,

--- a/firewood/src/proofs/change.rs
+++ b/firewood/src/proofs/change.rs
@@ -192,14 +192,37 @@ where
 /// Verification context captured after structural validation of a change proof.
 /// Stored so that downstream logic (root hash verification, `find_next_key`) can
 /// reference the original verification parameters without re-validating.
+///
+/// Constructible only by [`verify_change_proof_structure`]; fields are private
+/// so a context cannot be forged or altered after verification.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct ChangeProofVerificationContext {
+    end_root: HashKey,
+    start_key: Option<Box<[u8]>>,
+    end_key: Option<Box<[u8]>>,
+    right_edge_key: Option<Box<[u8]>>,
+}
+
+impl ChangeProofVerificationContext {
     /// The expected root hash of the ending revision.
-    pub end_root: HashKey,
+    #[must_use]
+    pub const fn end_root(&self) -> &HashKey {
+        &self.end_root
+    }
+
     /// The lower bound of the verified key range, if any.
-    pub start_key: Option<Box<[u8]>>,
+    #[must_use]
+    pub fn start_key(&self) -> Option<&[u8]> {
+        self.start_key.as_deref()
+    }
+
     /// The upper bound of the verified key range, if any.
-    pub end_key: Option<Box<[u8]>>,
+    #[must_use]
+    pub fn end_key(&self) -> Option<&[u8]> {
+        self.end_key.as_deref()
+    }
+
     /// The right edge of the range the proof proves: the key the end proof is
     /// anchored at, as the verifier determines it. This is `end_key` when the
     /// proof covers the requested range, and the last key in `batch_ops` when the
@@ -213,7 +236,29 @@ pub struct ChangeProofVerificationContext {
     /// this proof must resume strictly above the last operation's key, because
     /// both bounds of a request are inclusive —
     /// [`find_next_key_after_change_proof`] computes that resume point.
-    pub right_edge_key: Option<Box<[u8]>>,
+    #[must_use]
+    pub fn right_edge_key(&self) -> Option<&[u8]> {
+        self.right_edge_key.as_deref()
+    }
+
+    /// Test-only escape hatch that builds a context without running
+    /// [`verify_change_proof_structure`]. Some attack tests craft proofs
+    /// that are deliberately rejected by structural validation and need to
+    /// exercise `verify_change_proof_root_hash` directly against them.
+    #[cfg(test)]
+    pub(crate) const fn for_test(
+        end_root: HashKey,
+        start_key: Option<Box<[u8]>>,
+        end_key: Option<Box<[u8]>>,
+        right_edge_key: Option<Box<[u8]>>,
+    ) -> Self {
+        Self {
+            end_root,
+            start_key,
+            end_key,
+            right_edge_key,
+        }
+    }
 }
 
 type FrozenBatchOp = BatchOp<Box<[u8]>, Box<[u8]>>;

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -73,29 +73,57 @@ pub type KeyRange = (Box<[u8]>, Option<Box<[u8]>>);
 /// Verification context captured after structural validation of a range proof.
 /// Stored so that downstream logic (root hash verification, `find_next_key`)
 /// can reference the original verification parameters without re-validating.
+///
+/// Constructible only by [`verify_range_proof_structure`]; fields are private
+/// so a context cannot be forged or altered after verification.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct RangeProofVerificationContext {
+    root: HashKey,
+    start_key: Option<Box<[u8]>>,
+    end_key: Option<Box<[u8]>>,
+    max_length: Option<NonZeroUsize>,
+    right_edge_key: Option<Box<[u8]>>,
+}
+
+impl RangeProofVerificationContext {
     /// The expected root hash of the trie.
-    pub root: HashKey,
+    #[must_use]
+    pub const fn root(&self) -> &HashKey {
+        &self.root
+    }
+
     /// The lower bound of the verified key range, if any.
-    pub start_key: Option<Box<[u8]>>,
+    #[must_use]
+    pub fn start_key(&self) -> Option<&[u8]> {
+        self.start_key.as_deref()
+    }
+
     /// The upper bound the caller **requested**, if any.
-    pub end_key: Option<Box<[u8]>>,
+    #[must_use]
+    pub fn end_key(&self) -> Option<&[u8]> {
+        self.end_key.as_deref()
+    }
+
     /// The maximum number of key/value pairs the proof was permitted to
     /// contain. `None` means no limit.
-    pub max_length: Option<NonZeroUsize>,
-    /// The inclusive right edge of the **proven** range — [`ProvenRange::end`]
-    /// as returned by verification. Equals `end_key` when the responder covered
-    /// the whole request, a smaller key when the reply was truncated, and
-    /// `None` when unbounded above. Callers applying the proof must bound the
-    /// write to this key, not to `end_key`.
+    #[must_use]
+    pub const fn max_length(&self) -> Option<NonZeroUsize> {
+        self.max_length
+    }
+
+    /// The actual right edge of the **proven** range, inclusive. Equals
+    /// `end_key` when the responder covered the whole request, and a smaller
+    /// key when the reply was truncated. `None` means unbounded above.
     ///
     /// Mirrors [`ChangeProofVerificationContext::right_edge_key`].
     ///
     /// [`ProvenRange::end`]: crate::ProvenRange::end
     /// [`ChangeProofVerificationContext::right_edge_key`]: crate::ChangeProofVerificationContext::right_edge_key
-    pub right_edge_key: Option<Box<[u8]>>,
+    #[must_use]
+    pub fn right_edge_key(&self) -> Option<&[u8]> {
+        self.right_edge_key.as_deref()
+    }
 }
 
 /// Verify structural properties of a range proof and produce a

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -77,7 +77,6 @@ pub type KeyRange = (Box<[u8]>, Option<Box<[u8]>>);
 /// Constructible only by [`verify_range_proof_structure`]; fields are private
 /// so a context cannot be forged or altered after verification.
 #[derive(Debug)]
-#[non_exhaustive]
 pub struct RangeProofVerificationContext {
     root: HashKey,
     start_key: Option<Box<[u8]>>,

--- a/firewood/src/proofs/range.rs
+++ b/firewood/src/proofs/range.rs
@@ -71,8 +71,9 @@ use super::types::{Proof, ProofCollection};
 pub type KeyRange = (Box<[u8]>, Option<Box<[u8]>>);
 
 /// Verification context captured after structural validation of a range proof.
-/// Stored so that downstream logic (root hash verification, `find_next_key`)
-/// can reference the original verification parameters without re-validating.
+/// Stored so that downstream logic (root hash verification,
+/// [`find_next_key_after_range_proof`]) can reference the original
+/// verification parameters without re-validating.
 ///
 /// Constructible only by [`verify_range_proof_structure`]; fields are private
 /// so a context cannot be forged or altered after verification.
@@ -111,9 +112,11 @@ impl RangeProofVerificationContext {
         self.max_length
     }
 
-    /// The actual right edge of the **proven** range, inclusive. Equals
-    /// `end_key` when the responder covered the whole request, and a smaller
-    /// key when the reply was truncated. `None` means unbounded above.
+    /// The actual right edge of the **proven** range, inclusive — see
+    /// [`ProvenRange::end`]. Equals `end_key` when the responder covered the
+    /// whole request, and a smaller key when the reply was truncated. `None`
+    /// means unbounded above. Callers applying the proof must bound the write
+    /// to this key, not to `end_key`.
     ///
     /// Mirrors [`ChangeProofVerificationContext::right_edge_key`].
     ///


### PR DESCRIPTION
## Why this should be merged

A verification context is meant to be evidence that verification happened. Neither
of ours could carry that weight, and they failed differently:

- `RangeProofVerificationContext` already had `#[non_exhaustive]`, so it could not
  be *constructed* externally — but every field was `pub`, so a caller holding a
  legitimately obtained context could overwrite `root` or `right_edge_key` and hand
  it back alongside a different proof.
- `ChangeProofVerificationContext` had no such attribute. It was constructible from
  whole cloth via a struct literal, with no verification call involved at all.

Two sibling types with divergent extensibility contracts, one of them accepting
forgeries. This closes both holes with one shape.

The motivation is concrete rather than hygienic: hole detection (#352) adds public
entry points that take a context as a *witness* and skip re-verifying what it
attests. Those signatures cannot go `pub` while a context is forgeable.

## Notes for review

Accessors return borrows except where the type is `Copy`. `TrieHash` derives
`Clone` but not `Copy`, so borrowing avoids a 32-byte copy per read — and that
choice is why four `as_deref()` calls *disappear* at call sites rather than
migrating: `Option<&[u8]>` is what consumers already wanted.

The mutation surface really is closed, not just narrowed: workspace-wide these
types have exactly two `impl` blocks between them, with no `Clone`, `Default`,
`serde`, `From`, `Deref`, or `&mut` accessor. An external holder can read or drop,
and nothing else.

### What this does *not* establish

A context is not bound to the proof that produced it. Both entry points take the
proof and the context as independent arguments, so a caller can verify proof A,
obtain a perfectly legitimate context, and pass it alongside proof B. After this PR
a context witnesses that *some* verification ran with *those parameters* — not that
*this proof* was verified.

That is likely sufficient for hole detection, since the parameters are what bound
the range. It is still narrower than "witness" suggests, so the hole-detection PR
has to pick a resolution deliberately: pair them in one owning type (as
`RangeProofContext` already does on the FFI side), re-derive the binding by checking
`ctx.root()` against the proof, or define a mismatched pair as a caller error.
Recorded here so that decision is made rather than assumed.

### Rejected alternative

Three tests in `merkle/tests/change/attack.rs` build a context by struct literal on
purpose — they drive `verify_change_proof_root_hash` with proofs engineered to
*fail* structural validation, so the real constructor is unreachable by test design.
They now go through a `#[cfg(test)] pub(crate)` escape hatch.

`pub(crate)` fields were the obvious alternative and were rejected: they exist in
*every* build, which would let any in-crate module mutate a context — including the
hole-detection code arriving later in this same stack. That relocates the hazard
inside the crate boundary instead of removing it, and lands it exactly where the
future consumers live. The `#[cfg(test)]` hatch adds zero forgery surface outside
`cargo test`.

### Downstream impact beyond the field access

External consumers lose one legitimate capability: destructuring
`ChangeProofVerificationContext` to move its four boxed keys out zero-copy, which
was possible only because it lacked `#[non_exhaustive]`. Borrows cover every in-tree
use, and an `into_parts()` accessor remains a purely additive, non-breaking addition
if anyone needs it.

No C-ABI change. Neither struct is `#[repr(C)]`, both sit behind opaque FFI handles,
and the `ffi/` changes are Rust-internal — the Go binary contract is untouched.

## How this was tested

Mechanical refactor with no behavior change, so no new tests: the gate is that
existing coverage passes unchanged, with test counts measured before and after
rather than assumed. `just prepush` green; Go suite green in both hash modes.

Two things worth noting about the verification rather than the code:

- A missed reader is a compile error by construction, so a clean
  `cargo check --workspace --all-targets --all-features` is dispositive for
  completeness here, not merely suggestive.
- The rebase onto `HashOrRlp`-folded-into-`HashType` (#2150) forced a conflict
  inside this diff, at the change-proof root-hash equality check. The resolution
  compares `HashType` against `TrieHash` directly instead of converting up first.
  That is behavior-preserving, and the `Rlp` arm is why it needed checking: both
  `PartialEq` impls apply the same Keccak normalization to the mixed case, so no
  outcome changes. Confirmed by the ethhash profile and by the `attack.rs` tests
  that traverse that exact comparison.

## Breaking Changes

- [x] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl

BREAKING CHANGE: `RangeProofVerificationContext` and
`ChangeProofVerificationContext` no longer expose public fields. Read them through
the new accessors: `root()` / `end_root()`, `start_key()`, `end_key()`,
`right_edge_key()`, and `max_length()` on the range context.
`ChangeProofVerificationContext` is additionally `#[non_exhaustive]`.
