### PR TITLE
perf(manager): cap the parallel-merkle pool at the machine's parallelism

### DIFF
--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -10,7 +10,7 @@ use nonzero_ext::nonzero;
 use parking_lot::{Mutex, RwLock};
 use std::collections::{HashMap, VecDeque};
 use std::io;
-use std::num::{NonZero, NonZeroU64};
+use std::num::{NonZero, NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use std::sync::{Arc, OnceLock};
 
@@ -610,8 +610,11 @@ impl RevisionManager {
         // nightly release). The get_or_init should be replaced with get_or_try_init once it
         // is available to allow the error to be passed back to the caller.
         self.threadpool.get_or_init(|| {
+            let workers = std::thread::available_parallelism()
+                .map_or(BranchNode::MAX_CHILDREN, NonZeroUsize::get)
+                .min(BranchNode::MAX_CHILDREN);
             ThreadPoolBuilder::new()
-                .num_threads(BranchNode::MAX_CHILDREN)
+                .num_threads(workers)
                 .build()
                 .expect("Error in creating threadpool")
         })


### PR DESCRIPTION
## Why this should be merged

The pool was sized `num_threads(BranchNode::MAX_CHILDREN)` = 16, one per child nibble. On a machine with fewer cores this oversubscribes: workers spend most of their life blocked in `recv()`, so the surplus threads add scheduler churn and work-stealing traffic without adding parallelism. 

## How this works

Caps the rayon pool at `available_parallelism()`.

## How this was tested
UT.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
