### PR TITLE
docs(manager): correct comments that misdescribe their code

### DIFF
--- a/firewood/src/api.rs
+++ b/firewood/src/api.rs
@@ -106,7 +106,7 @@ pub enum Error {
 
     /// Incorrect root hash for commit
     #[error(
-        "The proposal cannot be committed since it is not a direct child of the most recent commit. Proposal parent: {provided:?}, current root: {expected:?}"
+        "The proposal cannot be committed since it is not a direct child of the most recent commit. Proposal root: {provided:?}, current root: {expected:?}"
     )]
     ParentNotLatest {
         /// the provided root hash

--- a/firewood/src/db/tests/concurrent_rebase.rs
+++ b/firewood/src/db/tests/concurrent_rebase.rs
@@ -18,11 +18,11 @@
 //!   `CommittedId` parent identity.
 //!
 //! - `test_trivial_rebase_succeeds_without_corruption`: two proposals
-//!   making the same `Put` race to commit. After the first commits, the
-//!   second's rebase produces a no-op (hash-identical to current). The
-//!   trivial-commit fast path must absorb this without pushing a duplicate
-//!   revision; otherwise the duplicate's deleted list aliases current's
-//!   root address and reaping double-frees it.
+//!   making the same `Put`, modeling a commit race. After the first
+//!   commits, the second's rebase produces a no-op (hash-identical to
+//!   current). The trivial-commit fast path must absorb this without
+//!   pushing a duplicate revision; otherwise the duplicate's deleted list
+//!   aliases current's root address and reaping double-frees it.
 //!
 //! - `test_round_trip_rejects_stale_parent`: an A→B→A sequence produces
 //!   two committed revisions with the same root hash but different
@@ -58,9 +58,9 @@ use crate::manager::RevisionManagerConfig;
 
 use super::TestDb;
 
-/// Number of concurrent commit threads. Each commits a single batch with
-/// a disjoint keyspace, so all batches can succeed (one direct commit,
-/// the rest rebased).
+/// Number of concurrent commit threads. Each one repeatedly commits batches
+/// over a keyspace disjoint from every other thread's, so every batch can
+/// succeed (whichever arrives first commits directly, the rest rebase).
 const THREADS: usize = 8;
 
 /// Number of commits per thread. Set high enough that the total number of
@@ -363,7 +363,7 @@ fn test_trivial_rebase_succeeds_without_corruption() {
     assert_eq!(view.val(&key).unwrap().as_deref(), Some(val.as_slice()));
     drop(view);
 
-    // Reopen forces the persist worker to flush before we run check();
+    // Reopen forces the persist worker to flush before check() runs;
     // otherwise the checker may race the worker and report `UnpersistedRoot`.
     let db = db.reopen();
     assert_check_clean(&db, "post-trivial-rebase", false);
@@ -496,7 +496,7 @@ fn test_empty_parent_rebase_after_reap() {
             .expect("commit filler");
     }
 
-    // P's parent is now stale (initial empty revision, possibly reaped).
+    // P's parent is now stale (the initial empty revision, now reaped).
     // commit_with_rebase must use a synthetic empty parent for diffing and
     // produce exactly [Put(p_key, p_val)] as the rebased batch.
     proposal

--- a/firewood/src/manager.rs
+++ b/firewood/src/manager.rs
@@ -3,7 +3,7 @@
 
 #![expect(
     clippy::default_trait_access,
-    reason = "Found 3 occurrences after enabling the lint."
+    reason = "Default::default() reads better than naming the type where the type is fixed by the field it initializes."
 )]
 
 use nonzero_ext::nonzero;
@@ -36,7 +36,7 @@ use firewood_storage::{
 pub(crate) const DB_FILE_NAME: &str = "firewood.db";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, TypedBuilder)]
