### PR TITLE
feat(metrics): tag metrics with per-database db_tag label

### DIFF
--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -149,6 +149,8 @@ type config struct {
 	rootStore bool
 	// expensiveMetricsEnabled controls whether expensive metrics recording is enabled.
 	expensiveMetricsEnabled bool
+	// metricsTag separates metrics and logs by database handle.
+	metricsTag string
 	// deferredPersistenceCommitCount determines the maximum number of unpersisted
 	// revisions that can exist at a given time.
 	// Note: revisions must be > deferredPersistenceCommitCount
@@ -233,6 +235,14 @@ func WithExpensiveMetrics() Option {
 	}
 }
 
+// WithMetricsTag sets a tag to attach to metrics and logs emitted for this database.
+// Default: empty (no tag)
+func WithMetricsTag(tag string) Option {
+	return func(c *config) {
+		c.metricsTag = tag
+	}
+}
+
 // WithDeferredPersistenceCommitCount sets the maximum number of unpersisted revisions
 // that can exist at a time. Note: `commitCount` must be greater than 0 and WithRevisions
 // must be greater than `commitCount`.
@@ -309,6 +319,7 @@ func New(dbDir string, nodeHashAlgorithm NodeHashAlgorithm, opts ...Option) (*Da
 		root_store:                        C.bool(conf.rootStore),
 		expensive_metrics:                 C.bool(conf.expensiveMetricsEnabled),
 		node_hash_algorithm:               C.enum_NodeHashAlgorithm(nodeHashAlgorithm),
+		db_tag:                            newBorrowedBytes([]byte(conf.metricsTag), &pinner),
 		deferred_persistence_commit_count: C.uint64_t(conf.deferredPersistenceCommitCount),
 	}
 

--- a/ffi/firewood.go
+++ b/ffi/firewood.go
@@ -234,7 +234,7 @@ func WithExpensiveMetrics() Option {
 }
 
 // WithMetricsTag sets a tag to attach to metrics and logs emitted for this database.
