### PR TITLE
perf(storage): stop deep-cloning unhashed children during ethhash classification

### DIFF
--- a/storage/src/nodestore/hash.rs
+++ b/storage/src/nodestore/hash.rs
@@ -68,7 +68,7 @@ impl DerefMut for PathGuard<'_> {
 /// Classified children for ethereum hash processing
 #[cfg(feature = "ethhash")]
 pub(super) struct ClassifiedChildren<'a> {
-    pub(super) unhashed: Vec<(PathComponent, Node)>,
+    pub(super) unhashed: Vec<PathComponent>,
     pub(super) hashed: Vec<(PathComponent, (MaybePersistedNode, &'a mut HashType))>,
 }
 
@@ -97,7 +97,7 @@ where
                         let maybe_persisted_node = MaybePersistedNode::from(*a);
                         acc.hashed.push((idx, (maybe_persisted_node, h)));
                     }
-                    Some(Child::Node(node)) => acc.unhashed.push((idx, node.clone())),
+                    Some(Child::Node(_)) => acc.unhashed.push(idx),
                     Some(Child::MaybePersisted(maybe_persisted, h)) => {
                         // For MaybePersisted, it's important to remember that we've already hashed it
                         acc.hashed.push((idx, (maybe_persisted.clone(), h)));
@@ -173,7 +173,7 @@ where
                 }
                 // handle the single-child case for an account special below
                 if hashed.is_empty() && unhashed.len() == 1 {
-                    Some(unhashed.last().expect("only one").0)
+                    Some(*unhashed.last().expect("only one"))
                 } else {
                     None
                 }


### PR DESCRIPTION
## Why this should be merged

`ethhash_classify_children` pushed `(idx, node.clone())` for every unhashed child, but `ClassifiedChildren::unhashed` is only ever read for `is_empty()`, `len()`, and the `PathComponent`, the `Node` is never dereferenced.  `Node::clone` is recursive, so this deep-cloned the entire in-memory subtree  hanging off the child and dropped it immediately. It runs for every dirty  branch at account depth, i.e. once per account touched by each block's batch.

## How this works

`unhashed` becomes `Vec<PathComponent>`; the clone is deleted. No behavior change. 

  ## How this was tested
UT.

  ## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl