### PR TITLE
build(just): Velocity: add a prepush-lite recipe for local iteration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,24 +140,44 @@ of the change.
 
 ## PR Strategy
 
-Before submitting or updating a PR, run the local pre-push checks:
+GitHub Actions is authoritative for the full check matrix. Locally, the default
+gate before submitting or updating a PR is the light one:
+
+```bash
+just prepush-lite
+```
+
+That runs `ci-format`, `ci-check-todos`, clippy and tests for the single
+`debug-ethhash-logger` profile, `ci-lint-markdown`, and `ci-docs`. Note that
+`ci-format` only *checks* formatting — run `cargo fmt` yourself to apply it.
+
+The full local matrix is available when a change warrants it — in particular
+when it touches the FFI, workspace dependencies, or code gated behind a feature
+that `debug-ethhash-logger` does not enable:
 
 ```bash
 just prepush
 ```
 
-This runs `just lint` followed by `just test`. These recipes use the same
-lower-level `ci-*` recipes as GitHub Actions, keeping the local and CI commands
-in sync. Run either phase separately while iterating:
+That is `just lint` followed by `just test`: 23 sub-invocations, which build
+`maxperf-ethhash-logger` (fat LTO) twice, drag in the AWS SDK via
+`debug-all-features`, and run six Go/cgo FFI steps. Expect roughly 15 minutes
+with a warm cache and considerably more cold. Run either phase separately while
+iterating:
 
 ```bash
 just lint
 just test
 ```
 
-If `just` is not installed, use `./scripts/run-just.sh prepush`. The wrapper
-uses `just` when available, falls back to Nix when available, and otherwise
-prints installation instructions.
+All of these recipes use the same lower-level `ci-*` recipes as GitHub Actions,
+keeping the local and CI commands in sync. Individual profiles are reachable
+directly — `just ci-rust clippy debug-all-features`, for example — which is
+usually cheaper than a whole phase when you already know what needs checking.
+
+If `just` is not installed, use `./scripts/run-just.sh prepush-lite`. The
+wrapper uses `just` when available, falls back to Nix when available, and
+otherwise prints installation instructions.
 
 The complete set of Rust profile names and Cargo arguments is defined in
 `scripts/run-rust-ci.sh`. Every profile there is portable to macOS, so the Just
@@ -203,10 +223,10 @@ default-profile test commands are useful during development, but do not replace
 
 ### Linux-only Checks
 
-The local `lint`, `test`, and `prepush` recipes are designed to run on macOS.
-They intentionally omit CI checks that require Linux: the differential fuzz jobs,
-which use Linux-specific resource limits and tooling. GitHub Actions remains
-authoritative for those.
+The local `lint`, `test`, `prepush`, and `prepush-lite` recipes are designed to
+run on macOS. They intentionally omit CI checks that require Linux: the
+differential fuzz jobs, which use Linux-specific resource limits and tooling.
+GitHub Actions remains authoritative for those.
 
 `--all-features` is *not* in that category. The `io-uring` feature is accepted on
 every platform but only takes effect on Linux, where `storage/build.rs` sets the
@@ -225,8 +245,8 @@ manually with `just ci-rust benchmark-example <profile>` and
 
 ### Markdown Linter
 
-`just lint` and `just prepush` run the Markdown checks used by CI. To run only
-the repository-wide Markdown check, use:
+`just lint`, `just prepush`, and `just prepush-lite` run the Markdown checks
+used by CI. To run only the repository-wide Markdown check, use:
 
 ```bash
 just ci-lint-markdown
@@ -276,7 +296,9 @@ Key dependencies are centrally managed in workspace `Cargo.toml`:
    utilized in the `ffi` crate.
 
 2. **Testing**: Any changes should include appropriate tests. Run targeted tests
-   while iterating and `./scripts/run-just.sh prepush` before handoff.
+   while iterating and `./scripts/run-just.sh prepush-lite` before handoff;
+   reach for the full `prepush` only when the change touches the FFI or a
+   feature combination `debug-ethhash-logger` does not cover.
 
 3. **Performance Context**: This is a database designed for blockchain state. Performance matters. Consider allocation patterns and hot paths.
 
@@ -285,8 +307,9 @@ Key dependencies are centrally managed in workspace `Cargo.toml`:
 5. **Feature Flags**: Be aware of `ethhash` feature flag when discussing Ethereum compatibility vs. default merkledb compatibility.
 
 6. **Documentation**: Public APIs should be well-documented. The documentation
-   check is included in `./scripts/run-just.sh lint`; run `./scripts/run-just.sh ci-docs` to invoke it
-   separately.
+   check is included in `./scripts/run-just.sh lint` and
+   `./scripts/run-just.sh prepush-lite`; run `./scripts/run-just.sh ci-docs` to
+   invoke it separately.
 
 7. **Workspace Awareness**: This is a multi-crate workspace. Changes may affect multiple crates. Check `Cargo.toml` for workspace structure.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,10 +159,7 @@ that `debug-ethhash-logger` does not enable:
 just prepush
 ```
 
