### PR TITLE
docs: require comments to earn their line, and fix stale references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ firewood/             # Core library and main database implementation
 └── benches/          # Benchmarks
 
 firewood-macros/      # Procedural macros for the project
+metrics/              # Shared metrics utilities
+replay/               # Replay log types and engine for database operations
 storage/              # Storage layer implementation
 triehash/             # Trie hashing functionality
 ffi/                  # Foreign Function Interface (FFI) binding for Golang
@@ -78,9 +80,10 @@ By default, Firewood uses SHA-256 hashing compatible with merkledb. Enable this 
   storage-child count
 - See `storage/src/hashers/ethhash.rs` for implementation details
 
-### `logging`
+### `logger`
 
-Enable for runtime logging. Set `RUST_LOG` environment variable accordingly (uses `env_logger`).
+Enable for runtime logging. Set the `RUST_LOG` environment variable accordingly
+(uses `env_logger`).
 
 ## Common Development Tasks
 
@@ -90,17 +93,21 @@ Building and using the FFI library is a multi-step process. To generate the
 Firewood Rust FFI bindings:
 
 ```bash
-cd ffi/src                                              # Go to Rust binding directory
+cd ffi                                                  # Go to the FFI crate root
 cargo clean                                             # Remove any existing bindings
 cargo build --profile maxperf --features ethhash,logger # Generate bindings
 ```
 
-To then have Golang utilize these new bindings:
+To then have Golang utilize these new bindings, from that same directory:
 
 ```bash
-cd ..                   # Go to ffi directory
 go tool cgo firewood.go # Generate cgo wrappers
 ```
+
+`go tool cgo` refreshes only the wrappers the Go linter reads. The `go:generate`
+directives in `ffi/firewood.go` additionally update the cgo pragmas and
+`LDFLAGS`, and CI checks that they leave the tree unchanged. Run
+`just ci-check-go-generate` when link flags or pragmas drift.
 
 Any tagged enums added to the FFI api where the union body contains a pointer must be defined as `#[repr(C, usize)]` so that the enum tag forces the C struct to have pointer alignment.
 
@@ -274,7 +281,9 @@ brew install markdownlint-cli2
 
 Key dependencies are centrally managed in workspace `Cargo.toml`:
 
-- `firewood`, `firewood-macros`, `firewood-storage`, `firewood-ffi`, `firewood-triehash` (workspace members)
+- Workspace members: `firewood`, `firewood-storage`, `firewood-triehash`,
+  `firewood-macros`, `firewood-metrics`, `firewood-ffi`, `firewood-fwdctl`,
+  `firewood-benchmark`, `firewood-replay`
 - Common deps: `clap`, `thiserror`, `smallvec`, `sha2`, `log`, etc.
 - Test deps: `criterion`, `tempfile`, `rand`, etc.
 
@@ -311,7 +320,19 @@ Key dependencies are centrally managed in workspace `Cargo.toml`:
    `./scripts/run-just.sh prepush-lite`; run `./scripts/run-just.sh ci-docs` to
    invoke it separately.
 
