### PR TITLE
refactor(ffi): make the code-hash iterator's proof borrow structural

### DIFF
--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -711,22 +711,12 @@ func getNextKeyRangeFromNextKeyRangeResult(result C.NextKeyRangeResult) (*NextKe
 // instead of silently reintroducing the use-after-free described on
 // [codeIterator].
 func newCodeIterator(result C.CodeIteratorResult, owner codeHashSource) (*codeIterator, error) {
-	it, err := getCodeHashIteratorFromCodeHashIteratorResult(result)
-	if err != nil {
-		return nil, err
-	}
-
-	it.owner = owner
-	return it, nil
-}
-
-func getCodeHashIteratorFromCodeHashIteratorResult(result C.CodeIteratorResult) (*codeIterator, error) {
 	switch result.tag {
 	case C.CodeIteratorResult_NullHandlePointer:
 		return nil, errDBClosed
 	case C.CodeIteratorResult_Ok:
 		ptr := *(**C.CodeIteratorHandle)(unsafe.Pointer(&result.anon0))
-		return &codeIterator{handle: ptr}, nil
+		return &codeIterator{handle: ptr, owner: owner}, nil
 	case C.CodeIteratorResult_Err:
 		err := newOwnedBytes(*(*C.OwnedBytes)(unsafe.Pointer(&result.anon0))).intoError()
 		return nil, err

--- a/ffi/proofs.go
+++ b/ffi/proofs.go
@@ -121,8 +121,23 @@ type NextKeyRange struct {
 	endKey   Maybe[*ownedBytes]
 }
 
+// codeHashSource is a proof whose data a code-hash iterator borrows.
+// Implemented by [*RangeProof] and [*ChangeProof].
+type codeHashSource interface {
+	codeIterator() (*codeIterator, error)
+}
+
 type codeIterator struct {
 	handle *C.CodeIteratorHandle
+
+	// owner is the proof whose key-values the Rust iterator borrows. Rust's
+	// CodeIteratorHandle<'p> wraps Box<dyn Iterator + 'p> built from the
+	// proof's key-values, so the proof must stay reachable for the whole
+	// life of the iterator, not just for the call that created it. Holding
+	// it here makes that borrow an ordinary Go reference: an iterator
+	// cannot be live without keeping its proof reachable, so no hand-placed
+	// keepalive spanning the iteration is required.
+	owner codeHashSource
 }
 
 // RangeProof returns a proof that the values in the range [startKey, endKey] are
@@ -293,27 +308,31 @@ func (p *RangeProof) FindNextKey() (*NextKeyRange, error) {
 // Note: this method is only relevant for Ethereum tries.
 // This method can only be called anytime after the proof is created.
 func (p *RangeProof) CodeHashes() iter.Seq2[Hash, error] {
+	return codeHashSeq(p)
+}
+
+// codeIterator creates a code-hash iterator borrowing this proof's key-values.
+// The returned iterator holds p as its owner; see [codeIterator] for why that
+// reference is what keeps the borrow sound.
+func (p *RangeProof) codeIterator() (*codeIterator, error) {
+	p.lease.mu.RLock()
+	defer p.lease.mu.RUnlock()
+	return newCodeIterator(C.fwd_range_proof_code_hash_iter(p.handle), p)
+}
+
+// codeHashSeq yields the code hashes produced by an iterator borrowed from src.
+// Concurrently calling Free on src during iteration remains unsupported, as
+// elsewhere on both proof types.
+func codeHashSeq(src codeHashSource) iter.Seq2[Hash, error] {
 	return func(yield func(Hash, error) bool) {
-		p.lease.mu.RLock()
-		it, err := getCodeHashIteratorFromCodeHashIteratorResult(C.fwd_range_proof_code_hash_iter(p.handle))
-		p.lease.mu.RUnlock()
+		it, err := src.codeIterator()
 		if err != nil {
 			yield(EmptyRoot, err)
 			return
 		}
-		// The Rust code iterator borrows the proof's key-values for its whole
-		// lifetime (CodeIteratorHandle<'p>), so the proof must stay alive until
-		// iteration finishes, not just for the create call above. Free the
-		// iterator and then KeepAlive p in the same deferred call: freeing first
-		// releases the borrow, and the trailing KeepAlive keeps the proof
-		// reachable across the entire loop so its GC finalizer cannot free the
-		// borrowed-from context mid-iteration. Concurrently calling Free during
-		// iteration remains unsupported, as elsewhere on RangeProof.
 		defer func() {
-			freeErr := it.Free()
-			runtime.KeepAlive(p)
-			if freeErr != nil {
-				panic(freeErr)
+			if err := it.Free(); err != nil {
+				panic(err)
 			}
 		}()
 		for hash, err := it.Next(); ; hash, err = it.Next() {
@@ -335,7 +354,14 @@ func (it *codeIterator) Next() (Hash, error) {
 	return getHashKeyFromHashResult(C.fwd_code_hash_iter_next(it.handle))
 }
 
+// Free releases the Rust iterator, ending its borrow of the owning proof.
 func (it *codeIterator) Free() error {
+	// The borrow ends with the call below, so the owner must remain reachable
+	// until it returns. Because the deferred Free in [codeHashSeq] captures
+	// the iterator, this also keeps the owner reachable for the whole
+	// iteration -- the Go reference, not this call, is what makes the borrow
+	// sound.
+	defer runtime.KeepAlive(it.owner)
 	return getErrorFromVoidResult(C.fwd_code_hash_iter_free(it.handle))
 }
 
@@ -528,40 +554,18 @@ func (proof *ChangeProof) FindNextKey(endKey Maybe[[]byte]) (*NextKeyRange, erro
 // (the post-state of accounts touched by the proof) are yielded; Delete and
 // DeleteRange entries are skipped.
 func (p *ChangeProof) CodeHashes() iter.Seq2[Hash, error] {
-	return func(yield func(Hash, error) bool) {
-		it, err := getCodeHashIteratorFromCodeHashIteratorResult(C.fwd_change_proof_code_hash_iter(p.handle))
-		if err != nil {
-			yield(EmptyRoot, err)
-			return
-		}
-		// The Rust code iterator borrows the proof's data for its whole lifetime
-		// (CodeIteratorHandle<'p>), so the proof must stay alive until iteration
-		// finishes, not just for the create call above. Free the iterator and
-		// then KeepAlive p in the same deferred call: freeing releases the
-		// borrow, and the trailing KeepAlive keeps the proof reachable across the
-		// loop so its GC finalizer cannot free the borrowed-from context
-		// mid-iteration. Concurrently calling Free during iteration remains
-		// unsupported, as elsewhere on ChangeProof.
-		defer func() {
-			freeErr := it.Free()
-			runtime.KeepAlive(p)
-			if freeErr != nil {
-				panic(freeErr)
-			}
-		}()
-		for hash, err := it.Next(); ; hash, err = it.Next() {
-			if err != nil {
-				yield(EmptyRoot, err)
-				return
-			}
-			if hash == EmptyRoot {
-				return
-			}
-			if !yield(hash, err) {
-				return
-			}
-		}
-	}
+	return codeHashSeq(p)
+}
+
+// codeIterator creates a code-hash iterator borrowing this proof's data. The
+// returned iterator holds p as its owner; see [codeIterator] for why that
+// reference is what keeps the borrow sound.
+//
+// Unlike [*RangeProof.codeIterator] there is no lease to read-lock: a
+// ChangeProof deliberately holds no database reference (see the Free doc
+// comment and https://github.com/ava-labs/firewood/issues/1978).
+func (p *ChangeProof) codeIterator() (*codeIterator, error) {
+	return newCodeIterator(C.fwd_change_proof_code_hash_iter(p.handle), p)
 }
 
 // MarshalBinary returns a serialized representation of this ChangeProof.
@@ -699,6 +703,21 @@ func getNextKeyRangeFromNextKeyRangeResult(result C.NextKeyRangeResult) (*NextKe
 	default:
 		return nil, fmt.Errorf("unknown C.NextKeyRangeResult tag: %d", result.tag)
 	}
+}
+
+// newCodeIterator converts a code-iterator result into a [codeIterator] that
+// borrows owner. The owner is a required argument rather than a field assigned
+// by the caller so that a future refactor which forgets it fails to compile
+// instead of silently reintroducing the use-after-free described on
+// [codeIterator].
+func newCodeIterator(result C.CodeIteratorResult, owner codeHashSource) (*codeIterator, error) {
+	it, err := getCodeHashIteratorFromCodeHashIteratorResult(result)
+	if err != nil {
+		return nil, err
+	}
+
+	it.owner = owner
+	return it, nil
 }
 
 func getCodeHashIteratorFromCodeHashIteratorResult(result C.CodeIteratorResult) (*codeIterator, error) {

--- a/ffi/proofs_test.go
+++ b/ffi/proofs_test.go
@@ -5,7 +5,6 @@ package ffi
 
 import (
 	"encoding/hex"
-	"iter"
 	"runtime"
 	"sync"
 	"testing"
@@ -74,6 +73,19 @@ func newVerifiedRangeProof(
 	r.NoError(proof.Verify(root, startKey, endKey, proofLen))
 
 	return proof
+}
+
+// ethAccountWithCodeHash returns a 32-byte account key, the RLP-encoded account
+// stored under it, and the code hash embedded in that account. Only
+// account-length keys reach the code-hash extractor, so this is the minimal
+// fixture that makes a proof yield exactly one code hash.
+func ethAccountWithCodeHash(t *testing.T) ([32]byte, []byte, Hash) {
+	t.Helper()
+
+	key := [32]byte{0x12, 0x34, 0x56} // account keys must be 32 bytes
+	val, err := hex.DecodeString("f8440164a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
+	require.NoError(t, err)
+	return key, val, stringToHash(t, "044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
 }
 
 // newSerializedRangeProof generates a range proof for the given parameters and
@@ -499,54 +511,75 @@ func TestRangeProofVerifyTwiceIdempotent(t *testing.T) {
 	r.NoError(db.Close(oneSecCtx(t)))
 }
 
-// TestRangeProofCodeHashesKeepsProofAlive is a regression test for the
-// code-hash iterator's borrow of the proof. The Rust CodeIteratorHandle holds
-// Box<dyn Iterator + 'p> over the proof's key-values, so the RangeProof must
-// stay alive for the whole iteration, not just the create call. CodeHashes uses
-// p only to create the iterator and then iterates the borrowing handle, so
-// without an explicit keepalive the proof can be garbage-collected mid-iteration
-// and its finalizer frees the key-values the iterator is still reading.
+// TestCodeIteratorRetainsProof pins the lifetime contract between a code-hash
+// iterator and the proof it borrows. Rust's CodeIteratorHandle<'p> wraps
+// Box<dyn Iterator + 'p> over the proof's key-values, so the iterator must hold
+// a Go reference to that proof; without one the proof is collectible the moment
+// CodeHashes stops mentioning it, and its finalizer frees the data the iterator
+// is still reading.
 //
-// A runtime.AddCleanup canary detects the root condition directly: if the proof
-// is reclaimed while the iterator is live, the cleanup fires. It is dropped from
-// the caller's scope so only the CodeHashes closure references it.
-func TestRangeProofCodeHashesKeepsProofAlive(t *testing.T) {
-	r := require.New(t)
+// The assertion is the reference itself rather than an observation of the
+// garbage collector. A reachable object is never collected, so proving the
+// reference exists proves the lifetime property outright -- deterministically,
+// with no forced collections, no timing, and no tuned constants. Probing the GC
+// can only ever fail to disprove the property within some arbitrary budget.
+func TestCodeIteratorRetainsProof(t *testing.T) {
 	if selectedHashMode != ethhashKey {
-		t.Skip("code hashes are only produced in ethhash mode")
+		t.Skip("code hash iterators are only created for ethereum-mode proofs")
 	}
 
-	db := newTestDatabase(t)
-	key := [32]byte{0x12, 0x34, 0x56} // account key must be length 32
-	val, err := hex.DecodeString("f8440164a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
-	r.NoError(err)
-	root, err := db.Update([]BatchOp{Put(key[:], val)})
-	r.NoError(err)
-	proofBytes := newSerializedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenUnbounded)
+	tests := []struct {
+		name string
+		// newProof builds a proof over the account fixture and registers its
+		// own cleanup. The concrete pointer is returned as the interface so
+		// the assertion below compares what the iterator actually stored.
+		newProof func(*testing.T, *require.Assertions, *Database) codeHashSource
+	}{
+		{
+			"range",
+			func(t *testing.T, r *require.Assertions, db *Database) codeHashSource {
+				key, val, _ := ethAccountWithCodeHash(t)
+				root, err := db.Update([]BatchOp{Put(key[:], val)})
+				r.NoError(err)
+				return newVerifiedRangeProof(t, db, root, nothing(), nothing(), rangeProofLenUnbounded)
+			},
+		},
+		{
+			"change",
+			func(t *testing.T, r *require.Assertions, db *Database) codeHashSource {
+				// Baseline insert so the change proof's start root is non-empty.
+				startRoot, err := db.Update([]BatchOp{Put([]byte("baseline"), []byte("v"))})
+				r.NoError(err)
+				key, val, _ := ethAccountWithCodeHash(t)
+				endRoot, err := db.Update([]BatchOp{Put(key[:], val)})
+				r.NoError(err)
 
-	collected := make(chan struct{})
-	// Build the iterator in a nested scope so the only remaining reference to the
-	// proof is the one captured by the CodeHashes closure.
-	seq := func() iter.Seq2[Hash, error] {
-		p := new(RangeProof)
-		r.NoError(p.UnmarshalBinary(proofBytes)) // arms the Free finalizer
-		runtime.AddCleanup(p, func(struct{}) { close(collected) }, struct{}{})
-		return p.CodeHashes()
-	}()
+				proof, err := db.ChangeProof(startRoot, endRoot, nothing(), nothing(), changeProofLenUnbounded)
+				r.NoError(err)
+				t.Cleanup(func() { r.NoError(proof.Free()) })
+				return proof
+			},
+		},
+	}
 
-	for _, err := range seq {
-		r.NoError(err)
-		// Mid-iteration: try hard to reclaim the proof. If CodeHashes stopped
-		// referencing it after creating the iterator, it is collectible here.
-		for range 50 {
-			runtime.GC()
-			select {
-			case <-collected:
-				r.FailNow("RangeProof was garbage-collected mid-iteration; CodeHashes must keep the proof alive while its borrowed iterator is live")
-			default:
-			}
-			runtime.Gosched()
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			db := newTestDatabase(t)
+			proof := tt.newProof(t, r, db)
+
+			it, err := proof.codeIterator()
+			r.NoError(err)
+			// Registered after the proof's own cleanup, so it runs first: the
+			// borrow is released before the borrowed-from proof is freed.
+			t.Cleanup(func() { r.NoError(it.Free()) })
+
+			// A nil owner means the Rust borrow is backed by no Go reference
+			// at all, which is the regression this test exists to catch;
+			// check it separately so the failure says so.
+			r.NotNil(it.owner, "%T.codeIterator() must retain the proof it borrows", proof)
+			r.Same(proof, it.owner, "%T.codeIterator() retained the wrong proof", proof)
+		})
 	}
 }
 
@@ -554,12 +587,7 @@ func TestRangeProofCodeHashes(t *testing.T) {
 	r := require.New(t)
 	db := newTestDatabase(t)
 
-	// RLP encoded account with code hash
-	key := [32]byte{0x12, 0x34, 0x56} // key must be length 32
-	val, err := hex.DecodeString("f8440164a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
-	r.NoError(err)
-	codeHash := stringToHash(t, "044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
-
+	key, val, codeHash := ethAccountWithCodeHash(t)
 	root, err := db.Update([]BatchOp{Put(key[:], val)})
 	r.NoError(err)
 
@@ -590,12 +618,7 @@ func TestChangeProofCodeHashes(t *testing.T) {
 	startRoot, err := db.Update([]BatchOp{Put([]byte("baseline"), []byte("v"))})
 	r.NoError(err)
 
-	// RLP encoded account with code hash — same blob as TestRangeProofCodeHashes.
-	key := [32]byte{0x12, 0x34, 0x56} // key must be length 32
-	val, err := hex.DecodeString("f8440164a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
-	r.NoError(err)
-	codeHash := stringToHash(t, "044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
-
+	key, val, codeHash := ethAccountWithCodeHash(t)
 	endRoot, err := db.Update([]BatchOp{Put(key[:], val)})
 	r.NoError(err)
 
@@ -738,55 +761,6 @@ func TestChangeProofSetFinalizerReset(t *testing.T) {
 
 		t.Cleanup(func() { _ = p.Free() })
 	})
-}
-
-// TestChangeProofCodeHashesKeepsProofAlive is the ChangeProof analogue of
-// TestRangeProofCodeHashesKeepsProofAlive. The Rust code iterator borrows the
-// proof's data for its whole lifetime (CodeIteratorHandle<'p>), so
-// ChangeProof.CodeHashes must keep the proof alive across iteration; otherwise
-// the proof can be garbage-collected mid-iteration and its finalizer frees the
-// key-values the iterator is still reading. A runtime.AddCleanup canary detects
-// that condition directly.
-func TestChangeProofCodeHashesKeepsProofAlive(t *testing.T) {
-	r := require.New(t)
-	if selectedHashMode != ethhashKey {
-		t.Skip("code hashes are only produced in ethhash mode")
-	}
-
-	db := newTestDatabase(t)
-	startRoot, err := db.Update([]BatchOp{Put([]byte("baseline"), []byte("v"))})
-	r.NoError(err)
-	key := [32]byte{0x12, 0x34, 0x56} // account key must be length 32
-	val, err := hex.DecodeString("f8440164a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d")
-	r.NoError(err)
-	endRoot, err := db.Update([]BatchOp{Put(key[:], val)})
-	r.NoError(err)
-	proofBytes := newSerializedChangeProof(t, db, startRoot, endRoot, nothing(), nothing())
-
-	collected := make(chan struct{})
-	// Build the iterator in a nested scope so the only remaining reference to the
-	// proof is the one captured by the CodeHashes closure.
-	seq := func() iter.Seq2[Hash, error] {
-		p := new(ChangeProof)
-		r.NoError(p.UnmarshalBinary(proofBytes)) // arms the Free finalizer
-		runtime.AddCleanup(p, func(struct{}) { close(collected) }, struct{}{})
-		return p.CodeHashes()
-	}()
-
-	for _, err := range seq {
-		r.NoError(err)
-		// Mid-iteration: try hard to reclaim the proof. If CodeHashes stopped
-		// referencing it after creating the iterator, it is collectible here.
-		for range 50 {
-			runtime.GC()
-			select {
-			case <-collected:
-				r.FailNow("ChangeProof was garbage-collected mid-iteration; CodeHashes must keep the proof alive while its borrowed iterator is live")
-			default:
-			}
-			runtime.Gosched()
-		}
-	}
 }
 
 func TestChangeProofEmptyDB(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

#2143 and #2144 each fixed a real use-after-free, and each proved it with a test
that forced up to 50 collections per yielded hash and asserted a
`runtime.AddCleanup` canary had not fired. Those tests could not establish what
they claimed:

- Asserting the GC did *not* collect something has no natural bound. The `50`
  traded runtime for confidence; no value is ever *correct*.
- Nothing verified the canary could fire at all, so one that silently stopped
  working would pass forever.
- The probe lived inside the `for … range seq` body with no yield count
  asserted, so a fixture that stopped producing code hashes would also pass,
  having asserted nothing.

The constant was really approximating a runtime rule the test never stated: the
proof carries both a `Free` finalizer and the cleanup, and `runtime.AddCleanup`
only runs a cleanup *"once it has been finalized and becomes unreachable without
an associated finalizer"* — at least two cycles plus two goroutine hops. Since
only *positive* facts about the collector are observable, this changes what is
asserted rather than how hard the test tries.

## How this works

The borrow becomes a fact the language guarantees: `codeIterator` holds the
proof, and the deferred `Free` in `codeHashSeq` captures the iterator, so the
owner stays reachable for the whole iteration by ordinary liveness rules.

The durable part is that the owner is a required `newCodeIterator` argument
rather than a field the caller assigns — a future refactor that forgets it fails
to compile instead of silently reintroducing the use-after-free. The assertion
only pins that; it no longer depends on GC timing.

`FindNextKey` and `MarshalBinary` keep their bare `runtime.KeepAlive`: no
wrapper object outlives those calls, so there is no structural analogue, and
their single fast cgo call leaves no window a deterministic test could target.

## Notes

**A coverage trade, stated explicitly:** the deleted tests were the only
end-to-end exercise of `CodeHashes` under GC pressure, and that goes away. I
judged it worth making, since they never established the property they claimed.
If behavioural coverage is wanted back, an ordering assertion — "collection
happened *after* iteration finished", two positive events bounded by the test
deadline — layers on without touching the production change.

`TestCodeIteratorRetainsProof` skips in merkledb mode, where
`fwd_*_code_hash_iter` errors and no iterator exists to inspect; that error path
stays covered by the `else` branch of `Test*CodeHashes`.

Mutation-checked: patching `newCodeIterator` to discard the owner fails both
subtests with `*ffi.RangeProof.codeIterator() must retain the proof it borrows`.

## Breaking Changes

n/a
