### PR TITLE
fix(manager): keep live revisions indexed across a reap

### DIFF
--- a/firewood/src/db/tests/concurrent_rebase.rs
+++ b/firewood/src/db/tests/concurrent_rebase.rs
@@ -35,6 +35,18 @@
 //!   enough other commits have reaped the initial empty revision out of
 //!   the manager's queue. The empty-parent diff must use a synthetic empty
 //!   view rather than `revisions_guard.front()` (which is no longer empty).
+//!
+//! - `test_rebase_onto_hash_equal_live_parent`: an A -> B -> A sequence
+//!   leaves two committed revisions sharing a root hash. Reaping the older
+//!   one must not evict the newer one from the manager's hash index, or a
+//!   proposal pinned to the newer one fails to find its parent to diff
+//!   against and `commit_with_rebase` reports `RevisionNotFound` for a
+//!   revision that is still in memory.
+//!
+//! - `test_rebase_after_failed_reap_of_parent`: an outstanding revision
+//!   handle makes the reap of a proposal's parent fail, so the parent goes
+//!   back onto the front of the queue. It is still live, so it must still
+//!   be findable by hash and the rebase must succeed.
 
 use std::thread;
 
@@ -512,4 +524,184 @@ fn test_empty_parent_rebase_after_reap() {
     // Reopen forces persist before check() to avoid `UnpersistedRoot` races.
     let db = db.reopen();
     assert_check_clean(&db, "post-empty-parent-rebase", false);
+}
+
+/// A -> B -> A leaves two committed revisions with the same root hash. The
+/// manager's hash index can only hold one entry per hash, and the newer
+/// revision owns it. Reaping the older revision must leave that entry alone.
+/// Reaping by hash without checking which revision currently owns the entry
+/// would unindex the newer revision while it is still in the queue; a
+/// proposal pinned to it would then fail to find its parent to diff against,
+/// and `commit_with_rebase` would report `RevisionNotFound` for a revision
+/// that is still in memory.
+#[test]
+fn test_rebase_onto_hash_equal_live_parent() {
+    // Sized so the round-trip pair is still in the queue when the older of
+    // the two is reaped: the queue holds [empty, C1, C2, C3] at capacity,
+    // and the two fillers below reap `empty` and then `C1`.
+    const TIGHT_MAX_REVISIONS: usize = 4;
+
+    let db = TestDb::new_with_config(
+        DbConfig::builder()
+            .manager(
+                RevisionManagerConfig::builder()
+                    .max_revisions(TIGHT_MAX_REVISIONS)
+                    .build(),
+            )
+            .build(),
+    );
+
+    let key = vec![0x42u8; 32];
+    let val_a = vec![0xaa, 0xbb];
+    let val_b = vec![0xcc, 0xdd];
+
+    // C1: K=A.
+    db.propose(vec![BatchOp::Put {
+        key: key.clone(),
+        value: val_a.clone(),
+    }])
+    .unwrap()
+    .commit()
+    .unwrap();
+    let hash_c1 = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(&db).unwrap();
+
+    // C2: K=B.
+    db.propose(vec![BatchOp::Put {
+        key: key.clone(),
+        value: val_b,
+    }])
+    .unwrap()
+    .commit()
+    .unwrap();
+
+    // C3: K=A again — same root hash as C1, different `CommittedId`.
+    db.propose(vec![BatchOp::Put {
+        key: key.clone(),
+        value: val_a.clone(),
+    }])
+    .unwrap()
+    .commit()
+    .unwrap();
+    let hash_c3 = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(&db).unwrap();
+    assert_eq!(
+        hash_c1, hash_c3,
+        "A -> B -> A must reproduce C1's root hash"
+    );
+
+    // P is pinned to C3, which is current at this point.
+    let key2 = vec![0x43u8; 32];
+    let val2 = vec![0xee, 0xff];
+    let proposal = db
+        .propose(vec![BatchOp::Put {
+            key: key2.clone(),
+            value: val2.clone(),
+        }])
+        .unwrap();
+
+    // These commits move C3 off the back of the queue and reap `empty` and
+    // C1. C3 stays in the queue, so P's parent is stale but still resident.
+    for i in 0..2u8 {
+        let mut filler = vec![0u8; 32];
+        filler[0] = 0x80; // distinct first nibble from `key`/`key2`
+        filler[31] = i;
+        db.propose(vec![BatchOp::Put {
+            key: filler,
+            value: vec![i; 4],
+        }])
+        .unwrap()
+        .commit()
+        .unwrap();
+    }
+
+    proposal
+        .commit_with_rebase()
+        .expect("rebase onto a live, hash-equal parent must succeed");
+
+    let final_hash = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(&db).unwrap();
+    let view =
+        <crate::db::Db<DefaultHashMode> as crate::api::Db>::revision(&db, final_hash).unwrap();
+    assert_eq!(view.val(&key).unwrap().as_deref(), Some(val_a.as_slice()));
+    assert_eq!(view.val(&key2).unwrap().as_deref(), Some(val2.as_slice()));
+    drop(view);
+
+    let db = db.reopen();
+    assert_check_clean(&db, "post-hash-equal-parent-rebase", false);
+}
+
+/// A revision with an outstanding handle cannot be reaped, so it goes back
+/// onto the front of the queue and stays live. Its hash-index entry has to go
+/// back with it: the entry is dropped as part of the reap attempt, before the
+/// outcome is known, so without restoring it the resident revision would be
+/// left unindexed and `commit_with_rebase` unable to diff against it.
+#[test]
+fn test_rebase_after_failed_reap_of_parent() {
+    // C1 is the only prior commit, so the queue holds [empty, C1] before the
+    // fillers run. The four fillers below take it to capacity, reap `empty`,
+    // and then attempt C1, which is pinned by `parent_handle`.
+    const TIGHT_MAX_REVISIONS: usize = 4;
+
+    let db = TestDb::new_with_config(
+        DbConfig::builder()
+            .manager(
+                RevisionManagerConfig::builder()
+                    .max_revisions(TIGHT_MAX_REVISIONS)
+                    .build(),
+            )
+            .build(),
+    );
+
+    // C1 becomes P's parent.
+    let key = vec![0x42u8; 32];
+    let val = vec![0xaa, 0xbb];
+    db.propose(vec![BatchOp::Put {
+        key: key.clone(),
+        value: val.clone(),
+    }])
+    .unwrap()
+    .commit()
+    .unwrap();
+    let hash_c1 = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(&db).unwrap();
+
+    let key2 = vec![0x43u8; 32];
+    let val2 = vec![0xee, 0xff];
+    let proposal = db
+        .propose(vec![BatchOp::Put {
+            key: key2.clone(),
+            value: val2.clone(),
+        }])
+        .unwrap();
+
+    // Hold a handle on C1 so its reap cannot take ownership of the revision.
+    let parent_handle =
+        <crate::db::Db<DefaultHashMode> as crate::api::Db>::revision(&db, hash_c1).unwrap();
+
+    // C1 reaches the front of the queue during these commits, fails to reap,
+    // and is pushed back — still resident, and still P's parent.
+    for i in 0..4u8 {
+        let mut filler = vec![0u8; 32];
+        filler[0] = 0x80; // distinct first nibble from `key`/`key2`
+        filler[31] = i;
+        db.propose(vec![BatchOp::Put {
+            key: filler,
+            value: vec![i; 4],
+        }])
+        .unwrap()
+        .commit()
+        .unwrap();
+    }
+
+    proposal
+        .commit_with_rebase()
+        .expect("rebase onto a parent that failed to reap must succeed");
+    drop(parent_handle);
+
+    let final_hash = <crate::db::Db<DefaultHashMode> as crate::api::Db>::root_hash(&db).unwrap();
+    let view =
+        <crate::db::Db<DefaultHashMode> as crate::api::Db>::revision(&db, final_hash).unwrap();
+    assert_eq!(view.val(&key).unwrap().as_deref(), Some(val.as_slice()));
+    assert_eq!(view.val(&key2).unwrap().as_deref(), Some(val2.as_slice()));
+    drop(view);
+
+    let db = db.reopen();
+    assert_check_clean(&db, "post-failed-reap-rebase", false);
 }

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -8,6 +8,7 @@
 
 use nonzero_ext::nonzero;
 use parking_lot::{Mutex, RwLock};
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 use std::io;
 use std::num::{NonZero, NonZeroU64};
