### PR TITLE
ci: speed up the ethhash differential fuzz job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -237,10 +237,17 @@ jobs:
 
   ffi:
     needs: [build, ffi-check-go-generate]
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-26]
+        include:
+          - hash-mode: firewood
+            profile-key: debug-no-features
+          - hash-mode: firewood
+            profile-key: debug-no-features
+            os: macos-26
+          - hash-mode: ethhash
+            profile-key: debug-ethhash-logger
     steps:
       - uses: actions/checkout@v6
       - uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
@@ -252,10 +259,10 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # @v2 -> v2.9.1
         with:
           save-if: "false"
-          shared-key: "debug-no-features"
+          shared-key: ${{ matrix.profile-key }}
       - name: Build Firewood FFI
         working-directory: ffi
-        run: ../scripts/run-just.sh ci-build-ffi firewood
+        run: ../scripts/run-just.sh ci-build-ffi ${{ matrix.hash-mode }}
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -268,7 +275,7 @@ jobs:
       - name: Test Go FFI bindings
         working-directory: ffi
         # cgocheck2 is expensive but provides complete pointer checks
-        run: ../scripts/run-just.sh ci-test-ffi firewood
+        run: ../scripts/run-just.sh ci-test-ffi ${{ matrix.hash-mode }}
 
   # Replay recorded C-Chain execution logs against Firewood to catch changes that would break the C-Chain.
   replay-test:
@@ -342,10 +349,6 @@ jobs:
         with:
           go-version-file: "ffi/tests/eth/go.mod"
           cache-dependency-path: "ffi/tests/eth/go.sum"
-      - name: Test Go FFI bindings
-        working-directory: ffi
-        # cgocheck2 is expensive but provides complete pointer checks
-        run: ../scripts/run-just.sh ci-test-ffi ethhash
       - name: Test Firewood <> Ethereum Differential Fuzz
         working-directory: ffi/tests/eth
         run: |
@@ -355,8 +358,8 @@ jobs:
           sudo prlimit --pid $$ --memlock=-1:-1 || echo "prlimit not available, locking kernel memory may fail when setting up io-uring"
           ulimit -Sa
           ulimit -Ha
-          go test -race -fuzz=FuzzFirewoodTree -fuzztime=1m
-          go test -race -fuzz=FuzzRangeProofCreation -fuzztime=1m
+          go test -fuzz=FuzzFirewoodTree -fuzztime=30s
+          go test -fuzz=FuzzRangeProofCreation -fuzztime=30s
       - name: Upload Fuzz testdata
         if: failure()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
> This is a developer velocity change.

## Why this should be merged

`firewood-ethhash-differential-fuzz` had grown to ~4m16s, making it the
long pole on most CI runs. Step timings from run 32764308259 (4m29s that
run):

| Step | Time |
|---|---|
| checkout + just + toolchain + rust-cache | 28s |
| Build Firewood FFI (ethhash) | 26s |
| Set up Go | 14s |
| Test Go FFI bindings (`ci-test-ffi ethhash`) | 63s |
| Test Firewood <> Ethereum Differential Fuzz | 136s |

Two thirds of the job was not the fuzzing budget, and the fuzzing that
did happen was starved.

Measured result of this PR (run 32898711369): **4m29s -> 3m17s**, a ~27%
reduction. See *Known remaining cost* below for why it is not more.

## How this works

**1. Move `ci-test-ffi ethhash` into the `ffi` job.**

That step is not fuzzing — it is the ethhash counterpart of the `ffi`
job's own "Test Go FFI bindings" step, bolted onto the fuzz job because
that job already had an ethhash cdylib lying around. The `ffi` job is
already a matrix, so this becomes a third leg running in parallel and
leaves the fuzz job 63s shorter.

The new `ffi (ethhash, debug-ethhash-logger)` leg takes 2m09s and starts
at the same instant as the others, against an existing critical path of
1m57s–2m15s for the macOS leg. Relocating 63s of work therefore costs
only a few seconds of wall clock. The leg is ubuntu-only, matching where
it ran before.

The matrix now carries `hash-mode` and `profile-key` per leg (the
rust-cache `shared-key` has to follow the hash mode:
`debug-ethhash-logger` vs `debug-no-features`), using the same
`matrix.os || 'ubuntu-latest'` idiom as the `build` job.

Side benefit: `ffi` is in `tests-required`'s `needs` list and the fuzz
jobs are not, so ethhash Go FFI coverage goes from advisory to blocking.