-/// Revision manager configuratoin
+/// Revision manager configuration
 pub struct RevisionManagerConfig {
     /// The number of committed revisions to keep in memory.
     ///
@@ -73,7 +73,8 @@ pub struct RevisionManagerConfig {
 
 #[derive(Clone, Debug, TypedBuilder)]
 #[non_exhaustive]
-/// Configuration manager that contains both truncate and revision manager config
+/// Configuration for opening or creating a database, including revision-manager
+/// tuning.
 pub struct ConfigManager {
     /// The directory where the database files will be stored (required).
     pub root_dir: PathBuf,
@@ -150,7 +151,7 @@ pub(crate) enum RevisionManagerError {
     #[error("Revision for {provided:?} has no address")]
     RevisionWithoutAddress { provided: HashKey },
     #[error(
-        "The proposal cannot be committed since it is not a direct child of the most recent commit. Proposal parent: {provided:?}, current root: {expected:?}"
+        "The proposal cannot be committed since it is not a direct child of the most recent commit. Proposal root: {provided:?}, current root: {expected:?}"
     )]
     NotLatest {
         provided: Option<HashKey>,
@@ -258,7 +259,8 @@ impl<H: HashMode> RevisionManager<H> {
             persist_worker,
         };
 
-        // On startup, we always write the latest revision to RootStore
+        // If RootStore is enabled and the current revision has a root hash, seed
+        // RootStore with it on startup.
         if let Some(root_hash) = manager.current_revision().root_hash() {
             let root_address = manager.current_revision().root_address().ok_or(
                 RevisionManagerError::RevisionWithoutAddress {
@@ -285,14 +287,16 @@ impl<H: HashMode> RevisionManager<H> {
     ///    further progress.
     /// 2. Commit check.
     ///    The proposal's parent must be the last committed revision, otherwise the commit fails.
-    ///    It only contains the address of the nodes that are deleted, which should be very small.
+    ///    Converting the proposal into a committed revision only records the
+    ///    addresses of the nodes it deleted, which should be very small.
     /// 3. Revision reaping.
     ///    If more than the maximum number of revisions are kept in memory, the
     ///    oldest revision is removed from memory and sent to the `PersistWorker`
-    ///    for reaping.
+    ///    for reaping. A revision that something else still holds cannot be
+    ///    reaped, so the queue can stay above the maximum until that handle is
+    ///    released.
     /// 4. Signal to the `PersistWorker` to persist this revision.
-    /// 5. Set last committed revision.
-    ///    Set last committed revision in memory.
+    /// 5. Set the last committed revision in memory.
     /// 6. Proposal Cleanup.
     ///    Any other proposals that have this proposal as a parent should be reparented to the committed version.
     ///
@@ -341,9 +345,11 @@ impl<H: HashMode> RevisionManager<H> {
     /// Validate and commit a proposal under the caller's write guard.
     ///
     /// Checks that the proposal's parent matches the latest revision, reaps
-    /// old revisions that exceed `max_revisions`, signals the persist worker,
-    /// and inserts the new committed revision into the queue. The caller must
-    /// hold the write lock on committed revisions and pass the locked queue in.
+    /// old revisions that exceed `max_revisions` — as far as it can; see that
+    /// field's documentation for why the cap is best-effort — signals the
+    /// persist worker, and inserts the new committed revision into the queue.
+    /// The caller must hold the write lock on committed revisions and pass the
+    /// locked queue in.
     ///
     /// Returns the [`CommittedId`] of the revision the proposal now lives in:
     /// either the freshly-inserted revision for a regular commit, or the
@@ -652,7 +658,7 @@ impl<H: HashMode> RevisionManager<H> {
     ///
     /// # Panics
     ///
-    /// Panics if the it cannot create a thread pool.
+    /// Panics if it cannot create a thread pool.
     pub fn threadpool(&self) -> &ThreadPool {
         // Note that OnceLock currently doesn't support get_or_try_init (it is available in a
         // nightly release). The get_or_init should be replaced with get_or_try_init once it
@@ -695,7 +701,8 @@ impl<H: HashMode> RevisionManager<H> {
         }
     }
 
-    /// Serial batch application shared by [`apply_batch`][Self::apply_batch].
+    /// Serial batch application, shared by [`apply_batch`][Self::apply_batch]
+    /// and [`apply_batch_recon`][Self::apply_batch_recon].
     fn apply_batch_serial<K: MutableKind, BH: HashMode>(
         mutable_nodestore: NodeStore<Mutable<K>, FileBacked, BH>,
         batch: impl IntoBatchIter,


### PR DESCRIPTION
## Why this should be merged

Comment and message text only, no behavior changes. These came out of a
cold read of `manager.rs` against its own code — the reviewer had no
conversation history, which is what surfaced the comments that only make
sense if you already know what the code does. Each claim below was checked
against the code it annotates.

The one a user actually hits is the `NotLatest` / `ParentNotLatest` message.
It labels `provided` as "Proposal parent", but the value stored there is
`proposal.root_hash()` — the proposal's own resultant hash, which is what
the field's own doc comment ("the provided root hash") already says.
Printed next to "current root", someone debugging a rejected commit reads
the wrong hash under the wrong name.

## How this works

Only the label is corrected: "Proposal parent" -> "Proposal root". The
alternative — populating the field from `committed_parent_hash()`, which is
what the label promises and arguably the more useful diagnostic — changes
the error's payload rather than its prose, so it belongs in its own change
against `api::Error`. Both the crate-internal variant and the public
`api::Error::ParentNotLatest` carry the same string, so both move together.
`ffi/firewood_test.go` asserts on the sentence *before* this clause
(`Contains`, not equality), so the Go tests are unaffected.

The rest correct comments that overstate or misattribute what the code
does: an "always" that guards doubly-conditional code, reaping described as
a hard cap when a held revision cannot be reaped, a pronoun with no
antecedent, a helper's doc naming one of its two callers, a struct doc
naming 2 of 5 fields, a stale occurrence count in a `#[expect]` reason, a
line that repeats itself, and two typos. In `concurrent_rebase.rs`: a
constant whose doc contradicts both its neighbour and the test body, and a
module bullet describing a single-threaded test as a race while sitting
between two genuinely threaded ones.

## How this was tested

`just prepush-lite`. `grep` over the workspace and the FFI confirmed no
other copy of the error message exists.

## Breaking Changes

- [ ] firewood
- [ ] firewood-storage
- [ ] firewood-ffi (C api)
- [ ] firewood-go (Go api)
- [ ] fwdctl
