### PR TITLE
style: reject bare clippy::allow_attributes across the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ missing_debug_implementations = "warn"
 
 [workspace.lints.clippy]
 allow_attributes = "warn"
-# allow_attributes_without_reason = "warn"
 unwrap_used = "warn"
 indexing_slicing = "warn"
 explicit_deref_methods = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ unsafe_code = "deny"
 missing_debug_implementations = "warn"
 
 [workspace.lints.clippy]
+allow_attributes = "warn"
+# allow_attributes_without_reason = "warn"
 unwrap_used = "warn"
 indexing_slicing = "warn"
 explicit_deref_methods = "warn"

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -960,7 +960,13 @@ pub extern "C" fn fwd_close_db(db: Option<Box<DatabaseHandle>>) -> VoidResult {
 /// - [`VoidResult::Ok`] if the flush succeeded or was a no-op.
 /// - [`VoidResult::Err`] if an I/O error occurred during the flush.
 #[unsafe(no_mangle)]
-#[allow(clippy::missing_const_for_fn)] // Can't be const when block-replay is enabled
+#[cfg_attr(
+    not(feature = "block-replay"),
+    expect(
+        clippy::missing_const_for_fn,
+        reason = "the no-op `VoidResult::Ok` body is const-able without block-replay, but invoke() isn't when the feature is on"
+    )
+)]
 pub extern "C" fn fwd_block_replay_flush() -> VoidResult {
     #[cfg(feature = "block-replay")]
     {

--- a/ffi/src/proofs/code_hash.rs
+++ b/ffi/src/proofs/code_hash.rs
@@ -92,7 +92,7 @@ impl<'p> CodeIteratorHandle<'p> {
     ///
     /// - Returns `api::Error::FeatureNotSupported` if the `ethhash` feature
     ///   is not enabled.
-    #[cfg_attr(not(feature = "ethhash"), allow(unused_variables))]
+    #[cfg_attr(not(feature = "ethhash"), expect(unused_variables))]
     pub fn from_key_values(key_values: &'p [KeyValuePair]) -> Result<Self, api::Error> {
         #[cfg(not(feature = "ethhash"))]
         {
@@ -131,7 +131,7 @@ impl<'p> CodeIteratorHandle<'p> {
     ///
     /// - Returns `api::Error::FeatureNotSupported` if the `ethhash` feature
     ///   is not enabled.
-    #[cfg_attr(not(feature = "ethhash"), allow(unused_variables))]
+    #[cfg_attr(not(feature = "ethhash"), expect(unused_variables))]
     pub fn from_batch_ops(
         batch_ops: &'p [BatchOp<firewood::Key, firewood::Value>],
     ) -> Result<Self, api::Error> {

--- a/ffi/src/proposal.rs
+++ b/ffi/src/proposal.rs
@@ -97,7 +97,7 @@ impl ProposalHandle<'_> {
 
     /// Creates an iterator on the proposal starting from the given key.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn iter_from(&self, first_key: Option<&[u8]>) -> CreateIteratorResult<'_> {
         let it = self
             .iter_option(first_key)

--- a/ffi/src/reconstructed.rs
+++ b/ffi/src/reconstructed.rs
@@ -69,7 +69,7 @@ impl<'db> ReconstructedHandle<'db> {
 
     /// Creates an iterator on the reconstructed view starting from the given key.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn iter_from(&self, first_key: Option<&[u8]>) -> CreateIteratorResult<'_> {
         let it = self
             .iter_option(first_key)

--- a/ffi/src/revision.rs
+++ b/ffi/src/revision.rs
@@ -35,7 +35,7 @@ impl<'db> RevisionHandle<'db> {
 
     /// Creates an iterator on the revision starting from the given key.
     #[must_use]
-    #[allow(clippy::missing_panics_doc)]
+    #[expect(clippy::missing_panics_doc)]
     pub fn iter_from(&self, first_key: Option<&[u8]>) -> CreateIteratorResult<'_> {
         let it = self
             .view

--- a/firewood/src/db.rs
+++ b/firewood/src/db.rs
@@ -96,7 +96,6 @@ where
     }
 }
 
-#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub enum UseParallel {
     Never,

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -793,7 +793,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn test_slow_concurrent_view_during_commit() {
         use firewood_storage::{
             ImmutableProposal, LeafNode, NibblesIterator, Node, NodeStore, Path,

--- a/firewood/src/merkle/collapse.rs
+++ b/firewood/src/merkle/collapse.rs
@@ -111,7 +111,7 @@ fn nibble_in_range(acc_prefix: &[u8], nibble: PathComponent, range: CollapseRang
 fn build_child_prefix(prefix: &[u8], nibble: u8, node: &Node) -> Box<[u8]> {
     let pp = &node.partial_path().0;
     // slice lengths are bounded by isize::MAX. Sum cannot overflow.
-    #[allow(clippy::arithmetic_side_effects)]
+    #[expect(clippy::arithmetic_side_effects)]
     let capacity = prefix.len() + 1 + pp.len();
     let mut v = Vec::with_capacity(capacity);
     v.extend_from_slice(prefix);

--- a/firewood/src/merkle/mod.rs
+++ b/firewood/src/merkle/mod.rs
@@ -925,7 +925,7 @@ fn right_edge<'a>(
 /// the proof's hash mode does not match `algorithm`, keys are outside the
 /// requested range, boundary proofs fail verification, or the reconstructed
 /// root hash doesn't match.
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub fn verify_range_proof<H: ProofCollection<Node = ProofNode>>(
     first_key: Option<impl KeyType>,
     last_key: Option<impl KeyType>,

--- a/firewood/src/merkle/tests/change/attack.rs
+++ b/firewood/src/merkle/tests/change/attack.rs
@@ -760,7 +760,7 @@ fn gap_boundaries() -> ([u8; 32], [u8; 32]) {
 
 /// Helper for the common adversarial pattern: generate a valid bounded proof
 /// for the 5-key setup, inject a spurious operation, and assert rejection.
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn inject_and_assert_rejected(
     db: &Db<DefaultHashMode>,
     root1: api::HashKey,

--- a/firewood/src/persist_worker.rs
+++ b/firewood/src/persist_worker.rs
@@ -125,7 +125,7 @@ impl<H: HashMode> PersistWorker<H> {
     /// Creates a new `PersistWorker` and starts the background thread.
     ///
     /// Returns the worker for sending messages to the background thread.
-    #[allow(clippy::large_types_passed_by_value)]
+    #[expect(clippy::large_types_passed_by_value)]
     pub(crate) fn new(
         commit_count: NonZeroU64,
         header: NodeStoreHeader,
@@ -413,7 +413,7 @@ impl<H> PersistChannel<H> {
     }
 
     #[cfg(test)]
-    #[allow(clippy::arithmetic_side_effects)]
+    #[expect(clippy::arithmetic_side_effects)]
     fn wait_all_released(&self) {
         use firewood_storage::logger::warn;
         use std::time::Duration;

--- a/fwdctl/src/import.rs
+++ b/fwdctl/src/import.rs
@@ -209,7 +209,7 @@ fn process_csv(
     Ok(())
 }
 
-#[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
+#[expect(clippy::cast_precision_loss, clippy::cast_sign_loss)]
 fn maybe_log_status(
     total_imported: usize,
     start_time: Instant,
@@ -249,7 +249,7 @@ fn commit_batch(
 /// `total_imported` realistically never exceeds a few billion keys in a single
 /// import run, well within `f64`'s 52-bit mantissa precision, and is always
 /// non-negative — so the precision/sign-loss lints are safe to suppress here.
-#[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
+#[expect(clippy::cast_precision_loss, clippy::cast_sign_loss)]
 fn keys_per_second(total_imported: usize, duration: Duration) -> usize {
     let secs = duration.as_secs_f64();
     if secs > 0.0 {

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -48,13 +48,13 @@ mod gauge_value {
         fn as_f64(self) -> f64;
     }
     impl GaugeValue for u64 {
-        #[allow(clippy::cast_precision_loss)]
+        #[expect(clippy::cast_precision_loss)]
         fn as_f64(self) -> f64 {
             self as f64
         }
     }
     impl GaugeValue for usize {
-        #[allow(clippy::cast_precision_loss)]
+        #[expect(clippy::cast_precision_loss)]
         fn as_f64(self) -> f64 {
             self as f64
         }
@@ -93,7 +93,7 @@ pub trait CounterExt {
 }
 
 impl CounterExt for metrics::Counter {
-    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
     fn increment_f64(&self, value: f64) {
         self.increment(value as u64);
     }

--- a/storage/src/arc_swap_triomphe.rs
+++ b/storage/src/arc_swap_triomphe.rs
@@ -27,7 +27,7 @@
 //! which is what `arc_swap`'s `RefCnt for Option<T>` relies on to distinguish
 //! `Some` from `None`.
 
-#![allow(
+#![expect(
     unsafe_code,
     reason = "arc_swap::RefCnt requires unsafe trait methods; sealed bridge for triomphe::Arc"
 )]

--- a/storage/src/checker/range_set.rs
+++ b/storage/src/checker/range_set.rs
@@ -798,7 +798,7 @@ mod test_linear_address_range_set {
     fn test_display(items: usize, expected: &str) {
         let mut range_set = LinearAddressRangeSet::new(0x2000).unwrap();
         for i in 0..items {
-            #[allow(clippy::arithmetic_side_effects)]
+            #[expect(clippy::arithmetic_side_effects)]
             let offset = i as u64 * 0x20 + 0x1000;
             range_set
                 .insert_area(LinearAddress::new(offset).unwrap(), 0x10, TEST_PARENT)

--- a/storage/src/linear/filebacked.rs
+++ b/storage/src/linear/filebacked.rs
@@ -388,8 +388,6 @@ impl std::ops::DerefMut for UnlockOnDrop {
 
 #[cfg(test)]
 mod test {
-    #![allow(clippy::unwrap_used)]
-
     use super::*;
     use crate::{DefaultHashMode, HashMode};
     use nonzero_ext::nonzero;


### PR DESCRIPTION
## Why this should be merged

`#[allow(...)]` suppressions silently rot: once the underlying lint stops firing (a refactor, a removed code path, a config change), the attribute keeps suppressing nothing and nobody notices. `#[expect(...)]` makes that self-enforcing — the build fails the moment a suppression becomes unnecessary. This enables `clippy::allow_attributes = "warn"` workspace-wide and fixes every site it flags.

## How this works

Converts each pre-existing `#[allow(...)]` to `#[expect(...)]`, with three sites handled differently:

- `ffi/src/lib.rs`: `fwd_block_replay_flush`'s `missing_const_for_fn` expectation only holds *without* the `block-replay` feature — `invoke()` isn't const-able once it's enabled — so the expectation is gated behind `cfg_attr(not(feature = "block-replay"), ...)` instead of applying unconditionally.
- `storage/src/linear/filebacked.rs`: dropped the `unwrap_used` allow from the test module outright. `clippy.toml`'s `allow-unwrap-in-tests = true` already exempts it, so the attribute was dead weight — `#[expect]` confirmed it never fires.
- `firewood/src/db.rs`: dropped `#[allow(dead_code)]` from `UseParallel` outright. The enum, including the `BatchSize` variant, is fully matched and constructed elsewhere, so the allow was stale.

## How this was tested

`just prepush` — all 5 clippy/test profiles (no-default-features, no-features, ethhash+logger, all-features, maxperf-ethhash-logger) plus the Go FFI test suites for both hash modes.

## Breaking Changes

none