### PR TITLE
perf(storage): take nodes out of the read cache when reading for update

### DIFF
--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -185,6 +185,11 @@ impl ReadableStorage for FileBacked {
         cached
     }
 
+    fn take_cached_node(&self, addr: LinearAddress) -> Option<SharedNode> {
+        let mut guard = self.cache.lock();
+        guard.remove_entry(&addr).map(|(_, cached)| cached.0)
+    }
+
     fn free_list_cache(&self, addr: LinearAddress) -> Option<Option<LinearAddress>> {
         // BLOCKING: mutex lock on the free-list LRU cache. Called during node allocation on
         // every proposal/commit. Contends with writes that also update the free-list cache.

--- a/storage/src/linear/mod.rs
+++ b/storage/src/linear/mod.rs
@@ -190,6 +190,11 @@ pub trait ReadableStorage: Debug + Sync + Send {
     /// Cache a node for future reads
     fn cache_node(&self, _addr: LinearAddress, _node: SharedNode) {}
 
+    /// Remove a node from the cache and return it, if it was present.
+    fn take_cached_node(&self, _addr: LinearAddress) -> Option<SharedNode> {
+        None
+    }
+
     /// Return the filename of the underlying storage
     fn filename(&self) -> Option<PathBuf> {
         None

--- a/storage/src/node/persist.rs
+++ b/storage/src/node/persist.rs
@@ -144,6 +144,18 @@ impl MaybePersistedNode {
         }
     }
 
+    /// Returns the address only when the node is fully persisted, i.e. its
+    /// contents are on disk and a caller may drop any in-memory copy and still
+    /// be able to re-read it. Unlike [`Self::as_linear_address`] this excludes
+    /// `Allocated`, whose contents have an address but have not been written yet.
+    #[must_use]
+    pub fn persisted_address(&self) -> Option<LinearAddress> {
+        match &*self.0.lock() {
+            MaybePersisted::Persisted(address) => Some(*address),
+            MaybePersisted::Unpersisted(_) | MaybePersisted::Allocated(_, _) => None,
+        }
+    }
+
     /// Returns a reference to the unpersisted node if it is unpersisted.
     ///
     /// # Returns

--- a/storage/src/nodestore/mod.rs
+++ b/storage/src/nodestore/mod.rs
@@ -416,7 +416,13 @@ impl<K: MutableKind, S: ReadableStorage> NodeStore<Mutable<K>, S> {
     /// Returns a [`FileIoError`] if the node cannot be read.
     #[inline]
     pub fn read_for_update(&mut self, node: MaybePersistedNode) -> Result<Node, FileIoError> {
-        let arc_wrapped_node = node.as_shared_node(self)?;
+        let arc_wrapped_node = match node.persisted_address() {
+            Some(addr) => match self.storage.take_cached_node(addr) {
+                Some(cached) => cached,
+                None => self.read_node_with_num_bytes_from_disk(addr)?.0,
+            },
+            None => node.as_shared_node(self)?,
+        };
         // Skip building the future-delete log when delete tracking is off
         // (it would never be consumed). This branch is on an immutable flag
         // and is perfectly predicted.


### PR DESCRIPTION
## Why this should be merged
`read_for_update` ends in `Arc::unwrap_or_clone`, which only moves when the`Arc` is unique. Under `CacheAllReads` the node cache holds a second reference to every node it just returned, so the cheap path is structurally unreachable and every call deep-copies a ~1.6KB `BranchNode`.

## How this works

Pop the entry out of the LRU instead of peeking it, making the `Arc` unique so `unwrap_or_clone` moves. This is also semantically right: the proposal is about to supersede the node, its address will be freed, and `invalidate_cached_nodes` drops it at reap time anyway. Only fully persisted nodes are dropped this way (`persisted_address()`).

## How this was tested
UT.

## Breaking Changes
- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