-7. **Workspace Awareness**: This is a multi-crate workspace. Changes may affect multiple crates. Check `Cargo.toml` for workspace structure.
+7. **Comments Must Earn Their Line**: A comment competes with the code for the
+   reader's attention and must win on information. Generated comments fail in
+   recognizable ways — restating the line below, repeating the same explanation
+   at every call site, and narrating the change that produced them ("now uses",
+   "previously this would", "fixed to handle"). Write comments that stand alone
+   for a reader years from now who has no diff and no review thread: present
+   tense or imperative, consistent terminology, no filler or hype, each piece of
+   context stated once and cross-referenced from everywhere else. The same bar
+   applies to user-facing strings — error messages, log lines, and CLI help. See
+   [Comments and documentation](./CONTRIBUTING.md#comments-and-documentation)
+   and [User-facing strings](./CONTRIBUTING.md#user-facing-strings).
+
+8. **Workspace Awareness**: This is a multi-crate workspace. Changes may affect multiple crates. Check `Cargo.toml` for workspace structure.
 
 ## Code Review Guidelines
 

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -16,9 +16,17 @@ providing inline feedback — in addition to general best practices.
   for the rare expression where every rewrite hurts clarity. Test-only arithmetic already
   runs under the dev-profile overflow canary, so a reasoned `#[expect]` there is
   acceptable. See **Lint Suppression Policy** below.
-- **`unwrap()`**: Hard reject outside `#[cfg(test)]` modules. Also reject
-  `#[allow(clippy::unwrap_used)]` and `#[expect(clippy::unwrap_used)]` outside test
-  modules.
+- **`unwrap()`**: Hard reject in production code, along with
+  `#[allow(clippy::unwrap_used)]` and `#[expect(clippy::unwrap_used)]` there. Judge test
+  context by location, not by `cfg(test)` alone: unit-test modules and integration tests
+  under `tests/` are exempt, and so are Criterion benches under `benches/`, which are
+  `harness = false` binaries that never compile with `cfg(test)` set.
+- **`expect()`**: The sanctioned alternative to `unwrap` (see
+  [Style Guide](./CONTRIBUTING.md#style-guide--coding-conventions)), and clippy does not
+  enforce `expect_used`, so review is the only gate. The message must state the invariant
+  that makes the panic unreachable — why reaching it would be a bug — rather than name the
+  operation that failed. Reject `.expect("valid")` and `.expect("should not fail")`. Where
+  the caller can act on the failure, returning a `Result` beats any message.
 - **Lint suppression**: No local `#[allow(...)]` / `#![allow(...)]`. Use a reasoned
   `#[expect(...)]` (or `#[cfg_attr(<cfg>, expect(...))]` for feature-gated lints),
   scoped as tightly as possible. See **Lint Suppression Policy** below for the full rules
@@ -60,7 +68,9 @@ Every suppression must be deliberate, minimally scoped, and self-documenting.
   inside a `mod`, or `#[expect]` on a `mod`) carries a higher bar and **must not** sit on a
   module that has non-test submodules — push it down. Exceptions: a module whose only
   submodule is a `#[cfg(test)] mod tests` (or an all-test subtree) may keep a module-level
-  suppression; and `ffi/src/lib.rs` keeps a single crate-root
+  suppression; benchmark and integration-test crate roots (`benches/*.rs`, `tests/*.rs`)
+  are test code and may carry a crate-root suppression, subject to the same bar on the
+  `reason`; and `ffi/src/lib.rs` keeps a single crate-root
   `#![expect(unsafe_code, ...)]` as a documented FFI-boundary carve-out.
 
 ### `unsafe_code` exemption
@@ -91,7 +101,11 @@ For lints we leave suppressible:
 
 - **Comments and messages**: Every comment, log message, and error string must be
   accurate, useful, and free of tautologies. Log and error messages must be unique enough
-  to locate their source quickly.
+  to locate their source quickly. Challenge text that reads as generated rather than
+  written — padded, hedged, repeated at every call site, or narrating the change that
+  introduced it. See
+  [Comments and documentation](./CONTRIBUTING.md#comments-and-documentation) and
+  [User-facing strings](./CONTRIBUTING.md#user-facing-strings) for the authoring rules.
 - **Atomic operations**: Verify correct memory ordering (`Ordering`) for every load,
   store, and read-modify-write operation.
 - **Locks**: Check for potential deadlocks, excessively long critical sections, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,20 +17,30 @@ guidelines for contributing to firewood.
 
 ## Quick Links
 
-* [Setting up docker](README.docker.md)
+* [Setting up the devcontainer](.devcontainer/)
 * [Auto-generated documentation](https://ava-labs.github.io/firewood/rustdoc/firewood/)
 * [Issue tracker](https://github.com/ava-labs/firewood/issues)
 
 ## Testing
 
-After submitting a PR, we'll run all the tests and verify your code meets our submission guidelines. To ensure it's more likely to pass these checks, you should run the following commands locally:
+After submitting a PR, we'll run all the tests and verify your code meets our submission guidelines. To ensure it's more likely to pass these checks, run the same recipes CI runs:
 
     cargo fmt
-    cargo nextest run
-    cargo clippy
-    cargo doc --no-deps
+    just prepush-lite
 
-Resolve any warnings or errors before making your PR.
+`cargo fmt` applies formatting; the recipes only check it. `prepush-lite` checks
+formatting and TODOs, runs clippy and the tests for one feature profile, and
+lints the Markdown and the documentation build.
+
+CI is authoritative for the full matrix, and a change that touches the FFI,
+workspace dependencies, or a feature that profile does not enable warrants the
+whole thing before you push:
+
+    just prepush
+
+Use `./scripts/run-just.sh <recipe>` in place of `just` if you do not have `just`
+installed; the wrapper falls back to Nix and otherwise prints installation
+instructions. Resolve any warnings or errors before making your PR.
 
 Also, if you update any versions of packages, notably the MSRV (Minimum Supported Rust Version), you ought to update the nix ffi flake lock file to pin compatible versions of nix packages as well:
 
@@ -156,6 +166,69 @@ the GitHub UI.
 We generally follow the same rules that `cargo fmt` and `cargo clippy` will report as warnings, with a few notable exceptions as documented in the associated Cargo.toml file.
 
 By default, we prohibit bare `unwrap` calls and index dereferencing, as there are usually better ways to write this code. In the case where you can't, please use `expect` with a message explaining why it would be a bug, which we currently allow. For more information on our motivation, please read this great article on unwrap: [Using unwrap() in Rust is Okay](https://blog.burntsushi.net/unwrap) by [Andrew Gallant](https://blog.burntsushi.net).
+
+### Comments and documentation
+
+A comment competes with the code for the reader's attention and must win on
+information. Write what the code cannot say for itself — the invariant, the
+reason for the ordering, the failure the guard prevents, the layout of the bytes
+on disk. This comment loses, and deleting it improves the file:
+
+    // Increment the count.
+    self.count += 1;
+
+This one wins, because nothing in the surrounding code states it:
+
+    // Publish the free-list head only after the node is durable. A crash
+    // between the two leaks the space; the reverse order can hand out an
+    // address that still holds a live node.
+
+Be deliberate about what each comment carries:
+
+* **Self-contained and context free.** The reader is a stranger years from now
+  who did not see the review, does not know the issue number, and has no diff in
+  front of them. Describe the code as it stands, not as it changed: avoid "now",
+  "no longer", "previously", "this fix", and pointers to a review conversation.
+  History belongs in the commit message and the PR description.
+* **Said once.** State each piece of context in the place that owns it and refer
+  to that place from everywhere else — an intra-doc link in Rust
+  (`` [`NodeStore::flush_to`] ``), a doc link in Go (`[Revision.EthGetProof]`), or a
+  plain path (`see storage/src/nodestore/persist.rs`) where neither is available. Copies
+  drift, and a stale copy misleads more than a reference ever could.
+  [Documenting wrappers, shims, and FFI adapters](#documenting-wrappers-shims-and-ffi-adapters)
+  applies this rule to delegating functions.
+* **Consistent in voice.** Prefer the present tense or the imperative mood
+  ("returns the root hash", "hold the lock across the flush"). Use the
+  terminology defined in [AGENTS.md](./AGENTS.md#important-terminology) —
+  revision, view, proposal, commit, batch — rather than a synonym coined on the
+  spot, and do not alternate between "we", "you", and "the caller" within a
+  file.
+* **Free of filler.** No throat-clearing ("Note that", "It is important to note
+  that", "Basically"), no hype ("blazing fast", "robust", "cleanly handles"), no
+  prose restatement of the signature, and no doc section that exists only to be
+  present.
+
+### User-facing strings
+
+Error messages, log lines, and CLI help are part of the interface. Hold them to
+the same bar as the API:
+
+* Name what failed and what the operator can do about it. "failed to open
+  database" is a category; "failed to open database at {path}: {source}" is a
+  starting point for a fix.
+* Keep capitalization, punctuation, and terminology consistent across messages,
+  following the convention of the surface rather than inventing one: Rust error
+  strings are lowercase and unpunctuated because they are composed into a larger
+  chain, while CLI help is sentence case.
+* Make each message distinct enough that searching the source for it lands on a
+  single site.
+* Do not apologize, and do not suggest retrying unless a retry can succeed.
+
+Reviewers should challenge comments and strings that read as generated rather
+than written — padded, hedged, repeated at every call site, or narrating the
+change that introduced them. "This comment does not earn its line" and "say this
+once here and link to it from the other two places" are legitimate review
+feedback. See [`CODE_REVIEW.md`](./CODE_REVIEW.md) for the full review checklist.
 
 ### Documenting wrappers, shims, and FFI adapters
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ It is worth noting that the hash stored as a value inside the account root RLP i
 During hash calculations, we know the hash of the children,
 and use that directly to modify the value in-place
 when hashing the node.
-See [replace\_hash](firewood/storage/src/hashers/ethhash.rs) for more details.
+See [replace\_hash](storage/src/hashers/ethhash.rs) for more details.
 
 ## Run
 


### PR DESCRIPTION
## Why this should be merged

Comments here increasingly read as generated rather than written — padded, repeated at every call site, and narrating the change that introduced them ("now uses", "fixed to handle") instead of describing the code as it stands. That last habit is the expensive one: the narration is already stale by the time the next reader arrives, and nothing flags it. No linter can catch any of this, so review is the only gate — which means both the authoring rules and the reviewer's mandate to enforce them have to be written down.

Reading the three governance docs closely enough to amend them surfaced a second problem: several of their references no longer resolve. Those corrections ride along rather than waiting for a separate pass.

## How this works

The authoring rules live in `CONTRIBUTING.md`. The reviewer-facing half extends `CODE_REVIEW.md`'s existing **Comments and messages** bullet instead of adding a parallel one, so the checklist does not accumulate the duplication the new rules prohibit.

The `AGENTS.md` note is deliberately redundant with `CONTRIBUTING.md` rather than a bare link. Agents act on that notes list directly and frequently without following links, so the failure modes are named where they will actually be seen. This is the one place the new "say it once and cross-reference" rule is knowingly broken, and the trade is intentional.

## How this was tested

`just ci-lint-markdown` is clean.

## Breaking Changes

None. Documentation change only.