-// Default: empty (no tag)
+// Default: empty (no tag; metrics are recorded with the fallback db_tag="untagged" label)
 func WithMetricsTag(tag string) Option {
 	return func(c *config) {
 		c.metricsTag = tag

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1713,6 +1713,14 @@ typedef struct DatabaseHandleArgs {
    */
   bool expensive_metrics;
   /**
+   * Optional tag used to separate metrics and logs per database.
+   *
+   * If empty, no tag is applied.
+   *
+   * This must be a valid UTF-8 string.
+   */
+  BorrowedBytes db_tag;
+  /**
    * The hashing mode to use for the database.
    *
    * This must match the compile-time feature:

--- a/ffi/firewood.h
+++ b/ffi/firewood.h
@@ -1713,11 +1713,12 @@ typedef struct DatabaseHandleArgs {
    */
   bool expensive_metrics;
   /**
-   * Optional tag used to separate metrics and logs per database.
-   *
-   * If empty, no tag is applied.
+   * Tag used to separate metrics and logs per database.
    *
    * This must be a valid UTF-8 string.
+   *
+   * If empty, no tag is applied and this database's metrics are recorded
+   * with the default `db_tag="untagged"` label.
    */
   BorrowedBytes db_tag;
   /**

--- a/ffi/metrics.go
+++ b/ffi/metrics.go
@@ -52,10 +52,77 @@ func init() {
 
 var _ prometheus.Gatherer = (*Gatherer)(nil)
 
-type Gatherer struct{}
+// Gatherer is a [prometheus.Gatherer] that collects metrics from the firewood
+// library.
+//
+// If DBTag is non-empty, only metrics carrying a `db_tag` label equal to DBTag
+// are returned, allowing metrics from multiple databases in the same process
+// to be separated.
+type Gatherer struct {
+	DBTag string
+}
 
-func (Gatherer) Gather() ([]*dto.MetricFamily, error) {
-	return GatherRenderedMetrics()
+func (g Gatherer) Gather() ([]*dto.MetricFamily, error) {
+	families, err := GatherRenderedMetrics()
+	if err != nil {
+		return nil, err
+	}
+
+	if g.DBTag == "" {
+		return families, nil
+	}
+
+	filtered := make([]*dto.MetricFamily, 0, len(families))
+	for _, mf := range families {
+		mf = filterMetricFamilyByDBTag(mf, g.DBTag)
+		if mf == nil {
+			continue
+		}
+		filtered = append(filtered, mf)
+	}
+
+	return filtered, nil
+}
+
+// filterMetricFamilyByDBTag returns a copy of the metric family containing only
+// the metrics that carry a `db_tag` label equal to dbTag, or nil if no metric
+// matches.
+func filterMetricFamilyByDBTag(mf *dto.MetricFamily, dbTag string) *dto.MetricFamily {
+	if mf == nil {
+		return nil
+	}
+
+	filteredMetrics := make([]*dto.Metric, 0, len(mf.Metric))
+	for _, metric := range mf.Metric {
+		if metricHasDBTag(metric, dbTag) {
+			filteredMetrics = append(filteredMetrics, metric)
+		}
+	}
+
+	if len(filteredMetrics) == 0 {
+		return nil
+	}
+
+	return &dto.MetricFamily{
+		Name:   mf.Name,
+		Help:   mf.Help,
+		Type:   mf.Type,
+		Unit:   mf.Unit,
+		Metric: filteredMetrics,
+	}
+}
+
+func metricHasDBTag(metric *dto.Metric, dbTag string) bool {
+	if metric == nil {
+		return false
+	}
+
+	for _, labelPair := range metric.Label {
+		if labelPair.GetName() == "db_tag" && labelPair.GetValue() == dbTag {
+			return true
+		}
+	}
+	return false
 }
 
 // GatherRenderedMetrics collects structured metrics from the global recorder

--- a/ffi/metrics.go
+++ b/ffi/metrics.go
@@ -55,74 +55,12 @@ var _ prometheus.Gatherer = (*Gatherer)(nil)
 // Gatherer is a [prometheus.Gatherer] that collects metrics from the firewood
 // library.
 //
-// If DBTag is non-empty, only metrics carrying a `db_tag` label equal to DBTag
-// are returned, allowing metrics from multiple databases in the same process
-// to be separated.
-type Gatherer struct {
-	DBTag string
-}
+// Metrics carry a `db_tag` label identifying the database that recorded them
+// (see [WithMetricsTag]).
+type Gatherer struct{}
 
-func (g Gatherer) Gather() ([]*dto.MetricFamily, error) {
-	families, err := GatherRenderedMetrics()
-	if err != nil {
-		return nil, err
-	}
-
-	if g.DBTag == "" {
-		return families, nil
-	}
-
-	filtered := make([]*dto.MetricFamily, 0, len(families))
-	for _, mf := range families {
-		mf = filterMetricFamilyByDBTag(mf, g.DBTag)
-		if mf == nil {
-			continue
-		}
-		filtered = append(filtered, mf)
-	}
-
-	return filtered, nil
-}
-
-// filterMetricFamilyByDBTag returns a copy of the metric family containing only
-// the metrics that carry a `db_tag` label equal to dbTag, or nil if no metric
-// matches.
-func filterMetricFamilyByDBTag(mf *dto.MetricFamily, dbTag string) *dto.MetricFamily {
-	if mf == nil {
-		return nil
-	}
-
-	filteredMetrics := make([]*dto.Metric, 0, len(mf.Metric))
-	for _, metric := range mf.Metric {
-		if metricHasDBTag(metric, dbTag) {
-			filteredMetrics = append(filteredMetrics, metric)
-		}
-	}
-
-	if len(filteredMetrics) == 0 {
-		return nil
-	}
-
-	return &dto.MetricFamily{
-		Name:   mf.Name,
-		Help:   mf.Help,
-		Type:   mf.Type,
-		Unit:   mf.Unit,
-		Metric: filteredMetrics,
-	}
-}
-
-func metricHasDBTag(metric *dto.Metric, dbTag string) bool {
-	if metric == nil {
-		return false
-	}
-
-	for _, labelPair := range metric.Label {
-		if labelPair.GetName() == "db_tag" && labelPair.GetValue() == dbTag {
-			return true
-		}
-	}
-	return false
+func (Gatherer) Gather() ([]*dto.MetricFamily, error) {
+	return GatherRenderedMetrics()
 }
 
 // GatherRenderedMetrics collects structured metrics from the global recorder

--- a/ffi/metrics_test.go
+++ b/ffi/metrics_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 
@@ -112,181 +111,120 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
-func TestGathererFiltersByDBTag(t *testing.T) {
-	r := require.New(t)
-	tagA := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_")) + "_a"
-	tagB := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_")) + "_b"
-
-	assertTagged := func(families []*dto.MetricFamily, expectedTag string) {
-		r.NotEmpty(families)
-		for _, family := range families {
-			for _, metric := range family.GetMetric() {
-				hasDBTag := false
-				for _, labelPair := range metric.GetLabel() {
-					if labelPair.GetName() == "db_tag" {
-						hasDBTag = true
-						r.Equal(expectedTag, labelPair.GetValue())
-					}
-				}
-				r.True(hasDBTag)
+// assertAllTagged asserts every metric in families carries a db_tag label equal to tag.
+func assertAllTagged(r *require.Assertions, families []*dto.MetricFamily, tag string) {
+	r.NotEmpty(families)
+	for _, family := range families {
+		for _, metric := range family.GetMetric() {
+			labels := make(map[string]string, len(metric.GetLabel()))
+			for _, pair := range metric.GetLabel() {
+				labels[pair.GetName()] = pair.GetValue()
 			}
+			r.Equal(tag, labels["db_tag"], "family %s", family.GetName())
 		}
 	}
+}
 
+func TestGathererFiltersByDBTag(t *testing.T) {
+	r := require.New(t)
 	ensureMetricsStarted(t)
-	dbA := newTestDatabase(t, WithMetricsTag(tagA))
-	_, _, batchA := kvForTest(3)
-	_, err := dbA.Update(batchA)
-	r.NoError(err)
-	r.NoError(dbA.Close(t.Context()))
 
-	dbB := newTestDatabase(t, WithMetricsTag(tagB))
-	_, _, batchB := kvForTest(4)
-	_, err = dbB.Update(batchB)
-	r.NoError(err)
-	r.NoError(dbB.Close(t.Context()))
+	tags := []string{"filter_by_db_tag_a", "filter_by_db_tag_b"}
+	for _, tag := range tags {
+		db := newTestDatabase(t, WithMetricsTag(tag))
+		_, _, batch := kvForTest(3)
+		_, err := db.Update(batch)
+		r.NoError(err)
+		r.NoError(db.Close(t.Context()))
+	}
 
-	metricsA, err := (Gatherer{DBTag: tagA}).Gather()
-	r.NoError(err)
-	assertTagged(metricsA, tagA)
-
-	metricsB, err := (Gatherer{DBTag: tagB}).Gather()
-	r.NoError(err)
-	assertTagged(metricsB, tagB)
+	for _, tag := range tags {
+		families, err := (Gatherer{DBTag: tag}).Gather()
+		r.NoError(err)
+		assertAllTagged(r, families, tag)
+	}
 }
 
 func TestGathererFiltersWithUntaggedDatabase(t *testing.T) {
 	r := require.New(t)
-	tag := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_"))
-
 	ensureMetricsStarted(t)
+	const tag = "untagged_filter_test"
 
-	// Expensive metrics are enabled so the commit duration histogram
-	// (expensive-gated) is recorded and can be checked for the tag.
+	// Expensive metrics are enabled so the expensive-gated commit duration
+	// histogram is recorded and can be checked for the tag.
 	dbTagged := newTestDatabase(t, WithMetricsTag(tag), WithExpensiveMetrics())
-	_, _, batchTagged := kvForTest(2)
-	_, err := dbTagged.Update(batchTagged)
+	_, _, batch := kvForTest(2)
+	_, err := dbTagged.Update(batch)
 	r.NoError(err)
 	r.NoError(dbTagged.Close(t.Context()))
 
 	dbUntagged := newTestDatabase(t)
-	_, _, batchUntagged := kvForTest(2)
-	_, err = dbUntagged.Update(batchUntagged)
+	_, _, batch = kvForTest(2)
+	_, err = dbUntagged.Update(batch)
 	r.NoError(err)
 	r.NoError(dbUntagged.Close(t.Context()))
 
-	// Ensure mixed tagged + untagged metrics remain gatherable.
-	_, err = (Gatherer{}).Gather()
+	// Filtering by tag must exclude the untagged database's series.
+	families, err := (Gatherer{DBTag: tag}).Gather()
 	r.NoError(err)
+	assertAllTagged(r, families, tag)
 
-	// Ensure tag filtering does not include untagged series.
-	metricsFamiliesForTag, err := (Gatherer{DBTag: tag}).Gather()
-	r.NoError(err)
-	r.NotEmpty(metricsFamiliesForTag)
-	seenProposalCommit := false
-	seenProposalCommitDuration := false
-	for _, family := range metricsFamiliesForTag {
-		if family.GetName() == "firewood_proposal_commits_total" {
-			seenProposalCommit = true
-		}
-		if family.GetName() == "firewood_proposal_commit_duration_seconds" {
-			seenProposalCommitDuration = true
-		}
-		for _, metric := range family.GetMetric() {
-			hasDBTag := false
-			for _, labelPair := range metric.GetLabel() {
-				if labelPair.GetName() == "db_tag" {
-					hasDBTag = true
-					r.Equal(tag, labelPair.GetValue())
-				}
-			}
-			r.True(hasDBTag)
-		}
+	names := make(map[string]bool, len(families))
+	for _, family := range families {
+		names[family.GetName()] = true
 	}
-	r.True(seenProposalCommit)
-	r.True(seenProposalCommitDuration)
+	r.True(names["firewood_proposal_commits_total"])
+	r.True(names["firewood_proposal_commit_duration_seconds"])
 }
 
+// TestTagMetricsConcurrentTLSIsolation commits to several tagged databases
+// concurrently and checks each tag's commit counter counts only its own commits.
 func TestTagMetricsConcurrentTLSIsolation(t *testing.T) {
 	r := require.New(t)
 	ensureMetricsStarted(t)
 
-	const workerCount = 12
-	const commitsPerWorker = 15
-	const commitMetricName = "firewood_proposal_commits_total"
+	const workers = 4
+	const commits = 5
+	const counterName = "firewood_proposal_commits_total"
 
-	type metricsWorker struct {
-		tag    string
-		db     *Database
-		before float64
-	}
-
-	workers := make([]metricsWorker, 0, workerCount)
-	baseTag := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_"))
-	for i := range workerCount {
-		tag := fmt.Sprintf("%s_worker_%02d", baseTag, i)
-		db := newTestDatabase(t, WithMetricsTag(tag))
-
-		before, err := gatherTaggedCounterValue(commitMetricName, tag)
+	tags := make([]string, workers)
+	dbs := make([]*Database, workers)
+	before := make([]float64, workers)
+	for i := range workers {
+		tags[i] = fmt.Sprintf("tls_isolation_worker_%d", i)
+		dbs[i] = newTestDatabase(t, WithMetricsTag(tags[i]))
+		v, err := gatherTaggedCounterValue(counterName, tags[i])
 		r.NoError(err)
-
-		workers = append(workers, metricsWorker{
-			tag:    tag,
-			db:     db,
-			before: before,
-		})
+		before[i] = v
 	}
 
-	start := make(chan struct{})
-	errs := make(chan error, workerCount)
 	var wg sync.WaitGroup
-
-	for _, worker := range workers {
+	errs := make(chan error, workers)
+	for i := range workers {
 		wg.Add(1)
-		go func(worker metricsWorker) {
+		go func() {
 			defer wg.Done()
-			<-start
-			for commitIdx := range commitsPerWorker {
-				key := []byte(fmt.Sprintf("%s_key_%03d", worker.tag, commitIdx))
-				value := []byte(fmt.Sprintf("value_%03d", commitIdx))
-				_, err := worker.db.Update([]BatchOp{Put(key, value)})
-				if err != nil {
-					errs <- fmt.Errorf("%s update %d failed: %w", worker.tag, commitIdx, err)
+			for c := range commits {
+				key := fmt.Appendf(nil, "%s_key_%d", tags[i], c)
+				if _, err := dbs[i].Update([]BatchOp{Put(key, []byte("value"))}); err != nil {
+					errs <- fmt.Errorf("%s update %d: %w", tags[i], c, err)
 					return
 				}
 			}
-		}(worker)
+		}()
 	}
-
-	close(start)
 	wg.Wait()
 	close(errs)
-
 	for err := range errs {
 		r.NoError(err)
 	}
 
-	totalDelta := 0.0
-	for _, worker := range workers {
-		r.NoError(worker.db.Close(oneSecCtx(t)))
-
-		after, err := gatherTaggedCounterValue(commitMetricName, worker.tag)
+	for i := range workers {
+		r.NoError(dbs[i].Close(t.Context()))
+		after, err := gatherTaggedCounterValue(counterName, tags[i])
 		r.NoError(err)
-
-		actualDelta := after - worker.before
-		totalDelta += actualDelta
-
-		r.InDelta(
-			float64(commitsPerWorker),
-			actualDelta,
-			0.0000001,
-			"unexpected %s count for db_tag=%s",
-			commitMetricName,
-			worker.tag,
-		)
+		r.InDelta(commits, after-before[i], 1e-9, "db_tag=%s", tags[i])
 	}
-
-	r.InDelta(float64(workerCount*commitsPerWorker), totalDelta, 0.0000001)
 }
 
 func gatherTaggedCounterValue(metricName, dbTag string) (float64, error) {

--- a/ffi/metrics_test.go
+++ b/ffi/metrics_test.go
@@ -111,6 +111,38 @@ func TestMetrics(t *testing.T) {
 	}
 }
 
+// gatherForTag gathers all metrics and returns only those carrying a db_tag
+// label equal to tag, the way a consumer of [Gatherer] would filter them.
+func gatherForTag(tag string) ([]*dto.MetricFamily, error) {
+	families, err := (Gatherer{}).Gather()
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]*dto.MetricFamily, 0, len(families))
+	for _, mf := range families {
+		var metrics []*dto.Metric
+		for _, metric := range mf.GetMetric() {
+			for _, pair := range metric.GetLabel() {
+				if pair.GetName() == "db_tag" && pair.GetValue() == tag {
+					metrics = append(metrics, metric)
+					break
+				}
+			}
+		}
+		if len(metrics) > 0 {
+			filtered = append(filtered, &dto.MetricFamily{
+				Name:   mf.Name,
+				Help:   mf.Help,
+				Type:   mf.Type,
+				Unit:   mf.Unit,
+				Metric: metrics,
+			})
+		}
+	}
+	return filtered, nil
+}
+
 // assertAllTagged asserts every metric in families carries a db_tag label equal to tag.
 func assertAllTagged(r *require.Assertions, families []*dto.MetricFamily, tag string) {
 	r.NotEmpty(families)
@@ -125,7 +157,7 @@ func assertAllTagged(r *require.Assertions, families []*dto.MetricFamily, tag st
 	}
 }
 
-func TestGathererFiltersByDBTag(t *testing.T) {
+func TestMetricsFilteredByDBTag(t *testing.T) {
 	r := require.New(t)
 	ensureMetricsStarted(t)
 
@@ -139,13 +171,13 @@ func TestGathererFiltersByDBTag(t *testing.T) {
 	}
 
 	for _, tag := range tags {
-		families, err := (Gatherer{DBTag: tag}).Gather()
+		families, err := gatherForTag(tag)
 		r.NoError(err)
 		assertAllTagged(r, families, tag)
 	}
 }
 
-func TestGathererFiltersWithUntaggedDatabase(t *testing.T) {
+func TestMetricsFilterExcludesUntaggedDatabase(t *testing.T) {
 	r := require.New(t)
 	ensureMetricsStarted(t)
 	const tag = "untagged_filter_test"
@@ -165,7 +197,7 @@ func TestGathererFiltersWithUntaggedDatabase(t *testing.T) {
 	r.NoError(dbUntagged.Close(t.Context()))
 
 	// Filtering by tag must exclude the untagged database's series.
-	families, err := (Gatherer{DBTag: tag}).Gather()
+	families, err := gatherForTag(tag)
 	r.NoError(err)
 	assertAllTagged(r, families, tag)
 
@@ -228,7 +260,7 @@ func TestTagMetricsConcurrentTLSIsolation(t *testing.T) {
 }
 
 func gatherTaggedCounterValue(metricName, dbTag string) (float64, error) {
-	families, err := (Gatherer{DBTag: dbTag}).Gather()
+	families, err := gatherForTag(dbTag)
 	if err != nil {
 		return 0, err
 	}

--- a/ffi/metrics_test.go
+++ b/ffi/metrics_test.go
@@ -233,9 +233,7 @@ func TestTagMetricsConcurrentTLSIsolation(t *testing.T) {
 	var wg sync.WaitGroup
 	errs := make(chan error, workers)
 	for i := range workers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for c := range commits {
 				key := fmt.Appendf(nil, "%s_key_%d", tags[i], c)
 				if _, err := dbs[i].Update([]BatchOp{Put(key, []byte("value"))}); err != nil {
@@ -243,7 +241,7 @@ func TestTagMetricsConcurrentTLSIsolation(t *testing.T) {
 					return
 				}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	close(errs)

--- a/ffi/metrics_test.go
+++ b/ffi/metrics_test.go
@@ -4,8 +4,10 @@
 package ffi
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -74,7 +76,8 @@ func newDbWithMetricsAndLogs(t *testing.T, opts ...Option) (db *Database, logPat
 func TestMetrics(t *testing.T) {
 	r := require.New(t)
 
-	db, logPath := newDbWithMetricsAndLogs(t)
+	const dbTag = "metrics-test-db"
+	db, logPath := newDbWithMetricsAndLogs(t, WithMetricsTag(dbTag))
 	// batch update
 	_, _, batch := kvForTest(10)
 	_, err := db.Update(batch)
@@ -107,6 +110,211 @@ func TestMetrics(t *testing.T) {
 	if logPath != "" {
 		r.True(assertNonEmptyFile(t, logPath))
 	}
+}
+
+func TestGathererFiltersByDBTag(t *testing.T) {
+	r := require.New(t)
+	tagA := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_")) + "_a"
+	tagB := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_")) + "_b"
+
+	assertTagged := func(families []*dto.MetricFamily, expectedTag string) {
+		r.NotEmpty(families)
+		for _, family := range families {
+			for _, metric := range family.GetMetric() {
+				hasDBTag := false
+				for _, labelPair := range metric.GetLabel() {
+					if labelPair.GetName() == "db_tag" {
+						hasDBTag = true
+						r.Equal(expectedTag, labelPair.GetValue())
+					}
+				}
+				r.True(hasDBTag)
+			}
+		}
+	}
+
+	ensureMetricsStarted(t)
+	dbA := newTestDatabase(t, WithMetricsTag(tagA))
+	_, _, batchA := kvForTest(3)
+	_, err := dbA.Update(batchA)
+	r.NoError(err)
+	r.NoError(dbA.Close(t.Context()))
+
+	dbB := newTestDatabase(t, WithMetricsTag(tagB))
+	_, _, batchB := kvForTest(4)
+	_, err = dbB.Update(batchB)
+	r.NoError(err)
+	r.NoError(dbB.Close(t.Context()))
+
+	metricsA, err := (Gatherer{DBTag: tagA}).Gather()
+	r.NoError(err)
+	assertTagged(metricsA, tagA)
+
+	metricsB, err := (Gatherer{DBTag: tagB}).Gather()
+	r.NoError(err)
+	assertTagged(metricsB, tagB)
+}
+
+func TestGathererFiltersWithUntaggedDatabase(t *testing.T) {
+	r := require.New(t)
+	tag := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_"))
+
+	ensureMetricsStarted(t)
+
+	// Expensive metrics are enabled so the commit duration histogram
+	// (expensive-gated) is recorded and can be checked for the tag.
+	dbTagged := newTestDatabase(t, WithMetricsTag(tag), WithExpensiveMetrics())
+	_, _, batchTagged := kvForTest(2)
+	_, err := dbTagged.Update(batchTagged)
+	r.NoError(err)
+	r.NoError(dbTagged.Close(t.Context()))
+
+	dbUntagged := newTestDatabase(t)
+	_, _, batchUntagged := kvForTest(2)
+	_, err = dbUntagged.Update(batchUntagged)
+	r.NoError(err)
+	r.NoError(dbUntagged.Close(t.Context()))
+
+	// Ensure mixed tagged + untagged metrics remain gatherable.
+	_, err = (Gatherer{}).Gather()
+	r.NoError(err)
+
+	// Ensure tag filtering does not include untagged series.
+	metricsFamiliesForTag, err := (Gatherer{DBTag: tag}).Gather()
+	r.NoError(err)
+	r.NotEmpty(metricsFamiliesForTag)
+	seenProposalCommit := false
+	seenProposalCommitDuration := false
+	for _, family := range metricsFamiliesForTag {
+		if family.GetName() == "firewood_proposal_commits_total" {
+			seenProposalCommit = true
+		}
+		if family.GetName() == "firewood_proposal_commit_duration_seconds" {
+			seenProposalCommitDuration = true
+		}
+		for _, metric := range family.GetMetric() {
+			hasDBTag := false
+			for _, labelPair := range metric.GetLabel() {
+				if labelPair.GetName() == "db_tag" {
+					hasDBTag = true
+					r.Equal(tag, labelPair.GetValue())
+				}
+			}
+			r.True(hasDBTag)
+		}
+	}
+	r.True(seenProposalCommit)
+	r.True(seenProposalCommitDuration)
+}
+
+func TestTagMetricsConcurrentTLSIsolation(t *testing.T) {
+	r := require.New(t)
+	ensureMetricsStarted(t)
+
+	const workerCount = 12
+	const commitsPerWorker = 15
+	const commitMetricName = "firewood_proposal_commits_total"
+
+	type metricsWorker struct {
+		tag    string
+		db     *Database
+		before float64
+	}
+
+	workers := make([]metricsWorker, 0, workerCount)
+	baseTag := strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_"))
+	for i := range workerCount {
+		tag := fmt.Sprintf("%s_worker_%02d", baseTag, i)
+		db := newTestDatabase(t, WithMetricsTag(tag))
+
+		before, err := gatherTaggedCounterValue(commitMetricName, tag)
+		r.NoError(err)
+
+		workers = append(workers, metricsWorker{
+			tag:    tag,
+			db:     db,
+			before: before,
+		})
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, workerCount)
+	var wg sync.WaitGroup
+
+	for _, worker := range workers {
+		wg.Add(1)
+		go func(worker metricsWorker) {
+			defer wg.Done()
+			<-start
+			for commitIdx := range commitsPerWorker {
+				key := []byte(fmt.Sprintf("%s_key_%03d", worker.tag, commitIdx))
+				value := []byte(fmt.Sprintf("value_%03d", commitIdx))
+				_, err := worker.db.Update([]BatchOp{Put(key, value)})
+				if err != nil {
+					errs <- fmt.Errorf("%s update %d failed: %w", worker.tag, commitIdx, err)
+					return
+				}
+			}
+		}(worker)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		r.NoError(err)
+	}
+
+	totalDelta := 0.0
+	for _, worker := range workers {
+		r.NoError(worker.db.Close(oneSecCtx(t)))
+
+		after, err := gatherTaggedCounterValue(commitMetricName, worker.tag)
+		r.NoError(err)
+
+		actualDelta := after - worker.before
+		totalDelta += actualDelta
+
+		r.InDelta(
+			float64(commitsPerWorker),
+			actualDelta,
+			0.0000001,
+			"unexpected %s count for db_tag=%s",
+			commitMetricName,
+			worker.tag,
+		)
+	}
+
+	r.InDelta(float64(workerCount*commitsPerWorker), totalDelta, 0.0000001)
+}
+
+func gatherTaggedCounterValue(metricName, dbTag string) (float64, error) {
+	families, err := (Gatherer{DBTag: dbTag}).Gather()
+	if err != nil {
+		return 0, err
+	}
+
+	total := 0.0
+	for _, family := range families {
+		if family.GetName() != metricName {
+			continue
+		}
+
+		if family.GetType() != dto.MetricType_COUNTER {
+			return 0, fmt.Errorf("metric %q is not a counter", metricName)
+		}
+
+		for _, metric := range family.GetMetric() {
+			counter := metric.GetCounter()
+			if counter == nil {
+				return 0, fmt.Errorf("counter metric %q missing counter value", metricName)
+			}
+			total += counter.GetValue()
+		}
+	}
+
+	return total, nil
 }
 
 func TestGatherRenderedMetrics(t *testing.T) {

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -92,11 +92,12 @@ pub struct DatabaseHandleArgs<'a> {
     /// Expensive metrics are disabled by default.
     pub expensive_metrics: bool,
 
-    /// Optional tag used to separate metrics and logs per database.
-    ///
-    /// If empty, no tag is applied.
+    /// Tag used to separate metrics and logs per database.
     ///
     /// This must be a valid UTF-8 string.
+    ///
+    /// If empty, no tag is applied and this database's metrics are recorded
+    /// with the default `db_tag="untagged"` label.
     pub db_tag: BorrowedBytes<'a>,
 
     /// The hashing mode to use for the database.
@@ -376,10 +377,6 @@ fn parse_db_tag(db_tag: BorrowedBytes<'_>) -> Result<Option<metrics::SharedStrin
         .as_str()
         .map_err(|err| invalid_data(format!("database tag contains invalid utf-8: {err}")))?;
 
-    if db_tag.is_empty() {
-        Ok(None)
-    } else {
-        let db_tag = Arc::<str>::from(db_tag);
-        Ok(Some(metrics::SharedString::from(db_tag)))
-    }
+    // Arc<str> keeps the per-recording clone of the tag a refcount bump.
+    Ok((!db_tag.is_empty()).then(|| metrics::SharedString::from(Arc::<str>::from(db_tag))))
 }

--- a/ffi/src/handle.rs
+++ b/ffi/src/handle.rs
@@ -2,6 +2,7 @@
 // See the file LICENSE.md for licensing terms.
 
 use std::num::{NonZeroU64, NonZeroUsize};
+use std::sync::Arc;
 
 use firewood::{
     DefaultHashMode,
@@ -94,6 +95,13 @@ pub struct DatabaseHandleArgs<'a> {
     /// Expensive metrics are disabled by default.
     pub expensive_metrics: bool,
 
+    /// Optional tag used to separate metrics and logs per database.
+    ///
+    /// If empty, no tag is applied.
+    ///
+    /// This must be a valid UTF-8 string.
+    pub db_tag: BorrowedBytes<'a>,
+
     /// The hashing mode to use for the database.
     ///
     /// This must match the compile-time feature:
@@ -160,7 +168,8 @@ impl DatabaseHandle {
     ///
     /// If the path is empty, or if the configuration is invalid, this will return an error.
     pub fn new(args: DatabaseHandleArgs<'_>) -> Result<Self, api::Error> {
-        let metrics_context = MetricsContext::new(args.expensive_metrics);
+        let db_tag = parse_db_tag(args.db_tag)?;
+        let metrics_context = MetricsContext::new(args.expensive_metrics).with_db_tag(db_tag);
 
         let cfg = DbConfig::builder()
             .node_hash_algorithm(args.node_hash_algorithm.into())
@@ -237,7 +246,7 @@ impl DatabaseHandle {
             Err(err) => return Err(err),
         };
         Ok(GetRevisionResult {
-            handle: RevisionHandle::new(view, historical, self.metrics_context, self),
+            handle: RevisionHandle::new(view, historical, self.metrics_context.clone(), self),
             root_hash: root,
         })
     }
@@ -345,10 +354,23 @@ impl<'db> CView<'db> for &'db crate::DatabaseHandle {
 
 impl crate::MetricsContextExt for DatabaseHandle {
     fn metrics_context(&self) -> Option<MetricsContext> {
-        Some(self.metrics_context)
+        Some(self.metrics_context.clone())
     }
 }
 
 fn invalid_data(error: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> api::Error {
     api::Error::IO(std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+fn parse_db_tag(db_tag: BorrowedBytes<'_>) -> Result<Option<metrics::SharedString>, api::Error> {
+    let db_tag = db_tag
+        .as_str()
+        .map_err(|err| invalid_data(format!("database tag contains invalid utf-8: {err}")))?;
+
+    if db_tag.is_empty() {
+        Ok(None)
+    } else {
+        let db_tag = Arc::<str>::from(db_tag);
+        Ok(Some(metrics::SharedString::from(db_tag)))
+    }
 }

--- a/ffi/src/iterator.rs
+++ b/ffi/src/iterator.rs
@@ -71,6 +71,6 @@ pub struct CreateIteratorResult<'db>(pub IteratorHandle<'db>);
 
 impl crate::MetricsContextExt for IteratorHandle<'_> {
     fn metrics_context(&self) -> Option<MetricsContext> {
-        self.metrics_context
+        self.metrics_context.clone()
     }
 }

--- a/ffi/src/revision.rs
+++ b/ffi/src/revision.rs
@@ -122,6 +122,6 @@ pub struct GetRevisionResult<'db> {
 
 impl crate::MetricsContextExt for RevisionHandle<'_> {
     fn metrics_context(&self) -> Option<MetricsContext> {
-        Some(self.metrics_context)
+        Some(self.metrics_context.clone())
     }
 }

--- a/firewood-macros/src/lib.rs
+++ b/firewood-macros/src/lib.rs
@@ -128,16 +128,13 @@ fn generate_metrics_wrapper(input_fn: &ItemFn, ident: &syn::Ident) -> proc_macro
 
             let __metrics_result = { #fn_block };
 
-            // Use static label arrays to avoid runtime allocation
-            static __METRICS_LABELS_SUCCESS: &[(&str, &str)] = &[("success", "true")];
-            static __METRICS_LABELS_ERROR: &[(&str, &str)] = &[("success", "false")];
-            let __metrics_labels = if __metrics_result.is_err() {
-                __METRICS_LABELS_ERROR
+            // Pass the success label as an explicit `key => value` pair so the
+            // firewood-metrics facade can prepend the thread-local `db_tag` label.
+            if __metrics_result.is_err() {
+                ::firewood_metrics::firewood_counter!(#ident, "success" => "false").increment(1);
             } else {
-                __METRICS_LABELS_SUCCESS
-            };
-
-            ::firewood_metrics::firewood_counter!(#ident, __metrics_labels).increment(1);
+                ::firewood_metrics::firewood_counter!(#ident, "success" => "true").increment(1);
+            }
             ::firewood_metrics::firewood_histogram!(#duration_ident).record(__metrics_start.elapsed().as_secs_f64());
 
             __metrics_result
@@ -194,8 +191,9 @@ mod tests {
         let generated_code = result.to_string();
 
         // Verify key components are present in the generated code
-        assert!(generated_code.contains("__METRICS_LABELS_SUCCESS"));
-        assert!(generated_code.contains("__METRICS_LABELS_ERROR"));
+        assert!(generated_code.contains("firewood_counter"));
+        assert!(generated_code.contains("success") && generated_code.contains("true"));
+        assert!(generated_code.contains("success") && generated_code.contains("false"));
         assert!(generated_code.contains("TEST_METRIC"));
         assert!(generated_code.contains("TEST_METRIC_DURATION_SECONDS"));
         assert!(

--- a/firewood/src/merkle/changes.rs
+++ b/firewood/src/merkle/changes.rs
@@ -1772,7 +1772,7 @@ mod tests {
 
             // Check the number of next calls on two full tree traversals.
             let diff_nexts_before =
-                recorder.counter_value(crate::registry::CHANGE_PROOF_NEXT, &[]);
+                recorder.counter_value(crate::registry::CHANGE_PROOF_NEXT, &[("db_tag", "untagged")]);
 
             let mut preorder_it = PreOrderIterator::new(m1.nodestore(), &Key::default()).unwrap();
             while preorder_it.next().is_some() {}
@@ -1780,20 +1780,20 @@ mod tests {
             while preorder_it.next().is_some() {}
 
             let diff_nexts_after =
-                recorder.counter_value(crate::registry::CHANGE_PROOF_NEXT, &[]);
+                recorder.counter_value(crate::registry::CHANGE_PROOF_NEXT, &[("db_tag", "untagged")]);
             let diff_iteration_count = diff_nexts_after - diff_nexts_before;
             println!("Next calls from traversing tries: {diff_iteration_count}");
 
             // DIFF TEST: Measure next calls from hash-optimized diff operation
             let diff_nexts_before =
-                recorder.counter_value(crate::registry::CHANGE_PROOF_NEXT, &[]);
+                recorder.counter_value(crate::registry::CHANGE_PROOF_NEXT, &[("db_tag", "untagged")]);
 
             let diff_stream =
                 DiffMerkleNodeStream::new(m1.nodestore(), m2.nodestore(), Box::new([])).unwrap();
             let diff_immutable_results_count = diff_stream.count();
 
             let diff_nexts_after =
-                recorder.counter_value(crate::registry::CHANGE_PROOF_NEXT, &[]);
+                recorder.counter_value(crate::registry::CHANGE_PROOF_NEXT, &[("db_tag", "untagged")]);
             let diff_immutable_nexts = diff_nexts_after - diff_nexts_before;
 
             println!("Diff next calls: {diff_immutable_nexts}");

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -210,12 +210,6 @@ impl MetricsContext {
     pub fn db_tag(&self) -> Option<&str> {
         self.db_tag.as_deref()
     }
-
-    /// Returns an owned database tag attached to this context, if any.
-    #[must_use]
-    pub fn db_tag_owned(&self) -> Option<SharedString> {
-        self.db_tag.clone()
-    }
 }
 
 thread_local! {

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -37,7 +37,8 @@
 //!
 //! For registration, use the [`define_metrics!`] macro in your crate's registry module.
 
-use std::cell::Cell;
+use metrics::SharedString;
+use std::cell::RefCell;
 
 /// Sealed helper for [`GaugeExt`]: integer types that can be stored in a gauge as `f64`.
 ///
@@ -175,9 +176,10 @@ pub fn strip_doc_leading_space(s: &str) -> &str {
 ///
 /// This is set at API boundaries (e.g., FFI entrypoints) and read when deciding
 /// whether to record expensive metrics.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct MetricsContext {
     expensive_metrics_enabled: bool,
+    db_tag: Option<SharedString>,
 }
 
 impl MetricsContext {
@@ -186,19 +188,41 @@ impl MetricsContext {
     pub const fn new(expensive_metrics_enabled: bool) -> Self {
         Self {
             expensive_metrics_enabled,
+            db_tag: None,
         }
+    }
+
+    /// Returns a copy of this context with a database tag attached.
+    #[must_use]
+    pub fn with_db_tag(mut self, db_tag: Option<SharedString>) -> Self {
+        self.db_tag = db_tag;
+        self
     }
 
     /// Whether expensive metrics are enabled.
     #[must_use]
-    pub const fn expensive_metrics_enabled(self) -> bool {
+    pub const fn expensive_metrics_enabled(&self) -> bool {
         self.expensive_metrics_enabled
+    }
+
+    /// Returns the database tag attached to this context, if any.
+    #[must_use]
+    pub fn db_tag(&self) -> Option<&str> {
+        self.db_tag.as_deref()
+    }
+
+    /// Returns an owned database tag attached to this context, if any.
+    #[must_use]
+    pub fn db_tag_owned(&self) -> Option<SharedString> {
+        self.db_tag.clone()
     }
 }
 
 thread_local! {
-    static METRICS_CONTEXT: Cell<Option<MetricsContext>> = const { Cell::new(None) };
+    static METRICS_CONTEXT: RefCell<Option<MetricsContext>> = const { RefCell::new(None) };
 }
+
+const DEFAULT_DB_TAG: &str = "untagged";
 
 /// A guard that restores the previous thread-local [`MetricsContext`].
 #[derive(Debug)]
@@ -208,21 +232,40 @@ pub struct MetricsContextGuard {
 
 impl Drop for MetricsContextGuard {
     fn drop(&mut self) {
-        METRICS_CONTEXT.set(self.previous);
+        METRICS_CONTEXT.with(|context| {
+            context.replace(self.previous.take());
+        });
     }
 }
 
 /// Sets the thread-local metrics context for the duration of the returned guard.
 #[must_use]
 pub fn set_metrics_context(context: Option<MetricsContext>) -> MetricsContextGuard {
-    let previous = METRICS_CONTEXT.replace(context);
+    let previous = METRICS_CONTEXT.with(|current| current.replace(context));
     MetricsContextGuard { previous }
 }
 
 /// Returns the current thread-local metrics context, if one is set.
 #[must_use]
 pub fn current_metrics_context() -> Option<MetricsContext> {
-    METRICS_CONTEXT.get()
+    METRICS_CONTEXT.with(|current| current.borrow().clone())
+}
+
+/// Returns the current metrics db tag, if one is set for this thread.
+#[must_use]
+pub fn current_db_tag() -> Option<SharedString> {
+    METRICS_CONTEXT.with(|current| {
+        current
+            .borrow()
+            .as_ref()
+            .and_then(|context| context.db_tag.clone())
+    })
+}
+
+/// Returns the current metrics db tag, or a default "untagged" label.
+#[must_use]
+pub fn current_db_tag_label() -> SharedString {
+    current_db_tag().unwrap_or_else(|| SharedString::const_str(DEFAULT_DB_TAG))
 }
 
 /// Returns whether expensive metrics are enabled for the current thread.
@@ -230,7 +273,12 @@ pub fn current_metrics_context() -> Option<MetricsContext> {
 /// If no context is set, this returns `false`.
 #[must_use]
 pub fn expensive_metrics_enabled() -> bool {
-    current_metrics_context().is_some_and(MetricsContext::expensive_metrics_enabled)
+    METRICS_CONTEXT.with(|current| {
+        current
+            .borrow()
+            .as_ref()
+            .is_some_and(|context| context.expensive_metrics_enabled)
+    })
 }
 
 /// Defines metric name constants and a `register()` function from a single schema.
@@ -561,24 +609,36 @@ macro_rules! define_metrics {
 macro_rules! firewood_counter {
     (expensive: $name:ident) => {
         if $crate::expensive_metrics_enabled() {
-            $crate::__private::metrics::counter!(crate::registry::$name)
+            let db_tag = $crate::current_db_tag_label();
+            $crate::__private::metrics::counter!(crate::registry::$name, "db_tag" => db_tag)
         } else {
             $crate::__private::metrics::Counter::noop()
         }
     };
     (expensive: $name:ident, $($labels:tt)+) => {
         if $crate::expensive_metrics_enabled() {
-            $crate::__private::metrics::counter!(crate::registry::$name, $($labels)+)
+            let db_tag = $crate::current_db_tag_label();
+            $crate::__private::metrics::counter!(
+                crate::registry::$name,
+                "db_tag" => db_tag,
+                $($labels)+
+            )
         } else {
             $crate::__private::metrics::Counter::noop()
         }
     };
-    ($name:ident) => {
-        $crate::__private::metrics::counter!(crate::registry::$name)
-    };
-    ($name:ident, $($labels:tt)+) => {
-        $crate::__private::metrics::counter!(crate::registry::$name, $($labels)+)
-    };
+    ($name:ident) => {{
+        let db_tag = $crate::current_db_tag_label();
+        $crate::__private::metrics::counter!(crate::registry::$name, "db_tag" => db_tag)
+    }};
+    ($name:ident, $($labels:tt)+) => {{
+        let db_tag = $crate::current_db_tag_label();
+        $crate::__private::metrics::counter!(
+            crate::registry::$name,
+            "db_tag" => db_tag,
+            $($labels)+
+        )
+    }};
 }
 
 /// Returns a gauge handle for advanced operations.
@@ -622,24 +682,36 @@ macro_rules! firewood_counter {
 macro_rules! firewood_gauge {
     (expensive: $name:ident) => {
         if $crate::expensive_metrics_enabled() {
-            $crate::__private::metrics::gauge!(crate::registry::$name)
+            let db_tag = $crate::current_db_tag_label();
+            $crate::__private::metrics::gauge!(crate::registry::$name, "db_tag" => db_tag)
         } else {
             $crate::__private::metrics::Gauge::noop()
         }
     };
     (expensive: $name:ident, $($labels:tt)+) => {
         if $crate::expensive_metrics_enabled() {
-            $crate::__private::metrics::gauge!(crate::registry::$name, $($labels)+)
+            let db_tag = $crate::current_db_tag_label();
+            $crate::__private::metrics::gauge!(
+                crate::registry::$name,
+                "db_tag" => db_tag,
+                $($labels)+
+            )
         } else {
             $crate::__private::metrics::Gauge::noop()
         }
     };
-    ($name:ident) => {
-        $crate::__private::metrics::gauge!(crate::registry::$name)
-    };
-    ($name:ident, $($labels:tt)+) => {
-        $crate::__private::metrics::gauge!(crate::registry::$name, $($labels)+)
-    };
+    ($name:ident) => {{
+        let db_tag = $crate::current_db_tag_label();
+        $crate::__private::metrics::gauge!(crate::registry::$name, "db_tag" => db_tag)
+    }};
+    ($name:ident, $($labels:tt)+) => {{
+        let db_tag = $crate::current_db_tag_label();
+        $crate::__private::metrics::gauge!(
+            crate::registry::$name,
+            "db_tag" => db_tag,
+            $($labels)+
+        )
+    }};
 }
 
 /// Returns a histogram handle for recording a single observation.
@@ -687,24 +759,36 @@ macro_rules! firewood_gauge {
 macro_rules! firewood_histogram {
     ($name:ident) => {
         if $crate::expensive_metrics_enabled() {
-            $crate::__private::metrics::histogram!(crate::registry::$name)
+            let db_tag = $crate::current_db_tag_label();
+            $crate::__private::metrics::histogram!(crate::registry::$name, "db_tag" => db_tag)
         } else {
             $crate::__private::metrics::Histogram::noop()
         }
     };
     ($name:ident, $($labels:tt)+) => {
         if $crate::expensive_metrics_enabled() {
-            $crate::__private::metrics::histogram!(crate::registry::$name, $($labels)+)
+            let db_tag = $crate::current_db_tag_label();
+            $crate::__private::metrics::histogram!(
+                crate::registry::$name,
+                "db_tag" => db_tag,
+                $($labels)+
+            )
         } else {
             $crate::__private::metrics::Histogram::noop()
         }
     };
-    (cheap: $name:ident) => {
-        $crate::__private::metrics::histogram!(crate::registry::$name)
-    };
-    (cheap: $name:ident, $($labels:tt)+) => {
-        $crate::__private::metrics::histogram!(crate::registry::$name, $($labels)+)
-    };
+    (cheap: $name:ident) => {{
+        let db_tag = $crate::current_db_tag_label();
+        $crate::__private::metrics::histogram!(crate::registry::$name, "db_tag" => db_tag)
+    }};
+    (cheap: $name:ident, $($labels:tt)+) => {{
+        let db_tag = $crate::current_db_tag_label();
+        $crate::__private::metrics::histogram!(
+            crate::registry::$name,
+            "db_tag" => db_tag,
+            $($labels)+
+        )
+    }};
 }
 
 #[doc(hidden)]
@@ -738,9 +822,9 @@ mod tests {
             let outer = MetricsContext::new(false);
             let inner = MetricsContext::new(true);
 
-            let guard1 = set_metrics_context(Some(outer));
+            let guard1 = set_metrics_context(Some(outer.clone()));
             {
-                let _guard2 = set_metrics_context(Some(inner));
+                let _guard2 = set_metrics_context(Some(inner.clone()));
                 assert_eq!(current_metrics_context(), Some(inner));
             }
             assert_eq!(current_metrics_context(), Some(outer));
@@ -754,7 +838,7 @@ mod tests {
     fn spawned_thread_does_not_inherit_context() {
         isolated(|| {
             let ctx = MetricsContext::new(true);
-            let _guard = set_metrics_context(Some(ctx));
+            let _guard = set_metrics_context(Some(ctx.clone()));
             assert_eq!(current_metrics_context(), Some(ctx));
 
             let child_ctx = std::thread::spawn(current_metrics_context).join().unwrap();
@@ -770,7 +854,7 @@ mod tests {
     fn capture_and_set_propagates_context_to_spawned_thread() {
         isolated(|| {
             let ctx = MetricsContext::new(true);
-            let _guard = set_metrics_context(Some(ctx));
+            let _guard = set_metrics_context(Some(ctx.clone()));
 
             // Capture on the parent thread, just like persist_worker.rs does.
             let captured = current_metrics_context();
@@ -789,12 +873,30 @@ mod tests {
 
             assert_eq!(
                 child_ctx,
-                Some(ctx),
+                Some(ctx.clone()),
                 "captured context must be available in child thread after set_metrics_context"
             );
 
             // Parent context is unaffected.
             assert_eq!(current_metrics_context(), Some(ctx));
+        });
+    }
+
+    #[test]
+    fn context_exposes_db_tag() {
+        isolated(|| {
+            let context =
+                MetricsContext::new(false).with_db_tag(Some(SharedString::const_str("db-a")));
+            let _guard = set_metrics_context(Some(context));
+
+            assert_eq!(current_db_tag().as_deref(), Some("db-a"));
+        });
+    }
+
+    #[test]
+    fn default_db_tag_label_is_untagged() {
+        isolated(|| {
+            assert_eq!(current_db_tag_label().as_ref(), "untagged");
         });
     }
 }

--- a/metrics/src/lib.rs
+++ b/metrics/src/lib.rs
@@ -179,6 +179,7 @@ pub fn strip_doc_leading_space(s: &str) -> &str {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct MetricsContext {
     expensive_metrics_enabled: bool,
+    // `SharedString` is optimized for metrics and is cheap to clone (per metric recording).
     db_tag: Option<SharedString>,
 }
 
@@ -216,7 +217,7 @@ thread_local! {
     static METRICS_CONTEXT: RefCell<Option<MetricsContext>> = const { RefCell::new(None) };
 }
 
-const DEFAULT_DB_TAG: &str = "untagged";
+const DEFAULT_DB_TAG: SharedString = SharedString::const_str("untagged");
 
 /// A guard that restores the previous thread-local [`MetricsContext`].
 #[derive(Debug)]
@@ -259,7 +260,7 @@ pub fn current_db_tag() -> Option<SharedString> {
 /// Returns the current metrics db tag, or a default "untagged" label.
 #[must_use]
 pub fn current_db_tag_label() -> SharedString {
-    current_db_tag().unwrap_or_else(|| SharedString::const_str(DEFAULT_DB_TAG))
+    current_db_tag().unwrap_or(DEFAULT_DB_TAG)
 }
 
 /// Returns whether expensive metrics are enabled for the current thread.


### PR DESCRIPTION
## Why this should be merged

A process using multiple Firewood databases (e.g. multiple chains in one node) currently gets all their metrics mixed into the same series, with no way to distinguish between databases. This PR adds a per-database tag so every metric series identifies its database, letting consumers split dashboards and alerts per database.

## How this works

`MetricsContext`, which was added to support expensive metrics and works through TLS, is extended with a `db_tag` field. The `firewood_counter!`/`firewood_gauge!`/`firewood_histogram!` macros inject it as the first label (`db_tag=<tag>`) on every recording, falling back to `db_tag="untagged"` when no tag is set so the label dimension stays consistent across all    series of a family. For FFI side, `DatabaseHandleArgs` gains a `db_tag` field and a new `WithMetricsTag(tag)` option plumbs the tag into `fwd_open_db`. `Gatherer` is unchanged and returns all series; consumers can filter on the `db_tag` label themselves if they need per-database views.

## How this was tested
UT. New Go tests in `ffi/metrics_test.go`: one for tagged filtering and one for concurrency.

  ## Breaking Changes

  - [ ] firewood
  - [ ] firewood-storage
  - [ ] firewood-ffi (C api)
  - [ ] firewood-go (Go api)
  - [ ] fwdctl

Note for dashboard: every Rust-side metric series now carries a `db_tag` label (`"untagged"` by default).

Closes #1090.