@@ -108,6 +109,10 @@ pub(crate) struct RevisionManager<H> {
     /// If `root_store` is `None`, the oldest revision's nodes are added to the
     /// free list for space reuse. Otherwise, the oldest revision
     /// is preserved on disk for historical queries.
+    ///
+    /// This is a best-effort cap, not a hard one: a revision with an
+    /// outstanding handle cannot be reaped, and reaping is ordered, so the
+    /// queue stays over the limit until that handle is released.
     max_revisions: usize,
 
     /// FIFO queue of committed revisions kept in memory. The queue always
@@ -381,13 +386,30 @@ impl<H: HashMode> RevisionManager<H> {
         while revisions.len() >= self.max_revisions {
             let oldest = revisions.pop_front().expect("must be present");
             let oldest_hash = oldest.root_hash().or_else(H::default_root_hash);
-            if let Some(ref hash) = oldest_hash {
+
+            // Drop the index entry before `Arc::try_unwrap`: `by_hash` holds a
+            // clone of the revision, so the unwrap cannot succeed while the
+            // entry is present.
+            //
+            // Only drop the entry that actually points at *this* revision. Two
+            // committed revisions can share a root hash (an A -> B -> A round
+            // trip), in which case the newer one owns the index entry and the
+            // older one — reaped first, since the queue is FIFO — must leave it
+            // alone. Removing by hash alone would evict the live newer
+            // revision.
+            let was_indexed = oldest_hash.as_ref().is_some_and(|hash| {
                 // BLOCKING: write lock on `by_hash` while already holding the
                 // revisions write lock. Nested locking order must remain
                 // consistent (always acquire revisions before `by_hash`) to
                 // avoid deadlocks.
-                self.by_hash.write().remove(hash);
-            }
+                match self.by_hash.write().entry(hash.clone()) {
+                    Entry::Occupied(entry) if Arc::ptr_eq(entry.get(), &oldest) => {
+                        entry.remove();
+                        true
+                    }
+                    _ => false,
+                }
+            });
 
             // The warning in the docs for `Arc::try_unwrap` does not apply here
             // because `original` is retained and not immediately dropped.
@@ -398,6 +420,15 @@ impl<H: HashMode> RevisionManager<H> {
                     .map_err(RevisionManagerError::PersistError)?,
                 Err(original) => {
                     warn!("Oldest revision could not be reaped; still referenced");
+                    // An outstanding handle (a caller's revision, or the
+                    // persist worker) keeps the oldest revision alive, so it
+                    // goes back to the front of the queue and the queue stays
+                    // over `max_revisions` until a later commit can reap it.
+                    // It is still live, so it must stay findable by hash:
+                    // restore the entry removed above.
+                    if was_indexed && let Some(hash) = oldest_hash {
+                        self.by_hash.write().insert(hash, original.clone());
+                    }
                     revisions.push_front(original);
                     break;
                 }


### PR DESCRIPTION
## Why this should be merged

Two independent defects at one site in `RevisionManager::commit_critical_section`
left a revision that is still resident in `in_memory_revisions` unreachable
through `by_hash`. Callers see `RevisionNotFound` for a revision that is in
memory — from `Db::revision`, `Db::view`, and most damagingly from
`Proposal::commit_with_rebase`, which looks its committed parent up by hash to
diff against. That call consumes the proposal whether or not it succeeds, so a
caller that hits this has to rebuild its batch from scratch; for a consensus
client that means re-executing the block.

## How this works

The `by_hash` entry holds a clone of the revision, so it has to be dropped
before `Arc::try_unwrap` can succeed — that ordering is load-bearing and is why
the removal cannot simply be moved after the unwrap. What was missing is that
the removal was unconditional and by hash alone:

- `Arc::try_unwrap` fails whenever something else still holds the revision — a
  caller's `Db::revision` handle, or the persist worker, which keeps a clone
  until it has written the revision out. The revision goes back onto the front
  of the queue and stays live, but its index entry was already gone.
- Root hashes are not unique across live revisions. An A -> B -> A round trip
  produces two committed revisions with the same hash, and the newer one owns
  the index entry; reaping the older one evicted it.

So the entry is now removed only when it is the one pointing at the revision
being reaped, and re-inserted if the unwrap then fails. `Arc::ptr_eq` is the
check rather than a `CommittedId` comparison because `by_hash` and the queue
hold clones of the same allocation, which makes it the direct expression of
"is this entry mine". Reaping is FIFO, so the older of two hash-equal revisions
is always reaped first and the index converges on the newest live revision for
that hash.

## How this was tested

One regression test per trigger, both driven through the public API and both
asserting a clean checker report after reopen. Each fails on `main` with
exactly the `RevisionNotFound` this fixes.

This is also the outcome of an investigation into #1985, and the parts that did
*not* turn into code are worth recording:

- **The corruption that issue reports is no longer reproducible.** #1987
  (`CommittedId` parent identity plus the trivial-commit fast path) fixed it but
  linked only #1986, so #1985 was never closed. Re-checked with 16 threads x 64
  barrier-synced rounds of mixed put/delete batches over a shared 1024-key
  keyspace, `max_revisions` in {2, 4, 16, 128}, six seeds, debug and release:
  zero `InvalidKey` or hash-mismatch errors in every run.
- **The `AreaLeaks` that issue reports are not concurrency-related.** A
  single-threaded control with the same op count leaks the same amount, and the
  volume tracks `max_revisions` (~2.7 MB at 128) because the revisions still
  queued at close are never reaped, so their deleted nodes never reach the free
  list. The existing tests are right to filter them out; the underlying
  reclamation gap is its own problem.

What this does *not* fix is #2241: when a proposal's parent is *genuinely*
reaped, there is no parent left to diff against and `RevisionNotFound` is
correct. That is why the retry loop in
`test_concurrent_commit_with_rebase_no_freelist_corruption` stays. It needs a
design decision, not a patch.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