-That is `just lint` followed by `just test`: 23 sub-invocations, which build
-`maxperf-ethhash-logger` (fat LTO) twice, drag in the AWS SDK via
-`debug-all-features`, and run six Go/cgo FFI steps. Expect roughly 15 minutes
-with a warm cache and considerably more cold. Run either phase separately while
+That is `just lint` followed by `just test`. Run either phase separately while
 iterating:
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -117,6 +117,15 @@ test:
 # Run every macOS-compatible pre-push check, with linting first.
 prepush: lint test
 
+# `prepush`, minus the four extra Rust profiles, the FFI steps, and ci-machete.
+prepush-lite:
+    ./scripts/run-just.sh ci-format
+    ./scripts/run-just.sh ci-check-todos
+    ./scripts/run-just.sh ci-rust clippy debug-ethhash-logger
+    ./scripts/run-just.sh ci-rust test debug-ethhash-logger
+    ./scripts/run-just.sh ci-lint-markdown
+    ./scripts/run-just.sh ci-docs
+
 # Regenerate proof wire serialization snapshots for both hash modes.
 #
 # Run this after any intentional change to the proof binary format (ser.rs,


### PR DESCRIPTION

> This is a developer-velocity change.

## Why this should be merged

Developer velocity suffers because Claude has been instructed to run
`just prepush` before every handoff, which is a 5+ minute wait to confirm your
changes won't cause any problems. Most of the time, we just need to run a basic
set of checks. The prepush might be helpful if you're in rarer areas of the
code, but I'd estimate >90% of all changes don't need that level of scrutiny.
If you miss anyway, it's going to CI which will run all those for you.

This mostly just boils down to developer preference: pay the extra local time
to be sure CI can't fail, or go faster and accept the occasional CI failure. I
suspect many people aren't running this at all and have their own stuff because
this is "just" too slow (no pun intended).

Why is `just prepush` so expensive? 23 sub-invocations: five clippy profiles,
five nextest profiles, six Go/cgo FFI steps, plus the docs, markdown, machete,
go-generate, FFI-lint, format and TODO checks.
It builds `maxperf-ethhash-logger` (panic=abort, single codegen unit, fat LTO)
twice and pulls the entire AWS SDK in through `debug-all-features` for
`fwdctl`'s `launch` feature.

## How this works

New `prepush-lite` recipe: `ci-format`, `ci-check-todos`, clippy and tests for
the single `debug-ethhash-logger` profile, `ci-lint-markdown`, `ci-docs`. Like
the other aggregates it shells out through `./scripts/run-just.sh`, so it stays
in sync with the CI commands.

Deliberately not included: the other four Rust profiles, the FFI steps, and
`ci-machete`. Those catch real breakage, but only for changes that touch the
FFI, workspace dependencies, or feature combinations `debug-ethhash-logger`
does not cover. The recipe comment and the reworked "PR Strategy" section in
`AGENTS.md` both say to reach for the full `prepush` in those cases.

`AGENTS.md` previously presented `prepush` as the only local gate. It now
presents `prepush-lite` as the default, `prepush` as the deliberate heavier
option, and CI as authoritative. Also notes
that `ci-format` only *checks* formatting, so `cargo fmt` remains a separate
step.

## Timings

Measured on my laptop: MacBook Pro (Mac17,6), Apple M5 Max, 18 cores
(12 performance + 6 efficiency), 64 GB, macOS 26.5.1, rustc 1.98.0,
cargo-nextest 0.9.132, Go 1.26.5, just 1.58.0, ~4 GB warm `target/`.

This is my working laptop, not a benchmark rig: no core pinning, no attempt to
control thermal or scheduler behavior, normal interactive load and background
daemons throughout, and the runs below are single samples rather than averaged
repetitions. Numbers are rounded and should be read as ballpark ratios, not
measurements — expect noise on the order of tens of percent on the longer runs.

After a source edit (`touch storage/src/lib.rs`, rebuilding `firewood-storage`
and everything downstream):

| recipe          | wall clock  | share of `prepush` |
| --------------- | ----------- | ------------------ |
| `prepush`       | ~5–6 min    | 100%               |
| `prepush-lite`  | ~45 sec     | ~13%               |

With nothing changed and every cache warm (floor):

| recipe          | wall clock  | share of `prepush` |
| --------------- | ----------- | ------------------ |
| `prepush`       | ~5 min      | 100%               |
| `prepush-lite`  | ~25 sec     | ~8%                |

For reference, the first `prepush` of a session against a partly warm `target/`
took ~11.5 min. So `prepush-lite` costs roughly a tenth of `prepush`, and the
repeated-run figure was stable across three consecutive runs (42/43/43 sec).

Worth knowing: `ci-docs` dominates `prepush-lite` and is the most
cache-sensitive step in it — it ranged from ~5 sec to ~108 sec depending on
what had run before. The Rust clippy and nextest steps for one profile are
consistently under 30 sec combined.

## How this was tested

`just --list` and `just -n prepush-lite` to check parsing and wiring, then
`just prepush-lite` and `just prepush` repeatedly against these changes — all
runs green, which is where the numbers above come from.

## Breaking Changes

None. `prepush`, `lint`, and `test` are unchanged.
