### PR TITLE
docs: Revise CODEOWNERS to use team groups

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
 # CODEOWNERS
-# Note: more specific rules overrule wildcard
+# Note: more specific rules overrule the wildcard rule. Always include @ava-labs/platform-firewood when adding more specific rules.
 *        @ava-labs/platform-firewood
-/ffi     @ava-labs/platform-firewood @alarso16 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
 # CODEOWNERS
 # Note: more specific rules overrule wildcard
-*        @rkuris @demosdemon @RodrigoVillar @bernard-avalabs
-/ffi     @rkuris @demosdemon @alarso16 @RodrigoVillar @bernard-avalabs
-/fwdctl  @rkuris @demosdemon @RodrigoVillar @bernard-avalabs @aminR443
+*        @ava-labs/platform-firewood
+/ffi     @ava-labs/platform-firewood @alarso16 


### PR DESCRIPTION
## Why this should be merged

A hand curated list of owners becomes stale.

## How this works

This replaces the hand curated list with the platform-firewood team, which already includes every mentioned user plus Juan.

## How this was tested

GitHub UI confirmed the file was valid.

## Breaking Changes

n/a