**2. Drop `-race` from the two fuzz invocations and halve `-fuzztime`.**

`-fuzztime` is a wall-clock budget that Go honors exactly, so dropping
`-race` alone saves no time — it only changes how much gets explored
inside the budget. Under `-race` that was very little: 1738 and 4291
execs across four workers in 60s each (7–70 execs/sec), with long
`0/sec` plateaus where every worker sat inside a single execution.

The race detector had little to look at. Both fuzz bodies are
single-goroutine: each `f.Fuzz` call constructs a fresh trie pair or DB
and drives it sequentially to completion. The FFI's actual concurrency
surface is exercised by `ffi`'s own test suite, which keeps both `-race`
and `GOEXPERIMENT=cgocheck2` — and, after change 1, now runs in both hash
modes rather than just `firewood`.

Removing the instrumentation lifted throughput 2.7–6.1x at an unchanged
1m budget (run 32897358888): 10652 and 11774 execs against 1738 and 4291.
Halving `-fuzztime` to 30s then bought the time back.

Effect on coverage is mixed and worth stating plainly:

| target | before (60s, `-race`) | after (30s, no race) | |
|---|---|---|---|
| `FuzzFirewoodTree` | 1738 execs | 3678 | 2.1x |
| `FuzzRangeProofCreation` | 4291 execs | 1300 | 0.30x |

`FuzzFirewoodTree` — the expensive account/storage differential against a
real geth trie, and the target that actually exercises the ethhash
codepaths — roughly doubles its exploration. `FuzzRangeProofCreation`
explores less than it did. Both counts are reported at a `(0/sec)`
sample, so batched worker reporting understates them somewhat, but not
enough to erase the regression on the second target.

That trade is accepted deliberately here rather than papered over: the
job is the CI long pole, `FuzzRangeProofCreation` is the cheaper and
shallower of the two, and its corpus is preserved between runs. If it
needs the budget back, the fix is the caching issue below, not `-race`.

Running the two targets concurrently instead was considered and rejected:
the `0/sec` plateaus were a `-race` artifact, and without it these
saturate a 4-core runner, so overlapping them would split throughput
rather than fill idle time.

## Known remaining cost

The fuzz step still spends **69s building the test binary before the
first execution** (against 7s pre-PR), which is now larger than the 62s
of fuzzing it precedes. Cause: `setup-go`'s cache key is
`…-go-<version>-<hash(go.sum)>` and does not encode `-race`, so it
*hits* on the race-instrumented cache built by `main` and therefore never
saves our non-instrumented objects. Permanent key hit, permanent content
miss.

This was initially assumed to be a one-time cold-cache cost; two
consecutive runs (68s, then 69s) showed it is not. Fixing it — an
explicit `actions/cache` for `~/.cache/go-build` under a key that encodes
the mode — would free ~60s and let `-fuzztime` go back to 1m, which would
land the job near 2m25s with the full throughput gain. That is left as a
follow-up rather than bundled here.

One further cost worth naming: `ffi/tests/eth`'s ordinary non-fuzz tests
run in CI *only* as a side effect of `go test -fuzz` — `ci-test-ffi-compat
ethhash` is wired into local recipes but not into any workflow — so they
lose `-race` as well. They are likewise single-goroutine, but that is a
deliberate call rather than an oversight, and the fix if we want it back
is to give `ci-test-ffi-compat` a CI home rather than to re-slow the
fuzzer.

Note the `ffi` matrix leg names change (`ffi (ubuntu-latest)` ->
`ffi (firewood, debug-no-features)`). Branch protection requires only
`tests-required`, which aggregates whole jobs, so no branch-protection
update is needed.

## How this was tested

Two full CI runs on this branch, both green:

- **32897358888** — change 1 plus the `-race` removal at `-fuzztime=1m`.
  Supplied the throughput numbers above.
- **32898711369** — this revision, at `-fuzztime=30s`. Job 3m17s; all
  three `ffi` legs green including the new ethhash one; both fuzz targets
  `PASS` with no new corpus failures.

Locally:

- `actionlint` clean on `.github/workflows/ci.yaml`; matrix expands to
  the three intended legs.
- `just ci-build-ffi ethhash` + `just ci-test-ffi ethhash`:
  `ok github.com/ava-labs/firewood/ffi 40.598s`.
- Both fuzz targets without `-race`: `PASS`.

## Breaking Changes

None.
